### PR TITLE
feat(playwright): configure iPhone 14 emulation profile

### DIFF
--- a/apps/playwright/.playwright/cli.config.json
+++ b/apps/playwright/.playwright/cli.config.json
@@ -3,6 +3,13 @@
     "browserName": "chromium",
     "launchOptions": {
       "channel": "chromium"
+    },
+    "contextOptions": {
+      "viewport": { "width": 390, "height": 644 },
+      "deviceScaleFactor": 3,
+      "isMobile": true,
+      "hasTouch": true,
+      "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Mobile/15E148 Safari/604.1"
     }
   }
 }

--- a/apps/playwright/playwright.config.ts
+++ b/apps/playwright/playwright.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from '@playwright/test';
+import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
   testDir: './tests',
@@ -9,7 +9,7 @@ export default defineConfig({
     trace: 'retain-on-failure',
   },
   projects: [
-    { name: 'chromium', use: { browserType: 'chromium' } },
+    { name: 'iPhone 14', use: { ...devices['iPhone 14'] } },
   ],
   reporter: [['html', { open: 'never' }]],
 });


### PR DESCRIPTION
## Summary

- `playwright.config.ts`: Switch from Chromium desktop to `devices['iPhone 14']` (WebKit, 390×644 viewport, iOS Safari UA)
- `.playwright/cli.config.json`: Add `contextOptions` with iPhone 14 viewport, `deviceScaleFactor: 3`, `isMobile`, `hasTouch`, and the official Playwright iOS 16.0 user-agent string

## Test plan

- [ ] `docker compose -f apps/compose.yml exec playwright node_modules/.bin/playwright test --list` shows `[iPhone 14]` project
- [ ] `playwright-cli screenshot` renders at 390×644px with iOS UA
- [ ] Screenshot confirms mobile layout with bottom tab bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)