### PR TITLE
feat(infra): add Sakura VPS test environment

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -16,17 +16,13 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  # These values must match infra/aws/variables.tf (project_name, environment, aws_region)
+  # These values must match infra/aws/variables.tf (project_name, aws_region)
   AWS_REGION: ap-northeast-1
   ECR_REPOSITORY: walking-dog-api
-  ECS_CLUSTER: walking-dog-dev
-  ECS_SERVICE: walking-dog-dev-api
-  TASK_FAMILY: walking-dog-dev-api
-  CONTAINER_NAME: api
 
 jobs:
-  deploy:
-    name: Build & Deploy
+  build:
+    name: Build & Push to ECR
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -57,66 +53,3 @@ jobs:
           provenance: false
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-      - name: Download current task definition
-        run: |
-          aws ecs describe-task-definition \
-            --task-definition "$TASK_FAMILY" \
-            --query 'taskDefinition' \
-            --output json > task-definition.json
-
-      - name: Update image in task definition
-        id: render-task-def
-        uses: aws-actions/amazon-ecs-render-task-definition@v1
-        with:
-          task-definition: task-definition.json
-          container-name: ${{ env.CONTAINER_NAME }}
-          image: ${{ steps.ecr-login.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}
-
-      - name: Register new task definition revision
-        id: register-task-def
-        env:
-          RENDERED_TASK_DEF: ${{ steps.render-task-def.outputs.task-definition }}
-        run: |
-          jq 'del(.taskDefinitionArn, .revision, .status, .requiresAttributes, .compatibilities, .registeredAt, .registeredBy)' \
-            "$RENDERED_TASK_DEF" > new-task-definition.json
-
-          REVISION_ARN=$(aws ecs register-task-definition \
-            --cli-input-json file://new-task-definition.json \
-            --query 'taskDefinition.taskDefinitionArn' \
-            --output text)
-
-          echo "revision-arn=$REVISION_ARN" >> "$GITHUB_OUTPUT"
-          echo "Registered: $REVISION_ARN"
-
-      - name: Update ECS service (if running)
-        env:
-          REVISION_ARN: ${{ steps.register-task-def.outputs.revision-arn }}
-        run: |
-          SERVICE_STATUS=$(aws ecs describe-services \
-            --cluster "$ECS_CLUSTER" \
-            --services "$ECS_SERVICE" \
-            --query 'services[0].status' \
-            --output text 2>/dev/null || echo "MISSING")
-
-          if [ "$SERVICE_STATUS" = "ACTIVE" ]; then
-            echo "Service is active. Updating..."
-            aws ecs update-service \
-              --cluster "$ECS_CLUSTER" \
-              --service "$ECS_SERVICE" \
-              --task-definition "$REVISION_ARN" \
-              --force-new-deployment \
-              --query 'service.serviceName' \
-              --output text
-
-            echo "Waiting for service to stabilize..."
-            aws ecs wait services-stable \
-              --cluster "$ECS_CLUSTER" \
-              --services "$ECS_SERVICE"
-            echo "Deployment completed successfully."
-          elif [ "$SERVICE_STATUS" = "None" ] || [ "$SERVICE_STATUS" = "MISSING" ]; then
-            echo "ECS service does not exist (scheduler has not created it). Skipping update."
-            echo "New task definition revision registered. It will be used on next service creation."
-          else
-            echo "Service status: $SERVICE_STATUS — skipping update."
-          fi

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ apps/api/.env.production
 *.tfstate.backup
 .terraform.lock.hcl
 infra/**/lambda/*.zip
+infra/sakura/.env

--- a/infra/aws/ecr.tf
+++ b/infra/aws/ecr.tf
@@ -1,0 +1,34 @@
+resource "aws_ecr_repository" "api" {
+  name                 = "${var.project_name}-api"
+  image_tag_mutability = "MUTABLE"
+  force_delete         = true
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = {
+    Environment = var.environment
+    Project     = var.project_name
+  }
+}
+
+# Keep only the latest 10 images to save storage cost.
+resource "aws_ecr_lifecycle_policy" "api" {
+  repository = aws_ecr_repository.api.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Keep last 10 images"
+        selection = {
+          tagStatus   = "any"
+          countType   = "imageCountMoreThan"
+          countNumber = 10
+        }
+        action = { type = "expire" }
+      }
+    ]
+  })
+}

--- a/infra/aws/github_oidc.tf
+++ b/infra/aws/github_oidc.tf
@@ -43,7 +43,6 @@ resource "aws_iam_role" "github_actions" {
   }
 }
 
-/*
 resource "aws_iam_role_policy" "github_actions" {
   name = "${var.project_name}-github-actions"
   role = aws_iam_role.github_actions.id
@@ -52,11 +51,9 @@ resource "aws_iam_role_policy" "github_actions" {
     Version = "2012-10-17"
     Statement = [
       {
-        Sid    = "ECRAuth"
-        Effect = "Allow"
-        Action = [
-          "ecr:GetAuthorizationToken",
-        ]
+        Sid      = "ECRAuth"
+        Effect   = "Allow"
+        Action   = ["ecr:GetAuthorizationToken"]
         Resource = "*"
       },
       {
@@ -73,34 +70,6 @@ resource "aws_iam_role_policy" "github_actions" {
         ]
         Resource = aws_ecr_repository.api.arn
       },
-      {
-        Sid    = "ECSTaskDefinition"
-        Effect = "Allow"
-        Action = [
-          "ecs:DescribeTaskDefinition",
-          "ecs:RegisterTaskDefinition",
-        ]
-        Resource = "*"
-      },
-      {
-        Sid    = "ECSService"
-        Effect = "Allow"
-        Action = [
-          "ecs:DescribeServices",
-          "ecs:UpdateService",
-        ]
-        Resource = "arn:aws:ecs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:service/${aws_ecs_cluster.main.name}/*"
-      },
-      {
-        Sid    = "PassRole"
-        Effect = "Allow"
-        Action = "iam:PassRole"
-        Resource = [
-          aws_iam_role.ecs_execution.arn,
-          aws_iam_role.ecs_task.arn,
-        ]
-      },
     ]
   })
 }
-*/

--- a/infra/aws/iam_vps.tf
+++ b/infra/aws/iam_vps.tf
@@ -1,0 +1,54 @@
+# --- IAM User for Sakura VPS API ---
+
+resource "aws_iam_user" "vps_api" {
+  name = "${var.project_name}-${var.environment}-vps-api"
+
+  tags = {
+    Environment = var.environment
+    Project     = var.project_name
+  }
+}
+
+resource "aws_iam_access_key" "vps_api" {
+  user = aws_iam_user.vps_api.name
+}
+
+resource "aws_iam_user_policy" "vps_api" {
+  name = "${var.project_name}-${var.environment}-vps-api"
+  user = aws_iam_user.vps_api.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "DynamoDB"
+        Effect = "Allow"
+        Action = [
+          "dynamodb:BatchWriteItem",
+          "dynamodb:Query",
+          "dynamodb:GetItem",
+          "dynamodb:PutItem",
+        ]
+        Resource = aws_dynamodb_table.walk_points.arn
+      },
+      {
+        Sid    = "S3"
+        Effect = "Allow"
+        Action = [
+          "s3:PutObject",
+          "s3:GetObject",
+        ]
+        Resource = "${aws_s3_bucket.dog_photos.arn}/*"
+      },
+      {
+        Sid    = "Cognito"
+        Effect = "Allow"
+        Action = [
+          "cognito-idp:AdminGetUser",
+          "cognito-idp:ListUsers",
+        ]
+        Resource = aws_cognito_user_pool.main.arn
+      },
+    ]
+  })
+}

