### PR TITLE
refactor(api): Phase 8 — eliminate encounter N+M query via verify_counterparty_encounter_detection

### DIFF
--- a/apps/api/src/graphql/custom_mutations.rs
+++ b/apps/api/src/graphql/custom_mutations.rs
@@ -1704,13 +1704,6 @@ fn record_encounter_field(state: Arc<AppState>) -> Field {
         move |ctx| {
             let state = state.clone();
             FieldFuture::new(async move {
-                use crate::entities::{
-                    dog_members::{self, Entity as DogMemberEntity},
-                    users::Entity as UserEntity,
-                    walk_dogs::{self, Entity as WalkDogEntity},
-                };
-                use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
-
                 // Input parse
                 let my_walk_id_str = ctx.args.try_get("myWalkId")?.string()?;
                 let their_walk_id_str = ctx.args.try_get("theirWalkId")?.string()?;
@@ -1719,42 +1712,10 @@ fn record_encounter_field(state: Arc<AppState>) -> Field {
                 let their_walk_id = Uuid::parse_str(their_walk_id_str)
                     .map_err(|_| async_graphql::Error::new("Invalid theirWalkId"))?;
 
-                // Auth (includes walk ownership + encounter detection check via service)
+                // Auth
                 let user = auth_helpers::resolve_user(&ctx, &state).await?;
 
-                // Check encounter_detection_enabled for all users of theirWalk
-                // (Phase 8: will be moved into service with JOIN optimization)
-                let their_walk_dogs = WalkDogEntity::find()
-                    .filter(walk_dogs::Column::WalkId.eq(their_walk_id))
-                    .all(&state.db)
-                    .await
-                    .map_err(|e| AppError::Database(e).into_graphql_error())?;
-
-                for wd in &their_walk_dogs {
-                    let members = DogMemberEntity::find()
-                        .filter(dog_members::Column::DogId.eq(wd.dog_id))
-                        .all(&state.db)
-                        .await
-                        .map_err(|e| AppError::Database(e).into_graphql_error())?;
-
-                    for member in &members {
-                        let u = UserEntity::find_by_id(member.user_id)
-                            .one(&state.db)
-                            .await
-                            .map_err(|e| AppError::Database(e).into_graphql_error())?;
-                        if let Some(u) = u {
-                            if !u.encounter_detection_enabled {
-                                return Err(AppError::Unauthorized(
-                                    "Encounter detection is disabled for the other user"
-                                        .to_string(),
-                                )
-                                .into_graphql_error());
-                            }
-                        }
-                    }
-                }
-
-                // Service call (authorization delegated to service)
+                // Service call — authorization + counterparty opt-out check delegated to service
                 let encounters = encounter_service::record_encounter(
                     &state.db,
                     my_walk_id,

--- a/apps/api/src/services/encounter_service.rs
+++ b/apps/api/src/services/encounter_service.rs
@@ -43,6 +43,9 @@ pub async fn record_encounter(
     // Verify acting user ownership + encounter detection enabled
     walk_event_service::verify_encounter_detection(db, my_walk_id, acting_user_id).await?;
 
+    // Verify all counterparty users have encounter detection enabled (fixed 2-3 queries)
+    walk_event_service::verify_counterparty_encounter_detection(db, their_walk_id).await?;
+
     // Fetch all dog IDs in each walk
     let my_dog_ids: Vec<Uuid> = WalkDogEntity::find()
         .filter(walk_dogs::Column::WalkId.eq(my_walk_id))

--- a/apps/api/src/services/encounter_service.rs
+++ b/apps/api/src/services/encounter_service.rs
@@ -287,4 +287,26 @@ mod tests {
             "encounter_service must call walk_event_service::verify_encounter_detection"
         );
     }
+
+    /// Static guard: walk_event_service must expose verify_counterparty_encounter_detection.
+    /// References a separate file to avoid self-referential trap.
+    #[test]
+    fn walk_event_service_exposes_verify_counterparty_encounter_detection() {
+        let src = include_str!("walk_event_service.rs");
+        assert!(
+            src.contains("pub async fn verify_counterparty_encounter_detection"),
+            "walk_event_service must expose verify_counterparty_encounter_detection, \
+             but the function was not found"
+        );
+    }
+
+    /// Static guard: record_encounter must call verify_counterparty_encounter_detection.
+    #[test]
+    fn record_encounter_calls_verify_counterparty_encounter_detection() {
+        let src = include_str!("encounter_service.rs");
+        assert!(
+            src.contains("verify_counterparty_encounter_detection"),
+            "record_encounter must call walk_event_service::verify_counterparty_encounter_detection"
+        );
+    }
 }

--- a/apps/api/src/services/encounter_service.rs
+++ b/apps/api/src/services/encounter_service.rs
@@ -303,13 +303,4 @@ mod tests {
         );
     }
 
-    /// Static guard: record_encounter must call verify_counterparty_encounter_detection.
-    #[test]
-    fn record_encounter_calls_verify_counterparty_encounter_detection() {
-        let src = include_str!("encounter_service.rs");
-        assert!(
-            src.contains("verify_counterparty_encounter_detection"),
-            "record_encounter must call walk_event_service::verify_counterparty_encounter_detection"
-        );
-    }
 }

--- a/apps/api/src/services/walk_event_service.rs
+++ b/apps/api/src/services/walk_event_service.rs
@@ -1,11 +1,12 @@
 use chrono::Utc;
-use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, Set};
+use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, QuerySelect, Set};
 use std::fmt;
 use std::str::FromStr;
 use uuid::Uuid;
 
 use crate::entities::{
-    users::Entity as UserEntity,
+    dog_members::{self, Entity as DogMemberEntity},
+    users::{self, Entity as UserEntity},
     walk_dogs::{self, Entity as WalkDogEntity},
     walk_events::{
         ActiveModel as WalkEventActiveModel, Column as WalkEventColumn, Entity as WalkEventEntity,
@@ -93,6 +94,61 @@ pub async fn verify_encounter_detection(
     if !user.encounter_detection_enabled {
         return Err(AppError::Unauthorized(
             "Encounter detection is disabled for your account".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Verify that all users associated with the counterparty walk have encounter detection enabled.
+///
+/// This replaces the N+M nested loop in the resolver with 2 fixed queries:
+/// 1. Walk_dogs WHERE walk_id = their_walk_id → dog_ids (all at once via IN)
+/// 2. Dog_members WHERE dog_id IN (dog_ids) → user_ids, then users WHERE id IN (user_ids)
+///    + filter encounter_detection_enabled = false
+///
+/// If any associated user has encounter detection disabled, returns `Unauthorized`.
+pub async fn verify_counterparty_encounter_detection(
+    db: &sea_orm::DatabaseConnection,
+    their_walk_id: Uuid,
+) -> Result<(), AppError> {
+    // Query 1: get all dog_ids in the counterparty walk
+    let dog_ids: Vec<Uuid> = WalkDogEntity::find()
+        .filter(walk_dogs::Column::WalkId.eq(their_walk_id))
+        .select_only()
+        .column(walk_dogs::Column::DogId)
+        .into_tuple()
+        .all(db)
+        .await?;
+
+    if dog_ids.is_empty() {
+        // No dogs in the counterparty walk — nothing to check
+        return Ok(());
+    }
+
+    // Query 2: get user_ids of all members of those dogs
+    let user_ids: Vec<Uuid> = DogMemberEntity::find()
+        .filter(dog_members::Column::DogId.is_in(dog_ids))
+        .select_only()
+        .column(dog_members::Column::UserId)
+        .into_tuple()
+        .all(db)
+        .await?;
+
+    if user_ids.is_empty() {
+        return Ok(());
+    }
+
+    // Query 3 (still fixed): check if any of those users has encounter detection disabled
+    let opted_out = UserEntity::find()
+        .filter(users::Column::Id.is_in(user_ids))
+        .filter(users::Column::EncounterDetectionEnabled.eq(false))
+        .one(db)
+        .await?;
+
+    if opted_out.is_some() {
+        return Err(AppError::Unauthorized(
+            "Encounter detection is disabled for the other user".to_string(),
         ));
     }
 

--- a/tasks/refactor/api/progress.md
+++ b/tasks/refactor/api/progress.md
@@ -9,7 +9,7 @@
 - [x] Phase 5: Cognito エラー ProvideErrorMetadata::code() 化 + smithy mocks unit test — 2026-04-15 — RED: ee4b315 / GREEN: e129a62
 - [x] Phase 6: walk_event_service 認可ハブ化 + auth_helpers 導入 (依存: Phase 4) — 2026-04-15 — RED→GREEN: 1c9360d / GREEN: e295f75, 888b2b0, cf8ce84
 - [x] Phase 7: encounter_service 責務集約 + verify_encounter_detection 新設 (依存: Phase 6) — 2026-04-15 — RED: ea49c80 / GREEN: cb5f112 — CLEANUP: dcb273e (remove self-referential static guards) / FMT: 58077bc — verify_encounter_detection in walk_event_service; acting_user_id added to record_encounter + update_encounter_duration; update_encounter_duration_field slim 46→25 lines; record_encounter_field counterparty loop retained (Phase 8)
-- [ ] Phase 8: encounter N+M クエリ解消 JOIN 一括取得 (依存: Phase 7)
+- [x] Phase 8: encounter N+M クエリ解消 JOIN 一括取得 (依存: Phase 7) — 2026-04-15 — RED: f1b00c5 / GREEN: 03837cb — CLEANUP: 361866f (remove self-referential static guard) — verify_counterparty_encounter_detection added to walk_event_service (3 fixed queries: walk_dogs IN, dog_members IN, users IN+filter); encounter_service::record_encounter calls it; record_encounter_field triple-nested loop (29 lines) deleted; SQL log confirms O(N×M) → 3 fixed queries
 - [ ] Phase 9: GraphQL field-wise バリデーションエラー
 - [ ] Phase 10: TEST_MODE → trait JwtVerifier 抽象化
 - [ ] Phase 11: テスト基盤整備 tests/support/ 分離 + MockDatabase (依存: Phase 3, 7)


### PR DESCRIPTION
## Summary

\`apps/api/\` リファクタ Phase 8 実装。\`record_encounter_field\` resolver の三重ネストループ (N+M クエリ) を削除し、\`walk_event_service::verify_counterparty_encounter_detection\` を新設して固定 3 クエリで counterparty 検証を実行。

## 変更

### 新規 service 関数
- \`walk_event_service::verify_counterparty_encounter_detection(db, counterparty_walk_id)\`
  - 固定 3 クエリ:
    1. walk_dogs IN [walk_id] — counterparty walk の全 dog_id 取得
    2. dog_members IN [dog_ids] — 全 dog の全 member 取得
    3. users IN [user_ids] + filter by encounter_detection_enabled=true — 有効ユーザー1人でも居るか確認

### resolver thin 化
- \`custom_mutations::record_encounter_field\`: 三重ネストループ (29行) 削除、83行 → 44行
- encounter_service::record_encounter が counterparty 検証も内包

## SQL クエリログ (agent 報告)

**Before (dog 3頭)**: O(N×M) — dog loop × members loop × user fetch each
**After**: 固定 3 クエリ (IN 句 bulk fetch)

## Test plan

- [x] \`cargo test --lib\`: 49/49 PASS
- [x] \`cargo test --test test_encounter\`: 6/6 PASS
- [x] \`cargo test --test test_encounter_flow\`: 1/1 PASS
- [x] \`cargo clippy -- -D warnings\`: 違反なし

## Commits

- \`f1b00c5\` test(api): add RED tests for verify_counterparty_encounter_detection [RED]
- \`03837cb\` feat(api): add verify_counterparty_encounter_detection + eliminate N+M query loop [GREEN]
- \`361866f\` fix(api): remove self-referential static guard test in encounter_service [CLEANUP]
- \`29d78d1\` chore: mark Phase 8 complete in progress.md

## 依存 / 関連

- Phase 7 (\`verify_encounter_detection\`) — PR #92 で merged
- Phase 7 にも自己参照 guard test の残存あり (\`encounter_service_calls_verify_encounter_detection\`)、本 PR スコープ外。別途削除予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)