### PR TITLE
fix(mobile): resolve Expo Router Unmatched Route on launch and post-login

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -36,7 +36,7 @@ function NavigationGuard() {
           deletePendingInviteToken();
           router.replace(`/invite/${token}` as never);
         } else {
-          router.replace('/(tabs)' as never);
+          router.replace('/(tabs)/walk');
         }
       });
     }

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -1,0 +1,5 @@
+import { Redirect } from 'expo-router';
+
+export default function Index() {
+  return <Redirect href="/(tabs)/walk" />;
+}


### PR DESCRIPTION
## Summary

- 実機 (`npx expo run:ios --device`) でアプリを起動すると **Unmatched Route — Page could not be found** になる、ログイン後も同じ画面に飛ぶ問題を修正
- 根本原因: `experiments.typedRoutes: true` 配下で expo-router は `/(tabs)` のような group-only パスを runtime で解決しない。`router.replace('/(tabs)' as never)` で型エラーを握りつぶしていたため気付かれなかった
- 修正:
  - `apps/mobile/app/index.tsx` 新規追加 — root `/` を `/(tabs)/walk` に Redirect（scheme launch 経路用）
  - `apps/mobile/app/_layout.tsx:39` — `router.replace('/(tabs)' as never)` → `router.replace('/(tabs)/walk')`

Refs #81（残りの `as never` キャスト棚卸し）

## Test plan

- [x] iOS Simulator (`iPhone 16 Pro`) で Metro 起動後アプリ launch → Login 画面表示（未認証）
- [x] Login → WALK タブ (Ready for the morning run? / Start Walk / Recent Walks) 表示
- [ ] 実機 `API_URL=https://walkingdogdev.dpdns.org npx expo run:ios --device` で Unmatched Route が出ないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)