### PR TITLE
style: apply cargo fmt to existing API code

### DIFF
--- a/apps/api/migration/src/m20260321_000001_create_users.rs
+++ b/apps/api/migration/src/m20260321_000001_create_users.rs
@@ -3,33 +3,58 @@ use sea_orm_migration::prelude::*;
 pub struct Migration;
 
 impl MigrationName for Migration {
-    fn name(&self) -> &str { "m20260321_000001_create_users" }
+    fn name(&self) -> &str {
+        "m20260321_000001_create_users"
+    }
 }
 
 #[async_trait::async_trait]
 impl MigrationTrait for Migration {
     async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
-        manager.create_table(
-            Table::create()
-                .table(Users::Table)
-                .if_not_exists()
-                .col(ColumnDef::new(Users::Id).uuid().not_null().primary_key()
-                    .extra("DEFAULT gen_random_uuid()"))
-                .col(ColumnDef::new(Users::CognitoSub).string().not_null().unique_key())
-                .col(ColumnDef::new(Users::DisplayName).string().null())
-                .col(ColumnDef::new(Users::AvatarUrl).string().null())
-                .col(ColumnDef::new(Users::CreatedAt).timestamp_with_time_zone().not_null()
-                    .extra("DEFAULT now()"))
-                .to_owned(),
-        ).await
+        manager
+            .create_table(
+                Table::create()
+                    .table(Users::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(Users::Id)
+                            .uuid()
+                            .not_null()
+                            .primary_key()
+                            .extra("DEFAULT gen_random_uuid()"),
+                    )
+                    .col(
+                        ColumnDef::new(Users::CognitoSub)
+                            .string()
+                            .not_null()
+                            .unique_key(),
+                    )
+                    .col(ColumnDef::new(Users::DisplayName).string().null())
+                    .col(ColumnDef::new(Users::AvatarUrl).string().null())
+                    .col(
+                        ColumnDef::new(Users::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null()
+                            .extra("DEFAULT now()"),
+                    )
+                    .to_owned(),
+            )
+            .await
     }
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
-        manager.drop_table(Table::drop().table(Users::Table).to_owned()).await
+        manager
+            .drop_table(Table::drop().table(Users::Table).to_owned())
+            .await
     }
 }
 
 #[derive(Iden)]
 enum Users {
-    Table, Id, CognitoSub, DisplayName, AvatarUrl, CreatedAt,
+    Table,
+    Id,
+    CognitoSub,
+    DisplayName,
+    AvatarUrl,
+    CreatedAt,
 }

--- a/apps/api/migration/src/m20260321_000002_create_dogs.rs
+++ b/apps/api/migration/src/m20260321_000002_create_dogs.rs
@@ -3,42 +3,70 @@ use sea_orm_migration::prelude::*;
 pub struct Migration;
 
 impl MigrationName for Migration {
-    fn name(&self) -> &str { "m20260321_000002_create_dogs" }
+    fn name(&self) -> &str {
+        "m20260321_000002_create_dogs"
+    }
 }
 
 #[async_trait::async_trait]
 impl MigrationTrait for Migration {
     async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
-        manager.create_table(
-            Table::create()
-                .table(Dogs::Table)
-                .if_not_exists()
-                .col(ColumnDef::new(Dogs::Id).uuid().not_null().primary_key()
-                    .extra("DEFAULT gen_random_uuid()"))
-                .col(ColumnDef::new(Dogs::UserId).uuid().not_null())
-                .col(ColumnDef::new(Dogs::Name).string().not_null())
-                .col(ColumnDef::new(Dogs::Breed).string().null())
-                .col(ColumnDef::new(Dogs::Gender).string().null())
-                .col(ColumnDef::new(Dogs::BirthDate).json_binary().null())
-                .col(ColumnDef::new(Dogs::PhotoUrl).string().null())
-                .col(ColumnDef::new(Dogs::CreatedAt).timestamp_with_time_zone().not_null()
-                    .extra("DEFAULT now()"))
-                .foreign_key(
-                    ForeignKey::create()
-                        .from(Dogs::Table, Dogs::UserId)
-                        .to(Users::Table, Users::Id)
-                        .on_delete(ForeignKeyAction::Cascade),
-                )
-                .to_owned(),
-        ).await
+        manager
+            .create_table(
+                Table::create()
+                    .table(Dogs::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(Dogs::Id)
+                            .uuid()
+                            .not_null()
+                            .primary_key()
+                            .extra("DEFAULT gen_random_uuid()"),
+                    )
+                    .col(ColumnDef::new(Dogs::UserId).uuid().not_null())
+                    .col(ColumnDef::new(Dogs::Name).string().not_null())
+                    .col(ColumnDef::new(Dogs::Breed).string().null())
+                    .col(ColumnDef::new(Dogs::Gender).string().null())
+                    .col(ColumnDef::new(Dogs::BirthDate).json_binary().null())
+                    .col(ColumnDef::new(Dogs::PhotoUrl).string().null())
+                    .col(
+                        ColumnDef::new(Dogs::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null()
+                            .extra("DEFAULT now()"),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .from(Dogs::Table, Dogs::UserId)
+                            .to(Users::Table, Users::Id)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .to_owned(),
+            )
+            .await
     }
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
-        manager.drop_table(Table::drop().table(Dogs::Table).to_owned()).await
+        manager
+            .drop_table(Table::drop().table(Dogs::Table).to_owned())
+            .await
     }
 }
 
 #[derive(Iden)]
-enum Dogs { Table, Id, UserId, Name, Breed, Gender, BirthDate, PhotoUrl, CreatedAt }
+enum Dogs {
+    Table,
+    Id,
+    UserId,
+    Name,
+    Breed,
+    Gender,
+    BirthDate,
+    PhotoUrl,
+    CreatedAt,
+}
 #[derive(Iden)]
-enum Users { Table, Id }
+enum Users {
+    Table,
+    Id,
+}

--- a/apps/api/migration/src/m20260321_000003_create_walks.rs
+++ b/apps/api/migration/src/m20260321_000003_create_walks.rs
@@ -3,41 +3,76 @@ use sea_orm_migration::prelude::*;
 pub struct Migration;
 
 impl MigrationName for Migration {
-    fn name(&self) -> &str { "m20260321_000003_create_walks" }
+    fn name(&self) -> &str {
+        "m20260321_000003_create_walks"
+    }
 }
 
 #[async_trait::async_trait]
 impl MigrationTrait for Migration {
     async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
-        manager.create_table(
-            Table::create()
-                .table(Walks::Table)
-                .if_not_exists()
-                .col(ColumnDef::new(Walks::Id).uuid().not_null().primary_key()
-                    .extra("DEFAULT gen_random_uuid()"))
-                .col(ColumnDef::new(Walks::UserId).uuid().not_null())
-                .col(ColumnDef::new(Walks::Status).string().not_null()
-                    .extra("DEFAULT 'active'"))
-                .col(ColumnDef::new(Walks::DistanceM).integer().null())
-                .col(ColumnDef::new(Walks::DurationSec).integer().null())
-                .col(ColumnDef::new(Walks::StartedAt).timestamp_with_time_zone().not_null())
-                .col(ColumnDef::new(Walks::EndedAt).timestamp_with_time_zone().null())
-                .foreign_key(
-                    ForeignKey::create()
-                        .from(Walks::Table, Walks::UserId)
-                        .to(Users::Table, Users::Id)
-                        .on_delete(ForeignKeyAction::Cascade),
-                )
-                .to_owned(),
-        ).await
+        manager
+            .create_table(
+                Table::create()
+                    .table(Walks::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(Walks::Id)
+                            .uuid()
+                            .not_null()
+                            .primary_key()
+                            .extra("DEFAULT gen_random_uuid()"),
+                    )
+                    .col(ColumnDef::new(Walks::UserId).uuid().not_null())
+                    .col(
+                        ColumnDef::new(Walks::Status)
+                            .string()
+                            .not_null()
+                            .extra("DEFAULT 'active'"),
+                    )
+                    .col(ColumnDef::new(Walks::DistanceM).integer().null())
+                    .col(ColumnDef::new(Walks::DurationSec).integer().null())
+                    .col(
+                        ColumnDef::new(Walks::StartedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(Walks::EndedAt)
+                            .timestamp_with_time_zone()
+                            .null(),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .from(Walks::Table, Walks::UserId)
+                            .to(Users::Table, Users::Id)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .to_owned(),
+            )
+            .await
     }
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
-        manager.drop_table(Table::drop().table(Walks::Table).to_owned()).await
+        manager
+            .drop_table(Table::drop().table(Walks::Table).to_owned())
+            .await
     }
 }
 
 #[derive(Iden)]
-enum Walks { Table, Id, UserId, Status, DistanceM, DurationSec, StartedAt, EndedAt }
+enum Walks {
+    Table,
+    Id,
+    UserId,
+    Status,
+    DistanceM,
+    DurationSec,
+    StartedAt,
+    EndedAt,
+}
 #[derive(Iden)]
-enum Users { Table, Id }
+enum Users {
+    Table,
+    Id,
+}

