### PR TITLE
refactor(api): Phase 7 — encounter_service consolidation with verify_encounter_detection

### DIFF
--- a/apps/api/src/graphql/custom_mutations.rs
+++ b/apps/api/src/graphql/custom_mutations.rs
@@ -1749,64 +1749,40 @@ fn record_encounter_field(state: Arc<AppState>) -> Field {
                     dog_members::{self, Entity as DogMemberEntity},
                     users::Entity as UserEntity,
                     walk_dogs::{self, Entity as WalkDogEntity},
-                    walks::Entity as WalkEntity,
                 };
                 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 
+                // 1. Parse input
                 let cognito_sub = auth::require_auth(&ctx)?;
-                let my_walk_id_str = ctx.args.try_get("myWalkId")?.string()?;
-                let their_walk_id_str = ctx.args.try_get("theirWalkId")?.string()?;
-                let my_walk_id = Uuid::parse_str(my_walk_id_str)
+                let my_walk_id = Uuid::parse_str(ctx.args.try_get("myWalkId")?.string()?)
                     .map_err(|_| async_graphql::Error::new("Invalid myWalkId"))?;
-                let their_walk_id = Uuid::parse_str(their_walk_id_str)
+                let their_walk_id = Uuid::parse_str(ctx.args.try_get("theirWalkId")?.string()?)
                     .map_err(|_| async_graphql::Error::new("Invalid theirWalkId"))?;
 
+                // 2. Resolve user
                 let user = user_service::get_or_create_user(&state.db, &cognito_sub)
                     .await
                     .map_err(AppError::into_graphql_error)?;
 
-                // Verify myWalkId belongs to the current user
-                let my_walk = WalkEntity::find_by_id(my_walk_id)
-                    .one(&state.db)
-                    .await
-                    .map_err(|e| AppError::Database(e).into_graphql_error())?
-                    .ok_or_else(|| async_graphql::Error::new("Walk not found"))?;
-                if my_walk.user_id != user.id {
-                    return Err(
-                        AppError::Unauthorized("Walk does not belong to user".to_string())
-                            .into_graphql_error(),
-                    );
-                }
-
-                // Check calling user's own encounter_detection_enabled
-                if !user.encounter_detection_enabled {
-                    return Err(AppError::Unauthorized(
-                        "Encounter detection is disabled for your account".to_string(),
-                    )
-                    .into_graphql_error());
-                }
-
                 // Check encounter_detection_enabled for all users of theirWalk
+                // (Phase 8 will consolidate this into the service layer)
                 let their_walk_dogs = WalkDogEntity::find()
                     .filter(walk_dogs::Column::WalkId.eq(their_walk_id))
                     .all(&state.db)
                     .await
                     .map_err(|e| AppError::Database(e).into_graphql_error())?;
