### PR TITLE
fix(api): save display_name to DB during sign-up

### DIFF
--- a/apps/api/src/auth/service.rs
+++ b/apps/api/src/auth/service.rs
@@ -3,6 +3,7 @@ use aws_sdk_cognitoidentityprovider::types::AttributeType;
 
 pub struct SignUpResult {
     pub user_confirmed: bool,
+    pub user_sub: String,
 }
 
 pub struct SignInResult {
@@ -54,6 +55,7 @@ pub async fn sign_up(
 
     Ok(SignUpResult {
         user_confirmed: result.user_confirmed,
+        user_sub: result.user_sub().to_string(),
     })
 }
 

--- a/apps/api/src/graphql/custom_mutations.rs
+++ b/apps/api/src/graphql/custom_mutations.rs
@@ -778,18 +778,14 @@ fn sign_up_field(state: Arc<AppState>) -> Field {
             .map_err(async_graphql::Error::new)?;
 
             // display_name 付きで DB ユーザーレコードを即時作成する。
-            // 失敗しても Cognito 登録は成功済みなので非致命的エラーとして扱う。
             if !result.user_sub.is_empty() {
-                if let Err(e) = user_service::create_user_with_profile(
+                user_service::create_user_with_profile(
                     &state.db,
                     &result.user_sub,
                     &display_name,
-                ).await {
-                    tracing::warn!(
-                        "Failed to create user record during sign-up: {}",
-                        e
-                    );
-                }
+                )
+                .await
+                .map_err(AppError::into_graphql_error)?;
             }
 
             Ok(Some(FieldValue::owned_any(SignUpOutput {

--- a/apps/api/src/graphql/custom_mutations.rs
+++ b/apps/api/src/graphql/custom_mutations.rs
@@ -777,6 +777,21 @@ fn sign_up_field(state: Arc<AppState>) -> Field {
             .await
             .map_err(async_graphql::Error::new)?;
 
+            // display_name 付きで DB ユーザーレコードを即時作成する。
+            // 失敗しても Cognito 登録は成功済みなので非致命的エラーとして扱う。
+            if !result.user_sub.is_empty() {
+                if let Err(e) = user_service::create_user_with_profile(
+                    &state.db,
+                    &result.user_sub,
+                    &display_name,
+                ).await {
+                    tracing::warn!(
+                        "Failed to create user record during sign-up: {}",
+                        e
+                    );
+                }
+            }
+
             Ok(Some(FieldValue::owned_any(SignUpOutput {
                 success: true,
                 user_confirmed: result.user_confirmed,

--- a/apps/api/src/services/user_service.rs
+++ b/apps/api/src/services/user_service.rs
@@ -40,6 +40,46 @@ pub async fn get_or_create_user(
     }
 }
 
+pub async fn create_user_with_profile(
+    db: &sea_orm::DatabaseConnection,
+    cognito_sub: &str,
+    display_name: &str,
+) -> Result<UserModel, AppError> {
+    if let Some(model) = UserEntity::find()
+        .filter(users::Column::CognitoSub.eq(cognito_sub))
+        .one(db)
+        .await?
+    {
+        return Ok(model);
+    }
+
+    let result = ActiveModel {
+        id: Set(Uuid::new_v4()),
+        cognito_sub: Set(cognito_sub.to_string()),
+        display_name: Set(Some(display_name.to_string())),
+        ..Default::default()
+    }
+    .insert(db)
+    .await;
+
+    match result {
+        Ok(model) => Ok(model),
+        Err(sea_orm::DbErr::Query(ref err))
+            if err.to_string().contains("duplicate key") =>
+        {
+            let model = UserEntity::find()
+                .filter(users::Column::CognitoSub.eq(cognito_sub))
+                .one(db)
+                .await?
+                .ok_or_else(|| AppError::Internal(
+                    "User disappeared after insert conflict".to_string(),
+                ))?;
+            Ok(model)
+        }
+        Err(e) => Err(AppError::Database(e)),
+    }
+}
+
 pub async fn update_profile(
     db: &sea_orm::DatabaseConnection,
     cognito_sub: &str,


### PR DESCRIPTION
## Summary

- `display_name` が signUp 時に Cognito には保存されるが PostgreSQL の `users` テーブルには保存されないバグを修正
- `SignUpResult` に `user_sub` フィールドを追加し、Cognito レスポンスから取得
- `sign_up` mutation 内で `create_user_with_profile()` を呼び出し、`display_name` 付きで DB レコードを即時作成

## Test plan

- [x] `cargo build` — ビルド成功
- [x] `cargo test --lib` — 既存テストパス
- [x] `cargo test --test test_health` — 統合テストパス
- [ ] 新規ユーザーでサインアップし、DB の `users` テーブルで `display_name` が設定されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)