--- a/apps/api/migration/src/m20260321_000004_create_walk_dogs.rs
+++ b/apps/api/migration/src/m20260321_000004_create_walk_dogs.rs
@@ -3,43 +3,59 @@ use sea_orm_migration::prelude::*;
 pub struct Migration;
 
 impl MigrationName for Migration {
-    fn name(&self) -> &str { "m20260321_000004_create_walk_dogs" }
+    fn name(&self) -> &str {
+        "m20260321_000004_create_walk_dogs"
+    }
 }
 
 #[async_trait::async_trait]
 impl MigrationTrait for Migration {
     async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
-        manager.create_table(
-            Table::create()
-                .table(WalkDogs::Table)
-                .if_not_exists()
-                .col(ColumnDef::new(WalkDogs::WalkId).uuid().not_null())
-                .col(ColumnDef::new(WalkDogs::DogId).uuid().not_null())
-                .primary_key(Index::create().col(WalkDogs::WalkId).col(WalkDogs::DogId))
-                .foreign_key(
-                    ForeignKey::create()
-                        .from(WalkDogs::Table, WalkDogs::WalkId)
-                        .to(Walks::Table, Walks::Id)
-                        .on_delete(ForeignKeyAction::Cascade),
-                )
-                .foreign_key(
-                    ForeignKey::create()
-                        .from(WalkDogs::Table, WalkDogs::DogId)
-                        .to(Dogs::Table, Dogs::Id)
-                        .on_delete(ForeignKeyAction::Cascade),
-                )
-                .to_owned(),
-        ).await
+        manager
+            .create_table(
+                Table::create()
+                    .table(WalkDogs::Table)
+                    .if_not_exists()
+                    .col(ColumnDef::new(WalkDogs::WalkId).uuid().not_null())
+                    .col(ColumnDef::new(WalkDogs::DogId).uuid().not_null())
+                    .primary_key(Index::create().col(WalkDogs::WalkId).col(WalkDogs::DogId))
+                    .foreign_key(
+                        ForeignKey::create()
+                            .from(WalkDogs::Table, WalkDogs::WalkId)
+                            .to(Walks::Table, Walks::Id)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .from(WalkDogs::Table, WalkDogs::DogId)
+                            .to(Dogs::Table, Dogs::Id)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .to_owned(),
+            )
+            .await
     }
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
-        manager.drop_table(Table::drop().table(WalkDogs::Table).to_owned()).await
+        manager
+            .drop_table(Table::drop().table(WalkDogs::Table).to_owned())
+            .await
     }
 }
 
 #[derive(Iden)]
-enum WalkDogs { Table, WalkId, DogId }
+enum WalkDogs {
+    Table,
+    WalkId,
+    DogId,
+}
 #[derive(Iden)]
-enum Walks { Table, Id }
+enum Walks {
+    Table,
+    Id,
+}
 #[derive(Iden)]
-enum Dogs { Table, Id }
+enum Dogs {
+    Table,
+    Id,
+}

--- a/apps/api/migration/src/m20260404_000001_create_dog_members_and_invitations.rs
+++ b/apps/api/migration/src/m20260404_000001_create_dog_members_and_invitations.rs
@@ -102,22 +102,14 @@ impl MigrationTrait for Migration {
                             .primary_key()
                             .extra("DEFAULT gen_random_uuid()"),
                     )
-                    .col(
-                        ColumnDef::new(DogInvitations::DogId)
-                            .uuid()
-                            .not_null(),
-                    )
+                    .col(ColumnDef::new(DogInvitations::DogId).uuid().not_null())
                     .col(
                         ColumnDef::new(DogInvitations::Token)
                             .string_len(64)
                             .not_null()
                             .unique_key(),
                     )
