### PR TITLE
refactor(api): Phase 6 — auth_helpers + walk_event_service authorization hub

### DIFF
--- a/apps/api/src/graphql/auth_helpers.rs
+++ b/apps/api/src/graphql/auth_helpers.rs
@@ -1,0 +1,90 @@
+use crate::entities::{dog_members::Model as DogMemberModel, users::Model as UserModel};
+use crate::error::AppError;
+use crate::services::{dog_member_service, user_service, walk_event_service};
+use crate::AppState;
+use async_graphql::dynamic::ResolverContext;
+use uuid::Uuid;
+
+/// Resolve the authenticated user from the GraphQL context.
+///
+/// Combines `require_auth` + `get_or_create_user` into a single call.
+pub async fn resolve_user(
+    ctx: &ResolverContext<'_>,
+    state: &AppState,
+) -> async_graphql::Result<UserModel> {
+    let cognito_sub = crate::auth::require_auth(ctx)?;
+    user_service::get_or_create_user(&state.db, &cognito_sub)
+        .await
+        .map_err(AppError::into_graphql_error)
+}
+
+/// Resolve the authenticated user and verify dog membership.
+///
+/// Returns `(user, dog_member)`. The caller can inspect `dog_member.role`
+/// when owner-only access is required.
+pub async fn resolve_user_and_dog(
+    ctx: &ResolverContext<'_>,
+    state: &AppState,
+    dog_id: Uuid,
+) -> async_graphql::Result<(UserModel, DogMemberModel)> {
+    let user = resolve_user(ctx, state).await?;
+    let member = dog_member_service::require_dog_member(&state.db, dog_id, user.id)
+        .await
+        .map_err(AppError::into_graphql_error)?;
+    Ok((user, member))
+}
+
+/// Resolve the authenticated user and verify walk access.
+///
+/// Uses `walk_event_service::require_walk_access` which checks walk ownership
+/// or membership through walk_dogs → dog_members.
+pub async fn resolve_user_and_walk(
+    ctx: &ResolverContext<'_>,
+    state: &AppState,
+    walk_id: Uuid,
+) -> async_graphql::Result<UserModel> {
+    let user = resolve_user(ctx, state).await?;
+    walk_event_service::require_walk_access(&state.db, walk_id, user.id)
+        .await
+        .map_err(AppError::into_graphql_error)?;
+    Ok(user)
+}
+
+#[cfg(test)]
+mod tests {
+
+    /// Static guard: resolve_user must call require_auth exactly once.
+    #[test]
+    fn resolve_user_calls_require_auth() {
+        let src = include_str!("auth_helpers.rs");
+        assert!(
+            src.contains("crate::auth::require_auth(ctx)"),
+            "resolve_user must call crate::auth::require_auth"
+        );
+    }
+
+    /// Static guard: resolve_user_and_dog must delegate to resolve_user (not inline require_auth).
+    #[test]
+    fn resolve_user_and_dog_delegates_to_resolve_user() {
+        let src = include_str!("auth_helpers.rs");
+        // resolve_user_and_dog should not call get_or_create_user directly (it goes via resolve_user)
+        assert!(
+            !src[src.find("fn resolve_user_and_dog").unwrap()..]
+                .splitn(2, "fn resolve_user_and_walk")
+                .next()
+                .unwrap_or("")
+                .contains("get_or_create_user"),
+            "resolve_user_and_dog must not call get_or_create_user directly"
+        );
+    }
+
+    /// Static guard: resolve_user_and_walk must delegate to resolve_user.
+    #[test]
+    fn resolve_user_and_walk_delegates_to_resolve_user() {
+        let src = include_str!("auth_helpers.rs");
+        assert!(
+            src.contains("resolve_user(ctx, state).await"),
+            "resolve_user_and_walk must call resolve_user internally"
+        );
+    }
+}

--- a/apps/api/src/graphql/custom_mutations.rs
+++ b/apps/api/src/graphql/custom_mutations.rs
@@ -1,5 +1,6 @@
 use crate::auth;
 use crate::error::AppError;
