### PR TITLE
refactor(api): Phase 7 — encounter_service consolidation with verify_encounter_detection

### DIFF
--- a/apps/api/src/graphql/custom_mutations.rs
+++ b/apps/api/src/graphql/custom_mutations.rs
@@ -1708,10 +1708,10 @@ fn record_encounter_field(state: Arc<AppState>) -> Field {
                     dog_members::{self, Entity as DogMemberEntity},
                     users::Entity as UserEntity,
                     walk_dogs::{self, Entity as WalkDogEntity},
-                    walks::Entity as WalkEntity,
                 };
                 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 
+                // Input parse
                 let my_walk_id_str = ctx.args.try_get("myWalkId")?.string()?;
                 let their_walk_id_str = ctx.args.try_get("theirWalkId")?.string()?;
                 let my_walk_id = Uuid::parse_str(my_walk_id_str)
@@ -1719,30 +1719,11 @@ fn record_encounter_field(state: Arc<AppState>) -> Field {
                 let their_walk_id = Uuid::parse_str(their_walk_id_str)
                     .map_err(|_| async_graphql::Error::new("Invalid theirWalkId"))?;
 
+                // Auth (includes walk ownership + encounter detection check via service)
                 let user = auth_helpers::resolve_user(&ctx, &state).await?;
 
-                // Verify myWalkId belongs to the current user
-                let my_walk = WalkEntity::find_by_id(my_walk_id)
-                    .one(&state.db)
-                    .await
-                    .map_err(|e| AppError::Database(e).into_graphql_error())?
-                    .ok_or_else(|| async_graphql::Error::new("Walk not found"))?;
-                if my_walk.user_id != user.id {
-                    return Err(
-                        AppError::Unauthorized("Walk does not belong to user".to_string())
-                            .into_graphql_error(),
-                    );
-                }
-
-                // Check calling user's own encounter_detection_enabled
-                if !user.encounter_detection_enabled {
-                    return Err(AppError::Unauthorized(
-                        "Encounter detection is disabled for your account".to_string(),
-                    )
-                    .into_graphql_error());
-                }
-
                 // Check encounter_detection_enabled for all users of theirWalk
+                // (Phase 8: will be moved into service with JOIN optimization)
                 let their_walk_dogs = WalkDogEntity::find()
                     .filter(walk_dogs::Column::WalkId.eq(their_walk_id))
                     .all(&state.db)
@@ -1750,7 +1731,6 @@ fn record_encounter_field(state: Arc<AppState>) -> Field {
                     .map_err(|e| AppError::Database(e).into_graphql_error())?;
 
                 for wd in &their_walk_dogs {
-                    // Find all dog_members for this dog
                     let members = DogMemberEntity::find()
                         .filter(dog_members::Column::DogId.eq(wd.dog_id))
                         .all(&state.db)
@@ -1774,11 +1754,18 @@ fn record_encounter_field(state: Arc<AppState>) -> Field {
                     }
                 }
 
-                let encounters =
-                    encounter_service::record_encounter(&state.db, my_walk_id, their_walk_id, 30)
-                        .await
-                        .map_err(AppError::into_graphql_error)?;
+                // Service call (authorization delegated to service)
+                let encounters = encounter_service::record_encounter(
+                    &state.db,
+                    my_walk_id,
+                    their_walk_id,
+                    30,
+                    user.id,
+                )
+                .await
+                .map_err(AppError::into_graphql_error)?;
 
+                // Output
                 let values: Vec<FieldValue> = encounters
                     .into_iter()
                     .map(|e| FieldValue::owned_any(EncounterOutput::from(e)))
@@ -1801,9 +1788,7 @@ fn update_encounter_duration_field(state: Arc<AppState>) -> Field {
         move |ctx| {
             let state = state.clone();
             FieldFuture::new(async move {
-                use crate::entities::walks::Entity as WalkEntity;
-                use sea_orm::EntityTrait;
-
+                // Input parse
                 let my_walk_id_str = ctx.args.try_get("myWalkId")?.string()?;
                 let their_walk_id_str = ctx.args.try_get("theirWalkId")?.string()?;
                 let duration_sec = ctx.args.try_get("durationSec")?.i64()? as i32;
@@ -1812,38 +1797,21 @@ fn update_encounter_duration_field(state: Arc<AppState>) -> Field {
                 let their_walk_id = Uuid::parse_str(their_walk_id_str)
                     .map_err(|_| async_graphql::Error::new("Invalid theirWalkId"))?;
 
+                // Auth
                 let user = auth_helpers::resolve_user(&ctx, &state).await?;
 
-                // Check calling user's own encounter_detection_enabled
-                if !user.encounter_detection_enabled {
-                    return Err(AppError::Unauthorized(
-                        "Encounter detection is disabled for your account".to_string(),
-                    )
-                    .into_graphql_error());
-                }
-
-                // Verify myWalkId belongs to the current user
-                let my_walk = WalkEntity::find_by_id(my_walk_id)
-                    .one(&state.db)
-                    .await
-                    .map_err(|e| AppError::Database(e).into_graphql_error())?
-                    .ok_or_else(|| async_graphql::Error::new("Walk not found"))?;
-                if my_walk.user_id != user.id {
-                    return Err(
-                        AppError::Unauthorized("Walk does not belong to user".to_string())
-                            .into_graphql_error(),
-                    );
-                }
-
+                // Service call (authorization delegated to service)
                 let result = encounter_service::update_encounter_duration(
                     &state.db,
                     my_walk_id,
                     their_walk_id,
                     duration_sec,
+                    user.id,
                 )
                 .await
                 .map_err(AppError::into_graphql_error)?;
 
+                // Output
                 Ok(Some(FieldValue::value(result)))
             })
         },

--- a/apps/api/src/services/encounter_service.rs
+++ b/apps/api/src/services/encounter_service.rs
@@ -14,6 +14,7 @@ use crate::entities::{
     walk_dogs::{self, Entity as WalkDogEntity},
 };
 use crate::error::AppError;
+use crate::services::walk_event_service;
 
 /// Normalize a dog pair so that `dog_id_1 < dog_id_2` (UUID lexicographic order).
 /// Returns `None` if both IDs are equal (same dog — skip).
@@ -29,12 +30,19 @@ fn normalize_dog_pair(a: Uuid, b: Uuid) -> Option<(Uuid, Uuid)> {
 
 /// Record encounters between all dog pairs from two walks.
 /// Creates or updates `encounters` and `friendships` rows.
+///
+/// Authorization: verifies that `my_walk_id` belongs to `acting_user_id` and
+/// that `acting_user_id` has encounter detection enabled.
 pub async fn record_encounter(
     db: &sea_orm::DatabaseConnection,
     my_walk_id: Uuid,
     their_walk_id: Uuid,
     duration_sec: i32,
+    acting_user_id: Uuid,
 ) -> Result<Vec<EncounterModel>, AppError> {
+    // Verify acting user ownership + encounter detection enabled
+    walk_event_service::verify_encounter_detection(db, my_walk_id, acting_user_id).await?;
+
     // Fetch all dog IDs in each walk
     let my_dog_ids: Vec<Uuid> = WalkDogEntity::find()
         .filter(walk_dogs::Column::WalkId.eq(my_walk_id))
@@ -125,12 +133,18 @@ pub async fn record_encounter(
 }
 
 /// Update the duration of an existing encounter (called when BLE signal ends).
+///
+/// Authorization: verifies that `my_walk_id` belongs to `acting_user_id` and
+/// that `acting_user_id` has encounter detection enabled.
 pub async fn update_encounter_duration(
     db: &sea_orm::DatabaseConnection,
     my_walk_id: Uuid,
     their_walk_id: Uuid,
     duration_sec: i32,
+    acting_user_id: Uuid,
 ) -> Result<bool, AppError> {
+    // Verify acting user ownership + encounter detection enabled
+    walk_event_service::verify_encounter_detection(db, my_walk_id, acting_user_id).await?;
     let their_dog_ids: Vec<Uuid> = WalkDogEntity::find()
         .filter(walk_dogs::Column::WalkId.eq(their_walk_id))
         .select_only()

--- a/apps/api/src/services/encounter_service.rs
+++ b/apps/api/src/services/encounter_service.rs
@@ -230,4 +230,47 @@ mod tests {
         let result = normalize_dog_pair(id, id);
         assert_eq!(result, None);
     }
+
+    /// Static guard: record_encounter must accept acting_user_id parameter.
+    #[test]
+    fn record_encounter_signature_has_acting_user_id() {
+        let src = include_str!("encounter_service.rs");
+        // The pub async fn record_encounter signature must include acting_user_id
+        let fn_start = src
+            .find("pub async fn record_encounter")
+            .expect("record_encounter must exist");
+        let fn_signature_end = src[fn_start..].find('{').unwrap_or(0);
+        let signature = &src[fn_start..fn_start + fn_signature_end];
+        assert!(
+            signature.contains("acting_user_id"),
+            "record_encounter signature must include acting_user_id: Uuid, got: {}",
+            signature
+        );
+    }
+
+    /// Static guard: update_encounter_duration must accept acting_user_id parameter.
+    #[test]
+    fn update_encounter_duration_signature_has_acting_user_id() {
+        let src = include_str!("encounter_service.rs");
+        let fn_start = src
+            .find("pub async fn update_encounter_duration")
+            .expect("update_encounter_duration must exist");
+        let fn_signature_end = src[fn_start..].find('{').unwrap_or(0);
+        let signature = &src[fn_start..fn_start + fn_signature_end];
+        assert!(
+            signature.contains("acting_user_id"),
+            "update_encounter_duration signature must include acting_user_id: Uuid, got: {}",
+            signature
+        );
+    }
+
+    /// Static guard: encounter_service must call verify_encounter_detection.
+    #[test]
+    fn encounter_service_calls_verify_encounter_detection() {
+        let src = include_str!("encounter_service.rs");
+        assert!(
+            src.contains("verify_encounter_detection"),
+            "encounter_service must call walk_event_service::verify_encounter_detection"
+        );
+    }
 }

--- a/apps/api/src/services/walk_event_service.rs
+++ b/apps/api/src/services/walk_event_service.rs
@@ -236,34 +236,4 @@ mod tests {
         }
     }
 
-    /// Static guard: verify_encounter_detection must exist in this module.
-    #[test]
-    fn verify_encounter_detection_exists_in_walk_event_service() {
-        let src = include_str!("walk_event_service.rs");
-        assert!(
-            src.contains("pub async fn verify_encounter_detection"),
-            "verify_encounter_detection must be defined as pub async fn in walk_event_service.rs"
-        );
-    }
-
-    /// Static guard: verify_encounter_detection must check encounter_detection_enabled.
-    #[test]
-    fn verify_encounter_detection_checks_encounter_detection_enabled() {
-        let src = include_str!("walk_event_service.rs");
-        assert!(
-            src.contains("encounter_detection_enabled"),
-            "verify_encounter_detection must check encounter_detection_enabled"
-        );
-    }
-
-    /// Static guard: verify_encounter_detection must check walk ownership (user_id).
-    #[test]
-    fn verify_encounter_detection_checks_walk_ownership() {
-        let src = include_str!("walk_event_service.rs");
-        // The function must verify that the walk belongs to the given user_id
-        assert!(
-            src.contains("user_id") && src.contains("verify_encounter_detection"),
-            "verify_encounter_detection must accept user_id and verify walk ownership"
-        );
-    }
 }

--- a/apps/api/src/services/walk_event_service.rs
+++ b/apps/api/src/services/walk_event_service.rs
@@ -235,5 +235,4 @@ mod tests {
             assert_eq!(back, t);
         }
     }
-
 }

--- a/apps/api/src/services/walk_event_service.rs
+++ b/apps/api/src/services/walk_event_service.rs
@@ -5,6 +5,7 @@ use std::str::FromStr;
 use uuid::Uuid;
 
 use crate::entities::{
+    users::Entity as UserEntity,
     walk_dogs::{self, Entity as WalkDogEntity},
     walk_events::{
         ActiveModel as WalkEventActiveModel, Column as WalkEventColumn, Entity as WalkEventEntity,
@@ -57,6 +58,45 @@ pub struct RecordEventInput {
     pub lng: Option<f64>,
     /// S3 key for photo events; required when event_type == "photo".
     pub photo_key: Option<String>,
+}
+
+/// Verify that encounter detection is allowed for the acting user's walk.
+///
+/// Checks:
+/// 1. The walk exists.
+/// 2. The walk belongs to `user_id` (ownership check).
+/// 3. The user has `encounter_detection_enabled = true`.
+pub async fn verify_encounter_detection(
+    db: &sea_orm::DatabaseConnection,
+    walk_id: Uuid,
+    user_id: Uuid,
+) -> Result<(), AppError> {
+    // 1. Fetch walk
+    let walk = WalkEntity::find_by_id(walk_id)
+        .one(db)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("Walk {} not found", walk_id)))?;
+
+    // 2. Ownership check
+    if walk.user_id != user_id {
+        return Err(AppError::Unauthorized(
+            "Walk does not belong to user".to_string(),
+        ));
+    }
+
+    // 3. Encounter detection enabled check
+    let user = UserEntity::find_by_id(user_id)
+        .one(db)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("User {} not found", user_id)))?;
+
+    if !user.encounter_detection_enabled {
+        return Err(AppError::Unauthorized(
+            "Encounter detection is disabled for your account".to_string(),
+        ));
+    }
+
+    Ok(())
 }
 
 /// Verify that the given user is authorized to record events for the walk.

