### PR TITLE
chore(mobile): remove unused expo-apple-authentication

### DIFF
--- a/apps/mobile/package-lock.json
+++ b/apps/mobile/package-lock.json
@@ -15,7 +15,6 @@
         "@react-navigation/native": "^7.1.8",
         "@tanstack/react-query": "^5.91.3",
         "expo": "~54.0.33",
-        "expo-apple-authentication": "~8.0.8",
         "expo-constants": "~18.0.13",
         "expo-font": "~14.0.11",
         "expo-haptics": "~15.0.8",
@@ -8498,16 +8497,6 @@
         "react-native-webview": {
           "optional": true
         }
-      }
-    },
-    "node_modules/expo-apple-authentication": {
-      "version": "8.0.8",
-      "resolved": "https://registry.npmjs.org/expo-apple-authentication/-/expo-apple-authentication-8.0.8.tgz",
-      "integrity": "sha512-TwCHWXYR1kS0zaeV7QZKLWYluxsvqL31LFJubzK30njZqeWoWO89HZ8nZVaeXbFV1LrArKsze4BmMb+94wS0AQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "expo": "*",
-        "react-native": "*"
       }
     },
     "node_modules/expo-asset": {

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -23,7 +23,6 @@
     "@react-navigation/native": "^7.1.8",
     "@tanstack/react-query": "^5.91.3",
     "expo": "~54.0.33",
-    "expo-apple-authentication": "~8.0.8",
     "expo-constants": "~18.0.13",
     "expo-font": "~14.0.11",
     "expo-haptics": "~15.0.8",


### PR DESCRIPTION
## Summary
- `expo-apple-authentication` は JS コードから一切 import されておらず dead weight
- Personal Team（無料 Apple ID）では `com.apple.developer.applesignin` entitlement で署名できず、実機ビルドが失敗する

## Why
iPhone 実機で `npx expo run:ios --device` を実行した際、以下のエラーでビルドが通らない：

```
Cannot create a iOS App Development provisioning profile for "com.walkingdog.dev".
Personal development teams do not support the Sign In with Apple capability.
```

`expo-apple-authentication` が prebuild 時に entitlement を注入するが、JS コード側で実際に使っている場所がない（`grep -rn "AppleAuthentication" app lib` で 0 件）。未使用なので削除する。

## Impact
- Sign In with Apple のサインインフローを導入する際は再度追加する必要がある（その時は Apple Developer Program への加入必須）
- 次回の `npx expo prebuild --clean` で `WalkingDoglocal.entitlements` から `com.apple.developer.applesignin` が消える

## Test plan
- [x] `npx expo prebuild --clean` 後に entitlements が空になることを確認済み
- [x] 実機ビルド `npx expo run:ios --device` が成功することを確認済み（Personal Team の署名で通る）

🤖 Generated with [Claude Code](https://claude.com/claude-code)