+use crate::graphql::auth_helpers;
 use crate::graphql::custom_queries::{EncounterOutput, WalkPointOutput};
 use crate::graphql::input::birth_date::parse_birth_date_input;
 use crate::services::{
@@ -1295,7 +1296,6 @@ fn create_dog_field(state: Arc<AppState>) -> Field {
     Field::new("createDog", TypeRef::named_nn("DogOutput"), move |ctx| {
         let state = state.clone();
         FieldFuture::new(async move {
-            let cognito_sub = auth::require_auth(&ctx)?;
             let input = ctx.args.try_get("input")?.object()?;
             let name = input.try_get("name")?.string()?.to_string();
             let breed = input
@@ -1308,9 +1308,7 @@ fn create_dog_field(state: Arc<AppState>) -> Field {
                 .transpose()?;
             let birth_date = parse_birth_date_input(input.get("birthDate"))?;
 
-            let user = user_service::get_or_create_user(&state.db, &cognito_sub)
-                .await
-                .map_err(AppError::into_graphql_error)?;
+            let user = auth_helpers::resolve_user(&ctx, &state).await?;
             let dog = dog_service::create_dog(&state.db, user.id, name, breed, gender, birth_date)
                 .await
                 .map_err(AppError::into_graphql_error)?;
@@ -1327,7 +1325,6 @@ fn update_dog_field(state: Arc<AppState>) -> Field {
     Field::new("updateDog", TypeRef::named_nn("DogOutput"), move |ctx| {
         let state = state.clone();
         FieldFuture::new(async move {
-            let cognito_sub = auth::require_auth(&ctx)?;
             let id_str = ctx.args.try_get("id")?.string()?;
             let dog_id =
                 Uuid::parse_str(id_str).map_err(|_| async_graphql::Error::new("Invalid dog ID"))?;
@@ -1350,12 +1347,7 @@ fn update_dog_field(state: Arc<AppState>) -> Field {
                 .map(|v| v.string().map(|s| s.to_string()))
                 .transpose()?;
 
-            let user = user_service::get_or_create_user(&state.db, &cognito_sub)
-                .await
-                .map_err(AppError::into_graphql_error)?;
-            dog_member_service::require_dog_member(&state.db, dog_id, user.id)
-                .await
-                .map_err(AppError::into_graphql_error)?;
+            auth_helpers::resolve_user_and_dog(&ctx, &state, dog_id).await?;
             let dog = dog_service::update_dog(
                 &state.db, dog_id, name, breed, gender, birth_date, photo_url,
             )
@@ -1375,7 +1367,6 @@ fn start_walk_field(state: Arc<AppState>) -> Field {
     Field::new("startWalk", TypeRef::named_nn("WalkOutput"), move |ctx| {
         let state = state.clone();
         FieldFuture::new(async move {
-            let cognito_sub = auth::require_auth(&ctx)?;
             let dog_ids_raw = ctx.args.try_get("dogIds")?;
             let dog_ids = dog_ids_raw
                 .list()?
@@ -1386,9 +1377,7 @@ fn start_walk_field(state: Arc<AppState>) -> Field {
                 })
                 .collect::<Result<Vec<Uuid>, _>>()?;
 
-            let user = user_service::get_or_create_user(&state.db, &cognito_sub)
-                .await
-                .map_err(AppError::into_graphql_error)?;
+            let user = auth_helpers::resolve_user(&ctx, &state).await?;
             // Verify membership for each dog
             for dog_id in &dog_ids {
                 dog_member_service::require_dog_member(&state.db, *dog_id, user.id)
@@ -1411,7 +1400,6 @@ fn finish_walk_field(state: Arc<AppState>) -> Field {
     Field::new("finishWalk", TypeRef::named_nn("WalkOutput"), move |ctx| {
         let state = state.clone();
         FieldFuture::new(async move {
-            let cognito_sub = auth::require_auth(&ctx)?;
             let walk_id_str = ctx.args.try_get("walkId")?.string()?;
             let walk_id = Uuid::parse_str(walk_id_str)
                 .map_err(|_| async_graphql::Error::new("Invalid walk ID"))?;
@@ -1421,9 +1409,7 @@ fn finish_walk_field(state: Arc<AppState>) -> Field {
                 .and_then(|v| v.i64().ok())
                 .map(|v| v as i32);
 
-            let user = user_service::get_or_create_user(&state.db, &cognito_sub)
-                .await
-                .map_err(AppError::into_graphql_error)?;
+            let user = auth_helpers::resolve_user(&ctx, &state).await?;
             let walk = walk_service::finish_walk(&state.db, walk_id, user.id, distance_m)
                 .await
                 .map_err(AppError::into_graphql_error)?;
@@ -1444,14 +1430,11 @@ fn add_walk_points_field(state: Arc<AppState>) -> Field {
                 use crate::entities::{walks, walks::Entity as WalkEntity};
                 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 
-                let cognito_sub = auth::require_auth(&ctx)?;
                 let walk_id_str = ctx.args.try_get("walkId")?.string()?;
                 let walk_id = Uuid::parse_str(walk_id_str)
                     .map_err(|_| async_graphql::Error::new("Invalid walk ID"))?;
 
-                let user = user_service::get_or_create_user(&state.db, &cognito_sub)
-                    .await
-                    .map_err(AppError::into_graphql_error)?;
+                let user = auth_helpers::resolve_user(&ctx, &state).await?;
                 // Only the walk owner can add points (walks.user_id check)
                 WalkEntity::find_by_id(walk_id)
                     .filter(walks::Column::UserId.eq(user.id))
@@ -1529,14 +1512,11 @@ fn delete_dog_field(state: Arc<AppState>) -> Field {
         move |ctx| {
             let state = state.clone();
             FieldFuture::new(async move {
-                let cognito_sub = auth::require_auth(&ctx)?;
                 let dog_id_str = ctx.args.try_get("id")?.string()?;
                 let dog_id = Uuid::parse_str(dog_id_str)
                     .map_err(|_| async_graphql::Error::new("Invalid dog ID"))?;
 
-                let user = user_service::get_or_create_user(&state.db, &cognito_sub)
-                    .await
-                    .map_err(AppError::into_graphql_error)?;
+                let user = auth_helpers::resolve_user(&ctx, &state).await?;
                 dog_member_service::require_dog_owner(&state.db, dog_id, user.id)
                     .await
                     .map_err(AppError::into_graphql_error)?;
@@ -1557,18 +1537,12 @@ fn generate_dog_photo_upload_url_field(state: Arc<AppState>) -> Field {
         move |ctx| {
             let state = state.clone();
             FieldFuture::new(async move {
-                let cognito_sub = auth::require_auth(&ctx)?;
                 let dog_id_str = ctx.args.try_get("dogId")?.string()?;
                 let dog_id = Uuid::parse_str(dog_id_str)
                     .map_err(|_| async_graphql::Error::new("Invalid dog ID"))?;
                 let content_type = ctx.args.try_get("contentType")?.string()?.to_string();
 
-                let user = user_service::get_or_create_user(&state.db, &cognito_sub)
-                    .await
-                    .map_err(AppError::into_graphql_error)?;
-                dog_member_service::require_dog_member(&state.db, dog_id, user.id)
-                    .await
-                    .map_err(AppError::into_graphql_error)?;
+                auth_helpers::resolve_user_and_dog(&ctx, &state, dog_id).await?;
 
                 let presigned = s3_service::generate_dog_photo_upload_url(
                     &state.s3,
@@ -1601,14 +1575,11 @@ fn generate_dog_invitation_field(state: Arc<AppState>) -> Field {
         move |ctx| {
             let state = state.clone();
             FieldFuture::new(async move {
-                let cognito_sub = auth::require_auth(&ctx)?;
                 let dog_id_str = ctx.args.try_get("dogId")?.string()?;
                 let dog_id = Uuid::parse_str(dog_id_str)
                     .map_err(|_| async_graphql::Error::new("Invalid dog ID"))?;
 
-                let user = user_service::get_or_create_user(&state.db, &cognito_sub)
-                    .await
-                    .map_err(AppError::into_graphql_error)?;
+                let user = auth_helpers::resolve_user(&ctx, &state).await?;
                 dog_member_service::require_dog_owner(&state.db, dog_id, user.id)
                     .await
                     .map_err(AppError::into_graphql_error)?;
@@ -1634,12 +1605,9 @@ fn accept_dog_invitation_field(state: Arc<AppState>) -> Field {
         move |ctx| {
             let state = state.clone();
             FieldFuture::new(async move {
-                let cognito_sub = auth::require_auth(&ctx)?;
                 let token = ctx.args.try_get("token")?.string()?.to_string();
 
-                let user = user_service::get_or_create_user(&state.db, &cognito_sub)
-                    .await
-                    .map_err(AppError::into_graphql_error)?;
+                let user = auth_helpers::resolve_user(&ctx, &state).await?;
 
                 let member = dog_invitation_service::accept_invitation(&state.db, &token, user.id)
                     .await
@@ -1664,7 +1632,6 @@ fn remove_dog_member_field(state: Arc<AppState>) -> Field {
         move |ctx| {
             let state = state.clone();
             FieldFuture::new(async move {
-                let cognito_sub = auth::require_auth(&ctx)?;
                 let dog_id_str = ctx.args.try_get("dogId")?.string()?;
                 let dog_id = Uuid::parse_str(dog_id_str)
                     .map_err(|_| async_graphql::Error::new("Invalid dog ID"))?;
@@ -1672,9 +1639,7 @@ fn remove_dog_member_field(state: Arc<AppState>) -> Field {
                 let target_user_id = Uuid::parse_str(target_user_id_str)
                     .map_err(|_| async_graphql::Error::new("Invalid user ID"))?;
 
-                let user = user_service::get_or_create_user(&state.db, &cognito_sub)
-                    .await
-                    .map_err(AppError::into_graphql_error)?;
+                let user = auth_helpers::resolve_user(&ctx, &state).await?;
 
                 // Only the owner can remove members
                 dog_member_service::require_dog_owner(&state.db, dog_id, user.id)
@@ -1707,18 +1672,12 @@ fn leave_dog_field(state: Arc<AppState>) -> Field {
         move |ctx| {
             let state = state.clone();
             FieldFuture::new(async move {
-                let cognito_sub = auth::require_auth(&ctx)?;
                 let dog_id_str = ctx.args.try_get("dogId")?.string()?;
                 let dog_id = Uuid::parse_str(dog_id_str)
                     .map_err(|_| async_graphql::Error::new("Invalid dog ID"))?;
 
-                let user = user_service::get_or_create_user(&state.db, &cognito_sub)
-                    .await
-                    .map_err(AppError::into_graphql_error)?;
-
-                let membership = dog_member_service::require_dog_member(&state.db, dog_id, user.id)
-                    .await
-                    .map_err(AppError::into_graphql_error)?;
+                let (user, membership) =
+                    auth_helpers::resolve_user_and_dog(&ctx, &state, dog_id).await?;
 
                 // Owners cannot leave their own dog
                 if membership.role == "owner" {
@@ -1753,7 +1712,6 @@ fn record_encounter_field(state: Arc<AppState>) -> Field {
                 };
                 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 
-                let cognito_sub = auth::require_auth(&ctx)?;
                 let my_walk_id_str = ctx.args.try_get("myWalkId")?.string()?;
                 let their_walk_id_str = ctx.args.try_get("theirWalkId")?.string()?;
                 let my_walk_id = Uuid::parse_str(my_walk_id_str)
@@ -1761,9 +1719,7 @@ fn record_encounter_field(state: Arc<AppState>) -> Field {
                 let their_walk_id = Uuid::parse_str(their_walk_id_str)
                     .map_err(|_| async_graphql::Error::new("Invalid theirWalkId"))?;
 
-                let user = user_service::get_or_create_user(&state.db, &cognito_sub)
-                    .await
-                    .map_err(AppError::into_graphql_error)?;
+                let user = auth_helpers::resolve_user(&ctx, &state).await?;
 
                 // Verify myWalkId belongs to the current user
                 let my_walk = WalkEntity::find_by_id(my_walk_id)
@@ -1848,7 +1804,6 @@ fn update_encounter_duration_field(state: Arc<AppState>) -> Field {
                 use crate::entities::walks::Entity as WalkEntity;
                 use sea_orm::EntityTrait;
 
-                let cognito_sub = auth::require_auth(&ctx)?;
                 let my_walk_id_str = ctx.args.try_get("myWalkId")?.string()?;
                 let their_walk_id_str = ctx.args.try_get("theirWalkId")?.string()?;
                 let duration_sec = ctx.args.try_get("durationSec")?.i64()? as i32;
@@ -1857,9 +1812,7 @@ fn update_encounter_duration_field(state: Arc<AppState>) -> Field {
                 let their_walk_id = Uuid::parse_str(their_walk_id_str)
                     .map_err(|_| async_graphql::Error::new("Invalid theirWalkId"))?;
 
-                let user = user_service::get_or_create_user(&state.db, &cognito_sub)
-                    .await
-                    .map_err(AppError::into_graphql_error)?;
+                let user = auth_helpers::resolve_user(&ctx, &state).await?;
 
                 // Check calling user's own encounter_detection_enabled
                 if !user.encounter_detection_enabled {
@@ -1916,12 +1869,9 @@ fn update_encounter_detection_field(state: Arc<AppState>) -> Field {
                 use crate::entities::users;
                 use sea_orm::{ActiveModelTrait, Set};
 
-                let cognito_sub = auth::require_auth(&ctx)?;
                 let enabled = ctx.args.try_get("enabled")?.boolean()?;
 
-                let user = user_service::get_or_create_user(&state.db, &cognito_sub)
-                    .await
-                    .map_err(AppError::into_graphql_error)?;
+                let user = auth_helpers::resolve_user(&ctx, &state).await?;
 
                 let mut active: users::ActiveModel = user.into();
                 active.encounter_detection_enabled = Set(enabled);
@@ -1947,7 +1897,6 @@ fn record_walk_event_field(state: Arc<AppState>) -> Field {
         move |ctx| {
             let state = state.clone();
             FieldFuture::new(async move {
-                let cognito_sub = auth::require_auth(&ctx)?;
                 let input = ctx.args.try_get("input")?.object()?;
 
                 let walk_id_str = input.try_get("walkId")?.string()?;
@@ -1975,9 +1924,7 @@ fn record_walk_event_field(state: Arc<AppState>) -> Field {
                     .and_then(|v| v.string().ok())
                     .map(|s| s.to_string());
 
-                let user = user_service::get_or_create_user(&state.db, &cognito_sub)
-                    .await
-                    .map_err(AppError::into_graphql_error)?;
+                let user = auth_helpers::resolve_user(&ctx, &state).await?;
 
                 let service_input = walk_event_service::RecordEventInput {
                     dog_id,
@@ -2010,19 +1957,12 @@ fn generate_walk_event_photo_upload_url_field(state: Arc<AppState>) -> Field {
         move |ctx| {
             let state = state.clone();
             FieldFuture::new(async move {
-                let cognito_sub = auth::require_auth(&ctx)?;
                 let walk_id_str = ctx.args.try_get("walkId")?.string()?;
                 let walk_id = Uuid::parse_str(walk_id_str)
                     .map_err(|_| async_graphql::Error::new("Invalid walk ID"))?;
                 let content_type = ctx.args.try_get("contentType")?.string()?.to_string();
 
-                let user = user_service::get_or_create_user(&state.db, &cognito_sub)
-                    .await
-                    .map_err(AppError::into_graphql_error)?;
-
-                walk_event_service::require_walk_access(&state.db, walk_id, user.id)
-                    .await
-                    .map_err(AppError::into_graphql_error)?;
+                auth_helpers::resolve_user_and_walk(&ctx, &state, walk_id).await?;
 
                 let presigned = s3_service::generate_walk_event_photo_upload_url(
                     &state.s3,

--- a/apps/api/src/graphql/custom_queries.rs
+++ b/apps/api/src/graphql/custom_queries.rs
@@ -1,10 +1,9 @@
 use super::auth_helpers;
 use super::custom_mutations::{DogOutput, UserOutput, WalkOutput};
-use crate::auth;
 use crate::error::AppError;
 use crate::services::{
-    dog_member_service, dog_service, encounter_service, friendship_service, user_service,
-    walk_points_service, walk_service,
+    dog_member_service, dog_service, encounter_service, friendship_service, walk_points_service,
+    walk_service,
 };
 use crate::AppState;
 use async_graphql::dynamic::{Field, FieldFuture, FieldValue, InputValue, Object, TypeRef};
@@ -362,18 +361,11 @@ fn dog_field(state: Arc<AppState>) -> Field {
     Field::new("dog", TypeRef::named("DogOutput"), move |ctx| {
         let state = state.clone();
         FieldFuture::new(async move {
-            let cognito_sub = auth::require_auth(&ctx)?;
             let dog_id_str = ctx.args.try_get("id")?.string()?;
             let dog_id = Uuid::parse_str(dog_id_str)
                 .map_err(|_| async_graphql::Error::new("Invalid dog ID"))?;
 
-            let user = user_service::get_or_create_user(&state.db, &cognito_sub)
-                .await
-                .map_err(AppError::into_graphql_error)?;
-
-            dog_member_service::require_dog_member(&state.db, dog_id, user.id)
-                .await
-                .map_err(AppError::into_graphql_error)?;
+            auth_helpers::resolve_user_and_dog(&ctx, &state, dog_id).await?;
 
             let dog = dog_service::get_dog_by_id(&state.db, dog_id)
                 .await
@@ -392,7 +384,6 @@ fn my_walks_field(state: Arc<AppState>) -> Field {
         move |ctx| {
             let state = state.clone();
             FieldFuture::new(async move {
-                let cognito_sub = auth::require_auth(&ctx)?;
                 let limit = ctx
                     .args
                     .get("limit")
@@ -403,9 +394,7 @@ fn my_walks_field(state: Arc<AppState>) -> Field {
                     .get("offset")
                     .and_then(|v| v.i64().ok())
                     .map(|v| v as u64);
-                let user = user_service::get_or_create_user(&state.db, &cognito_sub)
-                    .await
-                    .map_err(AppError::into_graphql_error)?;
+                let user = auth_helpers::resolve_user(&ctx, &state).await?;
                 let walks = walk_service::get_walks_for_user(&state.db, user.id, limit, offset)
                     .await
                     .map_err(AppError::into_graphql_error)?;
@@ -425,10 +414,7 @@ fn me_field(state: Arc<AppState>) -> Field {
     Field::new("me", TypeRef::named_nn("UserOutput"), move |ctx| {
         let state = state.clone();
         FieldFuture::new(async move {
-            let cognito_sub = auth::require_auth(&ctx)?;
-            let user = user_service::get_or_create_user(&state.db, &cognito_sub)
-                .await
-                .map_err(AppError::into_graphql_error)?;
+            let user = auth_helpers::resolve_user(&ctx, &state).await?;
             Ok(Some(FieldValue::owned_any(UserOutput::from(user))))
         })
     })
@@ -438,17 +424,11 @@ fn dog_walk_stats_field(state: Arc<AppState>) -> Field {
     Field::new("dogWalkStats", TypeRef::named_nn("WalkStats"), move |ctx| {
         let state = state.clone();
         FieldFuture::new(async move {
-            let cognito_sub = auth::require_auth(&ctx)?;
             let dog_id_str = ctx.args.try_get("dogId")?.string()?;
             let dog_id = Uuid::parse_str(dog_id_str)
                 .map_err(|_| async_graphql::Error::new("Invalid dog ID"))?;
 
-            let user = user_service::get_or_create_user(&state.db, &cognito_sub)
-                .await
-                .map_err(AppError::into_graphql_error)?;
-            dog_member_service::require_dog_member(&state.db, dog_id, user.id)
-                .await
-                .map_err(AppError::into_graphql_error)?;
+            auth_helpers::resolve_user_and_dog(&ctx, &state, dog_id).await?;
 
             let period = ctx.args.try_get("period")?.string()?;
             let stats = walk_service::get_walk_stats(&state.db, dog_id, period)
@@ -503,17 +483,11 @@ fn dog_friends_field(state: Arc<AppState>) -> Field {
         move |ctx| {
             let state = state.clone();
             FieldFuture::new(async move {
-                let cognito_sub = auth::require_auth(&ctx)?;
                 let dog_id_str = ctx.args.try_get("dogId")?.string()?;
                 let dog_id = Uuid::parse_str(dog_id_str)
                     .map_err(|_| async_graphql::Error::new("Invalid dog ID"))?;
 
-                let user = user_service::get_or_create_user(&state.db, &cognito_sub)
-                    .await
-                    .map_err(AppError::into_graphql_error)?;
-                dog_member_service::require_dog_member(&state.db, dog_id, user.id)
-                    .await
-                    .map_err(AppError::into_graphql_error)?;
+                auth_helpers::resolve_user_and_dog(&ctx, &state, dog_id).await?;
 
                 let friendships = friendship_service::get_friends_for_dog(&state.db, dog_id)
                     .await
@@ -537,7 +511,6 @@ fn dog_encounters_field(state: Arc<AppState>) -> Field {
         move |ctx| {
             let state = state.clone();
             FieldFuture::new(async move {
-                let cognito_sub = auth::require_auth(&ctx)?;
                 let dog_id_str = ctx.args.try_get("dogId")?.string()?;
                 let dog_id = Uuid::parse_str(dog_id_str)
                     .map_err(|_| async_graphql::Error::new("Invalid dog ID"))?;
@@ -552,12 +525,7 @@ fn dog_encounters_field(state: Arc<AppState>) -> Field {
                     .and_then(|v| v.i64().ok())
                     .map(|v| v as u64);
 
-                let user = user_service::get_or_create_user(&state.db, &cognito_sub)
-                    .await
-                    .map_err(AppError::into_graphql_error)?;
-                dog_member_service::require_dog_member(&state.db, dog_id, user.id)
-                    .await
-                    .map_err(AppError::into_graphql_error)?;
+                auth_helpers::resolve_user_and_dog(&ctx, &state, dog_id).await?;
 
                 let encounters =
                     encounter_service::get_encounters_for_dog(&state.db, dog_id, limit, offset)
@@ -584,7 +552,6 @@ fn friendship_field(state: Arc<AppState>) -> Field {
         move |ctx| {
             let state = state.clone();
             FieldFuture::new(async move {
-                let cognito_sub = auth::require_auth(&ctx)?;
                 let dog_id_1_str = ctx.args.try_get("dogId1")?.string()?;
                 let dog_id_2_str = ctx.args.try_get("dogId2")?.string()?;
                 let dog_id_1 = Uuid::parse_str(dog_id_1_str)
@@ -592,9 +559,7 @@ fn friendship_field(state: Arc<AppState>) -> Field {
                 let dog_id_2 = Uuid::parse_str(dog_id_2_str)
                     .map_err(|_| async_graphql::Error::new("Invalid dogId2"))?;
 
-                let user = user_service::get_or_create_user(&state.db, &cognito_sub)
-                    .await
-                    .map_err(AppError::into_graphql_error)?;
+                let user = auth_helpers::resolve_user(&ctx, &state).await?;
 
                 // User must be a member of at least one of the two dogs
                 let is_member_of_1 =

--- a/apps/api/src/graphql/custom_queries.rs
+++ b/apps/api/src/graphql/custom_queries.rs
@@ -1,3 +1,4 @@
+use super::auth_helpers;
 use super::custom_mutations::{DogOutput, UserOutput, WalkOutput};
 use crate::auth;
 use crate::error::AppError;
@@ -337,41 +338,14 @@ fn walk_by_id_field(state: Arc<AppState>) -> Field {
     Field::new("walk", TypeRef::named("WalkOutput"), move |ctx| {
         let state = state.clone();
         FieldFuture::new(async move {
-            use crate::entities::{
-                walk_dogs::{self, Entity as WalkDogEntity},
-                walks::Entity as WalkEntity,
-            };
-            use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+            use crate::entities::walks::Entity as WalkEntity;
+            use sea_orm::EntityTrait;
 
-            let cognito_sub = auth::require_auth(&ctx)?;
             let walk_id_str = ctx.args.try_get("id")?.string()?;
             let walk_id = Uuid::parse_str(walk_id_str)
                 .map_err(|_| async_graphql::Error::new("Invalid walk ID"))?;
 
-            let user = user_service::get_or_create_user(&state.db, &cognito_sub)
-                .await
-                .map_err(AppError::into_graphql_error)?;
-
-            // Check authorization via walk_dogs -> dog_members
-            let walk_dog_rows = WalkDogEntity::find()
-                .filter(walk_dogs::Column::WalkId.eq(walk_id))
-                .all(&state.db)
-                .await
-                .map_err(|e| AppError::Database(e).into_graphql_error())?;
-
-            let mut authorized = false;
-            for wd in &walk_dog_rows {
-                if dog_member_service::require_dog_member(&state.db, wd.dog_id, user.id)
-                    .await
-                    .is_ok()
-                {
-                    authorized = true;
-                    break;
-                }
-            }
-            if !authorized {
-                return Err(async_graphql::Error::new("Walk not found"));
-            }
+            auth_helpers::resolve_user_and_walk(&ctx, &state, walk_id).await?;
 
             let walk = WalkEntity::find_by_id(walk_id)
                 .one(&state.db)
@@ -497,38 +471,11 @@ fn walk_points_field(state: Arc<AppState>) -> Field {
         move |ctx| {
             let state = state.clone();
             FieldFuture::new(async move {
-                use crate::entities::walk_dogs::{self, Entity as WalkDogEntity};
-                use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
-
-                let cognito_sub = auth::require_auth(&ctx)?;
                 let walk_id_str = ctx.args.try_get("walkId")?.string()?;
                 let walk_id = Uuid::parse_str(walk_id_str)
                     .map_err(|_| async_graphql::Error::new("Invalid walk ID"))?;
 
-                let user = user_service::get_or_create_user(&state.db, &cognito_sub)
-                    .await
-                    .map_err(AppError::into_graphql_error)?;
-
-                // Check authorization via walk_dogs -> dog_members
-                let walk_dog_rows = WalkDogEntity::find()
-                    .filter(walk_dogs::Column::WalkId.eq(walk_id))
-                    .all(&state.db)
-                    .await
-                    .map_err(|e| AppError::Database(e).into_graphql_error())?;
-
-                let mut authorized = false;
-                for wd in &walk_dog_rows {
-                    if dog_member_service::require_dog_member(&state.db, wd.dog_id, user.id)
-                        .await
-                        .is_ok()
-                    {
-                        authorized = true;
-                        break;
-                    }
-                }
-                if !authorized {
-                    return Err(async_graphql::Error::new("Walk not found"));
-                }
+                auth_helpers::resolve_user_and_walk(&ctx, &state, walk_id).await?;
 
                 let points = walk_points_service::get_walk_points(
                     &state.dynamo,

--- a/apps/api/src/graphql/mod.rs
+++ b/apps/api/src/graphql/mod.rs
@@ -3,6 +3,7 @@ use async_graphql::dynamic::{Enum, EnumItem};
 use seaography::BuilderContext;
 use std::sync::Arc;
 
+pub mod auth_helpers;
 pub mod custom_mutations;
 pub mod custom_queries;
 pub mod input;

--- a/tasks/refactor/api/progress.md
+++ b/tasks/refactor/api/progress.md
@@ -7,7 +7,7 @@
 - [x] Phase 3: 純粋関数抽出 (normalize_dog_pair / parse_birth_date_input) — 2026-04-15 — RED: a9f3491/93b3339 / GREEN: 8818ea1/251109e
 - [x] Phase 4: user_service upsert 統合 + duplicate key 文字列判定撲滅 (SeaORM on_conflict) — 2026-04-15 — RED: 92c3a6b / GREEN: ca059a5 — FIX: bf6484b (test_authorization runtime bug) — HARDEN: 8160a5a (proper DbErr propagation)
 - [x] Phase 5: Cognito エラー ProvideErrorMetadata::code() 化 + smithy mocks unit test — 2026-04-15 — RED: ee4b315 / GREEN: e129a62
-- [ ] Phase 6: walk_event_service 認可ハブ化 + auth_helpers 導入 (依存: Phase 4)
+- [x] Phase 6: walk_event_service 認可ハブ化 + auth_helpers 導入 (依存: Phase 4) — 2026-04-15 — RED→GREEN: 1c9360d / GREEN: e295f75, 888b2b0, cf8ce84
 - [ ] Phase 7: encounter_service 責務集約 + verify_encounter_detection 新設 (依存: Phase 6)
 - [ ] Phase 8: encounter N+M クエリ解消 JOIN 一括取得 (依存: Phase 7)
 - [ ] Phase 9: GraphQL field-wise バリデーションエラー


### PR DESCRIPTION
## Summary

`apps/api/` リファクタ Phase 6 実装。`graphql/auth_helpers.rs` を新設し、resolver に散在していた認可3行イディオム (`require_auth → get_or_create_user → require_dog_member`) を1行呼び出しに集約。`walk_event_service::require_walk_access` を walk 系 query の認可ハブとして統合。

## 変更

### 新規
- `apps/api/src/graphql/auth_helpers.rs`
  - `resolve_user(ctx, state) -> Result<UserModel>` — require_auth + get_or_create_user
  - `resolve_user_and_dog(ctx, state, dog_id)` — +require_dog_member
  - `resolve_user_and_walk(ctx, state, walk_id)` — +require_walk_access

### 置換
- `custom_queries::walk_by_id_field` / `walk_points_field` → `resolve_user_and_walk`
- `custom_queries.rs` / `custom_mutations.rs` の認可3行イディオム多数 → `resolve_user` / `resolve_user_and_dog`
- `generate_dog_photo_upload_url_field` thin 化

## 維持した例外 (意図的)

- `add_walk_points_field`: walk_access より厳格な owner-only チェックのため `resolve_user` + 手動所有権検証を保持
- `friendship_field`: 「2犬のどちらかのメンバー」独自ロジックのため `resolve_user` + require_dog_member × 2
- `update_profile_field`: cognito_sub を直接 AWS SDK に渡すため `auth::require_auth` 直接呼び出しを維持

## セマンティクス改善

`walk_by_id_field` / `walk_points_field` が walk missing と auth failure を区別可能に (以前は両方 "Walk not found")。`NotFound` vs `Unauthorized` が正確に返る。

## Test plan

- [x] `cargo test --lib`: 45+ PASS
- [x] `test_authorization`: PASS
- [x] `test_walk`: PASS
- [x] `test_dog`: PASS
- [x] `test_dog_member`: PASS
- [x] `cargo clippy -- -D warnings`: 違反なし
- [x] `grep -A2 require_auth apps/api/src/graphql/*.rs | grep -c get_or_create_user` = 2 (helper 内部のみ、完了条件 "3 以下" クリア)

## Commits

- \`1c9360d\` test(api): add auth_helpers unit tests (structural guards)
- \`e295f75\` feat(api): replace walk_by_id/walk_points auth with resolve_user_and_walk
- \`888b2b0\` feat(api): replace 3-line auth idiom in custom_queries.rs
- \`cf8ce84\` feat(api): replace 3-line auth idiom in custom_mutations.rs
- \`24f3d3e\` chore: mark Phase 6 complete in progress.md

## 依存

- Phase 4 (upsert_user) — PR #87 で merged 済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)