### PR TITLE
refactor(mobile): extract useMutationWithAlert helper (Phase 3)

### DIFF
--- a/apps/mobile/app/dogs/[id]/edit.tsx
+++ b/apps/mobile/app/dogs/[id]/edit.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react';
-import { Alert, ScrollView, StyleSheet } from 'react-native';
+import { ScrollView, StyleSheet } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useDog } from '@/hooks/use-dog';
 import { useUpdateDog, useGeneratePhotoUploadUrl } from '@/hooks/use-dog-mutations';
+import { useMutationWithAlert } from '@/hooks/use-mutation-with-alert';
 import { DogForm, type DogFormValues } from '@/components/dogs/DogForm';
 import { PhotoPicker } from '@/components/dogs/PhotoPicker';
 import { LoadingScreen } from '@/components/ui/LoadingScreen';
@@ -20,6 +21,7 @@ export default function EditDogScreen() {
   const { data: dog, isLoading } = useDog(id, 'ALL');
   const { mutateAsync: updateDog } = useUpdateDog();
   const { mutateAsync: generateUploadUrl } = useGeneratePhotoUploadUrl();
+  const runWithAlert = useMutationWithAlert();
   const [photoLoading, setPhotoLoading] = useState(false);
   const [previewUri, setPreviewUri] = useState<string | null>(null);
 
@@ -28,17 +30,13 @@ export default function EditDogScreen() {
   async function handlePhotoChange(uri: string, contentType: string) {
     setPreviewUri(uri);
     setPhotoLoading(true);
-    try {
+    await runWithAlert(async () => {
       const { url, key } = await generateUploadUrl({ dogId: id, contentType });
       await uploadToPresignedUrl(url, uri, contentType);
       await updateDog({ id, input: { photoUrl: key } });
-      setPreviewUri(null);
-    } catch {
-      setPreviewUri(null);
-      Alert.alert(t('common.error'), t('dogs.edit.photoUploadError'));
-    } finally {
-      setPhotoLoading(false);
-    }
+    }, 'dogs.edit.photoUploadError');
+    setPreviewUri(null);
+    setPhotoLoading(false);
   }
 
   async function handleSubmit(values: DogFormValues) {

--- a/apps/mobile/app/dogs/[id]/index.tsx
+++ b/apps/mobile/app/dogs/[id]/index.tsx
@@ -1,11 +1,12 @@
 import { useState } from 'react';
-import { Alert, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { Image } from 'expo-image';
 import { useDog } from '@/hooks/use-dog';
 import { useDeleteDog } from '@/hooks/use-dog-mutations';
 import { useMe } from '@/hooks/use-me';
+import { useMutationWithAlert } from '@/hooks/use-mutation-with-alert';
 import { DogStatsCard } from '@/components/dogs/DogStatsCard';
 import { LoadingScreen } from '@/components/ui/LoadingScreen';
 import { Button } from '@/components/ui/Button';
@@ -22,6 +23,7 @@ export default function DogDetailScreen() {
   const { data: dog, isLoading } = useDog(id, 'ALL');
   const { data: me } = useMe();
   const { mutateAsync: deleteDog } = useDeleteDog();
+  const runWithAlert = useMutationWithAlert();
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
   if (isLoading || !dog) return <LoadingScreen />;
@@ -30,12 +32,8 @@ export default function DogDetailScreen() {
   const isOwner = currentMember?.role === 'owner';
 
   async function handleDelete() {
-    try {
-      await deleteDog(id);
-      router.replace('/(tabs)/dogs');
-    } catch {
-      Alert.alert(t('common.error'), t('dogs.detail.deleteError'));
-    }
+    const ok = await runWithAlert(() => deleteDog(id), 'dogs.detail.deleteError');
+    if (ok) router.replace('/(tabs)/dogs');
   }
 
   return (

--- a/apps/mobile/app/dogs/[id]/members.tsx
+++ b/apps/mobile/app/dogs/[id]/members.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Alert, ScrollView, Share, StyleSheet, View } from 'react-native';
+import { ScrollView, Share, StyleSheet, View } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useDog } from '@/hooks/use-dog';
@@ -9,6 +9,7 @@ import {
   useLeaveDog,
 } from '@/hooks/use-dog-member-mutations';
 import { useMe } from '@/hooks/use-me';
+import { useMutationWithAlert } from '@/hooks/use-mutation-with-alert';
 import { DogMembersList } from '@/components/dogs/DogMembersList';
 import { Button } from '@/components/ui/Button';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
@@ -27,6 +28,7 @@ export default function DogMembersScreen() {
   const generateInvitation = useGenerateInvitation();
   const removeMember = useRemoveMember();
   const leaveDog = useLeaveDog();
+  const runWithAlert = useMutationWithAlert();
 
   const [confirmRemove, setConfirmRemove] = useState<{
     userId: string;
@@ -43,35 +45,30 @@ export default function DogMembersScreen() {
   );
 
   async function handleInvite() {
-    try {
-      const invitation = await generateInvitation.mutateAsync(id);
-      const url = `walking-dog://invite/${invitation.token}`;
-      await Share.share({ message: url });
-    } catch {
-      Alert.alert(t('common.error'), t('dogs.members.inviteError'));
+    const invitation = await runWithAlert(
+      () => generateInvitation.mutateAsync(id),
+      'dogs.members.inviteError',
+    );
+    if (invitation) {
+      await Share.share({ message: `walking-dog://invite/${invitation.token}` });
     }
   }
 
   async function handleRemove() {
     if (!confirmRemove) return;
-    try {
-      await removeMember.mutateAsync({
-        dogId: id,
-        userId: confirmRemove.userId,
-      });
-      setConfirmRemove(null);
-    } catch {
-      Alert.alert(t('common.error'), t('dogs.members.removeError'));
-    }
+    const ok = await runWithAlert(
+      () => removeMember.mutateAsync({ dogId: id, userId: confirmRemove.userId }),
+      'dogs.members.removeError',
+    );
+    if (ok) setConfirmRemove(null);
   }
 
   async function handleLeave() {
-    try {
-      await leaveDog.mutateAsync(id);
-      router.replace('/(tabs)/dogs');
-    } catch {
-      Alert.alert(t('common.error'), t('dogs.members.leaveError'));
-    }
+    const ok = await runWithAlert(
+      () => leaveDog.mutateAsync(id),
+      'dogs.members.leaveError',
+    );
+    if (ok) router.replace('/(tabs)/dogs');
   }
 
   return (

--- a/apps/mobile/hooks/use-mutation-with-alert.test.ts
+++ b/apps/mobile/hooks/use-mutation-with-alert.test.ts
@@ -1,0 +1,48 @@
+import { renderHook, act } from '@testing-library/react-native';
+import { Alert } from 'react-native';
+import { useMutationWithAlert } from './use-mutation-with-alert';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe('useMutationWithAlert', () => {
+  beforeEach(() => {
+    jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns the mutation result when the operation succeeds', async () => {
+    const { result } = renderHook(() => useMutationWithAlert());
+
+    let value: string | null = null;
+    await act(async () => {
+      value = await result.current(
+        () => Promise.resolve('ok'),
+        'dogs.detail.deleteError',
+      );
+    });
+
+    expect(value).toBe('ok');
+    expect(Alert.alert).not.toHaveBeenCalled();
+  });
+
+  it('shows an alert with the i18n key and returns null on error', async () => {
+    const { result } = renderHook(() => useMutationWithAlert());
+
+    let value: string | null = 'sentinel';
+    await act(async () => {
+      value = await result.current(
+        () => Promise.reject(new Error('boom')),
+        'dogs.members.inviteError',
+      );
+    });
+
+    expect(value).toBeNull();
+    expect(Alert.alert).toHaveBeenCalledWith('common.error', 'dogs.members.inviteError');
+  });
+
+});

--- a/apps/mobile/hooks/use-mutation-with-alert.ts
+++ b/apps/mobile/hooks/use-mutation-with-alert.ts
@@ -1,0 +1,18 @@
+import { useCallback } from 'react';
+import { Alert } from 'react-native';
+import { useTranslation } from 'react-i18next';
+
+export function useMutationWithAlert() {
+  const { t } = useTranslation();
+  return useCallback(
+    async <T>(fn: () => Promise<T>, errorMessageKey: string): Promise<T | null> => {
+      try {
+        return await fn();
+      } catch {
+        Alert.alert(t('common.error'), t(errorMessageKey));
+        return null;
+      }
+    },
+    [t],
+  );
+}


### PR DESCRIPTION
## Summary

Phase 3 of `tasks/refactor/mobile/03-plan.md` — consolidate the try/catch + i18n-keyed `Alert.alert` pattern that was repeated across 5 mutation handlers.

### New hook
`hooks/use-mutation-with-alert.ts` wraps any async mutation call:

```ts
const runWithAlert = useMutationWithAlert();
const ok = await runWithAlert(() => mutation.mutateAsync(args), 'dogs.detail.deleteError');
if (ok) router.replace('/(tabs)/dogs');
```

- On success: returns the mutation result
- On error: shows `Alert.alert(t('common.error'), t(errorKey))` and returns `null`

### Call-sites replaced (5 handlers)
- `app/dogs/[id]/edit.tsx` — photo upload chain (presign → PUT → updateDog)
- `app/dogs/[id]/members.tsx` — invite / remove / leave (3 isomorphic handlers)
- `app/dogs/[id]/index.tsx` — delete

### Out of scope
- `app/(tabs)/walk.tsx` still has 3 `Alert.alert` calls — belongs to Phase 7 (walk screen split)
- `app/dogs/new.tsx` + `edit.tsx` form submit — no existing try/catch to replace

## Test plan

- [x] `npx jest` — 215/215 pass (2 new `use-mutation-with-alert.test.ts` tests)
- [x] `npm run lint` — clean (1 pre-existing warning in `invite/[token].tsx`)
- [x] `npx tsc --noEmit` — only pre-existing errors
- [x] `rg "Alert\.alert" apps/mobile/app/dogs` → 0 matches
- [ ] iOS Simulator smoke — optional; error paths hard to trigger without backend faults

🤖 Generated with [Claude Code](https://claude.com/claude-code)