### PR TITLE
style(mobile): tab bar tint-only selection style

### DIFF
--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -3,6 +3,7 @@ import { Tabs } from 'expo-router';
 import { HapticTab } from '@/components/haptic-tab';
 import { IconSymbol } from '@/components/ui/icon-symbol';
 import { useColors } from '@/hooks/use-colors';
+import { typography } from '@/theme/tokens';
 
 export default function TabLayout() {
   const theme = useColors();
@@ -10,11 +11,16 @@ export default function TabLayout() {
   return (
     <Tabs
       screenOptions={{
-        tabBarActiveTintColor: theme.onInteractive,
-        tabBarInactiveTintColor: theme.onSurfaceVariant,
-        tabBarActiveBackgroundColor: theme.interactive,
+        tabBarActiveTintColor: theme.interactive,
+        tabBarInactiveTintColor: theme.border,
         headerShown: false,
         tabBarButton: HapticTab,
+        tabBarLabelStyle: {
+          fontSize: typography.label.fontSize,
+          fontWeight: typography.label.fontWeight,
+          letterSpacing: typography.label.letterSpacing,
+          textTransform: typography.label.textTransform,
+        },
         tabBarStyle: {
           backgroundColor: theme.background,
           borderTopWidth: 0,


### PR DESCRIPTION
## Summary
- Remove background color inversion on active tab (no more black pill behind selected tab)
- Use `theme.interactive` / `theme.border` tint colors to distinguish selected vs unselected tabs
- Apply uppercase label style with letter-spacing using existing `typography.label` tokens

## Test plan
- [x] Verified on iOS Simulator (iPhone 16 Pro, light mode)
- [ ] Verify dark mode appearance
- [ ] Verify haptic feedback still works on tab press

🤖 Generated with [Claude Code](https://claude.com/claude-code)