### PR TITLE
fix(api): unify walk_access errors to prevent walk ID enumeration (security)

### DIFF
--- a/apps/api/src/graphql/auth_helpers.rs
+++ b/apps/api/src/graphql/auth_helpers.rs
@@ -38,6 +38,10 @@ pub async fn resolve_user_and_dog(
 ///
 /// Uses `walk_event_service::require_walk_access` which checks walk ownership
 /// or membership through walk_dogs → dog_members.
+///
+/// Security: unauthorized access and missing walks both return a uniform
+/// `"Walk not found"` error to prevent walk ID enumeration by unauthenticated
+/// or non-member users. See `tests/test_review_fixes.rs` (Fix 2).
 pub async fn resolve_user_and_walk(
     ctx: &ResolverContext<'_>,
     state: &AppState,
@@ -46,6 +50,12 @@ pub async fn resolve_user_and_walk(
     let user = resolve_user(ctx, state).await?;
     walk_event_service::require_walk_access(&state.db, walk_id, user.id)
         .await
+        .map_err(|e| match e {
+            AppError::Unauthorized(_) | AppError::NotFound(_) => {
+                AppError::NotFound("Walk not found".to_string())
+            }
+            other => other,
+        })
         .map_err(AppError::into_graphql_error)?;
     Ok(user)
 }


### PR DESCRIPTION
## Summary

Phase 6 (#90) で導入されたセキュリティ regression を修正。`auth_helpers::resolve_user_and_walk` で walk 不存在と権限なしを区別して返していたのを、外向けには統一 \`"Walk not found"\` に戻す。

## 問題

Phase 6 以前の behavior: walk が存在しても non-member にはすべて \`"Walk not found"\` を返し、walk ID の存在を漏洩させない (enumeration 防止)。

Phase 6 で \`walk_event_service::require_walk_access\` 経由にした結果:
- walk 不存在: \`AppError::NotFound("Walk {id} not found")\`
- 権限なし: \`AppError::Unauthorized("Not authorized to record events for this walk")\`

→ エラーメッセージ差分で walk 存在を推測可能に。

既存テスト \`test_review_fixes.rs:test_walk_by_id_returns_error_when_unauthorized\` (Fix 2 コメント付き) がこれを意図的にガードしていたが Phase 6 PR では fail 状態で merge されていた。

## 修正内容

\`auth_helpers::resolve_user_and_walk\` で \`AppError::Unauthorized\` と \`AppError::NotFound\` を統一 \`AppError::NotFound("Walk not found")\` にマップ。他の variant は通過させる (DB 等の運用エラーは引き続き診断可能)。

\`\`\`rust
.map_err(|e| match e {
    AppError::Unauthorized(_) | AppError::NotFound(_) => {
        AppError::NotFound(\"Walk not found\".to_string())
    }
    other => other,
})
\`\`\`

## Test plan

- [x] \`test_review_fixes\`: 4/4 PASS (previously 1 fail)
- [x] \`test_authorization\`: 7/7 PASS
- [x] \`test_walk\`: 5/5 PASS
- [x] \`test_walk_events\`: 13/13 PASS
- [x] 既存 Phase 6 機能 (resolver 認可統一) 維持

## 影響範囲

\`resolve_user_and_walk\` を呼ぶ 3 箇所:
- \`custom_queries::walk_by_id_field\` (読み取り) — 意図通り unified NotFound
- \`custom_queries::walk_points_field\` (読み取り) — 同上
- \`custom_mutations::generateWalkEventPhotoUploadUrl\` (書き込み) — 認可失敗時も \`"Walk not found"\` を返すことで既存ユーザーにも walk ID が存在しないように見える。認可のあるユーザーには影響なし

## 依存 / 関連

- Phase 6 PR #90 の regression 修正
- Phase 7 PR #92 の CI 緑化に必要 (main に入ってから rebase)

🤖 Generated with [Claude Code](https://claude.com/claude-code)