-
                 for wd in &their_walk_dogs {
-                    // Find all dog_members for this dog
                     let members = DogMemberEntity::find()
                         .filter(dog_members::Column::DogId.eq(wd.dog_id))
                         .all(&state.db)
                         .await
                         .map_err(|e| AppError::Database(e).into_graphql_error())?;
-
                     for member in &members {
-                        let u = UserEntity::find_by_id(member.user_id)
+                        if let Some(u) = UserEntity::find_by_id(member.user_id)
                             .one(&state.db)
                             .await
-                            .map_err(|e| AppError::Database(e).into_graphql_error())?;
-                        if let Some(u) = u {
+                            .map_err(|e| AppError::Database(e).into_graphql_error())?
+                        {
                             if !u.encounter_detection_enabled {
                                 return Err(AppError::Unauthorized(
                                     "Encounter detection is disabled for the other user"
@@ -1818,11 +1794,18 @@ fn record_encounter_field(state: Arc<AppState>) -> Field {
                     }
                 }
 
-                let encounters =
-                    encounter_service::record_encounter(&state.db, my_walk_id, their_walk_id, 30)
-                        .await
-                        .map_err(AppError::into_graphql_error)?;
+                // 3. Delegate to service (ownership + caller detection check inside)
+                let encounters = encounter_service::record_encounter(
+                    &state.db,
+                    my_walk_id,
+                    their_walk_id,
+                    30,
+                    user.id,
+                )
+                .await
+                .map_err(AppError::into_graphql_error)?;
 
+                // 4. Convert output
                 let values: Vec<FieldValue> = encounters
                     .into_iter()
                     .map(|e| FieldValue::owned_any(EncounterOutput::from(e)))
@@ -1845,52 +1828,31 @@ fn update_encounter_duration_field(state: Arc<AppState>) -> Field {
         move |ctx| {
             let state = state.clone();
             FieldFuture::new(async move {
-                use crate::entities::walks::Entity as WalkEntity;
-                use sea_orm::EntityTrait;
-
+                // 1. Parse input
                 let cognito_sub = auth::require_auth(&ctx)?;
-                let my_walk_id_str = ctx.args.try_get("myWalkId")?.string()?;
-                let their_walk_id_str = ctx.args.try_get("theirWalkId")?.string()?;
-                let duration_sec = ctx.args.try_get("durationSec")?.i64()? as i32;
-                let my_walk_id = Uuid::parse_str(my_walk_id_str)
+                let my_walk_id = Uuid::parse_str(ctx.args.try_get("myWalkId")?.string()?)
                     .map_err(|_| async_graphql::Error::new("Invalid myWalkId"))?;
-                let their_walk_id = Uuid::parse_str(their_walk_id_str)
+                let their_walk_id = Uuid::parse_str(ctx.args.try_get("theirWalkId")?.string()?)
                     .map_err(|_| async_graphql::Error::new("Invalid theirWalkId"))?;
+                let duration_sec = ctx.args.try_get("durationSec")?.i64()? as i32;
 
+                // 2. Resolve user
                 let user = user_service::get_or_create_user(&state.db, &cognito_sub)
                     .await
                     .map_err(AppError::into_graphql_error)?;
 
-                // Check calling user's own encounter_detection_enabled
-                if !user.encounter_detection_enabled {
-                    return Err(AppError::Unauthorized(
-                        "Encounter detection is disabled for your account".to_string(),
-                    )
-                    .into_graphql_error());
-                }
-
-                // Verify myWalkId belongs to the current user
-                let my_walk = WalkEntity::find_by_id(my_walk_id)
-                    .one(&state.db)
-                    .await
-                    .map_err(|e| AppError::Database(e).into_graphql_error())?
-                    .ok_or_else(|| async_graphql::Error::new("Walk not found"))?;
-                if my_walk.user_id != user.id {
-                    return Err(
-                        AppError::Unauthorized("Walk does not belong to user".to_string())
-                            .into_graphql_error(),
-                    );
-                }
-
+                // 3. Delegate to service (ownership + detection check inside)
                 let result = encounter_service::update_encounter_duration(
                     &state.db,
                     my_walk_id,
                     their_walk_id,
                     duration_sec,
+                    user.id,
                 )
                 .await
                 .map_err(AppError::into_graphql_error)?;
 
+                // 4. Convert output
                 Ok(Some(FieldValue::value(result)))
             })
         },

--- a/apps/api/src/services/encounter_service.rs
+++ b/apps/api/src/services/encounter_service.rs
@@ -208,6 +208,32 @@ pub async fn get_encounters_for_dog(
 mod tests {
     use super::*;
 
+    /// Static assertion: record_encounter accepts acting_user_id: Uuid.
+    /// Fails to compile until the signature is updated.
+    #[allow(dead_code)]
+    async fn record_encounter_accepts_acting_user_id(
+        db: &sea_orm::DatabaseConnection,
+        my_walk_id: Uuid,
+        their_walk_id: Uuid,
+        acting_user_id: Uuid,
+    ) {
+        let _: Result<Vec<crate::entities::encounters::Model>, AppError> =
+            record_encounter(db, my_walk_id, their_walk_id, 30, acting_user_id).await;
+    }
+
+    /// Static assertion: update_encounter_duration accepts acting_user_id: Uuid.
+    /// Fails to compile until the signature is updated.
+    #[allow(dead_code)]
+    async fn update_encounter_duration_accepts_acting_user_id(
+        db: &sea_orm::DatabaseConnection,
+        my_walk_id: Uuid,
+        their_walk_id: Uuid,
+        acting_user_id: Uuid,
+    ) {
+        let _: Result<bool, AppError> =
+            update_encounter_duration(db, my_walk_id, their_walk_id, 60, acting_user_id).await;
+    }
+
     #[test]
     fn normalize_dog_pair_returns_ordered_pair_when_a_less_than_b() {
         let a = Uuid::parse_str("00000000-0000-0000-0000-000000000001").unwrap();

--- a/apps/api/src/services/encounter_service.rs
+++ b/apps/api/src/services/encounter_service.rs
@@ -5,7 +5,7 @@ use sea_orm::{
 };
 use uuid::Uuid;
 
-use super::friendship_service;
+use super::{friendship_service, walk_event_service};
 use crate::entities::{
     encounters::{
         self, ActiveModel as EncounterActiveModel, Entity as EncounterEntity,
@@ -29,12 +29,19 @@ fn normalize_dog_pair(a: Uuid, b: Uuid) -> Option<(Uuid, Uuid)> {
 
 /// Record encounters between all dog pairs from two walks.
 /// Creates or updates `encounters` and `friendships` rows.
+///
+/// Authorization: `acting_user_id` must own `my_walk_id` and have
+/// `encounter_detection_enabled = true` (verified via `verify_encounter_detection`).
 pub async fn record_encounter(
     db: &sea_orm::DatabaseConnection,
     my_walk_id: Uuid,
     their_walk_id: Uuid,
     duration_sec: i32,
+    acting_user_id: Uuid,
 ) -> Result<Vec<EncounterModel>, AppError> {
+    // Verify walk ownership + encounter_detection_enabled for the acting user
+    walk_event_service::verify_encounter_detection(db, my_walk_id, acting_user_id).await?;
+
     // Fetch all dog IDs in each walk
     let my_dog_ids: Vec<Uuid> = WalkDogEntity::find()
         .filter(walk_dogs::Column::WalkId.eq(my_walk_id))
@@ -125,12 +132,19 @@ pub async fn record_encounter(
 }
 
 /// Update the duration of an existing encounter (called when BLE signal ends).
+///
+/// Authorization: `acting_user_id` must own `my_walk_id` and have
+/// `encounter_detection_enabled = true` (verified via `verify_encounter_detection`).
 pub async fn update_encounter_duration(
     db: &sea_orm::DatabaseConnection,
     my_walk_id: Uuid,
     their_walk_id: Uuid,
     duration_sec: i32,
+    acting_user_id: Uuid,
 ) -> Result<bool, AppError> {
+    // Verify walk ownership + encounter_detection_enabled for the acting user
+    walk_event_service::verify_encounter_detection(db, my_walk_id, acting_user_id).await?;
+
     let their_dog_ids: Vec<Uuid> = WalkDogEntity::find()
         .filter(walk_dogs::Column::WalkId.eq(their_walk_id))
         .select_only()

--- a/apps/api/src/services/walk_event_service.rs
+++ b/apps/api/src/services/walk_event_service.rs
@@ -5,6 +5,7 @@ use std::str::FromStr;
 use uuid::Uuid;
 
 use crate::entities::{
+    users::Entity as UserEntity,
     walk_dogs::{self, Entity as WalkDogEntity},
     walk_events::{
         ActiveModel as WalkEventActiveModel, Column as WalkEventColumn, Entity as WalkEventEntity,
@@ -95,6 +96,43 @@ pub async fn require_walk_access(
     Err(AppError::Unauthorized(
         "Not authorized to record events for this walk".to_string(),
     ))
+}
+
+/// Verify that:
+/// 1. The walk exists and belongs to `user_id`.
+/// 2. The user has `encounter_detection_enabled = true`.
+///
+/// Used by encounter_service to centralize encounter authorization checks.
+pub async fn verify_encounter_detection(
+    db: &sea_orm::DatabaseConnection,
+    walk_id: Uuid,
+    user_id: Uuid,
+) -> Result<(), AppError> {
+    // 1. Walk must exist and belong to user
+    let walk = WalkEntity::find_by_id(walk_id)
+        .one(db)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("Walk {} not found", walk_id)))?;
+
+    if walk.user_id != user_id {
+        return Err(AppError::Unauthorized(
+            "Walk does not belong to user".to_string(),
+        ));
+    }
+
+    // 2. User must have encounter detection enabled
+    let user = UserEntity::find_by_id(user_id)
+        .one(db)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("User {} not found", user_id)))?;
+
+    if !user.encounter_detection_enabled {
+        return Err(AppError::Unauthorized(
+            "Encounter detection is disabled for your account".to_string(),
+        ));
+    }
+
+    Ok(())
 }
 
 /// Record a walk event (pee / poo / photo).

--- a/apps/api/src/services/walk_event_service.rs
+++ b/apps/api/src/services/walk_event_service.rs
@@ -163,6 +163,17 @@ pub async fn list_events(
 mod tests {
     use super::*;
 
+    /// Static assertion: verify_encounter_detection has the expected signature.
+    /// Fails to compile until the function is implemented.
+    #[allow(dead_code)]
+    async fn verify_encounter_detection_signature_check(
+        db: &sea_orm::DatabaseConnection,
+        walk_id: uuid::Uuid,
+        user_id: uuid::Uuid,
+    ) {
+        let _: Result<(), AppError> = verify_encounter_detection(db, walk_id, user_id).await;
+    }
+
     #[test]
     fn walk_event_type_from_str_pee() {
         let t: WalkEventType = "pee".parse().unwrap();

--- a/tasks/refactor/api/progress.md
+++ b/tasks/refactor/api/progress.md
@@ -8,7 +8,7 @@
 - [x] Phase 4: user_service upsert 統合 + duplicate key 文字列判定撲滅 (SeaORM on_conflict) — 2026-04-15 — RED: 92c3a6b / GREEN: ca059a5 — FIX: bf6484b (test_authorization runtime bug) — HARDEN: 8160a5a (proper DbErr propagation)
 - [x] Phase 5: Cognito エラー ProvideErrorMetadata::code() 化 + smithy mocks unit test — 2026-04-15 — RED: ee4b315 / GREEN: e129a62
 - [ ] Phase 6: walk_event_service 認可ハブ化 + auth_helpers 導入 (依存: Phase 4)
-- [ ] Phase 7: encounter_service 責務集約 + verify_encounter_detection 新設 (依存: Phase 6)
+- [x] Phase 7: encounter_service 責務集約 + verify_encounter_detection 新設 — 2026-04-15 — RED: 9ca5399 / GREEN: 6e7dd96
 - [ ] Phase 8: encounter N+M クエリ解消 JOIN 一括取得 (依存: Phase 7)
 - [ ] Phase 9: GraphQL field-wise バリデーションエラー
 - [ ] Phase 10: TEST_MODE → trait JwtVerifier 抽象化


### PR DESCRIPTION
## Summary

`apps/api/` リファクタ Phase 7 実装。`walk_event_service::verify_encounter_detection` を認可ハブに新設し、encounter mutation の walk 所有権 + `encounter_detection_enabled` 検証を service 層に集約。resolver は thin 化。

## 変更

### 新規 service 関数
- `walk_event_service::verify_encounter_detection(db, walk_id, user_id) -> Result<(), AppError>`
  - walk 取得 + `user_id` 所有権検証 + 該当ユーザーの `encounter_detection_enabled` 検証を1関数に集約

### シグネチャ変更
- `encounter_service::record_encounter` に `acting_user_id: Uuid` を追加、内部で `verify_encounter_detection` 呼び出し
- `encounter_service::update_encounter_duration` に `acting_user_id: Uuid` を追加、同上

### resolver thin 化
- `custom_mutations::record_encounter_field` / `update_encounter_duration_field` を「入力parse → resolve_user → encounter_service.xxx → 出力変換」の3段に縮小

## スコープ外 (Phase 8 へ持ち越し)

- encounter の **相手側 (counterparty) walk** の `encounter_detection_enabled` 検証は N+M クエリ解消と同時に JOIN 化するため Phase 8 で扱う
- 現状 `custom_mutations.rs:1767-1786` にループベースの counterparty 検証が残存 (既存動作維持)

## Test plan

- [x] `cargo test --test test_encounter -- --test-threads=1`: 6/6 PASS
- [x] `cargo test --test test_encounter_flow -- --test-threads=1`: 1/1 PASS
- [x] `encounter_detection_enabled` acting user 検証ロジックの service 層集約確認 (walk_event_service.rs:129)

## Commits

- \`9ca5399\` test(api): add RED tests for verify_encounter_detection + acting_user_id params [RED]
- \`6e7dd96\` feat(api): add verify_encounter_detection + acting_user_id params + slim resolvers [GREEN]
- \`514e892\` chore: mark Phase 7 complete in progress.md

## 依存

- Phase 6 (`resolve_user` / `auth_helpers`) — PR #90 で merged 済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)