--- a/apps/api/src/services/walk_event_service.rs
+++ b/apps/api/src/services/walk_event_service.rs
@@ -195,4 +195,35 @@ mod tests {
             assert_eq!(back, t);
         }
     }
+
+    /// Static guard: verify_encounter_detection must exist in this module.
+    #[test]
+    fn verify_encounter_detection_exists_in_walk_event_service() {
+        let src = include_str!("walk_event_service.rs");
+        assert!(
+            src.contains("pub async fn verify_encounter_detection"),
+            "verify_encounter_detection must be defined as pub async fn in walk_event_service.rs"
+        );
+    }
+
+    /// Static guard: verify_encounter_detection must check encounter_detection_enabled.
+    #[test]
+    fn verify_encounter_detection_checks_encounter_detection_enabled() {
+        let src = include_str!("walk_event_service.rs");
+        assert!(
+            src.contains("encounter_detection_enabled"),
+            "verify_encounter_detection must check encounter_detection_enabled"
+        );
+    }
+
+    /// Static guard: verify_encounter_detection must check walk ownership (user_id).
+    #[test]
+    fn verify_encounter_detection_checks_walk_ownership() {
+        let src = include_str!("walk_event_service.rs");
+        // The function must verify that the walk belongs to the given user_id
+        assert!(
+            src.contains("user_id") && src.contains("verify_encounter_detection"),
+            "verify_encounter_detection must accept user_id and verify walk ownership"
+        );
+    }
 }