-                    .col(
-                        ColumnDef::new(DogInvitations::InvitedBy)
-                            .uuid()
-                            .not_null(),
-                    )
+                    .col(ColumnDef::new(DogInvitations::InvitedBy).uuid().not_null())
                     .col(ColumnDef::new(DogInvitations::UsedBy).uuid().null())
                     .col(
                         ColumnDef::new(DogInvitations::ExpiresAt)

--- a/apps/api/src/auth/mod.rs
+++ b/apps/api/src/auth/mod.rs
@@ -1,11 +1,6 @@
 pub mod service;
 
-use axum::{
-    extract::Request,
-    http::StatusCode,
-    middleware::Next,
-    response::Response,
-};
+use axum::{extract::Request, http::StatusCode, middleware::Next, response::Response};
 use jsonwebtoken::{decode, decode_header, Algorithm, DecodingKey, Validation};
 use serde::Deserialize;
 
@@ -23,14 +18,14 @@ struct CognitoClaims {
 /// JWT検証ミドルウェア
 /// TEST_MODE=true のとき、JWT検証をスキップして固定のcognito_subを返す
 /// Authorization ヘッダーがない場合は AuthUser を挿入せずに続行する（オプショナル認証）
-pub async fn auth_middleware(
-    mut request: Request,
-    next: Next,
-) -> Result<Response, StatusCode> {
+pub async fn auth_middleware(mut request: Request, next: Next) -> Result<Response, StatusCode> {
     // TEST_MODE: JWT検証をスキップ
     // Use the Bearer token value as cognito_sub to allow multi-user testing.
     // Default: "test-user-cognito-sub" for backwards compatibility.
-    if std::env::var("TEST_MODE").map(|v| v == "true" || v == "1").unwrap_or(false) {
+    if std::env::var("TEST_MODE")
+        .map(|v| v == "true" || v == "1")
+        .unwrap_or(false)
+    {
         let cognito_sub = request
             .headers()
             .get("Authorization")
@@ -70,7 +65,9 @@ pub async fn auth_middleware(
 
 /// GraphQL リゾルバ用: コンテキストから認証済みの cognito_sub を取得する。
 /// 未認証の場合は Unauthorized エラーを返す。
-pub fn require_auth(ctx: &async_graphql::dynamic::ResolverContext<'_>) -> async_graphql::Result<String> {
+pub fn require_auth(
+    ctx: &async_graphql::dynamic::ResolverContext<'_>,
+) -> async_graphql::Result<String> {
     ctx.data::<Option<String>>()?
         .clone()
         .ok_or_else(|| async_graphql::Error::new("Unauthorized"))
@@ -119,8 +116,8 @@ async fn verify_cognito_jwt(token: &str) -> Result<String, String> {
         )]);
     }
 
-    let token_data = decode::<CognitoClaims>(token, &decoding_key, &validation)
-        .map_err(|e| e.to_string())?;
+    let token_data =
+        decode::<CognitoClaims>(token, &decoding_key, &validation).map_err(|e| e.to_string())?;
 
     Ok(token_data.claims.sub)
 }

--- a/apps/api/src/aws/client.rs
+++ b/apps/api/src/aws/client.rs
@@ -1,11 +1,11 @@
 use aws_config::{BehaviorVersion, Region};
+use aws_sdk_cognitoidentityprovider::Client as CognitoClient;
 use aws_sdk_dynamodb::Client as DynamoClient;
 use aws_sdk_s3::Client as S3Client;
-use aws_sdk_cognitoidentityprovider::Client as CognitoClient;
 
 pub async fn build_dynamo_client(region: &str, endpoint_url: Option<&str>) -> DynamoClient {
-    let mut builder = aws_config::defaults(BehaviorVersion::latest())
-        .region(Region::new(region.to_string()));
+    let mut builder =
+        aws_config::defaults(BehaviorVersion::latest()).region(Region::new(region.to_string()));
     if let Some(url) = endpoint_url {
         builder = builder.endpoint_url(url);
     }
@@ -14,8 +14,8 @@ pub async fn build_dynamo_client(region: &str, endpoint_url: Option<&str>) -> Dy
 }
 
 pub async fn build_s3_client(region: &str, endpoint_url: Option<&str>) -> S3Client {
-    let mut builder = aws_config::defaults(BehaviorVersion::latest())
-        .region(Region::new(region.to_string()));
+    let mut builder =
+        aws_config::defaults(BehaviorVersion::latest()).region(Region::new(region.to_string()));
     if let Some(url) = endpoint_url {
         builder = builder.endpoint_url(url);
     }
@@ -27,8 +27,8 @@ pub async fn build_s3_client(region: &str, endpoint_url: Option<&str>) -> S3Clie
 }
 
 pub async fn build_cognito_client(region: &str, endpoint_url: Option<&str>) -> CognitoClient {
-    let mut builder = aws_config::defaults(BehaviorVersion::latest())
-        .region(Region::new(region.to_string()));
+    let mut builder =
+        aws_config::defaults(BehaviorVersion::latest()).region(Region::new(region.to_string()));
     if let Some(url) = endpoint_url {
         builder = builder.endpoint_url(url);
     }

--- a/apps/api/src/config.rs
+++ b/apps/api/src/config.rs
@@ -23,7 +23,8 @@ impl Config {
         dotenvy::from_filename(&env_file).ok();
         Self {
             database_url: std::env::var("DATABASE_URL").expect("DATABASE_URL must be set"),
-            aws_region: std::env::var("AWS_REGION").unwrap_or_else(|_| "ap-northeast-1".to_string()),
+            aws_region: std::env::var("AWS_REGION")
+                .unwrap_or_else(|_| "ap-northeast-1".to_string()),
             s3_endpoint_url: std::env::var("S3_ENDPOINT_URL")
                 .ok()
                 .filter(|s| !s.is_empty()),
@@ -36,8 +37,7 @@ impl Config {
                 .unwrap_or_else(|_| "dog-photos".to_string()),
             photo_cdn_url: std::env::var("PHOTO_CDN_URL")
                 .unwrap_or_else(|_| "http://localhost:4566/dog-photos".to_string()),
-            cognito_user_pool_id: std::env::var("COGNITO_USER_POOL_ID")
-                .unwrap_or_default(),
+            cognito_user_pool_id: std::env::var("COGNITO_USER_POOL_ID").unwrap_or_default(),
             cognito_endpoint_url: std::env::var("COGNITO_ENDPOINT_URL")
                 .ok()
                 .filter(|s| !s.is_empty()),

--- a/apps/api/src/error.rs
+++ b/apps/api/src/error.rs
@@ -20,21 +20,15 @@ impl AppError {
     pub fn into_graphql_error(self) -> async_graphql::Error {
         use async_graphql::ErrorExtensions;
         match self {
-            AppError::BadRequest(msg) => {
-                async_graphql::Error::new(msg).extend_with(|_, ext| {
-                    ext.set("code", "BAD_USER_INPUT");
-                })
-            }
-            AppError::NotFound(msg) => {
-                async_graphql::Error::new(msg).extend_with(|_, ext| {
-                    ext.set("code", "NOT_FOUND");
-                })
-            }
-            AppError::Unauthorized(msg) => {
-                async_graphql::Error::new(msg).extend_with(|_, ext| {
-                    ext.set("code", "UNAUTHENTICATED");
-                })
-            }
+            AppError::BadRequest(msg) => async_graphql::Error::new(msg).extend_with(|_, ext| {
+                ext.set("code", "BAD_USER_INPUT");
+            }),
+            AppError::NotFound(msg) => async_graphql::Error::new(msg).extend_with(|_, ext| {
+                ext.set("code", "NOT_FOUND");
+            }),
+            AppError::Unauthorized(msg) => async_graphql::Error::new(msg).extend_with(|_, ext| {
+                ext.set("code", "UNAUTHENTICATED");
+            }),
             other => async_graphql::Error::new(other.to_string()).extend_with(|_, ext| {
                 ext.set("code", "INTERNAL_SERVER_ERROR");
             }),

--- a/apps/api/src/graphql/custom_queries.rs
+++ b/apps/api/src/graphql/custom_queries.rs
@@ -1,11 +1,14 @@
+use super::custom_mutations::{DogOutput, UserOutput, WalkOutput};
+use crate::auth;
+use crate::error::AppError;
+use crate::services::{
+    dog_member_service, dog_service, encounter_service, friendship_service, user_service,
+    walk_points_service, walk_service,
+};
+use crate::AppState;
 use async_graphql::dynamic::{Field, FieldFuture, FieldValue, InputValue, Object, TypeRef};
 use std::sync::Arc;
 use uuid::Uuid;
-use crate::AppState;
-use crate::auth;
-use crate::error::AppError;
-use crate::services::{dog_member_service, dog_service, encounter_service, friendship_service, user_service, walk_service, walk_points_service};
-use super::custom_mutations::{DogOutput, UserOutput, WalkOutput};
 
 // ─── Custom output types ──────────────────────────────────────────────────────
 
@@ -103,68 +106,104 @@ impl FriendshipOutput {
 
 pub fn walk_point_type() -> Object {
     Object::new("WalkPoint")
-        .field(Field::new("lat", TypeRef::named_nn(TypeRef::FLOAT), |ctx| {
-            FieldFuture::new(async move {
-                let p = ctx.parent_value.try_downcast_ref::<WalkPointOutput>()?;
-                Ok(Some(FieldValue::value(p.lat)))
-            })
-        }))
-        .field(Field::new("lng", TypeRef::named_nn(TypeRef::FLOAT), |ctx| {
-            FieldFuture::new(async move {
-                let p = ctx.parent_value.try_downcast_ref::<WalkPointOutput>()?;
-                Ok(Some(FieldValue::value(p.lng)))
-            })
-        }))
-        .field(Field::new("recordedAt", TypeRef::named_nn(TypeRef::STRING), |ctx| {
-            FieldFuture::new(async move {
-                let p = ctx.parent_value.try_downcast_ref::<WalkPointOutput>()?;
-                Ok(Some(FieldValue::value(p.recorded_at.clone())))
-            })
-        }))
+        .field(Field::new(
+            "lat",
+            TypeRef::named_nn(TypeRef::FLOAT),
+            |ctx| {
+                FieldFuture::new(async move {
+                    let p = ctx.parent_value.try_downcast_ref::<WalkPointOutput>()?;
+                    Ok(Some(FieldValue::value(p.lat)))
+                })
+            },
+        ))
+        .field(Field::new(
+            "lng",
+            TypeRef::named_nn(TypeRef::FLOAT),
+            |ctx| {
+                FieldFuture::new(async move {
+                    let p = ctx.parent_value.try_downcast_ref::<WalkPointOutput>()?;
+                    Ok(Some(FieldValue::value(p.lng)))
+                })
+            },
+        ))
+        .field(Field::new(
+            "recordedAt",
+            TypeRef::named_nn(TypeRef::STRING),
+            |ctx| {
+                FieldFuture::new(async move {
+                    let p = ctx.parent_value.try_downcast_ref::<WalkPointOutput>()?;
+                    Ok(Some(FieldValue::value(p.recorded_at.clone())))
+                })
+            },
+        ))
 }
 
 pub fn walk_stats_type() -> Object {
     Object::new("WalkStats")
-        .field(Field::new("totalWalks", TypeRef::named_nn(TypeRef::INT), |ctx| {
-            FieldFuture::new(async move {
-                let s = ctx.parent_value.try_downcast_ref::<WalkStatsOutput>()?;
-                Ok(Some(FieldValue::value(s.total_walks)))
-            })
-        }))
-        .field(Field::new("totalDistanceM", TypeRef::named_nn(TypeRef::INT), |ctx| {
-            FieldFuture::new(async move {
-                let s = ctx.parent_value.try_downcast_ref::<WalkStatsOutput>()?;
-                Ok(Some(FieldValue::value(s.total_distance_m)))
-            })
-        }))
-        .field(Field::new("totalDurationSec", TypeRef::named_nn(TypeRef::INT), |ctx| {
-            FieldFuture::new(async move {
-                let s = ctx.parent_value.try_downcast_ref::<WalkStatsOutput>()?;
-                Ok(Some(FieldValue::value(s.total_duration_sec)))
-            })
-        }))
+        .field(Field::new(
+            "totalWalks",
+            TypeRef::named_nn(TypeRef::INT),
+            |ctx| {
+                FieldFuture::new(async move {
+                    let s = ctx.parent_value.try_downcast_ref::<WalkStatsOutput>()?;
+                    Ok(Some(FieldValue::value(s.total_walks)))
+                })
+            },
+        ))
+        .field(Field::new(
+            "totalDistanceM",
+            TypeRef::named_nn(TypeRef::INT),
+            |ctx| {
+                FieldFuture::new(async move {
+                    let s = ctx.parent_value.try_downcast_ref::<WalkStatsOutput>()?;
+                    Ok(Some(FieldValue::value(s.total_distance_m)))
+                })
+            },
+        ))
+        .field(Field::new(
+            "totalDurationSec",
+            TypeRef::named_nn(TypeRef::INT),
+            |ctx| {
+                FieldFuture::new(async move {
+                    let s = ctx.parent_value.try_downcast_ref::<WalkStatsOutput>()?;
+                    Ok(Some(FieldValue::value(s.total_duration_sec)))
+                })
+            },
+        ))
 }
 
 pub fn encounter_output_type() -> Object {
     Object::new("EncounterOutput")
-        .field(Field::new("id", TypeRef::named_nn(TypeRef::STRING), |ctx| {
-            FieldFuture::new(async move {
-                let e = ctx.parent_value.try_downcast_ref::<EncounterOutput>()?;
-                Ok(Some(FieldValue::value(e.id.to_string())))
-            })
-        }))
-        .field(Field::new("durationSec", TypeRef::named_nn(TypeRef::INT), |ctx| {
-            FieldFuture::new(async move {
-                let e = ctx.parent_value.try_downcast_ref::<EncounterOutput>()?;
-                Ok(Some(FieldValue::value(e.duration_sec)))
-            })
-        }))
-        .field(Field::new("metAt", TypeRef::named_nn(TypeRef::STRING), |ctx| {
-            FieldFuture::new(async move {
-                let e = ctx.parent_value.try_downcast_ref::<EncounterOutput>()?;
-                Ok(Some(FieldValue::value(e.met_at.clone())))
-            })
-        }))
+        .field(Field::new(
+            "id",
+            TypeRef::named_nn(TypeRef::STRING),
+            |ctx| {
+                FieldFuture::new(async move {
+                    let e = ctx.parent_value.try_downcast_ref::<EncounterOutput>()?;
+                    Ok(Some(FieldValue::value(e.id.to_string())))
+                })
+            },
+        ))
+        .field(Field::new(
+            "durationSec",
+            TypeRef::named_nn(TypeRef::INT),
+            |ctx| {
+                FieldFuture::new(async move {
+                    let e = ctx.parent_value.try_downcast_ref::<EncounterOutput>()?;
+                    Ok(Some(FieldValue::value(e.duration_sec)))
+                })
+            },
+        ))
+        .field(Field::new(
+            "metAt",
+            TypeRef::named_nn(TypeRef::STRING),
+            |ctx| {
+                FieldFuture::new(async move {
+                    let e = ctx.parent_value.try_downcast_ref::<EncounterOutput>()?;
+                    Ok(Some(FieldValue::value(e.met_at.clone())))
+                })
+            },
+        ))
         .field(Field::new("dog1", TypeRef::named_nn("DogOutput"), |ctx| {
             FieldFuture::new(async move {
                 use crate::entities::dogs::Entity as DogEntity;
@@ -201,57 +240,81 @@ pub fn encounter_output_type() -> Object {
 
 pub fn friendship_output_type() -> Object {
     Object::new("FriendshipOutput")
-        .field(Field::new("id", TypeRef::named_nn(TypeRef::STRING), |ctx| {
-            FieldFuture::new(async move {
-                let f = ctx.parent_value.try_downcast_ref::<FriendshipOutput>()?;
-                Ok(Some(FieldValue::value(f.id.to_string())))
-            })
-        }))
-        .field(Field::new("encounterCount", TypeRef::named_nn(TypeRef::INT), |ctx| {
-            FieldFuture::new(async move {
-                let f = ctx.parent_value.try_downcast_ref::<FriendshipOutput>()?;
-                Ok(Some(FieldValue::value(f.encounter_count)))
-            })
-        }))
-        .field(Field::new("totalInteractionSec", TypeRef::named_nn(TypeRef::INT), |ctx| {
-            FieldFuture::new(async move {
-                let f = ctx.parent_value.try_downcast_ref::<FriendshipOutput>()?;
-                Ok(Some(FieldValue::value(f.total_interaction_sec)))
-            })
-        }))
-        .field(Field::new("firstMetAt", TypeRef::named_nn(TypeRef::STRING), |ctx| {
-            FieldFuture::new(async move {
-                let f = ctx.parent_value.try_downcast_ref::<FriendshipOutput>()?;
-                Ok(Some(FieldValue::value(f.first_met_at.clone())))
-            })
-        }))
-        .field(Field::new("lastMetAt", TypeRef::named_nn(TypeRef::STRING), |ctx| {
-            FieldFuture::new(async move {
-                let f = ctx.parent_value.try_downcast_ref::<FriendshipOutput>()?;
-                Ok(Some(FieldValue::value(f.last_met_at.clone())))
-            })
-        }))
-        .field(Field::new("friend", TypeRef::named_nn("DogOutput"), |ctx| {
-            FieldFuture::new(async move {
-                use crate::entities::dogs::Entity as DogEntity;
-                use sea_orm::EntityTrait;
+        .field(Field::new(
+            "id",
+            TypeRef::named_nn(TypeRef::STRING),
+            |ctx| {
+                FieldFuture::new(async move {
+                    let f = ctx.parent_value.try_downcast_ref::<FriendshipOutput>()?;
+                    Ok(Some(FieldValue::value(f.id.to_string())))
+                })
+            },
+        ))
+        .field(Field::new(
+            "encounterCount",
+            TypeRef::named_nn(TypeRef::INT),
+            |ctx| {
+                FieldFuture::new(async move {
+                    let f = ctx.parent_value.try_downcast_ref::<FriendshipOutput>()?;
+                    Ok(Some(FieldValue::value(f.encounter_count)))
+                })
+            },
+        ))
+        .field(Field::new(
+            "totalInteractionSec",
+            TypeRef::named_nn(TypeRef::INT),
+            |ctx| {
+                FieldFuture::new(async move {
+                    let f = ctx.parent_value.try_downcast_ref::<FriendshipOutput>()?;
+                    Ok(Some(FieldValue::value(f.total_interaction_sec)))
+                })
+            },
+        ))
+        .field(Field::new(
+            "firstMetAt",
+            TypeRef::named_nn(TypeRef::STRING),
+            |ctx| {
+                FieldFuture::new(async move {
+                    let f = ctx.parent_value.try_downcast_ref::<FriendshipOutput>()?;
+                    Ok(Some(FieldValue::value(f.first_met_at.clone())))
+                })
+            },
+        ))
+        .field(Field::new(
+            "lastMetAt",
+            TypeRef::named_nn(TypeRef::STRING),
+            |ctx| {
+                FieldFuture::new(async move {
+                    let f = ctx.parent_value.try_downcast_ref::<FriendshipOutput>()?;
+                    Ok(Some(FieldValue::value(f.last_met_at.clone())))
+                })
+            },
+        ))
+        .field(Field::new(
+            "friend",
+            TypeRef::named_nn("DogOutput"),
+            |ctx| {
+                FieldFuture::new(async move {
+                    use crate::entities::dogs::Entity as DogEntity;
+                    use sea_orm::EntityTrait;
 
-                let f = ctx.parent_value.try_downcast_ref::<FriendshipOutput>()?;
-                // If requesting dog is dog_id_1, the friend is dog_id_2 and vice versa
-                let friend_id = if f.requesting_dog_id == f.dog_id_1 {
-                    f.dog_id_2
-                } else {
-                    f.dog_id_1
-                };
-                let state = ctx.data::<Arc<crate::AppState>>()?;
-                let dog = DogEntity::find_by_id(friend_id)
-                    .one(&state.db)
-                    .await
-                    .map_err(|e| AppError::Database(e).into_graphql_error())?
-                    .ok_or_else(|| async_graphql::Error::new("Dog not found"))?;
-                Ok(Some(FieldValue::owned_any(DogOutput::from(dog))))
-            })
-        }))
+                    let f = ctx.parent_value.try_downcast_ref::<FriendshipOutput>()?;
+                    // If requesting dog is dog_id_1, the friend is dog_id_2 and vice versa
+                    let friend_id = if f.requesting_dog_id == f.dog_id_1 {
+                        f.dog_id_2
+                    } else {
+                        f.dog_id_1
+                    };
+                    let state = ctx.data::<Arc<crate::AppState>>()?;
+                    let dog = DogEntity::find_by_id(friend_id)
+                        .one(&state.db)
+                        .await
+                        .map_err(|e| AppError::Database(e).into_graphql_error())?
+                        .ok_or_else(|| async_graphql::Error::new("Dog not found"))?;
+                    Ok(Some(FieldValue::owned_any(DogOutput::from(dog))))
+                })
+            },
+        ))
 }
 
 // ─── Query fields ─────────────────────────────────────────────────────────────
@@ -275,10 +338,10 @@ fn walk_by_id_field(state: Arc<AppState>) -> Field {
         let state = state.clone();
         FieldFuture::new(async move {
             use crate::entities::{
-                walks::Entity as WalkEntity,
                 walk_dogs::{self, Entity as WalkDogEntity},
+                walks::Entity as WalkEntity,
             };
-            use sea_orm::{EntityTrait, ColumnTrait, QueryFilter};
+            use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 
             let cognito_sub = auth::require_auth(&ctx)?;
             let walk_id_str = ctx.args.try_get("id")?.string()?;
@@ -349,29 +412,37 @@ fn dog_field(state: Arc<AppState>) -> Field {
 }
 
 fn my_walks_field(state: Arc<AppState>) -> Field {
-    Field::new("myWalks", TypeRef::named_nn_list_nn("WalkOutput"), move |ctx| {
-        let state = state.clone();
-        FieldFuture::new(async move {
-            let cognito_sub = auth::require_auth(&ctx)?;
-            let limit = ctx.args.get("limit")
-                .and_then(|v| v.i64().ok())
-                .map(|v| v as u64);
-            let offset = ctx.args.get("offset")
-                .and_then(|v| v.i64().ok())
-                .map(|v| v as u64);
-            let user = user_service::get_or_create_user(&state.db, &cognito_sub)
-                .await
-                .map_err(AppError::into_graphql_error)?;
-            let walks = walk_service::get_walks_for_user(&state.db, user.id, limit, offset)
-                .await
-                .map_err(AppError::into_graphql_error)?;
-            let values: Vec<FieldValue> = walks
-                .into_iter()
-                .map(|w| FieldValue::owned_any(WalkOutput::from(w)))
-                .collect();
-            Ok(Some(FieldValue::list(values)))
-        })
-    })
+    Field::new(
+        "myWalks",
+        TypeRef::named_nn_list_nn("WalkOutput"),
+        move |ctx| {
+            let state = state.clone();
+            FieldFuture::new(async move {
+                let cognito_sub = auth::require_auth(&ctx)?;
+                let limit = ctx
+                    .args
+                    .get("limit")
+                    .and_then(|v| v.i64().ok())
+                    .map(|v| v as u64);
+                let offset = ctx
+                    .args
+                    .get("offset")
+                    .and_then(|v| v.i64().ok())
+                    .map(|v| v as u64);
+                let user = user_service::get_or_create_user(&state.db, &cognito_sub)
+                    .await
+                    .map_err(AppError::into_graphql_error)?;
+                let walks = walk_service::get_walks_for_user(&state.db, user.id, limit, offset)
+                    .await
+                    .map_err(AppError::into_graphql_error)?;
+                let values: Vec<FieldValue> = walks
+                    .into_iter()
+                    .map(|w| FieldValue::owned_any(WalkOutput::from(w)))
+                    .collect();
+                Ok(Some(FieldValue::list(values)))
+            })
+        },
+    )
     .argument(InputValue::new("limit", TypeRef::named(TypeRef::INT)))
     .argument(InputValue::new("offset", TypeRef::named(TypeRef::INT)))
 }
@@ -413,167 +484,196 @@ fn dog_walk_stats_field(state: Arc<AppState>) -> Field {
         })
     })
     .argument(InputValue::new("dogId", TypeRef::named_nn(TypeRef::ID)))
-    .argument(InputValue::new("period", TypeRef::named_nn(TypeRef::STRING)))
+    .argument(InputValue::new(
+        "period",
+        TypeRef::named_nn(TypeRef::STRING),
+    ))
 }
 
 fn walk_points_field(state: Arc<AppState>) -> Field {
-    Field::new("walkPoints", TypeRef::named_nn_list_nn("WalkPoint"), move |ctx| {
-        let state = state.clone();
-        FieldFuture::new(async move {
-            use crate::entities::walk_dogs::{self, Entity as WalkDogEntity};
-            use sea_orm::{EntityTrait, ColumnTrait, QueryFilter};
+    Field::new(
+        "walkPoints",
+        TypeRef::named_nn_list_nn("WalkPoint"),
+        move |ctx| {
+            let state = state.clone();
+            FieldFuture::new(async move {
+                use crate::entities::walk_dogs::{self, Entity as WalkDogEntity};
+                use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 
-            let cognito_sub = auth::require_auth(&ctx)?;
-            let walk_id_str = ctx.args.try_get("walkId")?.string()?;
-            let walk_id = Uuid::parse_str(walk_id_str)
-                .map_err(|_| async_graphql::Error::new("Invalid walk ID"))?;
+                let cognito_sub = auth::require_auth(&ctx)?;
+                let walk_id_str = ctx.args.try_get("walkId")?.string()?;
+                let walk_id = Uuid::parse_str(walk_id_str)
+                    .map_err(|_| async_graphql::Error::new("Invalid walk ID"))?;
 
-            let user = user_service::get_or_create_user(&state.db, &cognito_sub)
+                let user = user_service::get_or_create_user(&state.db, &cognito_sub)
+                    .await
+                    .map_err(AppError::into_graphql_error)?;
+
+                // Check authorization via walk_dogs -> dog_members
+                let walk_dog_rows = WalkDogEntity::find()
+                    .filter(walk_dogs::Column::WalkId.eq(walk_id))
+                    .all(&state.db)
+                    .await
+                    .map_err(|e| AppError::Database(e).into_graphql_error())?;
+
+                let mut authorized = false;
+                for wd in &walk_dog_rows {
+                    if dog_member_service::require_dog_member(&state.db, wd.dog_id, user.id)
+                        .await
+                        .is_ok()
+                    {
+                        authorized = true;
+                        break;
+                    }
+                }
+                if !authorized {
+                    return Err(async_graphql::Error::new("Walk not found"));
+                }
+
+                let points = walk_points_service::get_walk_points(
+                    &state.dynamo,
+                    &state.config.dynamodb_table_walk_points,
+                    walk_id,
+                )
                 .await
                 .map_err(AppError::into_graphql_error)?;
 
-            // Check authorization via walk_dogs -> dog_members
-            let walk_dog_rows = WalkDogEntity::find()
-                .filter(walk_dogs::Column::WalkId.eq(walk_id))
-                .all(&state.db)
-                .await
-                .map_err(|e| AppError::Database(e).into_graphql_error())?;
-
-            let mut authorized = false;
-            for wd in &walk_dog_rows {
-                if dog_member_service::require_dog_member(&state.db, wd.dog_id, user.id)
-                    .await
-                    .is_ok()
-                {
-                    authorized = true;
-                    break;
-                }
-            }
-            if !authorized {
-                return Err(async_graphql::Error::new("Walk not found"));
-            }
-
-            let points = walk_points_service::get_walk_points(
-                &state.dynamo,
-                &state.config.dynamodb_table_walk_points,
-                walk_id,
-            )
-            .await
-            .map_err(AppError::into_graphql_error)?;
-
-            let values: Vec<FieldValue> = points
-                .into_iter()
-                .map(|p| FieldValue::owned_any(WalkPointOutput::from(p)))
-                .collect();
-            Ok(Some(FieldValue::list(values)))
-        })
-    })
+                let values: Vec<FieldValue> = points
+                    .into_iter()
+                    .map(|p| FieldValue::owned_any(WalkPointOutput::from(p)))
+                    .collect();
+                Ok(Some(FieldValue::list(values)))
+            })
+        },
+    )
     .argument(InputValue::new("walkId", TypeRef::named_nn(TypeRef::ID)))
 }
 
 fn dog_friends_field(state: Arc<AppState>) -> Field {
-    Field::new("dogFriends", TypeRef::named_nn_list_nn("FriendshipOutput"), move |ctx| {
-        let state = state.clone();
-        FieldFuture::new(async move {
-            let cognito_sub = auth::require_auth(&ctx)?;
-            let dog_id_str = ctx.args.try_get("dogId")?.string()?;
-            let dog_id = Uuid::parse_str(dog_id_str)
-                .map_err(|_| async_graphql::Error::new("Invalid dog ID"))?;
+    Field::new(
+        "dogFriends",
+        TypeRef::named_nn_list_nn("FriendshipOutput"),
+        move |ctx| {
+            let state = state.clone();
+            FieldFuture::new(async move {
+                let cognito_sub = auth::require_auth(&ctx)?;
+                let dog_id_str = ctx.args.try_get("dogId")?.string()?;
+                let dog_id = Uuid::parse_str(dog_id_str)
+                    .map_err(|_| async_graphql::Error::new("Invalid dog ID"))?;
 
-            let user = user_service::get_or_create_user(&state.db, &cognito_sub)
-                .await
-                .map_err(AppError::into_graphql_error)?;
-            dog_member_service::require_dog_member(&state.db, dog_id, user.id)
-                .await
-                .map_err(AppError::into_graphql_error)?;
+                let user = user_service::get_or_create_user(&state.db, &cognito_sub)
+                    .await
+                    .map_err(AppError::into_graphql_error)?;
+                dog_member_service::require_dog_member(&state.db, dog_id, user.id)
+                    .await
+                    .map_err(AppError::into_graphql_error)?;
 
-            let friendships = friendship_service::get_friends_for_dog(&state.db, dog_id)
-                .await
-                .map_err(AppError::into_graphql_error)?;
+                let friendships = friendship_service::get_friends_for_dog(&state.db, dog_id)
+                    .await
+                    .map_err(AppError::into_graphql_error)?;
 
-            let values: Vec<FieldValue> = friendships
-                .into_iter()
-                .map(|f| FieldValue::owned_any(FriendshipOutput::from_model(f, dog_id)))
-                .collect();
-            Ok(Some(FieldValue::list(values)))
-        })
-    })
+                let values: Vec<FieldValue> = friendships
+                    .into_iter()
+                    .map(|f| FieldValue::owned_any(FriendshipOutput::from_model(f, dog_id)))
+                    .collect();
+                Ok(Some(FieldValue::list(values)))
+            })
+        },
+    )
     .argument(InputValue::new("dogId", TypeRef::named_nn(TypeRef::ID)))
 }
 
 fn dog_encounters_field(state: Arc<AppState>) -> Field {
-    Field::new("dogEncounters", TypeRef::named_nn_list_nn("EncounterOutput"), move |ctx| {
-        let state = state.clone();
-        FieldFuture::new(async move {
-            let cognito_sub = auth::require_auth(&ctx)?;
-            let dog_id_str = ctx.args.try_get("dogId")?.string()?;
-            let dog_id = Uuid::parse_str(dog_id_str)
-                .map_err(|_| async_graphql::Error::new("Invalid dog ID"))?;
-            let limit = ctx.args.get("limit")
-                .and_then(|v| v.i64().ok())
-                .map(|v| v as u64);
-            let offset = ctx.args.get("offset")
-                .and_then(|v| v.i64().ok())
-                .map(|v| v as u64);
+    Field::new(
+        "dogEncounters",
+        TypeRef::named_nn_list_nn("EncounterOutput"),
+        move |ctx| {
+            let state = state.clone();
+            FieldFuture::new(async move {
+                let cognito_sub = auth::require_auth(&ctx)?;
+                let dog_id_str = ctx.args.try_get("dogId")?.string()?;
+                let dog_id = Uuid::parse_str(dog_id_str)
+                    .map_err(|_| async_graphql::Error::new("Invalid dog ID"))?;
+                let limit = ctx
+                    .args
+                    .get("limit")
+                    .and_then(|v| v.i64().ok())
+                    .map(|v| v as u64);
+                let offset = ctx
+                    .args
+                    .get("offset")
+                    .and_then(|v| v.i64().ok())
+                    .map(|v| v as u64);
 
-            let user = user_service::get_or_create_user(&state.db, &cognito_sub)
-                .await
-                .map_err(AppError::into_graphql_error)?;
-            dog_member_service::require_dog_member(&state.db, dog_id, user.id)
-                .await
-                .map_err(AppError::into_graphql_error)?;
+                let user = user_service::get_or_create_user(&state.db, &cognito_sub)
+                    .await
+                    .map_err(AppError::into_graphql_error)?;
+                dog_member_service::require_dog_member(&state.db, dog_id, user.id)
+                    .await
+                    .map_err(AppError::into_graphql_error)?;
 
-            let encounters = encounter_service::get_encounters_for_dog(&state.db, dog_id, limit, offset)
-                .await
-                .map_err(AppError::into_graphql_error)?;
+                let encounters =
+                    encounter_service::get_encounters_for_dog(&state.db, dog_id, limit, offset)
+                        .await
+                        .map_err(AppError::into_graphql_error)?;
 
-            let values: Vec<FieldValue> = encounters
-                .into_iter()
-                .map(|e| FieldValue::owned_any(EncounterOutput::from(e)))
-                .collect();
-            Ok(Some(FieldValue::list(values)))
-        })
-    })
+                let values: Vec<FieldValue> = encounters
+                    .into_iter()
+                    .map(|e| FieldValue::owned_any(EncounterOutput::from(e)))
+                    .collect();
+                Ok(Some(FieldValue::list(values)))
+            })
+        },
+    )
     .argument(InputValue::new("dogId", TypeRef::named_nn(TypeRef::ID)))
     .argument(InputValue::new("limit", TypeRef::named(TypeRef::INT)))
     .argument(InputValue::new("offset", TypeRef::named(TypeRef::INT)))
 }
 
 fn friendship_field(state: Arc<AppState>) -> Field {
-    Field::new("friendship", TypeRef::named("FriendshipOutput"), move |ctx| {
-        let state = state.clone();
-        FieldFuture::new(async move {
-            let cognito_sub = auth::require_auth(&ctx)?;
-            let dog_id_1_str = ctx.args.try_get("dogId1")?.string()?;
-            let dog_id_2_str = ctx.args.try_get("dogId2")?.string()?;
-            let dog_id_1 = Uuid::parse_str(dog_id_1_str)
-                .map_err(|_| async_graphql::Error::new("Invalid dogId1"))?;
-            let dog_id_2 = Uuid::parse_str(dog_id_2_str)
-                .map_err(|_| async_graphql::Error::new("Invalid dogId2"))?;
+    Field::new(
+        "friendship",
+        TypeRef::named("FriendshipOutput"),
+        move |ctx| {
+            let state = state.clone();
+            FieldFuture::new(async move {
+                let cognito_sub = auth::require_auth(&ctx)?;
+                let dog_id_1_str = ctx.args.try_get("dogId1")?.string()?;
+                let dog_id_2_str = ctx.args.try_get("dogId2")?.string()?;
+                let dog_id_1 = Uuid::parse_str(dog_id_1_str)
+                    .map_err(|_| async_graphql::Error::new("Invalid dogId1"))?;
+                let dog_id_2 = Uuid::parse_str(dog_id_2_str)
+                    .map_err(|_| async_graphql::Error::new("Invalid dogId2"))?;
 
-            let user = user_service::get_or_create_user(&state.db, &cognito_sub)
-                .await
-                .map_err(AppError::into_graphql_error)?;
+                let user = user_service::get_or_create_user(&state.db, &cognito_sub)
+                    .await
+                    .map_err(AppError::into_graphql_error)?;
 
-            // User must be a member of at least one of the two dogs
-            let is_member_of_1 = dog_member_service::require_dog_member(&state.db, dog_id_1, user.id)
-                .await
-                .is_ok();
-            let is_member_of_2 = dog_member_service::require_dog_member(&state.db, dog_id_2, user.id)
-                .await
-                .is_ok();
-            if !is_member_of_1 && !is_member_of_2 {
-                return Err(AppError::Unauthorized("Not a member of either dog".to_string())
-                    .into_graphql_error());
-            }
+                // User must be a member of at least one of the two dogs
+                let is_member_of_1 =
+                    dog_member_service::require_dog_member(&state.db, dog_id_1, user.id)
+                        .await
+                        .is_ok();
+                let is_member_of_2 =
+                    dog_member_service::require_dog_member(&state.db, dog_id_2, user.id)
+                        .await
+                        .is_ok();
+                if !is_member_of_1 && !is_member_of_2 {
+                    return Err(
+                        AppError::Unauthorized("Not a member of either dog".to_string())
+                            .into_graphql_error(),
+                    );
+                }
 
-            let friendship = friendship_service::get_friendship(&state.db, dog_id_1, dog_id_2)
-                .await
-                .map_err(AppError::into_graphql_error)?;
+                let friendship = friendship_service::get_friendship(&state.db, dog_id_1, dog_id_2)
+                    .await
+                    .map_err(AppError::into_graphql_error)?;
 
-            Ok(friendship.map(|f| FieldValue::owned_any(FriendshipOutput::from_model(f, dog_id_1))))
-        })
-    })
+                Ok(friendship
+                    .map(|f| FieldValue::owned_any(FriendshipOutput::from_model(f, dog_id_1))))
+            })
+        },
+    )
     .argument(InputValue::new("dogId1", TypeRef::named_nn(TypeRef::ID)))
     .argument(InputValue::new("dogId2", TypeRef::named_nn(TypeRef::ID)))
 }

--- a/apps/api/src/lib.rs
+++ b/apps/api/src/lib.rs
@@ -7,15 +7,19 @@ pub mod error;
 pub mod graphql;
 pub mod services;
 
-use std::sync::Arc;
-use axum::{Router, middleware, routing::{get, post}};
-use async_graphql_axum::{GraphQLRequest, GraphQLResponse};
-use sea_orm::DatabaseConnection;
-use aws_sdk_dynamodb::Client as DynamoClient;
-use aws_sdk_s3::Client as S3Client;
-use tower_http::cors::CorsLayer;
 use crate::config::Config;
 use crate::graphql::AppSchema;
+use async_graphql_axum::{GraphQLRequest, GraphQLResponse};
+use aws_sdk_dynamodb::Client as DynamoClient;
+use aws_sdk_s3::Client as S3Client;
+use axum::{
+    middleware,
+    routing::{get, post},
+    Router,
+};
+use sea_orm::DatabaseConnection;
+use std::sync::Arc;
+use tower_http::cors::CorsLayer;
 
 pub struct AppState {
     pub db: DatabaseConnection,
@@ -32,7 +36,13 @@ pub fn build_app(
     cognito: aws_sdk_cognitoidentityprovider::Client,
     config: Config,
 ) -> Router {
-    let state = Arc::new(AppState { db, dynamo, s3, cognito, config });
+    let state = Arc::new(AppState {
+        db,
+        dynamo,
+        s3,
+        cognito,
+        config,
+    });
     let schema = graphql::build_schema(state);
 
     Router::new()

--- a/apps/api/src/services/dog_service.rs
+++ b/apps/api/src/services/dog_service.rs
@@ -1,8 +1,3 @@
-use sea_orm::{
-    ActiveModelTrait, ColumnTrait, EntityTrait, PaginatorTrait, QueryFilter, Set,
-    TransactionTrait,
-};
-use uuid::Uuid;
 use crate::entities::{
     dogs::{ActiveModel, Entity as DogEntity, Model as DogModel},
     walk_dogs::{self, Entity as WalkDogEntity},
@@ -10,6 +5,10 @@ use crate::entities::{
 };
 use crate::error::AppError;
 use crate::services::dog_member_service;
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, EntityTrait, PaginatorTrait, QueryFilter, Set, TransactionTrait,
+};
+use uuid::Uuid;
 
 pub async fn create_dog(
     db: &sea_orm::DatabaseConnection,
@@ -92,10 +91,7 @@ pub async fn get_dog_by_id(
 /// Delete a dog. Only the owner should call this (authorization checked at GraphQL layer).
 /// ON DELETE CASCADE on walk_dogs removes related walk_dogs rows automatically.
 /// Walks with no remaining dogs are also deleted inside the transaction.
-pub async fn delete_dog(
-    db: &sea_orm::DatabaseConnection,
-    dog_id: Uuid,
-) -> Result<bool, AppError> {
+pub async fn delete_dog(db: &sea_orm::DatabaseConnection, dog_id: Uuid) -> Result<bool, AppError> {
     let txn = db.begin().await?;
 
     let dog = DogEntity::find_by_id(dog_id)

--- a/apps/api/src/services/friendship_service.rs
+++ b/apps/api/src/services/friendship_service.rs
@@ -5,7 +5,8 @@ use sea_orm::{
 use uuid::Uuid;
 
 use crate::entities::friendships::{
-    self, ActiveModel as FriendshipActiveModel, Entity as FriendshipEntity, Model as FriendshipModel,
+    self, ActiveModel as FriendshipActiveModel, Entity as FriendshipEntity,
+    Model as FriendshipModel,
 };
 use crate::error::AppError;
 
@@ -27,8 +28,7 @@ pub async fn upsert_friendship<C: sea_orm::ConnectionTrait>(
     let friendship = if let Some(existing) = existing {
         let mut active: friendships::ActiveModel = existing.into();
         active.encounter_count = Set(active.encounter_count.unwrap() + 1);
-        active.total_interaction_sec =
-            Set(active.total_interaction_sec.unwrap() + duration_sec);
+        active.total_interaction_sec = Set(active.total_interaction_sec.unwrap() + duration_sec);
         active.last_met_at = Set(met_at.into());
         active.update(db).await?
     } else {

--- a/apps/api/tests/common/mod.rs
+++ b/apps/api/tests/common/mod.rs
@@ -82,11 +82,7 @@ pub const USER_B: UserToken = UserToken("test-user-b-cognito-sub");
 
 /// Helper to send a GraphQL request as a specific user.
 #[allow(dead_code)]
-pub async fn graphql_as(
-    client: &TestClient,
-    user: &UserToken,
-    query: &str,
-) -> serde_json::Value {
+pub async fn graphql_as(client: &TestClient, user: &UserToken, query: &str) -> serde_json::Value {
     let res = client
         .post("/graphql")
         .header("Authorization", format!("Bearer {}", user.0))

--- a/apps/api/tests/test_dog.rs
+++ b/apps/api/tests/test_dog.rs
@@ -21,7 +21,11 @@ async fn test_create_dog() {
         .unwrap();
     assert_eq!(res.status(), 200);
     let body: serde_json::Value = res.json().await.unwrap();
-    assert_eq!(body["data"]["createDog"]["name"], "Pochi", "got: {:?}", body);
+    assert_eq!(
+        body["data"]["createDog"]["name"], "Pochi",
+        "got: {:?}",
+        body
+    );
     assert_eq!(body["data"]["createDog"]["birthDate"]["year"], 2020);
     assert_eq!(body["data"]["createDog"]["birthDate"]["month"], 4);
     assert!(body["data"]["createDog"]["birthDate"]["day"].is_null());
@@ -37,7 +41,9 @@ async fn test_update_dog() {
         .json(&serde_json::json!({
             "query": r#"mutation { createDog(input: { name: "Hachi" }) { id } }"#
         }))
-        .send().await.unwrap();
+        .send()
+        .await
+        .unwrap();
     let create_body: serde_json::Value = create_res.json().await.unwrap();
     let dog_id = create_body["data"]["createDog"]["id"].as_str().unwrap();
 
@@ -50,7 +56,11 @@ async fn test_update_dog() {
         }))
         .send().await.unwrap();
     let body: serde_json::Value = res.json().await.unwrap();
-    assert_eq!(body["data"]["updateDog"]["name"], "Hachi Updated", "got: {:?}", body);
+    assert_eq!(
+        body["data"]["updateDog"]["name"], "Hachi Updated",
+        "got: {:?}",
+        body
+    );
 }
 
 #[tokio::test]
@@ -62,7 +72,9 @@ async fn test_delete_dog() {
         .json(&serde_json::json!({
             "query": r#"mutation { createDog(input: { name: "DeleteMe" }) { id } }"#
         }))
-        .send().await.unwrap();
+        .send()
+        .await
+        .unwrap();
     let create_body: serde_json::Value = create_res.json().await.unwrap();
     let dog_id = create_body["data"]["createDog"]["id"].as_str().unwrap();
 
@@ -72,7 +84,9 @@ async fn test_delete_dog() {
         .json(&serde_json::json!({
             "query": format!(r#"mutation {{ deleteDog(id: "{}") }}"#, dog_id)
         }))
-        .send().await.unwrap();
+        .send()
+        .await
+        .unwrap();
     let body: serde_json::Value = res.json().await.unwrap();
     assert_eq!(body["data"]["deleteDog"], true, "got: {:?}", body);
 }
@@ -87,7 +101,9 @@ async fn test_generate_dog_photo_upload_url() {
         .json(&serde_json::json!({
             "query": r#"mutation { createDog(input: { name: "PhotoDog" }) { id } }"#
         }))
-        .send().await.unwrap();
+        .send()
+        .await
+        .unwrap();
     let create_body: serde_json::Value = create_res.json().await.unwrap();
     let dog_id = create_body["data"]["createDog"]["id"].as_str().unwrap();
 
@@ -104,12 +120,22 @@ async fn test_generate_dog_photo_upload_url() {
         .send().await.unwrap();
     assert_eq!(res.status(), 200);
     let body: serde_json::Value = res.json().await.unwrap();
-    let url = body["data"]["generateDogPhotoUploadUrl"]["url"].as_str().unwrap();
-    assert!(url.starts_with("http"), "URL should be an HTTP URL, got: {}", url);
+    let url = body["data"]["generateDogPhotoUploadUrl"]["url"]
+        .as_str()
+        .unwrap();
+    assert!(
+        url.starts_with("http"),
+        "URL should be an HTTP URL, got: {}",
+        url
+    );
     let key = body["data"]["generateDogPhotoUploadUrl"]["key"]
         .as_str()
         .unwrap();
-    assert!(key.ends_with(".png"), "key should end with .png, got: {}", key);
+    assert!(
+        key.ends_with(".png"),
+        "key should end with .png, got: {}",
+        key
+    );
     assert!(body["data"]["generateDogPhotoUploadUrl"]["expiresAt"].is_string());
 }
 
@@ -123,7 +149,9 @@ async fn test_generate_dog_photo_upload_url_rejects_invalid_content_type() {
         .json(&serde_json::json!({
             "query": r#"mutation { createDog(input: { name: "PhotoDogReject" }) { id } }"#
         }))
-        .send().await.unwrap();
+        .send()
+        .await
+        .unwrap();
     let create_body: serde_json::Value = create_res.json().await.unwrap();
     let dog_id = create_body["data"]["createDog"]["id"].as_str().unwrap();
 
@@ -162,7 +190,9 @@ async fn test_walk_stats() {
         .json(&serde_json::json!({
             "query": r#"mutation { createDog(input: { name: "StatsDog" }) { id } }"#
         }))
-        .send().await.unwrap();
+        .send()
+        .await
+        .unwrap();
     let create_body: serde_json::Value = create_res.json().await.unwrap();
     let dog_id = create_body["data"]["createDog"]["id"].as_str().unwrap();
 
@@ -175,6 +205,10 @@ async fn test_walk_stats() {
         }))
         .send().await.unwrap();
     let body: serde_json::Value = res.json().await.unwrap();
-    assert_eq!(body["data"]["dogWalkStats"]["totalWalks"], 0, "got: {:?}", body);
+    assert_eq!(
+        body["data"]["dogWalkStats"]["totalWalks"], 0,
+        "got: {:?}",
+        body
+    );
     assert_eq!(body["data"]["dogWalkStats"]["totalDistanceM"], 0);
 }

--- a/apps/api/tests/test_dog_member.rs
+++ b/apps/api/tests/test_dog_member.rs
@@ -119,11 +119,7 @@ async fn test_delete_dog_owner_only() {
     let body: serde_json::Value = res.json().await.unwrap();
     // Should return error (not found) or null
     let is_null_or_error = body["data"]["dog"].is_null() || body["errors"].is_array();
-    assert!(
-        is_null_or_error,
-        "Expected null or error, got: {:?}",
-        body
-    );
+    assert!(is_null_or_error, "Expected null or error, got: {:?}", body);
 }
 
 #[tokio::test]
@@ -142,13 +138,14 @@ async fn test_dog_output_has_members_field() {
         .unwrap();
     let body: serde_json::Value = res.json().await.unwrap();
     let members = body["data"]["createDog"]["members"].as_array();
-    assert!(
-        members.is_some(),
-        "Expected members array, got: {:?}",
-        body
-    );
+    assert!(members.is_some(), "Expected members array, got: {:?}", body);
     let members = members.unwrap();
-    assert_eq!(members.len(), 1, "Expected 1 member (owner), got: {:?}", members);
+    assert_eq!(
+        members.len(),
+        1,
+        "Expected 1 member (owner), got: {:?}",
+        members
+    );
     assert_eq!(members[0]["role"], "owner");
     assert!(members[0]["userId"].is_string());
     assert!(members[0]["user"].is_object());
@@ -174,7 +171,11 @@ async fn test_dog_output_has_role_field_in_me_query() {
         .unwrap();
     let body: serde_json::Value = res.json().await.unwrap();
     let dogs = body["data"]["me"]["dogs"].as_array().unwrap();
-    assert!(!dogs.is_empty(), "Expected at least one dog, got: {:?}", body);
+    assert!(
+        !dogs.is_empty(),
+        "Expected at least one dog, got: {:?}",
+        body
+    );
 
     // Find the dog we created and verify it has role = "owner"
     let has_owner_role = dogs.iter().any(|d| d["role"] == "owner");

--- a/apps/api/tests/test_encounter.rs
+++ b/apps/api/tests/test_encounter.rs
@@ -150,7 +150,10 @@ async fn test_record_encounter_dedup() {
     let body_friends = common::graphql_as(
         &client,
         &common::USER_A,
-        &format!(r#"{{ dogFriends(dogId: "{}") {{ id encounterCount }} }}"#, d1),
+        &format!(
+            r#"{{ dogFriends(dogId: "{}") {{ id encounterCount }} }}"#,
+            d1
+        ),
     )
     .await;
     assert!(
@@ -193,7 +196,10 @@ async fn test_record_encounter_multi_dog_walk() {
         .await
         .unwrap();
     let body: serde_json::Value = res.json().await.unwrap();
-    let w1 = body["data"]["startWalk"]["id"].as_str().unwrap().to_string();
+    let w1 = body["data"]["startWalk"]["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
 
     let d3 = create_dog(&client, "test-user-b-cognito-sub").await;
     let w2 = start_walk(&client, "test-user-b-cognito-sub", &d3).await;

--- a/apps/api/tests/test_encounter_flow.rs
+++ b/apps/api/tests/test_encounter_flow.rs
@@ -8,7 +8,11 @@ async fn enable_detection(client: &common::TestClient, token: &'static str) {
         r#"mutation { updateEncounterDetection(enabled: true) { encounterDetectionEnabled } }"#,
     )
     .await;
-    assert!(body["errors"].is_null(), "Enable detection failed: {:?}", body);
+    assert!(
+        body["errors"].is_null(),
+        "Enable detection failed: {:?}",
+        body
+    );
 }
 
 /// Helper: create a dog as user and return its ID.
@@ -30,7 +34,10 @@ async fn start_walk(client: &common::TestClient, token: &'static str, dog_id: &s
     let body = common::graphql_as(
         client,
         &common::UserToken(token),
-        &format!(r#"mutation {{ startWalk(dogIds: ["{}"]) {{ id }} }}"#, dog_id),
+        &format!(
+            r#"mutation {{ startWalk(dogIds: ["{}"]) {{ id }} }}"#,
+            dog_id
+        ),
     )
     .await;
     body["data"]["startWalk"]["id"]
@@ -82,13 +89,21 @@ async fn test_full_encounter_flow() {
 
     // 4. User A records encounter
     let body = record_encounter(&client, FLOW_USER_A, &w1a, &w2a).await;
-    assert!(body["errors"].is_null(), "First encounter failed: {:?}", body);
+    assert!(
+        body["errors"].is_null(),
+        "First encounter failed: {:?}",
+        body
+    );
     let encounters = body["data"]["recordEncounter"].as_array().unwrap();
     assert_eq!(encounters.len(), 1, "Expected 1 encounter pair");
 
     // 5. User B records same encounter (dedup)
     let body_b = record_encounter(&client, FLOW_USER_B, &w2a, &w1a).await;
-    assert!(body_b["errors"].is_null(), "Dedup call failed: {:?}", body_b);
+    assert!(
+        body_b["errors"].is_null(),
+        "Dedup call failed: {:?}",
+        body_b
+    );
 
     // 6. Verify friendship: encounter_count should be 1 (deduped)
     let friends = common::graphql_as(
@@ -100,7 +115,11 @@ async fn test_full_encounter_flow() {
         ),
     )
     .await;
-    assert!(friends["errors"].is_null(), "dogFriends failed: {:?}", friends);
+    assert!(
+        friends["errors"].is_null(),
+        "dogFriends failed: {:?}",
+        friends
+    );
     let friends_list = friends["data"]["dogFriends"].as_array().unwrap();
     assert_eq!(friends_list.len(), 1, "Expected 1 friend");
     assert_eq!(friends_list[0]["encounterCount"].as_i64().unwrap(), 1);
@@ -110,7 +129,11 @@ async fn test_full_encounter_flow() {
     let w1b = start_walk(&client, FLOW_USER_A, &d1).await;
     let w2b = start_walk(&client, FLOW_USER_B, &d2).await;
     let body2 = record_encounter(&client, FLOW_USER_A, &w1b, &w2b).await;
-    assert!(body2["errors"].is_null(), "Second encounter failed: {:?}", body2);
+    assert!(
+        body2["errors"].is_null(),
+        "Second encounter failed: {:?}",
+        body2
+    );
 
     // 8. Verify friendship: encounter_count should now be 2
     let friends2 = common::graphql_as(
@@ -136,7 +159,11 @@ async fn test_full_encounter_flow() {
         ),
     )
     .await;
-    assert!(history["errors"].is_null(), "dogEncounters failed: {:?}", history);
+    assert!(
+        history["errors"].is_null(),
+        "dogEncounters failed: {:?}",
+        history
+    );
     let enc_list = history["data"]["dogEncounters"].as_array().unwrap();
     assert_eq!(enc_list.len(), 2, "Expected 2 encounters in history");
 
@@ -163,10 +190,7 @@ async fn test_full_encounter_flow() {
     let friends3 = common::graphql_as(
         &client,
         &common::UserToken(FLOW_USER_A),
-        &format!(
-            r#"{{ dogFriends(dogId: "{}") {{ encounterCount }} }}"#,
-            d1
-        ),
+        &format!(r#"{{ dogFriends(dogId: "{}") {{ encounterCount }} }}"#, d1),
     )
     .await;
     let f3 = &friends3["data"]["dogFriends"].as_array().unwrap()[0];

--- a/apps/api/tests/test_sharing_flow.rs
+++ b/apps/api/tests/test_sharing_flow.rs
@@ -132,11 +132,7 @@ async fn test_sharing_flow() {
         ),
     )
     .await;
-    assert_eq!(
-        body["data"]["removeDogMember"], true,
-        "got: {:?}",
-        body
-    );
+    assert_eq!(body["data"]["removeDogMember"], true, "got: {:?}", body);
 
     // 8. User B can no longer access the dog
     let body = graphql_as(
@@ -153,12 +149,7 @@ async fn test_sharing_flow() {
     );
 
     // 9. User B's walk data still exists (User A can see it)
-    let body = graphql_as(
-        &client,
-        &USER_A,
-        r#"{ myWalks { id } }"#,
-    )
-    .await;
+    let body = graphql_as(&client, &USER_A, r#"{ myWalks { id } }"#).await;
     let walks = body["data"]["myWalks"].as_array().unwrap();
     let walk_still_exists = walks.iter().any(|w| w["id"].as_str().unwrap() == walk_id);
     assert!(

--- a/apps/api/tests/test_walk.rs
+++ b/apps/api/tests/test_walk.rs
@@ -7,9 +7,14 @@ async fn create_test_dog(client: &common::TestClient) -> String {
         .json(&serde_json::json!({
             "query": r#"mutation { createDog(input: { name: "WalkDog" }) { id } }"#
         }))
-        .send().await.unwrap();
+        .send()
+        .await
+        .unwrap();
     let body: serde_json::Value = res.json().await.unwrap();
-    body["data"]["createDog"]["id"].as_str().unwrap().to_string()
+    body["data"]["createDog"]["id"]
+        .as_str()
+        .unwrap()
+        .to_string()
 }
 
 #[tokio::test]
@@ -26,7 +31,11 @@ async fn test_start_walk() {
         .send().await.unwrap();
     assert_eq!(res.status(), 200);
     let body: serde_json::Value = res.json().await.unwrap();
-    assert_eq!(body["data"]["startWalk"]["status"], "active", "got: {:?}", body);
+    assert_eq!(
+        body["data"]["startWalk"]["status"], "active",
+        "got: {:?}",
+        body
+    );
     assert!(body["data"]["startWalk"]["id"].is_string());
 }
 
@@ -39,11 +48,21 @@ async fn test_start_walk_empty_dogs_returns_error() {
         .json(&serde_json::json!({
             "query": r#"mutation { startWalk(dogIds: []) { id } }"#
         }))
-        .send().await.unwrap();
+        .send()
+        .await
+        .unwrap();
     let body: serde_json::Value = res.json().await.unwrap();
-    assert!(body["errors"].is_array(), "expected errors, got: {:?}", body);
+    assert!(
+        body["errors"].is_array(),
+        "expected errors, got: {:?}",
+        body
+    );
     let err_msg = body["errors"][0]["message"].as_str().unwrap();
-    assert!(err_msg.contains("dogIds") || err_msg.to_lowercase().contains("empty"), "got: {}", err_msg);
+    assert!(
+        err_msg.contains("dogIds") || err_msg.to_lowercase().contains("empty"),
+        "got: {}",
+        err_msg
+    );
 }
 
 #[tokio::test]
@@ -58,7 +77,9 @@ async fn test_finish_walk() {
         .json(&serde_json::json!({
             "query": format!(r#"mutation {{ startWalk(dogIds: ["{}"]) {{ id }} }}"#, dog_id)
         }))
-        .send().await.unwrap();
+        .send()
+        .await
+        .unwrap();
     let start_body: serde_json::Value = start_res.json().await.unwrap();
     let walk_id = start_body["data"]["startWalk"]["id"].as_str().unwrap();
 
@@ -71,7 +92,11 @@ async fn test_finish_walk() {
         }))
         .send().await.unwrap();
     let body: serde_json::Value = res.json().await.unwrap();
-    assert_eq!(body["data"]["finishWalk"]["status"], "finished", "got: {:?}", body);
+    assert_eq!(
+        body["data"]["finishWalk"]["status"], "finished",
+        "got: {:?}",
+        body
+    );
     assert!(body["data"]["finishWalk"]["endedAt"].is_string());
 }
 
@@ -82,12 +107,15 @@ async fn test_my_walks_query() {
 
     // 散歩を2件作成
     for _ in 0..2 {
-        client.post("/graphql")
+        client
+            .post("/graphql")
             .header("Authorization", "Bearer test-token")
             .json(&serde_json::json!({
                 "query": format!(r#"mutation {{ startWalk(dogIds: ["{}"]) {{ id }} }}"#, dog_id)
             }))
-            .send().await.unwrap();
+            .send()
+            .await
+            .unwrap();
     }
 
     let res = client
@@ -96,11 +124,17 @@ async fn test_my_walks_query() {
         .json(&serde_json::json!({
             "query": r#"{ myWalks { id status startedAt } }"#
         }))
-        .send().await.unwrap();
+        .send()
+        .await
+        .unwrap();
     assert_eq!(res.status(), 200);
     let body: serde_json::Value = res.json().await.unwrap();
     let walks = body["data"]["myWalks"].as_array().unwrap();
-    assert!(walks.len() >= 2, "expected >= 2 walks, got: {}", walks.len());
+    assert!(
+        walks.len() >= 2,
+        "expected >= 2 walks, got: {}",
+        walks.len()
+    );
 }
 
 #[tokio::test]
@@ -114,7 +148,9 @@ async fn test_add_walk_points() {
         .json(&serde_json::json!({
             "query": format!(r#"mutation {{ startWalk(dogIds: ["{}"]) {{ id }} }}"#, dog_id)
         }))
-        .send().await.unwrap();
+        .send()
+        .await
+        .unwrap();
     let start_body: serde_json::Value = start_res.json().await.unwrap();
     let walk_id = start_body["data"]["startWalk"]["id"].as_str().unwrap();
 
@@ -129,7 +165,9 @@ async fn test_add_walk_points() {
                 ])
             }}"#, walk_id)
         }))
-        .send().await.unwrap();
+        .send()
+        .await
+        .unwrap();
     let body: serde_json::Value = res.json().await.unwrap();
     assert_eq!(body["data"]["addWalkPoints"], true, "got: {:?}", body);
 }


### PR DESCRIPTION
## Summary

`apps/api/` 配下の 20 ファイルに対する cargo fmt 整形のみの変更。ロジック・動作変更ゼロ。

セッション開始時点で長期未コミットだった fmt 差分を抽出し、Phase 1-5 リファクタ (#87) と分離して取り込む。

## 変更内容

- import 並び替え
- 関数引数の縦展開
- メソッドチェーン整形
- enum メンバー縦展開
- `assert!` / `assert_eq!` / `format!` 引数の改行配置

## 対象ファイル (20)

- `apps/api/migration/src/*` (5)
- `apps/api/src/{auth/mod, aws/client, config, error, graphql/custom_queries, lib, services/dog_service, services/friendship_service}.rs` (8)
- `apps/api/tests/{common/mod, test_dog, test_dog_member, test_encounter, test_encounter_flow, test_sharing_flow, test_walk}.rs` (7)

## 分類根拠

Explore サブエージェント + 直接 diff 確認で全 20 ファイルを PURE_FMT と判定。以下パターンのみ含有:
- import 並び替え / 縦展開
- 関数引数縦展開 (`fn foo(\n    a: A,\n    b: B,\n)`)
- メソッドチェーン改行
- マクロ引数改行配置

識別子 rename / 制御フロー追加削除 / リテラル値変更 / import 追加削除等は **含まれない**。

## Test plan

- [ ] CI 緑
- [ ] PR diff レビューで「fmt のみ」と目視確認
- [ ] `cargo test --lib` 緑 (動作変更なし前提の確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)