### PR TITLE
fix(mobile): use valid hex UUID for BLE service advertisement

### DIFF
--- a/apps/mobile/lib/ble/constants.ts
+++ b/apps/mobile/lib/ble/constants.ts
@@ -7,7 +7,9 @@
 
 // Custom 128-bit service UUID for Walking Dog BLE encounter detection.
 // Used to filter scan results to only our app's devices.
-export const WALKING_DOG_SERVICE_UUID = 'WD000001-0000-1000-8000-00805F9B34FB';
+// Prefix "5744" is the ASCII hex for "WD" — preserves the Walking Dog
+// symbolism while satisfying UUID's strict hex-only requirement.
+export const WALKING_DOG_SERVICE_UUID = '57440001-0000-1000-8000-00805F9B34FB';
 
 // Manufacturer data company ID (0xFFFF = reserved for testing/development).
 export const COMPANY_ID = 0xffff;

--- a/apps/mobile/modules/ble-advertiser/ios/BleAdvertiserModule.swift
+++ b/apps/mobile/modules/ble-advertiser/ios/BleAdvertiserModule.swift
@@ -24,8 +24,21 @@ public class BleAdvertiserModule: Module {
       delegate.onPoweredOn = { [weak self] in
         guard let self = self else { return }
 
-        let serviceUUID = CBUUID(string: serviceUuid)
-        let walkIdUUID = CBUUID(string: walkIdUuid)
+        // Validate UUIDs via Swift's failable `UUID(uuidString:)` first, then
+        // bridge to CBUUID. CBUUID(string:) throws NSException on invalid
+        // input and would crash the app; validating up front lets us reject
+        // the Promise with a clear error instead.
+        guard let serviceNsUuid = UUID(uuidString: serviceUuid) else {
+          promise.reject("INVALID_SERVICE_UUID", "Invalid service UUID: \(serviceUuid)")
+          return
+        }
+        guard let walkIdNsUuid = UUID(uuidString: walkIdUuid) else {
+          promise.reject("INVALID_WALK_ID_UUID", "Invalid walk ID UUID: \(walkIdUuid)")
+          return
+        }
+
+        let serviceUUID = CBUUID(nsuuid: serviceNsUuid)
+        let walkIdUUID = CBUUID(nsuuid: walkIdNsUuid)
 
         let advertisementData: [String: Any] = [
           CBAdvertisementDataServiceUUIDsKey: [serviceUUID, walkIdUUID],


### PR DESCRIPTION
## Summary
- `WALKING_DOG_SERVICE_UUID` を `WD000001-...` から `57440001-...` に変更（`W` は非 hex）
- iOS BleAdvertiserModule に `UUID(uuidString:)` 検証を追加してクラッシュ→Promise reject に変換

## Root cause
iOS 実機で「散歩スタート」時にクラッシュ。クラッシュログのバックトレースで `CBUUID(string:)` → `NSAssertionHandler` → `abort` を確認。`CBUUID(string:)` は hex のみ受ける仕様で `W` で assertion 失敗していた。

- Android: `UUID.fromString` が catchable な IllegalArgumentException を投げるので未発覚
- iOS Simulator: BLE `state` が Unsupported で早期 return → CBUUID 変換に到達せず未発覚

## Defense in depth
`CBUUID(string:)` は NSException throw 系で Swift の do/catch では捕捉不能。`UUID(uuidString:)` で先に検証して nil なら Promise reject する形に書き換え、将来の invalid UUID 流入でもプロセスクラッシュを防ぐ。

## Test plan
- [x] iPhone 実機で「散歩スタート」してクラッシュしないことを確認済み
- [ ] Android 実機でも散歩スタートが動くこと（service UUID 変更による互換性確認）
- [ ] BLE encounter 検出（2 台の実機で互いの walk ID を検出）— 本 PR の主目的外だが UUID 変更の影響範囲

🤖 Generated with [Claude Code](https://claude.com/claude-code)