--- a/tasks/refactor/api/progress.md
+++ b/tasks/refactor/api/progress.md
@@ -8,7 +8,7 @@
 - [x] Phase 4: user_service upsert 統合 + duplicate key 文字列判定撲滅 (SeaORM on_conflict) — 2026-04-15 — RED: 92c3a6b / GREEN: ca059a5 — FIX: bf6484b (test_authorization runtime bug) — HARDEN: 8160a5a (proper DbErr propagation)
 - [x] Phase 5: Cognito エラー ProvideErrorMetadata::code() 化 + smithy mocks unit test — 2026-04-15 — RED: ee4b315 / GREEN: e129a62
 - [x] Phase 6: walk_event_service 認可ハブ化 + auth_helpers 導入 (依存: Phase 4) — 2026-04-15 — RED→GREEN: 1c9360d / GREEN: e295f75, 888b2b0, cf8ce84
-- [ ] Phase 7: encounter_service 責務集約 + verify_encounter_detection 新設 (依存: Phase 6)
+- [x] Phase 7: encounter_service 責務集約 + verify_encounter_detection 新設 (依存: Phase 6) — 2026-04-15 — RED: ea49c80 / GREEN: cb5f112 — verify_encounter_detection in walk_event_service; acting_user_id added to record_encounter + update_encounter_duration; update_encounter_duration_field slim 46→25 lines; record_encounter_field counterparty loop retained (Phase 8)
 - [ ] Phase 8: encounter N+M クエリ解消 JOIN 一括取得 (依存: Phase 7)
 - [ ] Phase 9: GraphQL field-wise バリデーションエラー
 - [ ] Phase 10: TEST_MODE → trait JwtVerifier 抽象化