--- a/infra/aws/iam_vps.tf
+++ b/infra/aws/iam_vps.tf
@@ -49,6 +49,22 @@ resource "aws_iam_user_policy" "vps_api" {
         ]
         Resource = aws_cognito_user_pool.main.arn
       },
+      {
+        Sid      = "ECRAuth"
+        Effect   = "Allow"
+        Action   = ["ecr:GetAuthorizationToken"]
+        Resource = "*"
+      },
+      {
+        Sid    = "ECRPull"
+        Effect = "Allow"
+        Action = [
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage",
+        ]
+        Resource = aws_ecr_repository.api.arn
+      },
     ]
   })
 }

--- a/infra/aws/outputs.tf
+++ b/infra/aws/outputs.tf
@@ -94,6 +94,12 @@ output "acm_certificate_arn" {
   value = aws_acm_certificate.main.arn
 }
 
+# --- ECR ---
+
+output "ecr_repository_url" {
+  value = aws_ecr_repository.api.repository_url
+}
+
 # --- VPS API IAM User ---
 
 output "vps_api_access_key_id" {

--- a/infra/aws/outputs.tf
+++ b/infra/aws/outputs.tf
@@ -93,3 +93,14 @@ output "route53_nameservers" {
 output "acm_certificate_arn" {
   value = aws_acm_certificate.main.arn
 }
+
+# --- VPS API IAM User ---
+
+output "vps_api_access_key_id" {
+  value = aws_iam_access_key.vps_api.id
+}
+
+output "vps_api_secret_access_key" {
+  value     = aws_iam_access_key.vps_api.secret
+  sensitive = true
+}

--- a/infra/sakura/.env.example
+++ b/infra/sakura/.env.example
@@ -1,0 +1,20 @@
+# PostgreSQL (this VPS)
+POSTGRES_PASSWORD=<generate-a-strong-password>
+DATABASE_URL=postgres://walking_dog:<same-password>@postgres:5432/walking_dog_test
+
+# AWS credentials (from: terraform output vps_api_access_key_id / vps_api_secret_access_key)
+AWS_REGION=ap-northeast-1
+AWS_ACCESS_KEY_ID=<from-terraform-output>
+AWS_SECRET_ACCESS_KEY=<from-terraform-output>
+
+# AWS resources (reuse dev environment)
+DYNAMODB_TABLE_WALK_POINTS=walking-dog-dev-WalkPoints
+S3_BUCKET_DOG_PHOTOS=walking-dog-dev-dog-photos-967026628831
+COGNITO_USER_POOL_ID=ap-northeast-1_qxOTma0uA
+COGNITO_CLIENT_ID=64biiqesu1d3oku6olt817tmbl
+
+# API
+PORT=3000
+
+# Do NOT set *_ENDPOINT_URL variables.
+# Omitting them makes the AWS SDK connect to real AWS endpoints.

--- a/infra/sakura/.env.example
+++ b/infra/sakura/.env.example
@@ -7,6 +7,10 @@ AWS_REGION=ap-northeast-1
 AWS_ACCESS_KEY_ID=<from-terraform-output>
 AWS_SECRET_ACCESS_KEY=<from-terraform-output>
 
+# ECR image URL (from: terraform output ecr_repository_url)
+# Example: 967026628831.dkr.ecr.ap-northeast-1.amazonaws.com/walking-dog-api:latest
+ECR_IMAGE=<account-id>.dkr.ecr.ap-northeast-1.amazonaws.com/walking-dog-api:latest
+
 # AWS resources (reuse dev environment)
 DYNAMODB_TABLE_WALK_POINTS=walking-dog-dev-WalkPoints
 S3_BUCKET_DOG_PHOTOS=walking-dog-dev-dog-photos-967026628831

--- a/infra/sakura/compose.yml
+++ b/infra/sakura/compose.yml
@@ -1,0 +1,25 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: walking_dog
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: walking_dog_test
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    restart: unless-stopped
+
+  api:
+    build:
+      context: ../../apps/api
+      dockerfile: Dockerfile
+    ports:
+      - "3000:3000"
+    env_file:
+      - .env
+    depends_on:
+      - postgres
+    restart: unless-stopped
+
+volumes:
+  postgres_data:

--- a/infra/sakura/compose.yml
+++ b/infra/sakura/compose.yml
@@ -10,9 +10,7 @@ services:
     restart: unless-stopped
 
   api:
-    build:
-      context: ../../apps/api
-      dockerfile: Dockerfile
+    image: ${ECR_IMAGE}
     ports:
       - "3000:3000"
     env_file:

--- a/infra/sakura/deploy.sh
+++ b/infra/sakura/deploy.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Deploy the API on Sakura VPS: log into ECR, pull latest image, restart services.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+# Load .env
+set -a
+# shellcheck disable=SC1091
+source .env
+set +a
+
+# ECR login
+AWS_ACCOUNT_ID=$(echo "$ECR_IMAGE" | cut -d. -f1)
+aws ecr get-login-password --region "$AWS_REGION" \
+  | docker login --username AWS --password-stdin \
+      "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
+
+# Pull latest image and (re)start services.
+docker compose pull api
+docker compose up -d
+
+echo "Deploy complete."


### PR DESCRIPTION
## Summary
- GraphQL server + PostgreSQL をさくらVPS上で docker compose で運用するテスト環境を追加
- AWS の Cognito / DynamoDB / S3 は既存 dev リソースを共用し、IAM ユーザーのアクセスキーで認証
- **Docker イメージは GitHub Actions でビルドして ECR に push、VPS は pull するだけ** (VPS は非力で Rust コンパイル不可のため)

## Changes

### AWS (Terraform)
- `infra/aws/ecr.tf` — **新規** ECR リポジトリ + 10世代保持ライフサイクルポリシー
- `infra/aws/iam_vps.tf` — **新規** VPS 用 IAM ユーザー (DynamoDB / S3 / Cognito / ECR pull)
- `infra/aws/github_oidc.tf` — GitHub Actions に ECR push 権限付与 (ECS 関連は削除)
- `infra/aws/outputs.tf` — `ecr_repository_url` / `vps_api_access_key_id` / `vps_api_secret_access_key` 追加

### GitHub Actions
- `.github/workflows/deploy-api.yml` — ECS 関連ステップ削除、build + push ECR のみに簡略化

### VPS
- `infra/sakura/compose.yml` — **新規** postgres + api (ECR イメージ参照)
- `infra/sakura/.env.example` — **新規** 環境変数テンプレート
- `infra/sakura/deploy.sh` — **新規** ECR login → pull → compose up スクリプト

### Other
- `.gitignore` — `infra/sakura/.env` を除外

## Test plan
- [x] `terraform validate` 成功
- [x] `terraform apply` 成功 (ECR, IAM policies 作成済み)
- [ ] main マージ後、`deploy-api` workflow 手動実行で ECR に push 成功
- [ ] VPS で `./deploy.sh` → `curl /health` が `"ok"` を返す
- [ ] GraphQL ミューテーションで Cognito / DynamoDB / S3 連携を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)