### PR TITLE
refactor(api): Phase 9 — GraphQL field-wise validation errors

### DIFF
--- a/apps/api/src/error.rs
+++ b/apps/api/src/error.rs
@@ -1,6 +1,13 @@
 // apps/api/src/error.rs
 use thiserror::Error;
 
+/// Per-field validation error used in [`AppError::ValidationErrors`].
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct FieldError {
+    pub field: String,
+    pub message: String,
+}
+
 #[derive(Debug, Error)]
 pub enum AppError {
     #[error("Database error: {0}")]
@@ -13,6 +20,8 @@ pub enum AppError {
     BadRequest(String),
     #[error("Internal error: {0}")]
     Internal(String),
+    #[error("Validation errors")]
+    ValidationErrors(Vec<FieldError>),
 }
 
 impl AppError {
@@ -29,6 +38,16 @@ impl AppError {
             AppError::Unauthorized(msg) => async_graphql::Error::new(msg).extend_with(|_, ext| {
                 ext.set("code", "UNAUTHENTICATED");
             }),
+            AppError::ValidationErrors(errors) => {
+                let json = serde_json::to_value(&errors)
+                    .unwrap_or(serde_json::Value::Array(vec![]));
+                let fields = async_graphql::Value::from_json(json)
+                    .unwrap_or(async_graphql::Value::List(vec![]));
+                async_graphql::Error::new("Validation failed").extend_with(|_, ext| {
+                    ext.set("code", "BAD_USER_INPUT");
+                    ext.set("fields", fields);
+                })
+            }
             other => async_graphql::Error::new(other.to_string()).extend_with(|_, ext| {
                 ext.set("code", "INTERNAL_SERVER_ERROR");
             }),
@@ -43,16 +62,35 @@ mod tests {
     #[test]
     fn validation_errors_with_three_fields_produces_three_extensions_fields() {
         let errors = vec![
-            FieldError { field: "myWalkId".to_string(), message: "Invalid UUID format".to_string() },
-            FieldError { field: "theirWalkId".to_string(), message: "Invalid UUID format".to_string() },
-            FieldError { field: "recordedAt".to_string(), message: "Invalid RFC3339 format".to_string() },
+            FieldError {
+                field: "myWalkId".to_string(),
+                message: "Invalid UUID format".to_string(),
+            },
+            FieldError {
+                field: "theirWalkId".to_string(),
+                message: "Invalid UUID format".to_string(),
+            },
+            FieldError {
+                field: "recordedAt".to_string(),
+                message: "Invalid RFC3339 format".to_string(),
+            },
         ];
         let gql_err = AppError::ValidationErrors(errors).into_graphql_error();
 
         let ext = gql_err.extensions.expect("extensions must be set");
-        let fields = ext.get("fields").expect("fields key must be in extensions");
-        let fields_arr = fields.as_array().expect("fields must be a JSON array");
-        assert_eq!(fields_arr.len(), 3, "expected 3 field errors, got: {:?}", fields_arr);
+        let fields_val = ext.get("fields").expect("fields key must be in extensions");
+
+        // Convert async_graphql::Value back to serde_json for easy assertion
+        let fields_json: serde_json::Value = serde_json::Value::try_from(fields_val.clone())
+            .expect("fields must be JSON-convertible");
+        let fields_arr = fields_json.as_array().expect("fields must be a JSON array");
+
+        assert_eq!(
+            fields_arr.len(),
+            3,
+            "expected 3 field errors, got: {:?}",
+            fields_arr
+        );
 
         // Verify first field has correct structure
         assert_eq!(fields_arr[0]["field"], "myWalkId");
@@ -61,13 +99,15 @@ mod tests {
 
     #[test]
     fn validation_errors_sets_bad_user_input_code() {
-        let errors = vec![
-            FieldError { field: "walkId".to_string(), message: "Invalid UUID".to_string() },
-        ];
+        let errors = vec![FieldError {
+            field: "walkId".to_string(),
+            message: "Invalid UUID".to_string(),
+        }];
         let gql_err = AppError::ValidationErrors(errors).into_graphql_error();
 
         let ext = gql_err.extensions.expect("extensions must be set");
-        let code = ext.get("code").expect("code must be in extensions");
-        assert_eq!(code, "BAD_USER_INPUT");
+        let code_val = ext.get("code").expect("code must be in extensions");
+        // async_graphql::Value::String can be compared as string
+        assert_eq!(code_val, &async_graphql::Value::from("BAD_USER_INPUT"));
     }
 }

--- a/apps/api/src/error.rs
+++ b/apps/api/src/error.rs
@@ -39,8 +39,8 @@ impl AppError {
                 ext.set("code", "UNAUTHENTICATED");
             }),
             AppError::ValidationErrors(errors) => {
-                let json = serde_json::to_value(&errors)
-                    .unwrap_or(serde_json::Value::Array(vec![]));
+                let json =
+                    serde_json::to_value(&errors).unwrap_or(serde_json::Value::Array(vec![]));
                 let fields = async_graphql::Value::from_json(json)
                     .unwrap_or(async_graphql::Value::List(vec![]));
                 async_graphql::Error::new("Validation failed").extend_with(|_, ext| {

--- a/apps/api/src/error.rs
+++ b/apps/api/src/error.rs
@@ -35,3 +35,39 @@ impl AppError {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validation_errors_with_three_fields_produces_three_extensions_fields() {
+        let errors = vec![
+            FieldError { field: "myWalkId".to_string(), message: "Invalid UUID format".to_string() },
+            FieldError { field: "theirWalkId".to_string(), message: "Invalid UUID format".to_string() },
+            FieldError { field: "recordedAt".to_string(), message: "Invalid RFC3339 format".to_string() },
+        ];
+        let gql_err = AppError::ValidationErrors(errors).into_graphql_error();
+
+        let ext = gql_err.extensions.expect("extensions must be set");
+        let fields = ext.get("fields").expect("fields key must be in extensions");
+        let fields_arr = fields.as_array().expect("fields must be a JSON array");
+        assert_eq!(fields_arr.len(), 3, "expected 3 field errors, got: {:?}", fields_arr);
+
+        // Verify first field has correct structure
+        assert_eq!(fields_arr[0]["field"], "myWalkId");
+        assert_eq!(fields_arr[0]["message"], "Invalid UUID format");
+    }
+
+    #[test]
+    fn validation_errors_sets_bad_user_input_code() {
+        let errors = vec![
+            FieldError { field: "walkId".to_string(), message: "Invalid UUID".to_string() },
+        ];
+        let gql_err = AppError::ValidationErrors(errors).into_graphql_error();
+
+        let ext = gql_err.extensions.expect("extensions must be set");
+        let code = ext.get("code").expect("code must be in extensions");
+        assert_eq!(code, "BAD_USER_INPUT");
+    }
+}

--- a/apps/api/src/graphql/custom_mutations.rs
+++ b/apps/api/src/graphql/custom_mutations.rs
@@ -1,5 +1,5 @@
 use crate::auth;
-use crate::error::AppError;
+use crate::error::{AppError, FieldError};
 use crate::graphql::auth_helpers;
 use crate::graphql::custom_queries::{EncounterOutput, WalkPointOutput};
 use crate::graphql::input::birth_date::parse_birth_date_input;
@@ -1431,8 +1431,19 @@ fn add_walk_points_field(state: Arc<AppState>) -> Field {
                 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 
                 let walk_id_str = ctx.args.try_get("walkId")?.string()?;
-                let walk_id = Uuid::parse_str(walk_id_str)
-                    .map_err(|_| async_graphql::Error::new("Invalid walk ID"))?;
+
+                let mut field_errors: Vec<FieldError> = Vec::new();
+                let walk_id_opt = Uuid::parse_str(walk_id_str).ok().or_else(|| {
+                    field_errors.push(FieldError {
+                        field: "walkId".to_string(),
+                        message: "Invalid UUID format".to_string(),
+                    });
+                    None
+                });
+                if !field_errors.is_empty() {
+                    return Err(AppError::ValidationErrors(field_errors).into_graphql_error());
+                }
+                let walk_id = walk_id_opt.unwrap();
 
                 let user = auth_helpers::resolve_user(&ctx, &state).await?;
                 // Only the walk owner can add points (walks.user_id check)
@@ -1704,13 +1715,34 @@ fn record_encounter_field(state: Arc<AppState>) -> Field {
         move |ctx| {
             let state = state.clone();
             FieldFuture::new(async move {
-                // Input parse
+                // Input parse — accumulate all field errors before returning
                 let my_walk_id_str = ctx.args.try_get("myWalkId")?.string()?;
                 let their_walk_id_str = ctx.args.try_get("theirWalkId")?.string()?;
-                let my_walk_id = Uuid::parse_str(my_walk_id_str)
-                    .map_err(|_| async_graphql::Error::new("Invalid myWalkId"))?;
-                let their_walk_id = Uuid::parse_str(their_walk_id_str)
-                    .map_err(|_| async_graphql::Error::new("Invalid theirWalkId"))?;
+
+                let mut field_errors: Vec<FieldError> = Vec::new();
+
+                let my_walk_id = Uuid::parse_str(my_walk_id_str).ok().or_else(|| {
+                    field_errors.push(FieldError {
+                        field: "myWalkId".to_string(),
+                        message: "Invalid UUID format".to_string(),
+                    });
+                    None
+                });
+                let their_walk_id = Uuid::parse_str(their_walk_id_str).ok().or_else(|| {
+                    field_errors.push(FieldError {
+                        field: "theirWalkId".to_string(),
+                        message: "Invalid UUID format".to_string(),
+                    });
+                    None
+                });
+
+                if !field_errors.is_empty() {
+                    return Err(AppError::ValidationErrors(field_errors).into_graphql_error());
+                }
+
+                // Both values are Some since field_errors is empty
+                let my_walk_id = my_walk_id.unwrap();
+                let their_walk_id = their_walk_id.unwrap();
 
                 // Auth
                 let user = auth_helpers::resolve_user(&ctx, &state).await?;

--- a/apps/api/src/services/encounter_service.rs
+++ b/apps/api/src/services/encounter_service.rs
@@ -302,5 +302,4 @@ mod tests {
              but the function was not found"
         );
     }
-
 }

--- a/apps/api/src/services/walk_event_service.rs
+++ b/apps/api/src/services/walk_event_service.rs
@@ -1,5 +1,7 @@
 use chrono::Utc;
-use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, QuerySelect, Set};
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, QuerySelect, Set,
+};
 use std::fmt;
 use std::str::FromStr;
 use uuid::Uuid;

--- a/apps/api/tests/test_encounter.rs
+++ b/apps/api/tests/test_encounter.rs
@@ -339,3 +339,64 @@ async fn test_dog_encounters_history() {
     assert_eq!(encounters.len(), 1);
     assert_eq!(encounters[0]["durationSec"].as_i64().unwrap(), 30);
 }
+
+/// Phase 9: field-wise validation — both invalid UUIDs should produce
+/// extensions.fields with 2 entries (myWalkId + theirWalkId), not just the first.
+#[tokio::test]
+async fn test_record_encounter_invalid_both_uuids_returns_field_errors() {
+    let client = common::test_client().await;
+
+    let res = client
+        .post("/graphql")
+        .header("Authorization", "Bearer test-token")
+        .json(&serde_json::json!({
+            "query": r#"mutation {
+                recordEncounter(myWalkId: "not-a-uuid", theirWalkId: "also-not-a-uuid") {
+                    id
+                }
+            }"#
+        }))
+        .send()
+        .await
+        .unwrap();
+    let body: serde_json::Value = res.json().await.unwrap();
+
+    // Must have errors
+    assert!(
+        body["errors"].is_array(),
+        "expected errors array, got: {:?}",
+        body
+    );
+
+    // The error must contain extensions.fields with both field errors
+    let err = &body["errors"][0];
+    let fields = &err["extensions"]["fields"];
+    assert!(
+        fields.is_array(),
+        "expected extensions.fields array, got: {:?}",
+        err
+    );
+    let fields_arr = fields.as_array().unwrap();
+    assert_eq!(
+        fields_arr.len(),
+        2,
+        "expected 2 field errors (myWalkId + theirWalkId), got: {:?}",
+        fields_arr
+    );
+
+    // Verify field names are present
+    let field_names: Vec<&str> = fields_arr
+        .iter()
+        .filter_map(|e| e["field"].as_str())
+        .collect();
+    assert!(
+        field_names.contains(&"myWalkId"),
+        "expected myWalkId in fields, got: {:?}",
+        field_names
+    );
+    assert!(
+        field_names.contains(&"theirWalkId"),
+        "expected theirWalkId in fields, got: {:?}",
+        field_names
+    );
+}

--- a/tasks/refactor/api/progress.md
+++ b/tasks/refactor/api/progress.md
@@ -10,7 +10,7 @@
 - [x] Phase 6: walk_event_service 認可ハブ化 + auth_helpers 導入 (依存: Phase 4) — 2026-04-15 — RED→GREEN: 1c9360d / GREEN: e295f75, 888b2b0, cf8ce84
 - [x] Phase 7: encounter_service 責務集約 + verify_encounter_detection 新設 (依存: Phase 6) — 2026-04-15 — RED: ea49c80 / GREEN: cb5f112 — CLEANUP: dcb273e (remove self-referential static guards) / FMT: 58077bc — verify_encounter_detection in walk_event_service; acting_user_id added to record_encounter + update_encounter_duration; update_encounter_duration_field slim 46→25 lines; record_encounter_field counterparty loop retained (Phase 8)
 - [x] Phase 8: encounter N+M クエリ解消 JOIN 一括取得 (依存: Phase 7) — 2026-04-15 — RED: f1b00c5 / GREEN: 03837cb — CLEANUP: 361866f (remove self-referential static guard) — verify_counterparty_encounter_detection added to walk_event_service (3 fixed queries: walk_dogs IN, dog_members IN, users IN+filter); encounter_service::record_encounter calls it; record_encounter_field triple-nested loop (29 lines) deleted; SQL log confirms O(N×M) → 3 fixed queries
-- [ ] Phase 9: GraphQL field-wise バリデーションエラー
+- [x] Phase 9: GraphQL field-wise バリデーションエラー — 2026-04-15 — RED(error.rs): 6afd58d / GREEN(error.rs): f06396e / RED(integration): 83b3f79 / GREEN(resolvers): 0f955d2 — FieldError struct + ValidationErrors variant + into_graphql_error extensions.fields; record_encounter_field + add_walk_points_field UUID parse ? → accumulation; test_record_encounter_invalid_both_uuids_returns_field_errors integration test added
 - [ ] Phase 10: TEST_MODE → trait JwtVerifier 抽象化
 - [ ] Phase 11: テスト基盤整備 tests/support/ 分離 + MockDatabase (依存: Phase 3, 7)
 - [ ] Phase 12: sign_up facade 化 (依存: Phase 4)


### PR DESCRIPTION
## Summary

\`apps/api/\` リファクタ Phase 9 実装。GraphQL resolver の \`?\` チェーン (1フィールド失敗で全体失敗) を廃止し、\`FieldError\` 蓄積方式に変換。クライアントは不正フィールドごとに error extension を受け取れる。

## 変更

### error.rs
- \`struct FieldError { field: String, message: String }\` 新規
- \`AppError::ValidationErrors(Vec<FieldError>)\` variant 追加
- \`into_graphql_error\` の \`ValidationErrors\` アーム: \`extensions.fields\` に配列、\`code = "BAD_USER_INPUT"\`

### resolver 変換
- \`record_encounter_field\`: \`myWalkId\` / \`theirWalkId\` UUID parse を \`errors.push(...)\` 蓄積に
- \`add_walk_points_field\`: \`walkId\` UUID parse 同上

## Test plan

- [x] \`cargo test --lib\`: 51/51 PASS (+2 新規 unit test)
- [x] 新規 integration test: \`test_record_encounter_invalid_both_uuids_returns_field_errors\` PASS (2フィールドエラー検証)
- [x] 既存 \`test_walk\`, \`test_encounter\`, \`test_encounter_flow\`, \`test_sharing_flow\` 全 PASS
- [x] cargo clippy 警告なし

## Commits

- \`6afd58d\` test(api): ValidationErrors unit tests [RED]
- \`f06396e\` feat(api): FieldError struct + ValidationErrors variant [GREEN]
- \`83b3f79\` test(api): field-wise error integration test [RED]
- \`0f955d2\` feat(api): convert UUID parse chains to FieldError accumulation [GREEN]
- \`813f55c\` chore: mark Phase 9 complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)