--- a/tasks/refactor/api/progress.md
+++ b/tasks/refactor/api/progress.md
@@ -8,7 +8,7 @@
 - [x] Phase 4: user_service upsert 統合 + duplicate key 文字列判定撲滅 (SeaORM on_conflict) — 2026-04-15 — RED: 92c3a6b / GREEN: ca059a5 — FIX: bf6484b (test_authorization runtime bug) — HARDEN: 8160a5a (proper DbErr propagation)
 - [x] Phase 5: Cognito エラー ProvideErrorMetadata::code() 化 + smithy mocks unit test — 2026-04-15 — RED: ee4b315 / GREEN: e129a62
 - [x] Phase 6: walk_event_service 認可ハブ化 + auth_helpers 導入 (依存: Phase 4) — 2026-04-15 — RED→GREEN: 1c9360d / GREEN: e295f75, 888b2b0, cf8ce84
-- [x] Phase 7: encounter_service 責務集約 + verify_encounter_detection 新設 (依存: Phase 6) — 2026-04-15 — RED: ea49c80 / GREEN: cb5f112 — verify_encounter_detection in walk_event_service; acting_user_id added to record_encounter + update_encounter_duration; update_encounter_duration_field slim 46→25 lines; record_encounter_field counterparty loop retained (Phase 8)
+- [x] Phase 7: encounter_service 責務集約 + verify_encounter_detection 新設 (依存: Phase 6) — 2026-04-15 — RED: ea49c80 / GREEN: cb5f112 — CLEANUP: dcb273e (remove self-referential static guards) / FMT: 58077bc — verify_encounter_detection in walk_event_service; acting_user_id added to record_encounter + update_encounter_duration; update_encounter_duration_field slim 46→25 lines; record_encounter_field counterparty loop retained (Phase 8)
 - [ ] Phase 8: encounter N+M クエリ解消 JOIN 一括取得 (依存: Phase 7)
 - [ ] Phase 9: GraphQL field-wise バリデーションエラー
 - [ ] Phase 10: TEST_MODE → trait JwtVerifier 抽象化


