### PR TITLE
refactor(mobile): card and settings section primitives (Phase 4)

### DIFF
--- a/apps/mobile/app/dogs/[id]/friends/[friendDogId].tsx
+++ b/apps/mobile/app/dogs/[id]/friends/[friendDogId].tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { Image } from 'expo-image';
 import { useFriendship } from '@/hooks/use-friendship';
 import { LoadingScreen } from '@/components/ui/LoadingScreen';
-import { Card } from '@/components/ui/Card';
+import { OutlinedCard } from '@/components/ui/OutlinedCard';
 import { Button } from '@/components/ui/Button';
 import { useColors } from '@/hooks/use-colors';
 import { spacing, radius, typography } from '@/theme/tokens';
@@ -48,41 +48,41 @@ export default function FriendDogDetailScreen() {
       </View>
 
       <View style={styles.statsGrid}>
-        <Card padding="md">
+        <OutlinedCard padding="md">
           <Text style={[styles.statLabel, { color: theme.onSurfaceVariant }]}>
             {t('dogs.friends.encounters', 'Encounters').toUpperCase()}
           </Text>
           <Text style={[styles.statValue, { color: theme.onSurface }]}>
             {friendship.encounterCount}
           </Text>
-        </Card>
-        <Card padding="md">
+        </OutlinedCard>
+        <OutlinedCard padding="md">
           <Text style={[styles.statLabel, { color: theme.onSurfaceVariant }]}>
             {t('dogs.friends.totalTime', 'Total Time').toUpperCase()}
           </Text>
           <Text style={[styles.statValue, { color: theme.onSurface }]}>
             {formatDuration(friendship.totalInteractionSec)}
           </Text>
-        </Card>
+        </OutlinedCard>
       </View>
 
       <View style={styles.statsGrid}>
-        <Card padding="md">
+        <OutlinedCard padding="md">
           <Text style={[styles.statLabel, { color: theme.onSurfaceVariant }]}>
             {t('dogs.friends.firstMet', 'First Met').toUpperCase()}
           </Text>
           <Text style={[styles.statValue, { color: theme.onSurface }]}>
             {new Date(friendship.firstMetAt).toLocaleDateString()}
           </Text>
-        </Card>
-        <Card padding="md">
+        </OutlinedCard>
+        <OutlinedCard padding="md">
           <Text style={[styles.statLabel, { color: theme.onSurfaceVariant }]}>
             {t('dogs.friends.lastMet', 'Last Met').toUpperCase()}
           </Text>
           <Text style={[styles.statValue, { color: theme.onSurface }]}>
             {new Date(friendship.lastMetAt).toLocaleDateString()}
           </Text>
-        </Card>
+        </OutlinedCard>
       </View>
 
       <View style={styles.actions}>

--- a/apps/mobile/components/dogs/DogMembersList.tsx
+++ b/apps/mobile/components/dogs/DogMembersList.tsx
@@ -3,6 +3,7 @@ import { Image } from 'expo-image';
 import { useTranslation } from 'react-i18next';
 import { useColors } from '@/hooks/use-colors';
 import { spacing, radius, typography } from '@/theme/tokens';
+import { OutlinedCard } from '@/components/ui/OutlinedCard';
 import type { DogMember } from '@/types/graphql';
 
 interface DogMembersListProps {
@@ -27,15 +28,7 @@ export function DogMembersList({ members, currentUserId, isOwner, onRemove }: Do
         const canRemove = isOwner && item.userId !== currentUserId;
 
         return (
-          <View
-            style={[
-              styles.row,
-              {
-                backgroundColor: theme.surfaceContainerLowest,
-                borderColor: theme.border + '33',
-              },
-            ]}
-          >
+          <OutlinedCard style={styles.row}>
             {item.user.avatarUrl ? (
               <Image
                 source={{ uri: item.user.avatarUrl }}
@@ -71,7 +64,7 @@ export function DogMembersList({ members, currentUserId, isOwner, onRemove }: Do
                 </Text>
               </Pressable>
             ) : null}
-          </View>
+          </OutlinedCard>
         );
       }}
       ItemSeparatorComponent={() => <View style={styles.separator} />}
@@ -83,10 +76,6 @@ const styles = StyleSheet.create({
   row: {
     flexDirection: 'row',
     alignItems: 'center',
-    paddingVertical: spacing.md,
-    paddingHorizontal: spacing.md,
-    borderWidth: 1,
-    borderRadius: radius.lg,
   },
   separator: { height: spacing.sm },
   avatar: { width: 40, height: 40, borderRadius: radius.full },

--- a/apps/mobile/components/dogs/DogStatsCard.tsx
+++ b/apps/mobile/components/dogs/DogStatsCard.tsx
@@ -1,7 +1,8 @@
 import { StyleSheet, Text, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColors } from '@/hooks/use-colors';
-import { spacing, radius, typography } from '@/theme/tokens';
+import { spacing, typography } from '@/theme/tokens';
+import { OutlinedCard } from '@/components/ui/OutlinedCard';
 import type { WalkStats } from '@/types/graphql';
 
 interface DogStatsCardProps {
@@ -25,15 +26,7 @@ export function DogStatsCard({ stats }: DogStatsCardProps) {
     : t('dogs.stats.minutes', { count: minutes });
 
   return (
-    <View
-      style={[
-        styles.card,
-        {
-          backgroundColor: theme.surfaceContainerLowest,
-          borderColor: theme.border + '33',
-        },
-      ]}
-    >
+    <OutlinedCard style={styles.card}>
       <View style={styles.stat}>
         <Text style={[styles.value, { color: theme.onSurface }]}>{stats.totalWalks}</Text>
         <Text style={[styles.label, { color: theme.onSurfaceVariant }]}>{t('dogs.stats.walks')}</Text>
@@ -50,16 +43,13 @@ export function DogStatsCard({ stats }: DogStatsCardProps) {
         </Text>
         <Text style={[styles.label, { color: theme.onSurfaceVariant }]}>{t('dogs.stats.duration')}</Text>
       </View>
-    </View>
+    </OutlinedCard>
   );
 }
 
 const styles = StyleSheet.create({
   card: {
     flexDirection: 'row',
-    borderRadius: radius.lg,
-    borderWidth: 1,
-    padding: spacing.md,
     marginBottom: spacing.md,
   },
   stat: {

--- a/apps/mobile/components/dogs/EncounterCard.tsx
+++ b/apps/mobile/components/dogs/EncounterCard.tsx
@@ -3,6 +3,7 @@ import { Image } from 'expo-image';
 import { useTranslation } from 'react-i18next';
 import { useColors } from '@/hooks/use-colors';
 import { spacing, radius, typography } from '@/theme/tokens';
+import { OutlinedCard } from '@/components/ui/OutlinedCard';
 import type { Encounter } from '@/types/graphql';
 
 interface EncounterCardProps {
@@ -26,15 +27,7 @@ export function EncounterCard({ encounter, myDogId }: EncounterCardProps) {
   const metDate = new Date(encounter.metAt);
 
   return (
-    <View
-      style={[
-        styles.card,
-        {
-          backgroundColor: theme.surfaceContainerLowest,
-          borderColor: theme.border + '33',
-        },
-      ]}
-    >
+    <OutlinedCard style={styles.card}>
       <Image
         source={otherDog.photoUrl ?? require('@/assets/images/icon.png')}
         style={styles.avatar}
@@ -55,7 +48,7 @@ export function EncounterCard({ encounter, myDogId }: EncounterCardProps) {
           {t('dogs.encounters.duration', 'duration')}
         </Text>
       </View>
-    </View>
+    </OutlinedCard>
   );
 }
 
@@ -63,9 +56,6 @@ const styles = StyleSheet.create({
   card: {
     flexDirection: 'row',
     alignItems: 'center',
-    padding: spacing.md,
-    borderWidth: 1,
-    borderRadius: radius.lg,
     marginBottom: spacing.sm,
   },
   avatar: {

--- a/apps/mobile/components/settings/AppearanceSection.tsx
+++ b/apps/mobile/components/settings/AppearanceSection.tsx
@@ -4,6 +4,7 @@ import { useColors } from '@/hooks/use-colors';
 import { spacing, radius, typography } from '@/theme/tokens';
 import { SegmentedControl } from '@/components/ui/SegmentedControl';
 import { useSettingsStore } from '@/stores/settings-store';
+import { SettingsSection } from './SettingsSection';
 
 const LANGUAGES = [
   { label: '日本語', value: 'ja' },
@@ -48,19 +49,7 @@ export function AppearanceSection() {
   }
 
   return (
-    <View
-      style={[
-        styles.card,
-        {
-          backgroundColor: theme.surfaceContainerLowest,
-          borderColor: theme.border + '33',
-        },
-      ]}
-    >
-      <Text style={[styles.sectionTitle, { color: theme.onSurfaceVariant }]}>
-        {t('settings.appearance').toUpperCase()}
-      </Text>
-
+    <SettingsSection title={t('settings.appearance')}>
       <View style={styles.row}>
         <Text style={[styles.rowLabel, { color: theme.onSurface }]}>
           {t('settings.theme')}
@@ -82,7 +71,7 @@ export function AppearanceSection() {
           accessibilityRole="button"
           accessibilityLabel={`${t('settings.language')}: ${currentLanguageLabel}`}
           onPress={handleLanguagePress}
-          style={[styles.dropdown, { borderColor: theme.border + '33' }]}
+          style={[styles.dropdown, { borderColor: theme.cardBorder }]}
         >
           <Text style={[styles.dropdownText, { color: theme.onSurface }]}>
             {currentLanguageLabel}
@@ -90,21 +79,11 @@ export function AppearanceSection() {
           <Text style={[styles.dropdownArrow, { color: theme.onSurfaceVariant }]}>&#9660;</Text>
         </Pressable>
       </View>
-    </View>
+    </SettingsSection>
   );
 }
 
 const styles = StyleSheet.create({
-  card: {
-    borderRadius: radius.lg,
-    borderWidth: 1,
-    padding: spacing.md,
-    marginBottom: spacing.md,
-  },
-  sectionTitle: {
-    ...typography.label,
-    marginBottom: spacing.md,
-  },
   row: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/apps/mobile/components/settings/EncounterDetectionSection.tsx
+++ b/apps/mobile/components/settings/EncounterDetectionSection.tsx
@@ -2,10 +2,11 @@ import { StyleSheet, Switch, Text, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useMutation } from '@tanstack/react-query';
 import { useColors } from '@/hooks/use-colors';
-import { spacing, radius, typography } from '@/theme/tokens';
+import { spacing, typography } from '@/theme/tokens';
 import { authenticatedRequest } from '@/lib/graphql/client';
 import { UPDATE_ENCOUNTER_DETECTION_MUTATION } from '@/lib/graphql/mutations';
 import { useInvalidateUserQueries } from '@/hooks/use-invalidate-user-queries';
+import { SettingsSection } from './SettingsSection';
 import type { UpdateEncounterDetectionResponse } from '@/types/graphql';
 
 interface EncounterDetectionSectionProps {
@@ -28,19 +29,9 @@ export function EncounterDetectionSection({ enabled }: EncounterDetectionSection
   });
 
   return (
-    <View
-      style={[
-        styles.card,
-        {
-          backgroundColor: theme.surfaceContainerLowest,
-          borderColor: theme.border + '33',
-        },
-      ]}
+    <SettingsSection
+      title={t('settings.encounterDetection', 'ENCOUNTER DETECTION')}
     >
-      <Text style={[styles.sectionTitle, { color: theme.onSurfaceVariant }]}>
-        {t('settings.encounterDetection', 'ENCOUNTER DETECTION').toUpperCase()}
-      </Text>
-
       <View style={styles.row}>
         <View style={styles.labelContainer}>
           <Text style={[styles.rowLabel, { color: theme.onSurface }]}>
@@ -63,21 +54,11 @@ export function EncounterDetectionSection({ enabled }: EncounterDetectionSection
           trackColor={{ false: theme.border, true: theme.interactive }}
         />
       </View>
-    </View>
+    </SettingsSection>
   );
 }
 
 const styles = StyleSheet.create({
-  card: {
-    borderRadius: radius.lg,
-    borderWidth: 1,
-    padding: spacing.md,
-    marginBottom: spacing.md,
-  },
-  sectionTitle: {
-    ...typography.label,
-    marginBottom: spacing.md,
-  },
   row: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/apps/mobile/components/settings/ProfileSection.tsx
+++ b/apps/mobile/components/settings/ProfileSection.tsx
@@ -5,7 +5,8 @@ import { useUpdateProfile } from '@/hooks/use-profile-mutation';
 import { Button } from '@/components/ui/Button';
 import { TextInput } from '@/components/ui/TextInput';
 import { useColors } from '@/hooks/use-colors';
-import { spacing, radius, typography } from '@/theme/tokens';
+import { spacing, typography } from '@/theme/tokens';
+import { SettingsSection } from './SettingsSection';
 
 interface ProfileSectionProps {
   displayName: string | null;
@@ -38,18 +39,7 @@ export function ProfileSection({ displayName }: ProfileSectionProps) {
   }
 
   return (
-    <View
-      style={[
-        styles.card,
-        {
-          backgroundColor: theme.surfaceContainerLowest,
-          borderColor: theme.border + '33',
-        },
-      ]}
-    >
-      <Text style={[styles.sectionTitle, { color: theme.onSurfaceVariant }]}>
-        {t('settings.profile').toUpperCase()}
-      </Text>
+    <SettingsSection title={t('settings.profile')}>
       {isEditing ? (
         <View>
           <TextInput
@@ -94,21 +84,11 @@ export function ProfileSection({ displayName }: ProfileSectionProps) {
           />
         </View>
       )}
-    </View>
+    </SettingsSection>
   );
 }
 
 const styles = StyleSheet.create({
-  card: {
-    borderRadius: radius.lg,
-    borderWidth: 1,
-    padding: spacing.md,
-    marginBottom: spacing.md,
-  },
-  sectionTitle: {
-    ...typography.label,
-    marginBottom: spacing.md,
-  },
   displayRow: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/apps/mobile/components/settings/SettingsSection.test.tsx
+++ b/apps/mobile/components/settings/SettingsSection.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react-native';
+import { Text } from 'react-native';
+import { SettingsSection } from './SettingsSection';
+
+jest.mock('@/hooks/use-color-scheme', () => ({
+  useColorScheme: () => 'light',
+}));
+
+describe('SettingsSection', () => {
+  it('renders title in uppercase and children', () => {
+    render(
+      <SettingsSection title="Profile">
+        <Text>body content</Text>
+      </SettingsSection>,
+    );
+    expect(screen.getByText('PROFILE')).toBeTruthy();
+    expect(screen.getByText('body content')).toBeTruthy();
+  });
+});

--- a/apps/mobile/components/settings/SettingsSection.tsx
+++ b/apps/mobile/components/settings/SettingsSection.tsx
@@ -1,0 +1,30 @@
+import type { ReactNode } from 'react';
+import { StyleSheet, Text } from 'react-native';
+import { useColors } from '@/hooks/use-colors';
+import { spacing, typography } from '@/theme/tokens';
+import { OutlinedCard } from '@/components/ui/OutlinedCard';
+
+interface SettingsSectionProps {
+  title: string;
+  children: ReactNode;
+}
+
+export function SettingsSection({ title, children }: SettingsSectionProps) {
+  const theme = useColors();
+  return (
+    <OutlinedCard style={styles.section}>
+      <Text style={[styles.title, { color: theme.onSurfaceVariant }]}>
+        {title.toUpperCase()}
+      </Text>
+      {children}
+    </OutlinedCard>
+  );
+}
+
+const styles = StyleSheet.create({
+  section: { marginBottom: spacing.md },
+  title: {
+    ...typography.label,
+    marginBottom: spacing.md,
+  },
+});

--- a/apps/mobile/components/ui/OutlinedCard.test.tsx
+++ b/apps/mobile/components/ui/OutlinedCard.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react-native';
+import { Text } from 'react-native';
+import { OutlinedCard } from './OutlinedCard';
+
+jest.mock('@/hooks/use-color-scheme', () => ({
+  useColorScheme: () => 'light',
+}));
+
+describe('OutlinedCard', () => {
+  it('renders children', () => {
+    render(
+      <OutlinedCard>
+        <Text>inside card</Text>
+      </OutlinedCard>,
+    );
+    expect(screen.getByText('inside card')).toBeTruthy();
+  });
+
+  it('applies surfaceContainerLowest background and cardBorder color', () => {
+    render(
+      <OutlinedCard testID="card">
+        <Text>x</Text>
+      </OutlinedCard>,
+    );
+    const node = screen.getByTestId('card');
+    const styles = (
+      Array.isArray(node.props.style) ? node.props.style : [node.props.style]
+    ).flat() as Array<Record<string, unknown> | undefined>;
+    const flat: Record<string, unknown> = styles.reduce<Record<string, unknown>>(
+      (acc: Record<string, unknown>, s: Record<string, unknown> | undefined) => ({
+        ...acc,
+        ...(s ?? {}),
+      }),
+      {},
+    );
+    expect(flat.backgroundColor).toBe('#ffffff');
+    expect(flat.borderColor).toBe('#c6c6c633');
+    expect(flat.borderWidth).toBe(1);
+  });
+
+  it('accepts a padding prop mapped to spacing token', () => {
+    render(
+      <OutlinedCard testID="card" padding="lg">
+        <Text>x</Text>
+      </OutlinedCard>,
+    );
+    const node = screen.getByTestId('card');
+    const styles = (
+      Array.isArray(node.props.style) ? node.props.style : [node.props.style]
+    ).flat() as Array<Record<string, unknown> | undefined>;
+    const flat: Record<string, unknown> = styles.reduce<Record<string, unknown>>(
+      (acc: Record<string, unknown>, s: Record<string, unknown> | undefined) => ({
+        ...acc,
+        ...(s ?? {}),
+      }),
+      {},
+    );
+    expect(flat.padding).toBe(24);
+  });
+});

--- a/apps/mobile/components/ui/OutlinedCard.tsx
+++ b/apps/mobile/components/ui/OutlinedCard.tsx
@@ -1,14 +1,18 @@
 import { View, StyleSheet, type ViewProps } from 'react-native';
-import { useColorScheme } from '@/hooks/use-color-scheme';
-import { colors, spacing, radius } from '@/theme/tokens';
+import { useColors } from '@/hooks/use-colors';
+import { spacing, radius } from '@/theme/tokens';
 
-interface CardProps extends ViewProps {
+interface OutlinedCardProps extends ViewProps {
   padding?: keyof typeof spacing;
 }
 
-export function Card({ style, padding = 'md', children, ...rest }: CardProps) {
-  const colorScheme = useColorScheme();
-  const theme = colors[colorScheme ?? 'light'];
+export function OutlinedCard({
+  style,
+  padding = 'md',
+  children,
+  ...rest
+}: OutlinedCardProps) {
+  const theme = useColors();
 
   return (
     <View
@@ -16,7 +20,7 @@ export function Card({ style, padding = 'md', children, ...rest }: CardProps) {
         styles.base,
         {
           backgroundColor: theme.surfaceContainerLowest,
-          borderColor: theme.border + '33', // 20% opacity ghost border
+          borderColor: theme.cardBorder,
           padding: spacing[padding],
         },
         style,

--- a/apps/mobile/components/walk/WalkControls.tsx
+++ b/apps/mobile/components/walk/WalkControls.tsx
@@ -3,6 +3,7 @@ import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { useColors } from '@/hooks/use-colors';
 import { spacing, radius, typography } from '@/theme/tokens';
 import { useWalkStore } from '@/stores/walk-store';
+import { OutlinedCard } from '@/components/ui/OutlinedCard';
 import { formatTime, formatDistance } from '@/lib/walk/format';
 
 interface WalkControlsProps {
@@ -34,20 +35,12 @@ export function WalkControls({ onStop, isStopping }: WalkControlsProps) {
       </View>
 
       <View style={styles.metrics}>
-        <View
-          style={[
-            styles.metricCard,
-            {
-              backgroundColor: theme.surfaceContainerLowest,
-              borderColor: theme.border + '33',
-            },
-          ]}
-        >
+        <OutlinedCard style={styles.metricCard}>
           <Text style={[styles.metricValue, { color: theme.onSurface }]}>
             {formatDistance(totalDistanceM)}
           </Text>
           <Text style={[styles.metricLabel, { color: theme.onSurfaceVariant }]}>Distance</Text>
-        </View>
+        </OutlinedCard>
       </View>
 
       <View style={styles.buttonRow}>
@@ -92,9 +85,6 @@ const styles = StyleSheet.create({
   metricCard: {
     flex: 1,
     alignItems: 'center',
-    padding: spacing.md,
-    borderRadius: radius.lg,
-    borderWidth: 1,
   },
   metricValue: { ...typography.h2 },
   metricLabel: { ...typography.label, marginTop: spacing.xs },

--- a/apps/mobile/components/walk/WalkSummaryCard.tsx
+++ b/apps/mobile/components/walk/WalkSummaryCard.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'expo-router';
 import { useColors } from '@/hooks/use-colors';
 import { spacing, radius, typography } from '@/theme/tokens';
 import { useWalkStore } from '@/stores/walk-store';
+import { OutlinedCard } from '@/components/ui/OutlinedCard';
 import { formatTime, formatDistance } from '@/lib/walk/format';
 
 export function WalkSummaryCard() {
@@ -23,15 +24,7 @@ export function WalkSummaryCard() {
     <View style={[styles.container, { backgroundColor: theme.background }]}>
       <Text style={[styles.title, { color: theme.onSurface }]}>{t('walk.finished.title')}</Text>
 
-      <View
-        style={[
-          styles.card,
-          {
-            backgroundColor: theme.surfaceContainerLowest,
-            borderColor: theme.border + '33',
-          },
-        ]}
-      >
+      <OutlinedCard padding="lg">
         <View style={styles.stats}>
           <View style={styles.stat}>
             <Text style={[styles.statValue, { color: theme.onSurface }]}>
@@ -50,7 +43,7 @@ export function WalkSummaryCard() {
             </Text>
           </View>
         </View>
-      </View>
+      </OutlinedCard>
 
       <View style={styles.buttons}>
         <Pressable
@@ -63,7 +56,7 @@ export function WalkSummaryCard() {
             styles.button,
             {
               backgroundColor: theme.surfaceContainerLowest,
-              borderColor: theme.border + '33',
+              borderColor: theme.cardBorder,
               borderWidth: 1,
             },
           ]}
@@ -90,11 +83,6 @@ export function WalkSummaryCard() {
 const styles = StyleSheet.create({
   container: { flex: 1, padding: spacing.lg, justifyContent: 'center' },
   title: { ...typography.h2, textAlign: 'center', marginBottom: spacing.lg },
-  card: {
-    borderRadius: radius.lg,
-    borderWidth: 1,
-    padding: spacing.lg,
-  },
   stats: { flexDirection: 'row', justifyContent: 'space-around' },
   stat: { alignItems: 'center' },
   statValue: { fontSize: 24, fontWeight: '700' },

--- a/apps/mobile/theme/tokens.test.ts
+++ b/apps/mobile/theme/tokens.test.ts
@@ -32,6 +32,14 @@ describe('ColorTokens interface', () => {
     const token: ColorTokens = colors.light;
     expect(token.primaryContainer).toBeDefined();
   });
+
+  it('has cardBorder in light tokens with 20% alpha suffix', () => {
+    expect(colors.light.cardBorder).toBe('#c6c6c633');
+  });
+
+  it('has cardBorder in dark tokens with 20% alpha suffix', () => {
+    expect(colors.dark.cardBorder).toBe('#3a3a3a33');
+  });
 });
 
 describe('radius', () => {

--- a/apps/mobile/theme/tokens.ts
+++ b/apps/mobile/theme/tokens.ts
@@ -11,6 +11,7 @@ export const colors = {
     interactive: '#000000',
     onInteractive: '#ffffff',
     border: '#c6c6c6',
+    cardBorder: '#c6c6c633',
     error: '#ba1a1a',
     overlay: 'rgba(0,0,0,0.4)',
     primaryContainer: '#3c3b3b',
@@ -27,6 +28,7 @@ export const colors = {
     interactive: '#f0f0f0',
     onInteractive: '#111111',
     border: '#3a3a3a',
+    cardBorder: '#3a3a3a33',
     error: '#ffb4ab',
     overlay: 'rgba(0,0,0,0.6)',
     primaryContainer: '#d4d4d4',
@@ -47,6 +49,7 @@ export interface ColorTokens {
   interactive: string;
   onInteractive: string;
   border: string;
+  cardBorder: string;
   error: string;
   overlay: string;
   primaryContainer: string;


### PR DESCRIPTION
## Summary

Phase 4 of `tasks/refactor/mobile/03-plan.md` — consolidate the ghost-border card pattern and the 3 isomorphic settings sections.

### New primitives
- `components/ui/OutlinedCard.tsx` — View wrapper (`backgroundColor: surfaceContainerLowest`, `borderColor: cardBorder`, `borderRadius: radius.lg`, `borderWidth: 1`, configurable `padding` prop). The old `Card.tsx` was renamed — semantically the same, clearer name.
- `components/settings/SettingsSection.tsx` — uppercase label + `OutlinedCard` wrapper.
- `colors.cardBorder` token — pre-baked 20% alpha suffix so call-sites stop concatenating `'+ 33'` strings.

### Refactored
- 3 settings sections: `ProfileSection`, `AppearanceSection`, `EncounterDetectionSection`
- 5 card call-sites: `DogStatsCard`, `EncounterCard`, `WalkControls` metricCard, `WalkSummaryCard` inner card, `DogMembersList` row
- Residual `theme.border + '33'` in `AppearanceSection` dropdown + `WalkSummaryCard` details button → `theme.cardBorder`

### Out of scope
16 `theme.border + '33'` occurrences remain in Pressable-based cards (FriendCard, DogListItem, DogSelector, etc.) and screens. OutlinedCard is View-only; Pressable variants could come later if the pattern is worth absorbing.

## Test plan

- [x] `npx jest` — 221/221 pass (6 new tests: 2 tokens + 3 OutlinedCard + 1 SettingsSection)
- [x] `npm run lint` — clean (1 pre-existing warning)
- [x] `npx tsc --noEmit` — only pre-existing errors (`ble/permissions.ts`, `graphql/errors.test.ts`)
- [ ] iOS Simulator smoke — optional; style values bit-exact (cardBorder token == border + '33')

🤖 Generated with [Claude Code](https://claude.com/claude-code)