### PR TITLE
chore: move compose.yml to apps/ and add start:lan script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,25 +11,32 @@
   - `cargo build`, `cargo test`, `cargo run` などは直接実行しない
   - Docker Compose の `api` サービス経由で実行する:
     ```bash
-    docker compose -f apps/api/compose.yml run --rm api cargo build
-    docker compose -f apps/api/compose.yml run --rm api cargo test
+    docker compose -f apps/compose.yml run --rm api cargo build
+    docker compose -f apps/compose.yml run --rm api cargo test
     ```
   - または既存コンテナで実行:
     ```bash
-    docker compose -f apps/api/compose.yml exec api cargo test
+    docker compose -f apps/compose.yml exec api cargo test
     ```
 
 ### Mobile (apps/mobile/)
+- **Expo QR コードの確認方法**
+  - ターミナルでは QR コードが表示されないため、ブラウザで以下の URL を開く:
+    ```
+    https://api.qrserver.com/v1/create-qr-code/?size=300x300&data=exp%3A%2F%2F192.168.68.66%3A8081
+    ```
+  - `192.168.68.66` はホストマシンの LAN IP。変わった場合は `REACT_NATIVE_PACKAGER_HOSTNAME` も更新する。
+
 - **npm コマンドはすべて Docker 経由で実行する**
   - `npm install`, `npm run`, `npx` などは直接実行しない
   - Docker Compose の `mobile` サービス経由で実行する:
     ```bash
-    docker compose -f apps/api/compose.yml run --rm mobile npm install
-    docker compose -f apps/api/compose.yml run --rm mobile npx expo start
+    docker compose -f apps/compose.yml run --rm mobile npm install
+    docker compose -f apps/compose.yml run --rm mobile npx expo start
     ```
   - または既存コンテナで実行:
     ```bash
-    docker compose -f apps/api/compose.yml exec mobile npm test
+    docker compose -f apps/compose.yml exec mobile npm test
     ```
 
 ## Directory Structure

--- a/apps/compose.yml
+++ b/apps/compose.yml
@@ -29,16 +29,16 @@ services:
 
   api:
     build:
-      context: .
+      context: ./api
       dockerfile: Dockerfile.dev
     ports:
       - "3000:3000"
     volumes:
-      - .:/app                          # ソースコードをマウント
+      - ./api:/app                          # ソースコードをマウント
       - cargo_cache:/usr/local/cargo    # cargoキャッシュを永続化
       - target_cache:/app/target        # ビルドキャッシュを永続化
     env_file:
-      - .env
+      - ./api/.env
     environment:
       DATABASE_URL: postgres://walking_dog:password@postgres:5432/walking_dog_dev
       AWS_ENDPOINT_URL: http://localstack:4566
@@ -50,7 +50,7 @@ services:
 
   mobile:
     build:
-      context: ../mobile
+      context: ./mobile
       dockerfile: Dockerfile.dev
     ports:
       - "8081:8081"                     # Metro Bundler
@@ -58,47 +58,30 @@ services:
       - "19001:19001"                   # Expo DevTools
       - "19002:19002"                   # Expo DevTools
     volumes:
-      - ../mobile:/app                  # ソースコードをマウント
+      - ./mobile:/app                   # ソースコードをマウント
       - mobile_node_modules:/app/node_modules  # node_modulesを永続化
     environment:
       EXPO_DEVTOOLS_LISTEN_ADDRESS: "0.0.0.0"
+      REACT_NATIVE_PACKAGER_HOSTNAME: "192.168.68.66"
       API_URL: http://api:3000
     depends_on:
       - api
-
-  mobile-web:
-    build:
-      context: ../mobile
-      dockerfile: Dockerfile.dev
-    ports:
-      - "8082:8081"                     # Expo Web (ホスト8082 → コンテナ8081)
-    volumes:
-      - ../mobile:/app
-      - mobile_node_modules:/app/node_modules
-    environment:
-      EXPO_DEVTOOLS_LISTEN_ADDRESS: "0.0.0.0"
-      API_URL: http://api:3000
-    depends_on:
-      - api
-    command: ["npx", "expo", "start", "--web", "--host", "lan"]
-    profiles:
-      - e2e
 
   playwright:
     build:
-      context: ../mobile/e2e
+      context: ./mobile/e2e
       dockerfile: Dockerfile
     working_dir: /app
     volumes:
-      - ../mobile/e2e:/app
-      - ../../logs:/logs                # スクリーンショット保存先
+      - ./mobile/e2e:/app
+      - ../logs:/logs                   # スクリーンショット保存先
     environment:
-      BASE_URL: http://mobile-web:8081
+      BASE_URL: http://mobile:8081
       DISPLAY: ":99"
     ports:
       - "5900:5900"                     # VNC (headed モードの視覚確認用)
     depends_on:
-      - mobile-web
+      - mobile
     profiles:
       - e2e
 

--- a/apps/mobile/Dockerfile.dev
+++ b/apps/mobile/Dockerfile.dev
@@ -15,4 +15,4 @@ COPY . .
 EXPOSE 8081 19000 19001 19002
 
 # Start Expo on LAN mode for Docker network access
-CMD ["npx", "expo", "start", "--host", "lan"]
+CMD ["npm", "run", "start:lan"]

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.0",
   "scripts": {
     "start": "expo start",
+    "start:lan": "expo start --host lan",
     "reset-project": "node ./scripts/reset-project.js",
     "android": "expo start --android",
     "ios": "expo start --ios",


### PR DESCRIPTION
## Summary

- `apps/api/compose.yml` → `apps/compose.yml` に移動し、全サービスをモノレポルートから管理
- `mobile/package.json` に `start:lan` スクリプト追加（`expo start --host lan`）
- `Dockerfile.dev` の CMD を `npm run start:lan` に統一
- `CLAUDE.md` の compose ファイルパス参照を更新
- `mobile-web` サービスを削除（`mobile` サービスに統合）
- Expo QR コードの確認方法を `CLAUDE.md` に追記

## Test plan

- [ ] `docker compose -f apps/compose.yml up` で全サービスが起動すること
- [ ] `http://localhost:8081` で Web 版アプリが表示されること
- [ ] QR コード URL でブラウザから QR コードが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)