### PR TITLE
refactor(mobile): split invite/[token] screen into hook + helpers (Phase 6)

### DIFF
--- a/apps/mobile/__tests__/app/invite/accept-invite.test.tsx
+++ b/apps/mobile/__tests__/app/invite/accept-invite.test.tsx
@@ -3,13 +3,19 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import * as SecureStore from 'expo-secure-store';
 import AcceptInviteScreen from '../../../app/invite/[token]';
 
-const mockReplace = jest.fn();
-const mockBack = jest.fn();
-
-jest.mock('expo-router', () => ({
-  useLocalSearchParams: () => ({ token: 'test-token' }),
-  useRouter: () => ({ replace: mockReplace, back: mockBack }),
-}));
+jest.mock('expo-router', () => {
+  const router = { replace: jest.fn(), back: jest.fn() };
+  return {
+    useLocalSearchParams: () => ({ token: 'test-token' }),
+    useRouter: () => router,
+    __router: router,
+  };
+});
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { __router } = require('expo-router') as {
+  __router: { replace: jest.Mock; back: jest.Mock };
+};
+const mockReplace = __router.replace;
 
 jest.mock('expo-secure-store', () => ({
   setItemAsync: jest.fn(),
@@ -17,13 +23,18 @@ jest.mock('expo-secure-store', () => ({
   deleteItemAsync: jest.fn(),
 }));
 
-const mockMutateAsync = jest.fn();
-jest.mock('@/hooks/use-accept-invitation', () => ({
-  useAcceptInvitation: () => ({
-    mutateAsync: mockMutateAsync,
-    isPending: false,
-  }),
-}));
+jest.mock('@/hooks/use-accept-invitation', () => {
+  const mutation = { mutateAsync: jest.fn(), isPending: false };
+  return {
+    useAcceptInvitation: () => mutation,
+    __mutation: mutation,
+  };
+});
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { __mutation } = require('@/hooks/use-accept-invitation') as {
+  __mutation: { mutateAsync: jest.Mock; isPending: boolean };
+};
+const mockMutateAsync = __mutation.mutateAsync;
 
 let mockIsAuthenticated = true;
 jest.mock('@/stores/auth-store', () => ({

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -15,7 +15,7 @@ import { ErrorScreen } from '@/components/ui/ErrorScreen';
 import {
   getPendingInviteToken,
   deletePendingInviteToken,
-} from '@/app/invite/[token]';
+} from '@/lib/auth/pending-invite-token';
 
 function NavigationGuard() {
   const { isAuthenticated, isLoading } = useAuthStore();

--- a/apps/mobile/app/invite/[token].tsx
+++ b/apps/mobile/app/invite/[token].tsx
@@ -1,128 +1,45 @@
-import { useEffect, useState } from 'react';
-import { ActivityIndicator, Platform, Pressable, StyleSheet, Text, View } from 'react-native';
+import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import * as SecureStore from 'expo-secure-store';
 import { useTranslation } from 'react-i18next';
 import { Ionicons } from '@expo/vector-icons';
 import { useColors } from '@/hooks/use-colors';
 import { spacing, typography } from '@/theme/tokens';
-import { useIsAuthenticated } from '@/hooks/use-is-authenticated';
-import { useAcceptInvitation } from '@/hooks/use-accept-invitation';
-import { extractGraphQLErrorMessage } from '@/lib/graphql/errors';
+import { useAcceptInviteFlow } from '@/hooks/use-accept-invite-flow';
 import { Button } from '@/components/ui/Button';
-
-const PENDING_INVITE_KEY = 'pending_invite_token';
-
-export async function savePendingInviteToken(token: string): Promise<void> {
-  if (Platform.OS === 'web') {
-    if (typeof localStorage !== 'undefined') localStorage.setItem(PENDING_INVITE_KEY, token);
-    return;
-  }
-  await SecureStore.setItemAsync(PENDING_INVITE_KEY, token);
-}
-
-export async function getPendingInviteToken(): Promise<string | null> {
-  if (Platform.OS === 'web') {
-    return typeof localStorage !== 'undefined'
-      ? localStorage.getItem(PENDING_INVITE_KEY)
-      : null;
-  }
-  return SecureStore.getItemAsync(PENDING_INVITE_KEY);
-}
-
-export async function deletePendingInviteToken(): Promise<void> {
-  if (Platform.OS === 'web') {
-    if (typeof localStorage !== 'undefined') localStorage.removeItem(PENDING_INVITE_KEY);
-    return;
-  }
-  await SecureStore.deleteItemAsync(PENDING_INVITE_KEY);
-}
-
-function mapInviteErrorMessage(
-  errorMsg: string | null,
-  t: (key: string) => string,
-): string {
-  if (errorMsg) {
-    const lower = errorMsg.toLowerCase();
-    if (lower.includes('expired')) return t('invite.error.expired');
-    if (lower.includes('already been used')) return t('invite.error.alreadyUsed');
-    if (lower.includes('already a member')) return t('invite.error.alreadyMember');
-  }
-  return t('invite.error.generic');
-}
 
 export default function AcceptInviteScreen() {
   const { token } = useLocalSearchParams<{ token: string }>();
   const { t } = useTranslation();
   const router = useRouter();
   const theme = useColors();
-  const isAuthenticated = useIsAuthenticated();
-  const acceptInvitation = useAcceptInvitation();
+  const flow = useAcceptInviteFlow(token);
+  const bg = { backgroundColor: theme.background };
 
-  const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
-  const [dogName, setDogName] = useState<string | null>(null);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (!token) return;
-
-    if (!isAuthenticated) {
-      savePendingInviteToken(token)
-        .then(() => {
-          router.replace('/(auth)/login');
-        })
-        .catch(() => {
-          setErrorMessage(t('invite.error.saveFailed'));
-          setStatus('error');
-        });
-      return;
-    }
-
-    setStatus('loading');
-    acceptInvitation
-      .mutateAsync(token)
-      .then((dog) => {
-        setDogName(dog.name);
-        setStatus('success');
-      })
-      .catch((error: unknown) => {
-        const msg = extractGraphQLErrorMessage(error);
-        setErrorMessage(mapInviteErrorMessage(msg, t));
-        setStatus('error');
-      });
-  }, [token, isAuthenticated]);
-
-  if (status === 'loading') {
+  if (flow.status === 'loading') {
     return (
-      <View style={[styles.container, { backgroundColor: theme.background }]}>
+      <View style={[styles.container, bg]}>
         <ActivityIndicator size="large" />
-        <Text style={[styles.message, { color: theme.onSurfaceVariant }]}>
-          {t('invite.accepting')}
-        </Text>
+        <Text style={[styles.message, { color: theme.onSurfaceVariant }]}>{t('invite.accepting')}</Text>
       </View>
     );
   }
 
-  if (status === 'error') {
+  if (flow.status === 'error') {
     return (
-      <View style={[styles.container, { backgroundColor: theme.background }]}>
+      <View style={[styles.container, bg]}>
         <Text style={[styles.errorText, { color: theme.error }]}>
-          {errorMessage}
+          {t(flow.errorKey ?? 'invite.error.generic')}
         </Text>
-        <Button
-          label={t('common.retry')}
-          onPress={() => router.back()}
-          style={styles.button}
-        />
+        <Button label={t('common.retry')} onPress={() => router.back()} style={styles.button} />
       </View>
     );
   }
 
-  if (status === 'success') {
+  if (flow.status === 'success') {
     return (
-      <View style={[styles.container, { backgroundColor: theme.background }]}>
+      <View style={[styles.container, bg]}>
         <Text style={[styles.successText, { color: theme.onSurface }]}>
-          {t('invite.success', { name: dogName })}
+          {t('invite.success', { name: flow.dogName })}
         </Text>
         <Button
           label={t('invite.goToDog')}
@@ -133,42 +50,19 @@ export default function AcceptInviteScreen() {
     );
   }
 
-  // idle — invitation landing screen
   return (
-    <View style={[styles.container, { backgroundColor: theme.background }]}>
+    <View style={[styles.container, bg]}>
       <View style={[styles.iconContainer, { backgroundColor: theme.surfaceContainerHigh }]}>
         <Ionicons name="mail" size={36} color={theme.onSurface} />
       </View>
-
-      <Text style={[styles.heroText, { color: theme.onSurface }]}>
-        {t('invite.title')}
-      </Text>
-
-      <Text style={[styles.bodyText, { color: theme.onSurfaceVariant }]}>
-        {t('invite.description')}
-      </Text>
-
+      <Text style={[styles.heroText, { color: theme.onSurface }]}>{t('invite.title')}</Text>
+      <Text style={[styles.bodyText, { color: theme.onSurfaceVariant }]}>{t('invite.description')}</Text>
       <Button
         label={t('invite.accept')}
         variant="primary"
-        onPress={() => {
-          setStatus('loading');
-          if (!token) return;
-          acceptInvitation
-            .mutateAsync(token)
-            .then((dog) => {
-              setDogName(dog.name);
-              setStatus('success');
-            })
-            .catch((error: unknown) => {
-              const msg = extractGraphQLErrorMessage(error);
-              setErrorMessage(mapInviteErrorMessage(msg, t));
-              setStatus('error');
-            });
-        }}
+        onPress={() => void flow.accept()}
         style={styles.acceptButton}
       />
-
       <Pressable
         accessibilityRole="button"
         accessibilityLabel={t('invite.decline')}
@@ -176,22 +70,14 @@ export default function AcceptInviteScreen() {
         style={styles.declineButton}
         hitSlop={12}
       >
-        <Text style={[styles.declineText, { color: theme.onSurfaceVariant }]}>
-          {t('invite.decline')}
-        </Text>
+        <Text style={[styles.declineText, { color: theme.onSurfaceVariant }]}>{t('invite.decline')}</Text>
       </Pressable>
-
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    padding: spacing.xl,
-  },
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: spacing.xl },
   iconContainer: {
     width: 80,
     height: 80,
@@ -207,22 +93,10 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     marginBottom: spacing.md,
   },
-  bodyText: {
-    ...typography.body,
-    textAlign: 'center',
-    marginBottom: spacing.xl,
-  },
-  acceptButton: {
-    width: '100%',
-    marginBottom: spacing.md,
-  },
-  declineButton: {
-    paddingVertical: spacing.sm,
-    marginBottom: spacing.xl,
-  },
-  declineText: {
-    ...typography.body,
-  },
+  bodyText: { ...typography.body, textAlign: 'center', marginBottom: spacing.xl },
+  acceptButton: { width: '100%', marginBottom: spacing.md },
+  declineButton: { paddingVertical: spacing.sm, marginBottom: spacing.xl },
+  declineText: { ...typography.body },
   message: { ...typography.body, marginTop: spacing.lg },
   successText: { ...typography.h2, textAlign: 'center' },
   errorText: { ...typography.body, textAlign: 'center' },

--- a/apps/mobile/hooks/use-accept-invite-flow.test.ts
+++ b/apps/mobile/hooks/use-accept-invite-flow.test.ts
@@ -1,0 +1,147 @@
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import { useAcceptInviteFlow } from './use-accept-invite-flow';
+import * as isAuth from './use-is-authenticated';
+import * as acceptInvitation from './use-accept-invitation';
+import * as pending from '@/lib/auth/pending-invite-token';
+import * as gqlErrors from '@/lib/graphql/errors';
+
+jest.mock('./use-is-authenticated');
+jest.mock('./use-accept-invitation');
+jest.mock('@/lib/auth/pending-invite-token', () => ({
+  savePendingInviteToken: jest.fn(),
+}));
+jest.mock('@/lib/graphql/errors', () => ({
+  extractGraphQLErrorMessage: jest.fn(),
+}));
+jest.mock('expo-router', () => {
+  const router = { replace: jest.fn() };
+  return {
+    useRouter: () => router,
+    __router: router,
+  };
+});
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const mockReplace = (require('expo-router') as { __router: { replace: jest.Mock } }).__router
+  .replace;
+
+const mockMutateAsync = jest.fn();
+
+function setupMocks(opts: { isAuthenticated: boolean }) {
+  (isAuth.useIsAuthenticated as jest.Mock).mockReturnValue(opts.isAuthenticated);
+  (acceptInvitation.useAcceptInvitation as jest.Mock).mockReturnValue({
+    mutateAsync: mockMutateAsync,
+    isPending: false,
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (pending.savePendingInviteToken as jest.Mock).mockResolvedValue(undefined);
+  (gqlErrors.extractGraphQLErrorMessage as jest.Mock).mockReturnValue(null);
+});
+
+describe('useAcceptInviteFlow — unauthenticated', () => {
+  beforeEach(() => setupMocks({ isAuthenticated: false }));
+
+  it('on mount with token, saves token and redirects to login', async () => {
+    renderHook(() => useAcceptInviteFlow('tok-1'));
+
+    await waitFor(() => {
+      expect(pending.savePendingInviteToken).toHaveBeenCalledWith('tok-1');
+      expect(mockReplace).toHaveBeenCalledWith('/(auth)/login');
+    });
+    expect(mockMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('when savePendingInviteToken fails, transitions to error with saveFailed key', async () => {
+    (pending.savePendingInviteToken as jest.Mock).mockRejectedValue(new Error('boom'));
+
+    const { result } = renderHook(() => useAcceptInviteFlow('tok-1'));
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('error');
+      expect(result.current.errorKey).toBe('invite.error.saveFailed');
+    });
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it('does not attempt anything when token is undefined', async () => {
+    renderHook(() => useAcceptInviteFlow(undefined));
+    await new Promise((r) => setTimeout(r, 10));
+    expect(pending.savePendingInviteToken).not.toHaveBeenCalled();
+    expect(mockReplace).not.toHaveBeenCalled();
+    expect(mockMutateAsync).not.toHaveBeenCalled();
+  });
+});
+
+describe('useAcceptInviteFlow — authenticated', () => {
+  beforeEach(() => setupMocks({ isAuthenticated: true }));
+
+  it('on mount with token, auto-accepts and transitions to success with dogName', async () => {
+    mockMutateAsync.mockResolvedValue({ id: 'dog-1', name: 'Rex' });
+
+    const { result } = renderHook(() => useAcceptInviteFlow('tok-1'));
+
+    await waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith('tok-1');
+      expect(result.current.status).toBe('success');
+      expect(result.current.dogName).toBe('Rex');
+    });
+  });
+
+  it('on accept failure, transitions to error with mapped key', async () => {
+    mockMutateAsync.mockRejectedValue(new Error('graphql err'));
+    (gqlErrors.extractGraphQLErrorMessage as jest.Mock).mockReturnValue('Invitation has expired');
+
+    const { result } = renderHook(() => useAcceptInviteFlow('tok-1'));
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('error');
+      expect(result.current.errorKey).toBe('invite.error.expired');
+    });
+  });
+
+  it('on unknown accept failure, uses generic key', async () => {
+    mockMutateAsync.mockRejectedValue(new Error('wat'));
+    (gqlErrors.extractGraphQLErrorMessage as jest.Mock).mockReturnValue('random thing');
+
+    const { result } = renderHook(() => useAcceptInviteFlow('tok-1'));
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('error');
+      expect(result.current.errorKey).toBe('invite.error.generic');
+    });
+  });
+
+  it('does not redirect to login', async () => {
+    mockMutateAsync.mockResolvedValue({ id: 'd', name: 'X' });
+    renderHook(() => useAcceptInviteFlow('tok-1'));
+    await waitFor(() => expect(mockMutateAsync).toHaveBeenCalled());
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it('accept() called explicitly re-runs the mutation', async () => {
+    mockMutateAsync.mockResolvedValue({ id: 'd', name: 'X' });
+    const { result } = renderHook(() => useAcceptInviteFlow('tok-1'));
+    await waitFor(() => expect(result.current.status).toBe('success'));
+
+    mockMutateAsync.mockClear();
+    mockMutateAsync.mockResolvedValue({ id: 'd2', name: 'Y' });
+    await act(async () => {
+      await result.current.accept();
+    });
+    expect(mockMutateAsync).toHaveBeenCalledTimes(1);
+    expect(result.current.dogName).toBe('Y');
+  });
+});
+
+describe('useAcceptInviteFlow — initial state', () => {
+  beforeEach(() => setupMocks({ isAuthenticated: false }));
+
+  it('starts with status=idle, dogName=null, errorKey=null', () => {
+    const { result } = renderHook(() => useAcceptInviteFlow(undefined));
+    expect(result.current.status).toBe('idle');
+    expect(result.current.dogName).toBeNull();
+    expect(result.current.errorKey).toBeNull();
+  });
+});

--- a/apps/mobile/hooks/use-accept-invite-flow.ts
+++ b/apps/mobile/hooks/use-accept-invite-flow.ts
@@ -1,0 +1,66 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useRouter } from 'expo-router';
+import { useIsAuthenticated } from './use-is-authenticated';
+import { useAcceptInvitation } from './use-accept-invitation';
+import { savePendingInviteToken } from '@/lib/auth/pending-invite-token';
+import { extractGraphQLErrorMessage } from '@/lib/graphql/errors';
+import { mapInviteErrorKey, type InviteErrorKey } from '@/lib/errors/invite-error-map';
+
+export type AcceptInviteStatus = 'idle' | 'loading' | 'success' | 'error';
+export type AcceptInviteErrorKey = InviteErrorKey | 'invite.error.saveFailed';
+
+interface AcceptInviteFlowState {
+  status: AcceptInviteStatus;
+  dogName: string | null;
+  errorKey: AcceptInviteErrorKey | null;
+}
+
+const INITIAL_STATE: AcceptInviteFlowState = {
+  status: 'idle',
+  dogName: null,
+  errorKey: null,
+};
+
+export function useAcceptInviteFlow(token: string | undefined) {
+  const isAuthenticated = useIsAuthenticated();
+  const acceptInvitation = useAcceptInvitation();
+  const router = useRouter();
+
+  const [state, setState] = useState<AcceptInviteFlowState>(INITIAL_STATE);
+
+  const runAccept = useCallback(
+    async (inviteToken: string) => {
+      setState({ status: 'loading', dogName: null, errorKey: null });
+      try {
+        const dog = await acceptInvitation.mutateAsync(inviteToken);
+        setState({ status: 'success', dogName: dog.name, errorKey: null });
+      } catch (err: unknown) {
+        const msg = extractGraphQLErrorMessage(err);
+        setState({ status: 'error', dogName: null, errorKey: mapInviteErrorKey(msg) });
+      }
+    },
+    [acceptInvitation],
+  );
+
+  useEffect(() => {
+    if (!token) return;
+
+    if (!isAuthenticated) {
+      savePendingInviteToken(token)
+        .then(() => router.replace('/(auth)/login'))
+        .catch(() => {
+          setState({ status: 'error', dogName: null, errorKey: 'invite.error.saveFailed' });
+        });
+      return;
+    }
+
+    void runAccept(token);
+  }, [token, isAuthenticated, router, runAccept]);
+
+  const accept = useCallback(async () => {
+    if (!token) return;
+    await runAccept(token);
+  }, [token, runAccept]);
+
+  return { ...state, accept };
+}

--- a/apps/mobile/lib/auth/pending-invite-token.test.ts
+++ b/apps/mobile/lib/auth/pending-invite-token.test.ts
@@ -1,0 +1,91 @@
+import { Platform } from 'react-native';
+import * as SecureStore from 'expo-secure-store';
+import {
+  savePendingInviteToken,
+  getPendingInviteToken,
+  deletePendingInviteToken,
+  PENDING_INVITE_KEY,
+} from './pending-invite-token';
+
+jest.mock('expo-secure-store');
+
+const mockSecureStore = SecureStore as jest.Mocked<typeof SecureStore>;
+
+describe('pending-invite-token (native)', () => {
+  beforeAll(() => {
+    Object.defineProperty(Platform, 'OS', { get: () => 'ios', configurable: true });
+  });
+  beforeEach(() => jest.clearAllMocks());
+
+  it('savePendingInviteToken calls SecureStore.setItemAsync', async () => {
+    await savePendingInviteToken('tok-1');
+    expect(mockSecureStore.setItemAsync).toHaveBeenCalledWith(PENDING_INVITE_KEY, 'tok-1');
+  });
+
+  it('getPendingInviteToken calls SecureStore.getItemAsync', async () => {
+    mockSecureStore.getItemAsync.mockResolvedValue('tok-1');
+    expect(await getPendingInviteToken()).toBe('tok-1');
+    expect(mockSecureStore.getItemAsync).toHaveBeenCalledWith(PENDING_INVITE_KEY);
+  });
+
+  it('getPendingInviteToken returns null when no token stored', async () => {
+    mockSecureStore.getItemAsync.mockResolvedValue(null);
+    expect(await getPendingInviteToken()).toBeNull();
+  });
+
+  it('deletePendingInviteToken calls SecureStore.deleteItemAsync', async () => {
+    await deletePendingInviteToken();
+    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith(PENDING_INVITE_KEY);
+  });
+});
+
+describe('pending-invite-token (web)', () => {
+  let store: Record<string, string>;
+
+  beforeAll(() => {
+    Object.defineProperty(Platform, 'OS', { get: () => 'web', configurable: true });
+    store = {};
+    Object.defineProperty(global, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem: (k: string) => (k in store ? store[k] : null),
+        setItem: (k: string, v: string) => {
+          store[k] = v;
+        },
+        removeItem: (k: string) => {
+          delete store[k];
+        },
+      },
+    });
+  });
+  beforeEach(() => {
+    store = {};
+    jest.clearAllMocks();
+  });
+  afterAll(() => {
+    Object.defineProperty(Platform, 'OS', { get: () => 'ios', configurable: true });
+  });
+
+  it('savePendingInviteToken writes to localStorage', async () => {
+    await savePendingInviteToken('web-tok');
+    expect(store[PENDING_INVITE_KEY]).toBe('web-tok');
+    expect(mockSecureStore.setItemAsync).not.toHaveBeenCalled();
+  });
+
+  it('getPendingInviteToken reads from localStorage', async () => {
+    store[PENDING_INVITE_KEY] = 'web-tok';
+    expect(await getPendingInviteToken()).toBe('web-tok');
+    expect(mockSecureStore.getItemAsync).not.toHaveBeenCalled();
+  });
+
+  it('getPendingInviteToken returns null when localStorage empty', async () => {
+    expect(await getPendingInviteToken()).toBeNull();
+  });
+
+  it('deletePendingInviteToken removes from localStorage', async () => {
+    store[PENDING_INVITE_KEY] = 'web-tok';
+    await deletePendingInviteToken();
+    expect(PENDING_INVITE_KEY in store).toBe(false);
+    expect(mockSecureStore.deleteItemAsync).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/lib/auth/pending-invite-token.ts
+++ b/apps/mobile/lib/auth/pending-invite-token.ts
@@ -1,0 +1,29 @@
+import { Platform } from 'react-native';
+import * as SecureStore from 'expo-secure-store';
+
+export const PENDING_INVITE_KEY = 'pending_invite_token';
+
+export async function savePendingInviteToken(token: string): Promise<void> {
+  if (Platform.OS === 'web') {
+    if (typeof localStorage !== 'undefined') localStorage.setItem(PENDING_INVITE_KEY, token);
+    return;
+  }
+  await SecureStore.setItemAsync(PENDING_INVITE_KEY, token);
+}
+
+export async function getPendingInviteToken(): Promise<string | null> {
+  if (Platform.OS === 'web') {
+    return typeof localStorage !== 'undefined'
+      ? localStorage.getItem(PENDING_INVITE_KEY)
+      : null;
+  }
+  return SecureStore.getItemAsync(PENDING_INVITE_KEY);
+}
+
+export async function deletePendingInviteToken(): Promise<void> {
+  if (Platform.OS === 'web') {
+    if (typeof localStorage !== 'undefined') localStorage.removeItem(PENDING_INVITE_KEY);
+    return;
+  }
+  await SecureStore.deleteItemAsync(PENDING_INVITE_KEY);
+}

--- a/apps/mobile/lib/errors/invite-error-map.test.ts
+++ b/apps/mobile/lib/errors/invite-error-map.test.ts
@@ -1,0 +1,29 @@
+import { mapInviteErrorKey } from './invite-error-map';
+
+describe('mapInviteErrorKey', () => {
+  it('returns expired key when message mentions "expired"', () => {
+    expect(mapInviteErrorKey('Invitation has expired')).toBe('invite.error.expired');
+    expect(mapInviteErrorKey('this invite is EXPIRED')).toBe('invite.error.expired');
+  });
+
+  it('returns alreadyUsed key when message mentions "already been used"', () => {
+    expect(mapInviteErrorKey('Token has already been used')).toBe('invite.error.alreadyUsed');
+    expect(mapInviteErrorKey('Already Been Used')).toBe('invite.error.alreadyUsed');
+  });
+
+  it('returns alreadyMember key when message mentions "already a member"', () => {
+    expect(mapInviteErrorKey('User is already a member')).toBe('invite.error.alreadyMember');
+  });
+
+  it('returns generic key when message is null', () => {
+    expect(mapInviteErrorKey(null)).toBe('invite.error.generic');
+  });
+
+  it('returns generic key when message does not match any known pattern', () => {
+    expect(mapInviteErrorKey('Something weird happened')).toBe('invite.error.generic');
+  });
+
+  it('returns generic key when message is empty string', () => {
+    expect(mapInviteErrorKey('')).toBe('invite.error.generic');
+  });
+});

--- a/apps/mobile/lib/errors/invite-error-map.ts
+++ b/apps/mobile/lib/errors/invite-error-map.ts
@@ -1,0 +1,14 @@
+export type InviteErrorKey =
+  | 'invite.error.expired'
+  | 'invite.error.alreadyUsed'
+  | 'invite.error.alreadyMember'
+  | 'invite.error.generic';
+
+export function mapInviteErrorKey(errorMsg: string | null): InviteErrorKey {
+  if (!errorMsg) return 'invite.error.generic';
+  const lower = errorMsg.toLowerCase();
+  if (lower.includes('expired')) return 'invite.error.expired';
+  if (lower.includes('already been used')) return 'invite.error.alreadyUsed';
+  if (lower.includes('already a member')) return 'invite.error.alreadyMember';
+  return 'invite.error.generic';
+}


### PR DESCRIPTION
## Summary

Phase 6 of `tasks/refactor/mobile/03-plan.md` — split 230-line invite/[token].tsx.

- `lib/auth/pending-invite-token.ts` (new) — Platform-branched SecureStore/localStorage abstraction extracted from screen.
- `lib/errors/invite-error-map.ts` (new) — i18n-key based invite error mapping (`invite.error.expired|alreadyUsed|alreadyMember|generic`).
- `hooks/use-accept-invite-flow.ts` (new) — state machine (idle/loading/success/error) orchestrating the unauth-redirect branch vs auto-accept, with explicit `accept()` for the landing-screen button.
- `app/invite/[token].tsx` — **230 → 104 lines**, presentational only.
- `app/_layout.tsx` — updated import path for pending-invite-token helpers.
- `__tests__/app/invite/accept-invite.test.tsx` — stable-ref mocks for router and mutation (required because hook now includes them in useCallback deps; previously passing tests would have infinite-looped with fresh-object mocks).

## Test plan

- [x] `lib/auth/pending-invite-token.test.ts` — 8 tests (native SecureStore branch + web localStorage branch)
- [x] `lib/errors/invite-error-map.test.ts` — 6 tests (all 4 keys + null + empty)
- [x] `hooks/use-accept-invite-flow.test.ts` — 9 tests (unauth save/redirect, save-failed error, token undefined; authenticated auto-accept + mapped errors; explicit accept())
- [x] `__tests__/app/invite/accept-invite.test.tsx` — 7 tests (updated for hook composition, all passing)
- [x] Full `npx jest` — 264 passed / 47 suites
- [x] `npx tsc --noEmit` — no new errors in Phase 6 files
- [x] `npx expo lint` — no new warnings (the previous exhaustive-deps warning on invite/[token] is gone, since the useEffect moved into the hook with complete deps)
- [ ] **Manual deep-link smoke pending (plan line 108): auth済 / 未認証 / 期限切れ / 使用済み** — reviewer or author to verify via `npx uri-scheme open exp://...invite/<token> --ios`

🤖 Generated with [Claude Code](https://claude.com/claude-code)