### PR TITLE
refactor(mobile): split (tabs)/walk into 4 session hooks (Phase 7)

### DIFF
--- a/apps/mobile/app/(tabs)/walk.tsx
+++ b/apps/mobile/app/(tabs)/walk.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Alert, StyleSheet } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router, useLocalSearchParams } from 'expo-router';
@@ -6,26 +6,16 @@ import { useTranslation } from 'react-i18next';
 import { useColors } from '@/hooks/use-colors';
 import { useWalkStore } from '@/stores/walk-store';
 import { useMe } from '@/hooks/use-me';
-import { useStartWalk, useFinishWalk, useAddWalkPoints } from '@/hooks/use-walk-mutations';
-import { useRecordEncounter, useUpdateEncounterDuration } from '@/hooks/use-encounter-mutations';
-import { requestPermission, startTracking } from '@/lib/walk/gps-tracker';
-import { requestBluetoothPermission } from '@/lib/ble/permissions';
-import { startScanning, startAdvertising, type BleScanner } from '@/lib/ble/scanner';
-import { EncounterTracker } from '@/lib/ble/encounter-tracker';
+import { useWalkSession } from '@/hooks/use-walk-session';
+import { useBleSession } from '@/hooks/use-ble-session';
+import { useEncounterSession } from '@/hooks/use-encounter-session';
+import { useWalkPermissions } from '@/hooks/use-walk-permissions';
 import { WalkReadyView } from '@/components/walk/WalkReadyView';
 import { DogSelectorSheet } from '@/components/walk/DogSelectorSheet';
 import { WalkMap } from '@/components/walk/WalkMap';
 import { WalkControls } from '@/components/walk/WalkControls';
 import { WalkEventActions } from '@/components/walk/WalkEventActions';
 import { WalkSummaryCard } from '@/components/walk/WalkSummaryCard';