### PR DESCRIPTION
## Summary

`apps/api/` リファクタ Phase 7 実装。`walk_event_service::verify_encounter_detection` を新設し、encounter mutation の walk 所有権 + `encounter_detection_enabled` 検証を service 層に集約。resolver は Phase 6 の `auth_helpers::resolve_user` を使って thin 化。

## 変更

### 新規 service 関数
- `walk_event_service::verify_encounter_detection(db, walk_id, user_id) -> Result<(), AppError>`
  - walk 取得 + `user_id` 所有権検証 + 該当ユーザーの `encounter_detection_enabled` 検証を1関数に集約

### シグネチャ変更
- `encounter_service::record_encounter` に `acting_user_id: Uuid` を追加、内部で `verify_encounter_detection` 呼び出し
- `encounter_service::update_encounter_duration` に `acting_user_id: Uuid` を追加、同上

### resolver thin 化
- `custom_mutations::record_encounter_field` / `update_encounter_duration_field` を「入力parse → `auth_helpers::resolve_user` → encounter_service.xxx → 出力変換」パターンに縮小
- 両 resolver とも Phase 6 の `resolve_user` 利用 (コードベース全体で一貫)

## スコープ外 (Phase 8 へ持ち越し)

- encounter の **counterparty (相手側) walk** の `encounter_detection_enabled` 検証は N+M クエリ解消と同時に JOIN 化 → Phase 8
- 現状 `record_encounter_field` の counterparty ループ約28行は残置 (既存動作維持)
- そのため `record_encounter_field` は計画の30行制約を一時的に超過、Phase 8 で解消予定

## Test plan

- [x] `cargo test --lib`: 48/48 PASS
- [x] `cargo test --test test_encounter`: PASS
- [x] `cargo test --test test_encounter_flow`: PASS
- [x] `cargo fmt --check`: 違反なし
- [x] `cargo clippy -- -D warnings`: 違反なし
- [x] 両 encounter resolver が `auth_helpers::resolve_user` 使用確認

## Commits

- \`ea49c80\` test(api): static guard tests for encounter_service [RED]
- \`cb5f112\` feat(api): verify_encounter_detection + acting_user_id implementation [GREEN]
- \`dcb273e\` cleanup: remove self-referential static guard tests
- \`58077bc\` style: fmt trailing blank line
- \`13b6fdf\` chore: mark Phase 7 complete in progress.md

## 学び (tasks/lessons.md 追加候補)

`include_str!` 自己参照テストは即時 pass する (production コードと同じファイルに assertion 文字列が存在)。別ファイルを指す場合のみ RED/GREEN サイクルが成立する。本 PR の RED フェーズ後、この問題を検出してテスト削除 (commit \`dcb273e\`)。

## 依存

- Phase 6 (\`auth_helpers::resolve_user\`) — PR #90 で merged 済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)