### PR TITLE
feat(mobile): merge HOME tab into WALK tab

### DIFF
--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -10,6 +10,7 @@ export default function TabLayout() {
 
   return (
     <Tabs
+      initialRouteName="walk"
       screenOptions={{
         tabBarActiveTintColor: theme.interactive,
         tabBarInactiveTintColor: theme.border,
@@ -26,13 +27,6 @@ export default function TabLayout() {
           borderTopWidth: 0,
         },
       }}>
-      <Tabs.Screen
-        name="index"
-        options={{
-          title: 'Home',
-          tabBarIcon: ({ color }) => <IconSymbol size={28} name="house.fill" color={color} />,
-        }}
-      />
       <Tabs.Screen
         name="walk"
         options={{

--- a/apps/mobile/app/(tabs)/walk.tsx
+++ b/apps/mobile/app/(tabs)/walk.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Alert, StyleSheet } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
@@ -11,7 +11,8 @@ import { requestPermission, startTracking } from '@/lib/walk/gps-tracker';
 import { requestBluetoothPermission } from '@/lib/ble/permissions';
 import { startScanning, startAdvertising, type BleScanner } from '@/lib/ble/scanner';
 import { EncounterTracker } from '@/lib/ble/encounter-tracker';
-import { DogSelector } from '@/components/walk/DogSelector';
+import { WalkReadyView } from '@/components/walk/WalkReadyView';
+import { DogSelectorSheet } from '@/components/walk/DogSelectorSheet';
 import { WalkMap } from '@/components/walk/WalkMap';
 import { WalkControls } from '@/components/walk/WalkControls';
 import { WalkEventActions } from '@/components/walk/WalkEventActions';
@@ -41,6 +42,13 @@ export default function WalkScreen() {
   const bleAdvertiserRef = useRef<{ stop: () => void } | null>(null);
   const encounterTrackerRef = useRef<EncounterTracker | null>(null);
   const [isStopping, setIsStopping] = useState(false);
+  const [isSheetOpen, setIsSheetOpen] = useState(false);
+
+  useEffect(() => {
+    if (phase !== 'ready') {
+      setIsSheetOpen(false);
+    }
+  }, [phase]);
 
   const handleStart = useCallback(async () => {
     const granted = await requestPermission();
@@ -134,7 +142,15 @@ export default function WalkScreen() {
   return (
     <SafeAreaView edges={['top']} style={[styles.container, { backgroundColor: theme.background }]}>
       {phase === 'ready' && (
-        <DogSelector onStart={handleStart} isStarting={startWalk.isPending} />
+        <>
+          <WalkReadyView onStartPress={() => setIsSheetOpen(true)} />
+          <DogSelectorSheet
+            visible={isSheetOpen}
+            onClose={() => setIsSheetOpen(false)}
+            onStart={handleStart}
+            isStarting={startWalk.isPending}
+          />
+        </>
       )}
       {phase === 'recording' && (
         <>

--- a/apps/mobile/components/walk/DogSelectorSheet.test.tsx
+++ b/apps/mobile/components/walk/DogSelectorSheet.test.tsx
@@ -1,0 +1,84 @@
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { DogSelectorSheet } from './DogSelectorSheet';
+
+jest.mock('@/hooks/use-color-scheme', () => ({
+  useColorScheme: () => 'light',
+}));
+
+jest.mock('@/hooks/use-me', () => ({
+  useMe: () => ({
+    data: {
+      dogs: [
+        { id: 'dog-1', name: 'Pochi', breed: 'Shiba', photoUrl: null, createdAt: '2026-01-01' },
+      ],
+    },
+    isLoading: false,
+  }),
+}));
+
+jest.mock('@/stores/walk-store', () => ({
+  useWalkStore: (selector: (s: unknown) => unknown) =>
+    selector({
+      selectedDogIds: ['dog-1'],
+      selectDog: jest.fn(),
+    }),
+}));
+
+jest.mock('expo-image', () => ({
+  Image: 'Image',
+}));
+
+describe('DogSelectorSheet', () => {
+  it('does not render content when visible is false', () => {
+    render(
+      <DogSelectorSheet
+        visible={false}
+        onClose={jest.fn()}
+        onStart={jest.fn()}
+        isStarting={false}
+      />,
+    );
+    expect(screen.queryByText("Let's go for a walk!")).toBeNull();
+  });
+
+  it('renders DogSelector content when visible', () => {
+    render(
+      <DogSelectorSheet
+        visible={true}
+        onClose={jest.fn()}
+        onStart={jest.fn()}
+        isStarting={false}
+      />,
+    );
+    expect(screen.getByText("Let's go for a walk!")).toBeTruthy();
+    expect(screen.getByText('Pochi')).toBeTruthy();
+  });
+
+  it('invokes onClose when Cancel is pressed', () => {
+    const onClose = jest.fn();
+    render(
+      <DogSelectorSheet
+        visible={true}
+        onClose={onClose}
+        onStart={jest.fn()}
+        isStarting={false}
+      />,
+    );
+    fireEvent.press(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokes onStart when Start Walk is pressed', () => {
+    const onStart = jest.fn();
+    render(
+      <DogSelectorSheet
+        visible={true}
+        onClose={jest.fn()}
+        onStart={onStart}
+        isStarting={false}
+      />,
+    );
+    fireEvent.press(screen.getByRole('button', { name: 'Start Walk' }));
+    expect(onStart).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/mobile/components/walk/DogSelectorSheet.tsx
+++ b/apps/mobile/components/walk/DogSelectorSheet.tsx
@@ -1,0 +1,68 @@
+import { Modal, Platform, Pressable, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useTranslation } from 'react-i18next';
+import { useColors } from '@/hooks/use-colors';
+import { spacing, typography } from '@/theme/tokens';
+import { DogSelector } from './DogSelector';
+
+interface DogSelectorSheetProps {
+  visible: boolean;
+  onClose: () => void;
+  onStart: () => void;
+  isStarting: boolean;
+}
+
+export function DogSelectorSheet({ visible, onClose, onStart, isStarting }: DogSelectorSheetProps) {
+  const { t } = useTranslation();
+  const theme = useColors();
+
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <Modal
+      visible={visible}
+      onRequestClose={onClose}
+      animationType="slide"
+      presentationStyle={Platform.OS === 'ios' ? 'pageSheet' : 'overFullScreen'}
+      transparent={Platform.OS !== 'ios'}
+    >
+      <SafeAreaView
+        edges={['top']}
+        style={[styles.container, { backgroundColor: theme.background }]}
+      >
+        <View style={styles.header}>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={t('settings.cancel')}
+            onPress={onClose}
+            hitSlop={12}
+            style={styles.cancelButton}
+          >
+            <Text style={[styles.cancelText, { color: theme.interactive }]}>
+              {t('settings.cancel')}
+            </Text>
+          </Pressable>
+        </View>
+        <DogSelector onStart={onStart} isStarting={isStarting} />
+      </SafeAreaView>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'flex-start',
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.md,
+  },
+  cancelButton: {
+    paddingVertical: spacing.xs,
+  },
+  cancelText: {
+    ...typography.button,
+  },
+});

--- a/apps/mobile/components/walk/WalkReadyView.test.tsx
+++ b/apps/mobile/components/walk/WalkReadyView.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from '@testing-library/react-native';
-import HomeScreen from '../../../app/(tabs)/index';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { WalkReadyView } from './WalkReadyView';
 
 jest.mock('@/hooks/use-color-scheme', () => ({
   useColorScheme: () => 'light',
@@ -7,7 +7,6 @@ jest.mock('@/hooks/use-color-scheme', () => ({
 
 jest.mock('expo-router', () => ({
   useRouter: () => ({ push: jest.fn() }),
-  usePathname: () => '/',
 }));
 
 jest.mock('@/hooks/use-walks', () => ({
@@ -18,24 +17,31 @@ jest.mock('@/components/walk/WalkHistoryItem', () => ({
   WalkHistoryItem: () => null,
 }));
 
-describe('HomeScreen', () => {
-  it('renders editorial hero heading', () => {
-    render(<HomeScreen />);
+describe('WalkReadyView', () => {
+  it('renders hero heading', () => {
+    render(<WalkReadyView onStartPress={jest.fn()} />);
     expect(screen.getByText('Ready for the morning run?')).toBeTruthy();
   });
 
   it('renders Start Walk CTA button', () => {
-    render(<HomeScreen />);
+    render(<WalkReadyView onStartPress={jest.fn()} />);
     expect(screen.getByRole('button', { name: 'Start Walk →' })).toBeTruthy();
   });
 
   it('renders walk history section title', () => {
-    render(<HomeScreen />);
+    render(<WalkReadyView onStartPress={jest.fn()} />);
     expect(screen.getByText('Recent Walks')).toBeTruthy();
   });
 
   it('renders empty state when no walks', () => {
-    render(<HomeScreen />);
+    render(<WalkReadyView onStartPress={jest.fn()} />);
     expect(screen.getByText('No walks yet. Start your first walk!')).toBeTruthy();
+  });
+
+  it('invokes onStartPress when CTA is pressed', () => {
+    const onStartPress = jest.fn();
+    render(<WalkReadyView onStartPress={onStartPress} />);
+    fireEvent.press(screen.getByRole('button', { name: 'Start Walk →' }));
+    expect(onStartPress).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/mobile/components/walk/WalkReadyView.tsx
+++ b/apps/mobile/components/walk/WalkReadyView.tsx
@@ -1,6 +1,4 @@
 import { FlatList, Pressable, StyleSheet, Text, View } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
-import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useColors } from '@/hooks/use-colors';
 import { spacing, typography, radius } from '@/theme/tokens';
@@ -8,10 +6,13 @@ import { useMyWalks } from '@/hooks/use-walks';
 import { WalkHistoryItem } from '@/components/walk/WalkHistoryItem';
 import type { Walk } from '@/types/graphql';
 
-export default function HomeScreen() {
+interface WalkReadyViewProps {
+  onStartPress: () => void;
+}
+
+export function WalkReadyView({ onStartPress }: WalkReadyViewProps) {
   const { t } = useTranslation();
   const theme = useColors();
-  const router = useRouter();
   const { data: walks, isLoading } = useMyWalks();
 
   const ListHeader = (
@@ -22,7 +23,7 @@ export default function HomeScreen() {
       <Pressable
         accessibilityRole="button"
         accessibilityLabel={t('walk.home.startWalk')}
-        onPress={() => router.push('/(tabs)/walk')}
+        onPress={onStartPress}
         style={[styles.heroCta, { backgroundColor: theme.interactive }]}
       >
         <Text style={[styles.heroCtaText, { color: theme.onInteractive }]}>
@@ -35,25 +36,26 @@ export default function HomeScreen() {
     </View>
   );
 
+  if (!isLoading && (!walks || walks.length === 0)) {
+    return (
+      <View style={styles.container}>
+        {ListHeader}
+        <Text style={[styles.empty, { color: theme.onSurfaceVariant }]}>
+          {t('walk.history.empty')}
+        </Text>
+      </View>
+    );
+  }
+
   return (
-    <SafeAreaView edges={['top']} style={[styles.container, { backgroundColor: theme.background }]}>
-      {!isLoading && (!walks || walks.length === 0) ? (
-        <>
-          {ListHeader}
-          <Text style={[styles.empty, { color: theme.onSurfaceVariant }]}>
-            {t('walk.history.empty')}
-          </Text>
-        </>
-      ) : (
-        <FlatList
-          data={walks}
-          keyExtractor={(item: Walk) => item.id}
-          renderItem={({ item }) => <WalkHistoryItem walk={item} />}
-          ListHeaderComponent={ListHeader}
-          contentContainerStyle={styles.list}
-        />
-      )}
-    </SafeAreaView>
+    <FlatList
+      style={styles.container}
+      data={walks}
+      keyExtractor={(item: Walk) => item.id}
+      renderItem={({ item }) => <WalkHistoryItem walk={item} />}
+      ListHeaderComponent={ListHeader}
+      contentContainerStyle={styles.list}
+    />
   );
 }
 
@@ -85,6 +87,11 @@ const styles = StyleSheet.create({
     ...typography.label,
     marginBottom: spacing.sm,
   },
-  empty: { ...typography.body, textAlign: 'center', marginTop: spacing.xl, paddingHorizontal: spacing.lg },
+  empty: {
+    ...typography.body,
+    textAlign: 'center',
+    marginTop: spacing.xl,
+    paddingHorizontal: spacing.lg,
+  },
   list: { paddingBottom: spacing.xl },
 });

--- a/apps/mobile/components/walk/WalkSummaryCard.tsx
+++ b/apps/mobile/components/walk/WalkSummaryCard.tsx
@@ -74,12 +74,12 @@ export function WalkSummaryCard() {
         </Pressable>
         <Pressable
           accessibilityRole="button"
-          accessibilityLabel={t('walk.finished.walkAgain')}
+          accessibilityLabel={t('walk.finished.done')}
           onPress={reset}
           style={[styles.button, { backgroundColor: theme.interactive }]}
         >
           <Text style={[styles.buttonText, { color: theme.onInteractive }]}>
-            {t('walk.finished.walkAgain')}
+            {t('walk.finished.done')}
           </Text>
         </Pressable>
       </View>

--- a/apps/mobile/lib/i18n/locales/en.json
+++ b/apps/mobile/lib/i18n/locales/en.json
@@ -126,7 +126,7 @@
     "finished": {
       "title": "Walk Complete!",
       "details": "View Details",
-      "walkAgain": "Walk Again",
+      "done": "Done",
       "saving": "Saving walk data..."
     },
     "home": {

--- a/apps/mobile/lib/i18n/locales/ja.json
+++ b/apps/mobile/lib/i18n/locales/ja.json
@@ -126,7 +126,7 @@
     "finished": {
       "title": "散歩完了！",
       "details": "詳細を見る",
-      "walkAgain": "もう一度散歩",
+      "done": "閉じる",
       "saving": "散歩データを保存中..."
     },
     "home": {


### PR DESCRIPTION
## Summary
- HOMEタブを廃止し、WALKタブに散歩機能を集約（タブ数 4 → 3、WALKが先頭）
- WALKの ready フェーズに HOME の UI（ヒーロー + Start Walk + RECENT WALKS）を移植した `WalkReadyView` を追加
- Start Walk をタップするとボトムシート（`DogSelectorSheet`）がスライドアップして犬を選択、確定で散歩開始
- Walk Complete 画面の「Walk Again」を「Done」/「閉じる」にリネーム（挙動は同じく ready へ戻る）

## Test plan
- [x] `npm test` — 35 suites / 199 tests 全 pass
- [x] iOS Simulator でタブ構成（WALK/DOGS/SETTINGS、WALK が先頭・初期選択）を確認
- [x] ready 画面のヒーロー・Start Walk・RECENT WALKS 描画を確認
- [x] Start Walk → ボトムシート表示、Cancel で閉じる、犬選択 → 散歩開始 → recording → Finish → Done で ready に戻る全フローを確認
- [ ] Android エミュレータでの見た目確認（`presentationStyle="pageSheet"` は iOS のみ、Android では overFullScreen）
- [x] ダークモード/ライトモードの視認性確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)