-import {
-  startLiveActivity,
-  updateLiveActivityDistance,
-  endLiveActivity,
-} from '@/lib/walk/live-activity';
-import type { WalkPoint } from '@/types/graphql';
-
-const MAX_POINTS_PER_BATCH = 200;
 
 export default function WalkScreen() {
   const { t } = useTranslation();
@@ -33,29 +23,19 @@ export default function WalkScreen() {
   const phase = useWalkStore((s) => s.phase);
   const walkId = useWalkStore((s) => s.walkId);
   const selectedDogIds = useWalkStore((s) => s.selectedDogIds);
-  const addPoint = useWalkStore((s) => s.addPoint);
-  const startRecording = useWalkStore((s) => s.startRecording);
-  const finish = useWalkStore((s) => s.finish);
   const requestCamera = useWalkStore((s) => s.requestCamera);
   const params = useLocalSearchParams<{ action?: string }>();
 
   const { data: me } = useMe();
-  const startWalk = useStartWalk();
-  const finishWalk = useFinishWalk();
-  const addWalkPoints = useAddWalkPoints();
-  const recordEncounter = useRecordEncounter();
-  const updateEncounterDuration = useUpdateEncounterDuration();
-  const stopTrackingRef = useRef<(() => void) | null>(null);
-  const bleScannerRef = useRef<BleScanner | null>(null);
-  const bleAdvertiserRef = useRef<{ stop: () => void } | null>(null);
-  const encounterTrackerRef = useRef<EncounterTracker | null>(null);
+  const walkSession = useWalkSession();
+  const bleSession = useBleSession();
+  const encounterSession = useEncounterSession();
+  const permissions = useWalkPermissions();
   const [isStopping, setIsStopping] = useState(false);
   const [isSheetOpen, setIsSheetOpen] = useState(false);
 
   useEffect(() => {
-    if (phase !== 'ready') {
-      setIsSheetOpen(false);
-    }
+    if (phase !== 'ready') setIsSheetOpen(false);
   }, [phase]);
 
   // Live Activity の Camera ボタン (Link) からのディープリンク
@@ -63,113 +43,51 @@ export default function WalkScreen() {
   // setParams で action を null にして再来訪での連続発火を防ぐ。
   useEffect(() => {
     if (params.action !== 'camera') return;
-    if (phase === 'recording' && walkId) {
-      requestCamera();
-    }
+    if (phase === 'recording' && walkId) requestCamera();
     router.setParams({ action: undefined });
   }, [params.action, phase, walkId, requestCamera]);
 
   const handleStart = useCallback(async () => {
-    const granted = await requestPermission();
-    if (!granted) {
+    const gpsGranted = await permissions.requestGpsPermission();
+    if (!gpsGranted) {
       Alert.alert(t('walk.permission.title'), t('walk.permission.message'));
       return;
     }
 
     try {
-      const walk = await startWalk.mutateAsync(selectedDogIds);
-      startRecording(walk.id);
+      const liveActivityDogName =
+        selectedDogIds.length === 1
+          ? t('walk.liveActivity.walking')
+          : t('walk.liveActivity.walkingWithDogs', { count: selectedDogIds.length });
+      const newWalkId = await walkSession.start({ selectedDogIds, liveActivityDogName });
 
-      const dogName =
-        selectedDogIds.length === 1 ? t('walk.liveActivity.walking') : t('walk.liveActivity.walkingWithDogs', { count: selectedDogIds.length });
-      await startLiveActivity({
-        walkId: walk.id,
-        dogId: selectedDogIds[0],
-        dogName,
-        startedAt: useWalkStore.getState().startedAt ?? new Date(),
-        distanceM: 0,
-      });
-
-      const stop = await startTracking((point: WalkPoint) => {
-        addPoint(point);
-        void updateLiveActivityDistance(useWalkStore.getState().totalDistanceM);
-      });
-      stopTrackingRef.current = stop;
-
-      // Start BLE encounter detection if enabled
-      const bleEnabled = me?.encounterDetectionEnabled ?? true;
-      if (bleEnabled) {
-        const bleGranted = await requestBluetoothPermission();
+      if (me?.encounterDetectionEnabled ?? true) {
+        const bleGranted = await permissions.requestBlePermission();
         if (bleGranted) {
-          const currentWalkId = walk.id;
-          const tracker = new EncounterTracker({
-            onEncounterDetected: (theirWalkId) => {
-              recordEncounter.mutate({ myWalkId: currentWalkId, theirWalkId });
-            },
-            onEncounterFinalized: (theirWalkId, durationMs) => {
-              updateEncounterDuration.mutate({
-                myWalkId: currentWalkId,
-                theirWalkId,
-                durationSec: Math.round(durationMs / 1000),
-              });
-            },
-          });
-          tracker.start();
-          encounterTrackerRef.current = tracker;
-
-          const scanner = await startScanning((detectedWalkId) => {
-            tracker.onDeviceDetected(detectedWalkId);
-          });
-          bleScannerRef.current = scanner;
-
-          const advertiser = await startAdvertising(currentWalkId);
-          bleAdvertiserRef.current = advertiser;
+          encounterSession.start(newWalkId);
+          await bleSession.start(newWalkId, (detected) =>
+            encounterSession.onDeviceDetected(detected),
+          );
         }
       }
     } catch {
       Alert.alert(t('common.error'), t('walk.error.startFailed'));
     }
-  }, [selectedDogIds, startWalk, startRecording, addPoint, me, recordEncounter, updateEncounterDuration, t]);
+  }, [selectedDogIds, walkSession, bleSession, encounterSession, permissions, me, t]);
 
   const handleStop = useCallback(async () => {
     if (!walkId) return;
     setIsStopping(true);
-
-    stopTrackingRef.current?.();
-    stopTrackingRef.current = null;
-
-    // Stop BLE
-    bleScannerRef.current?.stop();
-    bleScannerRef.current = null;
-    bleAdvertiserRef.current?.stop();
-    bleAdvertiserRef.current = null;
-    encounterTrackerRef.current?.stop();
-    encounterTrackerRef.current = null;
-
+    bleSession.stop();
+    encounterSession.stop();
     try {
-      const currentPoints = useWalkStore.getState().points;
-      for (let i = 0; i < currentPoints.length; i += MAX_POINTS_PER_BATCH) {
-        const batch = currentPoints.slice(i, i + MAX_POINTS_PER_BATCH).map((p) => ({
-          lat: p.lat,
-          lng: p.lng,
-          recordedAt: p.recordedAt,
-        }));
-        await addWalkPoints.mutateAsync({ walkId, points: batch });
-      }
-
-      const totalDistanceM = useWalkStore.getState().totalDistanceM;
-      await finishWalk.mutateAsync({
-        walkId,
-        distanceM: Math.round(totalDistanceM),
-      });
-      finish();
-      void endLiveActivity();
+      await walkSession.stop(walkId);
     } catch {
       Alert.alert(t('common.error'), t('walk.error.finishFailed'));
     } finally {
       setIsStopping(false);
     }
-  }, [walkId, addWalkPoints, finishWalk, finish, t]);
+  }, [walkId, walkSession, bleSession, encounterSession, t]);
 
   return (
     <SafeAreaView edges={['top']} style={[styles.container, { backgroundColor: theme.background }]}>
@@ -180,7 +98,7 @@ export default function WalkScreen() {
             visible={isSheetOpen}
             onClose={() => setIsSheetOpen(false)}
             onStart={handleStart}
-            isStarting={startWalk.isPending}
+            isStarting={walkSession.isStarting}
           />
         </>
       )}

--- a/apps/mobile/hooks/use-ble-session.test.ts
+++ b/apps/mobile/hooks/use-ble-session.test.ts
@@ -1,0 +1,75 @@
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import { useBleSession } from './use-ble-session';
+import * as scanner from '@/lib/ble/scanner';
+
+jest.mock('@/lib/ble/scanner', () => ({
+  startScanning: jest.fn(),
+  startAdvertising: jest.fn(),
+}));
+
+const mockScannerStop = jest.fn();
+const mockAdvertiserStop = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (scanner.startScanning as jest.Mock).mockResolvedValue({ stop: mockScannerStop });
+  (scanner.startAdvertising as jest.Mock).mockResolvedValue({ stop: mockAdvertiserStop });
+});
+
+describe('useBleSession', () => {
+  it('start() calls startScanning with onDetected and startAdvertising with walkId', async () => {
+    const onDetected = jest.fn();
+    const { result } = renderHook(() => useBleSession());
+
+    await act(async () => {
+      await result.current.start('walk-1', onDetected);
+    });
+
+    expect(scanner.startScanning).toHaveBeenCalledWith(onDetected);
+    expect(scanner.startAdvertising).toHaveBeenCalledWith('walk-1');
+  });
+
+  it('stop() calls scanner.stop and advertiser.stop after start', async () => {
+    const { result } = renderHook(() => useBleSession());
+
+    await act(async () => {
+      await result.current.start('walk-1', jest.fn());
+    });
+    await waitFor(() => {
+      expect(scanner.startAdvertising).toHaveBeenCalled();
+    });
+
+    act(() => {
+      result.current.stop();
+    });
+
+    expect(mockScannerStop).toHaveBeenCalledTimes(1);
+    expect(mockAdvertiserStop).toHaveBeenCalledTimes(1);
+  });
+
+  it('stop() is safe to call when never started', () => {
+    const { result } = renderHook(() => useBleSession());
+    expect(() => {
+      act(() => {
+        result.current.stop();
+      });
+    }).not.toThrow();
+    expect(mockScannerStop).not.toHaveBeenCalled();
+    expect(mockAdvertiserStop).not.toHaveBeenCalled();
+  });
+
+  it('stop() clears refs so calling twice does not re-stop', async () => {
+    const { result } = renderHook(() => useBleSession());
+    await act(async () => {
+      await result.current.start('walk-1', jest.fn());
+    });
+    act(() => {
+      result.current.stop();
+    });
+    act(() => {
+      result.current.stop();
+    });
+    expect(mockScannerStop).toHaveBeenCalledTimes(1);
+    expect(mockAdvertiserStop).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/mobile/hooks/use-ble-session.ts
+++ b/apps/mobile/hooks/use-ble-session.ts
@@ -1,0 +1,30 @@
+import { useCallback, useRef } from 'react';
+import { startAdvertising, startScanning, type BleScanner } from '@/lib/ble/scanner';
+
+interface BleAdvertiser {
+  stop: () => void;
+}
+
+export function useBleSession() {
+  const scannerRef = useRef<BleScanner | null>(null);
+  const advertiserRef = useRef<BleAdvertiser | null>(null);
+
+  const start = useCallback(
+    async (walkId: string, onDetected: (detectedWalkId: string) => void) => {
+      const s = await startScanning(onDetected);
+      const a = await startAdvertising(walkId);
+      scannerRef.current = s;
+      advertiserRef.current = a;
+    },
+    [],
+  );
+
+  const stop = useCallback(() => {
+    scannerRef.current?.stop();
+    scannerRef.current = null;
+    advertiserRef.current?.stop();
+    advertiserRef.current = null;
+  }, []);
+
+  return { start, stop };
+}

--- a/apps/mobile/hooks/use-encounter-session.test.ts
+++ b/apps/mobile/hooks/use-encounter-session.test.ts
@@ -1,0 +1,128 @@
+import { act, renderHook } from '@testing-library/react-native';
+import { useEncounterSession } from './use-encounter-session';
+import * as encounterMutations from './use-encounter-mutations';
+import { EncounterTracker } from '@/lib/ble/encounter-tracker';
+
+jest.mock('./use-encounter-mutations', () => ({
+  useRecordEncounter: jest.fn(),
+  useUpdateEncounterDuration: jest.fn(),
+}));
+
+jest.mock('@/lib/ble/encounter-tracker', () => {
+  const instances: Array<{
+    start: jest.Mock;
+    stop: jest.Mock;
+    onDeviceDetected: jest.Mock;
+    callbacks: unknown;
+  }> = [];
+  const EncounterTracker = jest.fn().mockImplementation(function (
+    this: unknown,
+    callbacks: unknown,
+  ) {
+    const instance = {
+      start: jest.fn(),
+      stop: jest.fn(),
+      onDeviceDetected: jest.fn(),
+      callbacks,
+    };
+    instances.push(instance);
+    Object.assign(this as object, instance);
+    return instance;
+  });
+  return { EncounterTracker, __instances: instances };
+});
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { __instances } = require('@/lib/ble/encounter-tracker') as {
+  __instances: Array<{
+    start: jest.Mock;
+    stop: jest.Mock;
+    onDeviceDetected: jest.Mock;
+    callbacks: {
+      onEncounterDetected: (w: string, d: number) => void;
+      onEncounterFinalized: (w: string, d: number) => void;
+    };
+  }>;
+};
+
+const mockRecordMutate = jest.fn();
+const mockUpdateMutate = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  __instances.length = 0;
+  (encounterMutations.useRecordEncounter as jest.Mock).mockReturnValue({
+    mutate: mockRecordMutate,
+  });
+  (encounterMutations.useUpdateEncounterDuration as jest.Mock).mockReturnValue({
+    mutate: mockUpdateMutate,
+  });
+});
+
+describe('useEncounterSession', () => {
+  it('start() creates an EncounterTracker and calls tracker.start', () => {
+    const { result } = renderHook(() => useEncounterSession());
+    act(() => {
+      result.current.start('walk-1');
+    });
+    expect(EncounterTracker).toHaveBeenCalledTimes(1);
+    expect(__instances[0].start).toHaveBeenCalledTimes(1);
+  });
+
+  it('tracker.onEncounterDetected triggers recordEncounter with myWalkId + theirWalkId', () => {
+    const { result } = renderHook(() => useEncounterSession());
+    act(() => {
+      result.current.start('walk-1');
+    });
+    __instances[0].callbacks.onEncounterDetected('their-walk', 30000);
+    expect(mockRecordMutate).toHaveBeenCalledWith({
+      myWalkId: 'walk-1',
+      theirWalkId: 'their-walk',
+    });
+  });
+
+  it('tracker.onEncounterFinalized triggers updateEncounterDuration with seconds', () => {
+    const { result } = renderHook(() => useEncounterSession());
+    act(() => {
+      result.current.start('walk-1');
+    });
+    __instances[0].callbacks.onEncounterFinalized('their-walk', 125_678);
+    expect(mockUpdateMutate).toHaveBeenCalledWith({
+      myWalkId: 'walk-1',
+      theirWalkId: 'their-walk',
+      durationSec: 126,
+    });
+  });
+
+  it('onDeviceDetected forwards to tracker.onDeviceDetected when started', () => {
+    const { result } = renderHook(() => useEncounterSession());
+    act(() => {
+      result.current.start('walk-1');
+    });
+    act(() => {
+      result.current.onDeviceDetected('their-walk');
+    });
+    expect(__instances[0].onDeviceDetected).toHaveBeenCalledWith('their-walk');
+  });
+
+  it('onDeviceDetected is a no-op when not started', () => {
+    const { result } = renderHook(() => useEncounterSession());
+    expect(() => result.current.onDeviceDetected('their-walk')).not.toThrow();
+  });
+
+  it('stop() stops tracker and clears ref', () => {
+    const { result } = renderHook(() => useEncounterSession());
+    act(() => {
+      result.current.start('walk-1');
+    });
+    const trackerStop = __instances[0].stop;
+    act(() => {
+      result.current.stop();
+    });
+    expect(trackerStop).toHaveBeenCalledTimes(1);
+    act(() => {
+      result.current.onDeviceDetected('x');
+    });
+    expect(__instances[0].onDeviceDetected).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/hooks/use-encounter-session.ts
+++ b/apps/mobile/hooks/use-encounter-session.ts
@@ -1,0 +1,43 @@
+import { useCallback, useRef } from 'react';
+import { EncounterTracker } from '@/lib/ble/encounter-tracker';
+import {
+  useRecordEncounter,
+  useUpdateEncounterDuration,
+} from './use-encounter-mutations';
+
+export function useEncounterSession() {
+  const recordEncounter = useRecordEncounter();
+  const updateEncounterDuration = useUpdateEncounterDuration();
+  const trackerRef = useRef<EncounterTracker | null>(null);
+
+  const start = useCallback(
+    (walkId: string) => {
+      const tracker = new EncounterTracker({
+        onEncounterDetected: (theirWalkId) => {
+          recordEncounter.mutate({ myWalkId: walkId, theirWalkId });
+        },
+        onEncounterFinalized: (theirWalkId, durationMs) => {
+          updateEncounterDuration.mutate({
+            myWalkId: walkId,
+            theirWalkId,
+            durationSec: Math.round(durationMs / 1000),
+          });
+        },
+      });
+      tracker.start();
+      trackerRef.current = tracker;
+    },
+    [recordEncounter, updateEncounterDuration],
+  );
+
+  const onDeviceDetected = useCallback((theirWalkId: string) => {
+    trackerRef.current?.onDeviceDetected(theirWalkId);
+  }, []);
+
+  const stop = useCallback(() => {
+    trackerRef.current?.stop();
+    trackerRef.current = null;
+  }, []);
+
+  return { start, stop, onDeviceDetected };
+}

--- a/apps/mobile/hooks/use-walk-permissions.test.ts
+++ b/apps/mobile/hooks/use-walk-permissions.test.ts
@@ -1,0 +1,44 @@
+import { renderHook } from '@testing-library/react-native';
+import { useWalkPermissions } from './use-walk-permissions';
+import * as gpsTracker from '@/lib/walk/gps-tracker';
+import * as blePermissions from '@/lib/ble/permissions';
+
+jest.mock('@/lib/walk/gps-tracker', () => ({
+  requestPermission: jest.fn(),
+}));
+
+jest.mock('@/lib/ble/permissions', () => ({
+  requestBluetoothPermission: jest.fn(),
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('useWalkPermissions', () => {
+  it('requestGpsPermission returns true when location permission is granted', async () => {
+    (gpsTracker.requestPermission as jest.Mock).mockResolvedValue(true);
+    const { result } = renderHook(() => useWalkPermissions());
+    expect(await result.current.requestGpsPermission()).toBe(true);
+    expect(gpsTracker.requestPermission).toHaveBeenCalledTimes(1);
+  });
+
+  it('requestGpsPermission returns false when location permission is denied', async () => {
+    (gpsTracker.requestPermission as jest.Mock).mockResolvedValue(false);
+    const { result } = renderHook(() => useWalkPermissions());
+    expect(await result.current.requestGpsPermission()).toBe(false);
+  });
+
+  it('requestBlePermission returns true when BLE permission is granted', async () => {
+    (blePermissions.requestBluetoothPermission as jest.Mock).mockResolvedValue(true);
+    const { result } = renderHook(() => useWalkPermissions());
+    expect(await result.current.requestBlePermission()).toBe(true);
+    expect(blePermissions.requestBluetoothPermission).toHaveBeenCalledTimes(1);
+  });
+
+  it('requestBlePermission returns false when BLE permission is denied', async () => {
+    (blePermissions.requestBluetoothPermission as jest.Mock).mockResolvedValue(false);
+    const { result } = renderHook(() => useWalkPermissions());
+    expect(await result.current.requestBlePermission()).toBe(false);
+  });
+});

--- a/apps/mobile/hooks/use-walk-permissions.ts
+++ b/apps/mobile/hooks/use-walk-permissions.ts
@@ -1,0 +1,9 @@
+import { useCallback } from 'react';
+import { requestPermission } from '@/lib/walk/gps-tracker';
+import { requestBluetoothPermission } from '@/lib/ble/permissions';
+
+export function useWalkPermissions() {
+  const requestGpsPermission = useCallback(() => requestPermission(), []);
+  const requestBlePermission = useCallback(() => requestBluetoothPermission(), []);
+  return { requestGpsPermission, requestBlePermission };
+}

--- a/apps/mobile/hooks/use-walk-session.test.ts
+++ b/apps/mobile/hooks/use-walk-session.test.ts
@@ -1,0 +1,227 @@
+import { act, renderHook } from '@testing-library/react-native';
+import { useWalkSession, MAX_POINTS_PER_BATCH } from './use-walk-session';
+import * as walkMutations from './use-walk-mutations';
+import * as gpsTracker from '@/lib/walk/gps-tracker';
+import * as liveActivity from '@/lib/walk/live-activity';
+import type { WalkPoint } from '@/types/graphql';
+
+jest.mock('./use-walk-mutations', () => ({
+  useStartWalk: jest.fn(),
+  useFinishWalk: jest.fn(),
+  useAddWalkPoints: jest.fn(),
+}));
+
+jest.mock('@/lib/walk/gps-tracker', () => ({
+  startTracking: jest.fn(),
+}));
+
+jest.mock('@/lib/walk/live-activity', () => ({
+  startLiveActivity: jest.fn(),
+  endLiveActivity: jest.fn(),
+  updateLiveActivityDistance: jest.fn(),
+}));
+
+const mockStoreStartRecording = jest.fn();
+const mockStoreAddPoint = jest.fn();
+const mockStoreFinish = jest.fn();
+let mockStorePoints: WalkPoint[] = [];
+let mockStoreTotalDistanceM = 0;
+let mockStoreStartedAt: Date | null = null;
+
+jest.mock('@/stores/walk-store', () => {
+  const state = {
+    startRecording: (...args: unknown[]) => mockStoreStartRecording(...args),
+    addPoint: (...args: unknown[]) => mockStoreAddPoint(...args),
+    finish: () => mockStoreFinish(),
+    get points() {
+      return mockStorePoints;
+    },
+    get totalDistanceM() {
+      return mockStoreTotalDistanceM;
+    },
+    get startedAt() {
+      return mockStoreStartedAt;
+    },
+  };
+  const useWalkStoreMock = (selector: (s: typeof state) => unknown) => selector(state);
+  (useWalkStoreMock as unknown as { getState: () => typeof state }).getState = () => state;
+  return { useWalkStore: useWalkStoreMock };
+});
+
+const mockStartWalkMutateAsync = jest.fn();
+const mockFinishWalkMutateAsync = jest.fn();
+const mockAddPointsMutateAsync = jest.fn();
+const mockStopTracking = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockStorePoints = [];
+  mockStoreTotalDistanceM = 0;
+  mockStoreStartedAt = new Date('2026-04-01T00:00:00Z');
+
+  (walkMutations.useStartWalk as jest.Mock).mockReturnValue({
+    mutateAsync: mockStartWalkMutateAsync,
+    isPending: false,
+  });
+  (walkMutations.useFinishWalk as jest.Mock).mockReturnValue({
+    mutateAsync: mockFinishWalkMutateAsync,
+  });
+  (walkMutations.useAddWalkPoints as jest.Mock).mockReturnValue({
+    mutateAsync: mockAddPointsMutateAsync,
+  });
+  (gpsTracker.startTracking as jest.Mock).mockResolvedValue(mockStopTracking);
+  (liveActivity.startLiveActivity as jest.Mock).mockResolvedValue(undefined);
+  (liveActivity.endLiveActivity as jest.Mock).mockResolvedValue(undefined);
+  (liveActivity.updateLiveActivityDistance as jest.Mock).mockResolvedValue(undefined);
+});
+
+describe('useWalkSession.start', () => {
+  it('calls startWalk mutation with dog ids and returns the walk id', async () => {
+    mockStartWalkMutateAsync.mockResolvedValue({ id: 'walk-1' });
+
+    const { result } = renderHook(() => useWalkSession());
+    let walkId: string | undefined;
+    await act(async () => {
+      walkId = await result.current.start({
+        selectedDogIds: ['dog-1'],
+        liveActivityDogName: 'Rex',
+      });
+    });
+
+    expect(mockStartWalkMutateAsync).toHaveBeenCalledWith(['dog-1']);
+    expect(walkId).toBe('walk-1');
+  });
+
+  it('calls startRecording on the walk store with the walk id', async () => {
+    mockStartWalkMutateAsync.mockResolvedValue({ id: 'walk-1' });
+
+    const { result } = renderHook(() => useWalkSession());
+    await act(async () => {
+      await result.current.start({ selectedDogIds: ['dog-1'], liveActivityDogName: 'Rex' });
+    });
+
+    expect(mockStoreStartRecording).toHaveBeenCalledWith('walk-1');
+  });
+
+  it('starts live activity with walk id, dog id, dog name, and initial distance 0', async () => {
+    mockStartWalkMutateAsync.mockResolvedValue({ id: 'walk-1' });
+
+    const { result } = renderHook(() => useWalkSession());
+    await act(async () => {
+      await result.current.start({ selectedDogIds: ['dog-1'], liveActivityDogName: 'Rex' });
+    });
+
+    expect(liveActivity.startLiveActivity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        walkId: 'walk-1',
+        dogId: 'dog-1',
+        dogName: 'Rex',
+        distanceM: 0,
+      }),
+    );
+  });
+
+  it('startTracking callback adds point to store and updates live activity distance', async () => {
+    mockStartWalkMutateAsync.mockResolvedValue({ id: 'walk-1' });
+    let capturedOnPoint: ((point: WalkPoint) => void) | null = null;
+    (gpsTracker.startTracking as jest.Mock).mockImplementation(
+      async (cb: (p: WalkPoint) => void) => {
+        capturedOnPoint = cb;
+        return mockStopTracking;
+      },
+    );
+
+    const { result } = renderHook(() => useWalkSession());
+    await act(async () => {
+      await result.current.start({ selectedDogIds: ['dog-1'], liveActivityDogName: 'Rex' });
+    });
+
+    const point: WalkPoint = { lat: 35.68, lng: 139.76, recordedAt: '2026-04-01T00:01:00Z' };
+    mockStoreTotalDistanceM = 42;
+    capturedOnPoint!(point);
+
+    expect(mockStoreAddPoint).toHaveBeenCalledWith(point);
+    expect(liveActivity.updateLiveActivityDistance).toHaveBeenCalledWith(42);
+  });
+
+  it('exposes isStarting from startWalk mutation', () => {
+    (walkMutations.useStartWalk as jest.Mock).mockReturnValue({
+      mutateAsync: mockStartWalkMutateAsync,
+      isPending: true,
+    });
+
+    const { result } = renderHook(() => useWalkSession());
+    expect(result.current.isStarting).toBe(true);
+  });
+});
+
+describe('useWalkSession.stop', () => {
+  it('calls the stopTracking function returned by startTracking', async () => {
+    mockStartWalkMutateAsync.mockResolvedValue({ id: 'walk-1' });
+
+    const { result } = renderHook(() => useWalkSession());
+    await act(async () => {
+      await result.current.start({ selectedDogIds: ['dog-1'], liveActivityDogName: 'Rex' });
+    });
+    await act(async () => {
+      await result.current.stop('walk-1');
+    });
+
+    expect(mockStopTracking).toHaveBeenCalledTimes(1);
+  });
+
+  it('batches points by MAX_POINTS_PER_BATCH and calls addWalkPoints per batch', async () => {
+    mockStartWalkMutateAsync.mockResolvedValue({ id: 'walk-1' });
+    mockStorePoints = Array.from({ length: MAX_POINTS_PER_BATCH + 50 }, (_, i) => ({
+      lat: 35.68,
+      lng: 139.76,
+      recordedAt: `2026-04-01T00:0${i % 10}:00Z`,
+    }));
+
+    const { result } = renderHook(() => useWalkSession());
+    await act(async () => {
+      await result.current.start({ selectedDogIds: ['dog-1'], liveActivityDogName: 'Rex' });
+    });
+    await act(async () => {
+      await result.current.stop('walk-1');
+    });
+
+    expect(mockAddPointsMutateAsync).toHaveBeenCalledTimes(2);
+    const firstBatch = (mockAddPointsMutateAsync.mock.calls[0][0] as { points: WalkPoint[] }).points;
+    expect(firstBatch).toHaveLength(MAX_POINTS_PER_BATCH);
+    const secondBatch = (mockAddPointsMutateAsync.mock.calls[1][0] as { points: WalkPoint[] }).points;
+    expect(secondBatch).toHaveLength(50);
+  });
+
+  it('calls finishWalk with rounded distance and ends live activity', async () => {
+    mockStartWalkMutateAsync.mockResolvedValue({ id: 'walk-1' });
+    mockStoreTotalDistanceM = 1234.7;
+
+    const { result } = renderHook(() => useWalkSession());
+    await act(async () => {
+      await result.current.start({ selectedDogIds: ['dog-1'], liveActivityDogName: 'Rex' });
+    });
+    await act(async () => {
+      await result.current.stop('walk-1');
+    });
+
+    expect(mockFinishWalkMutateAsync).toHaveBeenCalledWith({ walkId: 'walk-1', distanceM: 1235 });
+    expect(mockStoreFinish).toHaveBeenCalledTimes(1);
+    expect(liveActivity.endLiveActivity).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call addWalkPoints when there are no points', async () => {
+    mockStartWalkMutateAsync.mockResolvedValue({ id: 'walk-1' });
+    mockStorePoints = [];
+
+    const { result } = renderHook(() => useWalkSession());
+    await act(async () => {
+      await result.current.start({ selectedDogIds: ['dog-1'], liveActivityDogName: 'Rex' });
+    });
+    await act(async () => {
+      await result.current.stop('walk-1');
+    });
+
+    expect(mockAddPointsMutateAsync).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/hooks/use-walk-session.ts
+++ b/apps/mobile/hooks/use-walk-session.ts
@@ -1,0 +1,84 @@
+import { useCallback, useRef } from 'react';
+import { startTracking } from '@/lib/walk/gps-tracker';
+import {
+  endLiveActivity,
+  startLiveActivity,
+  updateLiveActivityDistance,
+} from '@/lib/walk/live-activity';
+import { useWalkStore } from '@/stores/walk-store';
+import { useAddWalkPoints, useFinishWalk, useStartWalk } from './use-walk-mutations';
+
+// Server-side validation rejects payloads over ~200 points per addWalkPoints
+// call (request size cap). Keep batches under this ceiling when flushing on stop.
+export const MAX_POINTS_PER_BATCH = 200;
+
+export interface WalkSessionStartOptions {
+  selectedDogIds: string[];
+  liveActivityDogName: string;
+}
+
+export function useWalkSession() {
+  const startWalkMutation = useStartWalk();
+  const finishWalkMutation = useFinishWalk();
+  const addWalkPointsMutation = useAddWalkPoints();
+  const startRecording = useWalkStore((s) => s.startRecording);
+  const addPoint = useWalkStore((s) => s.addPoint);
+  const finish = useWalkStore((s) => s.finish);
+  const stopTrackingRef = useRef<(() => void) | null>(null);
+
+  const start = useCallback(
+    async ({ selectedDogIds, liveActivityDogName }: WalkSessionStartOptions): Promise<string> => {
+      const walk = await startWalkMutation.mutateAsync(selectedDogIds);
+      startRecording(walk.id);
+
+      await startLiveActivity({
+        walkId: walk.id,
+        dogId: selectedDogIds[0],
+        dogName: liveActivityDogName,
+        startedAt: useWalkStore.getState().startedAt ?? new Date(),
+        distanceM: 0,
+      });
+
+      const stopTracking = await startTracking((point) => {
+        addPoint(point);
+        void updateLiveActivityDistance(useWalkStore.getState().totalDistanceM);
+      });
+      stopTrackingRef.current = stopTracking;
+
+      return walk.id;
+    },
+    [startWalkMutation, startRecording, addPoint],
+  );
+
+  const stop = useCallback(
+    async (walkId: string) => {
+      stopTrackingRef.current?.();
+      stopTrackingRef.current = null;
+
+      const currentPoints = useWalkStore.getState().points;
+      for (let i = 0; i < currentPoints.length; i += MAX_POINTS_PER_BATCH) {
+        const batch = currentPoints.slice(i, i + MAX_POINTS_PER_BATCH).map((p) => ({
+          lat: p.lat,
+          lng: p.lng,
+          recordedAt: p.recordedAt,
+        }));
+        await addWalkPointsMutation.mutateAsync({ walkId, points: batch });
+      }
+
+      const totalDistanceM = useWalkStore.getState().totalDistanceM;
+      await finishWalkMutation.mutateAsync({
+        walkId,
+        distanceM: Math.round(totalDistanceM),
+      });
+      finish();
+      void endLiveActivity();
+    },
+    [addWalkPointsMutation, finishWalkMutation, finish],
+  );
+
+  return {
+    start,
+    stop,
+    isStarting: startWalkMutation.isPending,
+  };
+}


### PR DESCRIPTION
## Summary

Phase 7 of `tasks/refactor/mobile/03-plan.md` — split 201-line `(tabs)/walk.tsx`.

New hooks (all tested):
- `hooks/use-walk-permissions.ts` — GPS + BLE permission wrappers.
- `hooks/use-encounter-session.ts` — `EncounterTracker` orchestration; `start(walkId)` / `stop()` / `onDeviceDetected(id)`.
- `hooks/use-ble-session.ts` — scanner + advertiser refs; `start(walkId, onDetected)` / `stop()`.
- `hooks/use-walk-session.ts` — startWalk + LiveActivity + GPS tracking + point-batch flush (`MAX_POINTS_PER_BATCH=200`, server payload cap) + finishWalk.

`app/(tabs)/walk.tsx`: **201 → 119 lines**. Screen now composes the 4 hooks. Kept in the screen per advisor recommendation: GPS permission prompt, `encounterDetectionEnabled` gate (reads `useMe()`), camera deep-link effect, phase-based rendering.

## Test plan

- [x] `use-walk-permissions.test.ts` — 4 tests
- [x] `use-encounter-session.test.ts` — 6 tests (tracker lifecycle, onEncounterDetected → recordEncounter, onEncounterFinalized → updateEncounterDuration with ms→sec conversion)
- [x] `use-ble-session.test.ts` — 4 tests (stable stop on start/no-start/double-stop)
- [x] `use-walk-session.test.ts` — 9 tests (start flow, GPS callback → addPoint + live activity distance, stop point-batching at `MAX_POINTS_PER_BATCH`, finish rounded distance, empty-points short-circuit)
- [x] Full `npx jest` — 287 passed / 51 suites
- [x] `npx tsc --noEmit` — no new errors in Phase 7 files
- [x] `npx expo lint` — clean
- [ ] **Manual iOS Simulator smoke pending (plan line 122): walk start → stop, GPS tracking, BLE scan/advertise, encounter record** — reviewer or author to verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)