### PR TITLE
refactor(mobile): extract view-model + authorization + Tokyo constant (Phase 8)

### DIFF
--- a/apps/mobile/app/dogs/[id]/index.tsx
+++ b/apps/mobile/app/dogs/[id]/index.tsx
@@ -7,6 +7,7 @@ import { useDog } from '@/hooks/use-dog';
 import { useDeleteDog } from '@/hooks/use-dog-mutations';
 import { useMe } from '@/hooks/use-me';
 import { useMutationWithAlert } from '@/hooks/use-mutation-with-alert';
+import { useDogDetailAuthorization } from '@/hooks/use-dog-detail-authorization';
 import { DogStatsCard } from '@/components/dogs/DogStatsCard';
 import { LoadingScreen } from '@/components/ui/LoadingScreen';
 import { Button } from '@/components/ui/Button';
@@ -25,11 +26,9 @@ export default function DogDetailScreen() {
   const { mutateAsync: deleteDog } = useDeleteDog();
   const runWithAlert = useMutationWithAlert();
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const { isOwner } = useDogDetailAuthorization(dog ?? undefined, me ?? undefined);
 
   if (isLoading || !dog) return <LoadingScreen />;
-
-  const currentMember = dog.members?.find((m) => m.userId === me?.id);
-  const isOwner = currentMember?.role === 'owner';
 
   async function handleDelete() {
     const ok = await runWithAlert(() => deleteDog(id), 'dogs.detail.deleteError');

--- a/apps/mobile/app/walks/[id].tsx
+++ b/apps/mobile/app/walks/[id].tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { useColors } from '@/hooks/use-colors';
 import { spacing, radius, typography } from '@/theme/tokens';
 import { useWalk } from '@/hooks/use-walks';
-import { formatClockTime } from '@/lib/walk/format';
+import { useWalkDetailViewModel } from '@/hooks/use-walk-detail-view-model';
 import { WalkEventTimeline } from '@/components/walk/WalkEventTimeline';
 import { EVENT_EMOJIS } from '@/lib/walk/event-emojis';
 
@@ -15,8 +15,9 @@ export default function WalkDetailScreen() {
   const { t } = useTranslation();
   const theme = useColors();
   const { data: walk, isLoading } = useWalk(id ?? '');
+  const vm = useWalkDetailViewModel(walk);
 
-  if (isLoading || !walk) {
+  if (isLoading || !walk || !vm) {
     return (
       <View style={[styles.center, { backgroundColor: theme.background }]}>
         <ActivityIndicator />
@@ -24,140 +25,119 @@ export default function WalkDetailScreen() {
     );
   }
 
-  const coordinates = (walk.points ?? []).map((p) => ({ latitude: p.lat, longitude: p.lng }));
-  const events = walk.events ?? [];
-  const durationMin = walk.durationSec ? Math.round(walk.durationSec / 60) : 0;
-  const distanceKm = walk.distanceM ? (walk.distanceM / 1000).toFixed(2) : '0';
-  const date = new Date(walk.startedAt).toLocaleDateString();
-  const dogNames = walk.dogs.map((d) => d.name).join(', ');
-  const startTime = formatClockTime(walk.startedAt);
-  const endTime = walk.endedAt ? formatClockTime(walk.endedAt) : null;
   const separator = t('walk.detail.timeSeparator');
-  const timeLabel = endTime
-    ? `${t('walk.detail.startTime')} ${startTime}${separator}${t('walk.detail.endTime')} ${endTime}`
-    : `${t('walk.detail.startTime')} ${startTime}`;
-
-  const midpoint = coordinates.length > 0
-    ? coordinates[Math.floor(coordinates.length / 2)]
-    : { latitude: 35.6812, longitude: 139.7671 };
+  const timeLabel = vm.endTime
+    ? `${t('walk.detail.startTime')} ${vm.startTime}${separator}${t('walk.detail.endTime')} ${vm.endTime}`
+    : `${t('walk.detail.startTime')} ${vm.startTime}`;
 
   return (
     <View style={[styles.container, { backgroundColor: theme.background }]}>
       <ScrollView contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
-      <View style={[styles.mapContainer, { borderColor: theme.border + '33' }]}>
-        <MapView
-          style={styles.map}
-          initialRegion={{
-            latitude: midpoint.latitude,
-            longitude: midpoint.longitude,
-            latitudeDelta: 0.01,
-            longitudeDelta: 0.01,
-          }}
-        >
-          {coordinates.length >= 2 ? (
-            <Polyline coordinates={coordinates} strokeColor={theme.interactive} strokeWidth={4} />
-          ) : null}
-          {events
-            .filter((e) => e.lat != null && e.lng != null)
-            .map((e) => (
-              <Marker
-                key={e.id}
-                coordinate={{ latitude: e.lat!, longitude: e.lng! }}
-                accessibilityLabel={`${EVENT_EMOJIS[e.eventType]} event`}
-              >
-                <Text style={styles.eventMarker}>{EVENT_EMOJIS[e.eventType]}</Text>
-              </Marker>
-            ))}
-        </MapView>
-      </View>
-
-      <View style={styles.info}>
-        <Text style={[styles.heroTitle, { color: theme.onSurface }]}>
-          {t('walk.detail.title')}
-        </Text>
-
-        <Text style={[styles.date, { color: theme.onSurface }]}>{date}</Text>
-        <Text style={[styles.dogs, { color: theme.onSurfaceVariant }]}>{dogNames}</Text>
-        <Text
-          testID="walk-time"
-          style={[styles.time, { color: theme.onSurfaceVariant }]}
-          accessibilityLabel={timeLabel}
-        >
-          {startTime}
-          {endTime ? `${separator}${endTime}` : null}
-        </Text>
-
-        {walk.walker ? (
-          <View style={styles.walkerSection}>
-            <Text style={[styles.walkerLabel, { color: theme.onSurfaceVariant }]}>
-              {t('walk.detail.walker')}
-            </Text>
-            <View style={styles.walkerRow}>
-              {walk.walker.avatarUrl ? (
-                <Image
-                  source={{ uri: walk.walker.avatarUrl }}
-                  style={styles.walkerAvatar}
-                  contentFit="cover"
-                  cachePolicy="memory-disk"
-                  accessibilityLabel={walk.walker.displayName ?? ''}
-                />
-              ) : (
-                <View
-                  style={[
-                    styles.walkerAvatar,
-                    styles.walkerInitialBg,
-                    { backgroundColor: theme.primaryContainer },
-                  ]}
+        <View style={[styles.mapContainer, { borderColor: theme.border + '33' }]}>
+          <MapView
+            style={styles.map}
+            initialRegion={{
+              latitude: vm.midpoint.latitude,
+              longitude: vm.midpoint.longitude,
+              latitudeDelta: 0.01,
+              longitudeDelta: 0.01,
+            }}
+          >
+            {vm.coordinates.length >= 2 ? (
+              <Polyline coordinates={vm.coordinates} strokeColor={theme.interactive} strokeWidth={4} />
+            ) : null}
+            {vm.events
+              .filter((e) => e.lat != null && e.lng != null)
+              .map((e) => (
+                <Marker
+                  key={e.id}
+                  coordinate={{ latitude: e.lat!, longitude: e.lng! }}
+                  accessibilityLabel={`${EVENT_EMOJIS[e.eventType]} event`}
                 >
-                  <Text style={[styles.walkerInitialText, { color: theme.onInteractive }]}>
-                    {walk.walker.displayName?.charAt(0)?.toUpperCase() ?? '?'}
-                  </Text>
-                </View>
-              )}
-              <Text style={[styles.walkerName, { color: theme.onSurface }]}>
-                {walk.walker.displayName}
+                  <Text style={styles.eventMarker}>{EVENT_EMOJIS[e.eventType]}</Text>
+                </Marker>
+              ))}
+          </MapView>
+        </View>
+
+        <View style={styles.info}>
+          <Text style={[styles.heroTitle, { color: theme.onSurface }]}>{t('walk.detail.title')}</Text>
+          <Text style={[styles.date, { color: theme.onSurface }]}>{vm.date}</Text>
+          <Text style={[styles.dogs, { color: theme.onSurfaceVariant }]}>{vm.dogNames}</Text>
+          <Text
+            testID="walk-time"
+            style={[styles.time, { color: theme.onSurfaceVariant }]}
+            accessibilityLabel={timeLabel}
+          >
+            {vm.startTime}
+            {vm.endTime ? `${separator}${vm.endTime}` : null}
+          </Text>
+
+          {walk.walker ? (
+            <View style={styles.walkerSection}>
+              <Text style={[styles.walkerLabel, { color: theme.onSurfaceVariant }]}>
+                {t('walk.detail.walker')}
+              </Text>
+              <View style={styles.walkerRow}>
+                {walk.walker.avatarUrl ? (
+                  <Image
+                    source={{ uri: walk.walker.avatarUrl }}
+                    style={styles.walkerAvatar}
+                    contentFit="cover"
+                    cachePolicy="memory-disk"
+                    accessibilityLabel={walk.walker.displayName ?? ''}
+                  />
+                ) : (
+                  <View
+                    style={[
+                      styles.walkerAvatar,
+                      styles.walkerInitialBg,
+                      { backgroundColor: theme.primaryContainer },
+                    ]}
+                  >
+                    <Text style={[styles.walkerInitialText, { color: theme.onInteractive }]}>
+                      {walk.walker.displayName?.charAt(0)?.toUpperCase() ?? '?'}
+                    </Text>
+                  </View>
+                )}
+                <Text style={[styles.walkerName, { color: theme.onSurface }]}>
+                  {walk.walker.displayName}
+                </Text>
+              </View>
+            </View>
+          ) : null}
+
+          <View style={styles.stats}>
+            <View
+              style={[
+                styles.statCard,
+                { backgroundColor: theme.surfaceContainerLowest, borderColor: theme.border + '33' },
+              ]}
+            >
+              <Text style={[styles.statValue, { color: theme.onSurface }]}>
+                {t('walk.history.minutes', { count: vm.durationMin })}
+              </Text>
+              <Text style={[styles.statLabel, { color: theme.onSurfaceVariant }]}>
+                {t('walk.recording.time')}
+              </Text>
+            </View>
+            <View
+              style={[
+                styles.statCard,
+                { backgroundColor: theme.surfaceContainerLowest, borderColor: theme.border + '33' },
+              ]}
+            >
+              <Text style={[styles.statValue, { color: theme.onSurface }]}>
+                {t('walk.history.km', { value: vm.distanceKm })}
+              </Text>
+              <Text style={[styles.statLabel, { color: theme.onSurfaceVariant }]}>
+                {t('walk.recording.distance')}
               </Text>
             </View>
           </View>
-        ) : null}
-
-        <View style={styles.stats}>
-          <View
-            style={[
-              styles.statCard,
-              {
-                backgroundColor: theme.surfaceContainerLowest,
-                borderColor: theme.border + '33',
-              },
-            ]}
-          >
-            <Text style={[styles.statValue, { color: theme.onSurface }]}>
-              {t('walk.history.minutes', { count: durationMin })}
-            </Text>
-            <Text style={[styles.statLabel, { color: theme.onSurfaceVariant }]}>
-              {t('walk.recording.time')}
-            </Text>
-          </View>
-          <View
-            style={[
-              styles.statCard,
-              {
-                backgroundColor: theme.surfaceContainerLowest,
-                borderColor: theme.border + '33',
-              },
-            ]}
-          >
-            <Text style={[styles.statValue, { color: theme.onSurface }]}>
-              {t('walk.history.km', { value: distanceKm })}
-            </Text>
-            <Text style={[styles.statLabel, { color: theme.onSurfaceVariant }]}>
-              {t('walk.recording.distance')}
-            </Text>
-          </View>
         </View>
-      </View>
 
-      {events.length > 0 ? <WalkEventTimeline events={events} /> : null}
+        {vm.events.length > 0 ? <WalkEventTimeline events={vm.events} /> : null}
       </ScrollView>
     </View>
   );
@@ -167,20 +147,10 @@ const styles = StyleSheet.create({
   container: { flex: 1 },
   scrollContent: { flexGrow: 1 },
   center: { flex: 1, alignItems: 'center', justifyContent: 'center' },
-  mapContainer: {
-    borderWidth: 1,
-    borderRadius: radius.lg,
-    overflow: 'hidden',
-    margin: spacing.lg,
-  },
+  mapContainer: { borderWidth: 1, borderRadius: radius.lg, overflow: 'hidden', margin: spacing.lg },
   map: { height: 280 },
   info: { paddingHorizontal: spacing.lg, paddingBottom: spacing.lg },
-  heroTitle: {
-    fontSize: 32,
-    fontWeight: '900',
-    letterSpacing: -0.64,
-    marginBottom: spacing.sm,
-  },
+  heroTitle: { fontSize: 32, fontWeight: '900', letterSpacing: -0.64, marginBottom: spacing.sm },
   date: { ...typography.h3 },
   dogs: { ...typography.body, marginTop: spacing.xs },
   time: { ...typography.body, marginTop: spacing.xs },

--- a/apps/mobile/components/walk/WalkMap.tsx
+++ b/apps/mobile/components/walk/WalkMap.tsx
@@ -5,6 +5,7 @@ import { useColors } from '@/hooks/use-colors';
 import { spacing, radius } from '@/theme/tokens';
 import { useWalkStore } from '@/stores/walk-store';
 import { EVENT_EMOJIS } from '@/lib/walk/event-emojis';
+import { TOKYO_STATION_COORDINATE } from '@/lib/walk/constants';
 import type { WalkEvent } from '@/types/graphql';
 
 interface WalkMapProps {
@@ -34,8 +35,8 @@ export function WalkMap({ events = [] }: WalkMapProps) {
                 longitudeDelta: 0.005,
               }
             : {
-                latitude: 35.6812,
-                longitude: 139.7671,
+                latitude: TOKYO_STATION_COORDINATE.latitude,
+                longitude: TOKYO_STATION_COORDINATE.longitude,
                 latitudeDelta: 0.01,
                 longitudeDelta: 0.01,
               }

--- a/apps/mobile/hooks/use-dog-detail-authorization.test.ts
+++ b/apps/mobile/hooks/use-dog-detail-authorization.test.ts
@@ -1,0 +1,88 @@
+import { renderHook } from '@testing-library/react-native';
+import { useDogDetailAuthorization } from './use-dog-detail-authorization';
+import type { DogWithStats, User } from '@/types/graphql';
+
+function makeMe(id: string): User {
+  return {
+    id,
+    displayName: null,
+    avatarUrl: null,
+    encounterDetectionEnabled: true,
+    dogs: [],
+    createdAt: '',
+  };
+}
+
+function makeDog(members: { userId: string; role: 'owner' | 'member' }[]): DogWithStats {
+  return {
+    id: 'd-1',
+    name: 'Rex',
+    breed: null,
+    gender: null,
+    birthDate: null,
+    photoUrl: null,
+    createdAt: '',
+    walkStats: null,
+    members: members.map((m, i) => ({
+      id: `m-${i}`,
+      userId: m.userId,
+      role: m.role,
+      user: { displayName: null, avatarUrl: null },
+      createdAt: '',
+    })),
+  };
+}
+
+describe('useDogDetailAuthorization', () => {
+  it('isOwner is true when current user is the owner', () => {
+    const { result } = renderHook(() =>
+      useDogDetailAuthorization(
+        makeDog([{ userId: 'u-1', role: 'owner' }]),
+        makeMe('u-1'),
+      ),
+    );
+    expect(result.current.isOwner).toBe(true);
+  });
+
+  it('isOwner is false when current user is a member (not owner)', () => {
+    const { result } = renderHook(() =>
+      useDogDetailAuthorization(
+        makeDog([
+          { userId: 'u-1', role: 'owner' },
+          { userId: 'u-2', role: 'member' },
+        ]),
+        makeMe('u-2'),
+      ),
+    );
+    expect(result.current.isOwner).toBe(false);
+  });
+
+  it('isOwner is false when current user is not a member of the dog', () => {
+    const { result } = renderHook(() =>
+      useDogDetailAuthorization(
+        makeDog([{ userId: 'u-1', role: 'owner' }]),
+        makeMe('u-other'),
+      ),
+    );
+    expect(result.current.isOwner).toBe(false);
+  });
+
+  it('isOwner is false when dog has no members field', () => {
+    const { result } = renderHook(() =>
+      useDogDetailAuthorization({ ...makeDog([]), members: undefined }, makeMe('u-1')),
+    );
+    expect(result.current.isOwner).toBe(false);
+  });
+
+  it('isOwner is false when me is undefined', () => {
+    const { result } = renderHook(() =>
+      useDogDetailAuthorization(makeDog([{ userId: 'u-1', role: 'owner' }]), undefined),
+    );
+    expect(result.current.isOwner).toBe(false);
+  });
+
+  it('isOwner is false when dog is undefined', () => {
+    const { result } = renderHook(() => useDogDetailAuthorization(undefined, makeMe('u-1')));
+    expect(result.current.isOwner).toBe(false);
+  });
+});

--- a/apps/mobile/hooks/use-dog-detail-authorization.ts
+++ b/apps/mobile/hooks/use-dog-detail-authorization.ts
@@ -1,0 +1,17 @@
+import { useMemo } from 'react';
+import type { DogWithStats, User } from '@/types/graphql';
+
+export interface DogDetailAuthorization {
+  isOwner: boolean;
+}
+
+export function useDogDetailAuthorization(
+  dog: DogWithStats | undefined,
+  me: User | undefined,
+): DogDetailAuthorization {
+  return useMemo(() => {
+    if (!dog || !me) return { isOwner: false };
+    const currentMember = dog.members?.find((m) => m.userId === me.id);
+    return { isOwner: currentMember?.role === 'owner' };
+  }, [dog, me]);
+}

--- a/apps/mobile/hooks/use-walk-detail-view-model.test.ts
+++ b/apps/mobile/hooks/use-walk-detail-view-model.test.ts
@@ -1,0 +1,143 @@
+import { renderHook } from '@testing-library/react-native';
+import { useWalkDetailViewModel } from './use-walk-detail-view-model';
+import { TOKYO_STATION_COORDINATE } from '@/lib/walk/constants';
+import type { Walk } from '@/types/graphql';
+
+function makeWalk(overrides: Partial<Walk> = {}): Walk {
+  return {
+    id: 'w-1',
+    dogs: [
+      {
+        id: 'd-1',
+        name: 'Rex',
+        breed: null,
+        gender: null,
+        birthDate: null,
+        photoUrl: null,
+        createdAt: '',
+      },
+    ],
+    status: 'FINISHED',
+    distanceM: 2500,
+    durationSec: 1800,
+    startedAt: '2026-04-01T09:00:00Z',
+    endedAt: '2026-04-01T09:30:00Z',
+    points: [
+      { lat: 35.0, lng: 139.0, recordedAt: '' },
+      { lat: 35.1, lng: 139.1, recordedAt: '' },
+      { lat: 35.2, lng: 139.2, recordedAt: '' },
+    ],
+    events: [],
+    ...overrides,
+  };
+}
+
+describe('useWalkDetailViewModel', () => {
+  it('returns null when walk is undefined', () => {
+    const { result } = renderHook(() => useWalkDetailViewModel(undefined));
+    expect(result.current).toBeNull();
+  });
+
+  it('maps points to coordinates', () => {
+    const { result } = renderHook(() => useWalkDetailViewModel(makeWalk()));
+    expect(result.current!.coordinates).toEqual([
+      { latitude: 35.0, longitude: 139.0 },
+      { latitude: 35.1, longitude: 139.1 },
+      { latitude: 35.2, longitude: 139.2 },
+    ]);
+  });
+
+  it('rounds durationSec to minutes', () => {
+    const { result } = renderHook(() =>
+      useWalkDetailViewModel(makeWalk({ durationSec: 1850 })),
+    );
+    expect(result.current!.durationMin).toBe(31);
+  });
+
+  it('returns 0 duration when durationSec is null', () => {
+    const { result } = renderHook(() =>
+      useWalkDetailViewModel(makeWalk({ durationSec: null })),
+    );
+    expect(result.current!.durationMin).toBe(0);
+  });
+
+  it('formats distance in kilometers with 2 decimals', () => {
+    const { result } = renderHook(() =>
+      useWalkDetailViewModel(makeWalk({ distanceM: 1234 })),
+    );
+    expect(result.current!.distanceKm).toBe('1.23');
+  });
+
+  it('returns "0" distance when distanceM is null', () => {
+    const { result } = renderHook(() =>
+      useWalkDetailViewModel(makeWalk({ distanceM: null })),
+    );
+    expect(result.current!.distanceKm).toBe('0');
+  });
+
+  it('joins dog names with comma', () => {
+    const { result } = renderHook(() =>
+      useWalkDetailViewModel(
+        makeWalk({
+          dogs: [
+            {
+              id: 'a',
+              name: 'Rex',
+              breed: null,
+              gender: null,
+              birthDate: null,
+              photoUrl: null,
+              createdAt: '',
+            },
+            {
+              id: 'b',
+              name: 'Buddy',
+              breed: null,
+              gender: null,
+              birthDate: null,
+              photoUrl: null,
+              createdAt: '',
+            },
+          ],
+        }),
+      ),
+    );
+    expect(result.current!.dogNames).toBe('Rex, Buddy');
+  });
+
+  it('returns null endTime when walk.endedAt is null', () => {
+    const { result } = renderHook(() =>
+      useWalkDetailViewModel(makeWalk({ endedAt: null })),
+    );
+    expect(result.current!.endTime).toBeNull();
+  });
+
+  it('midpoint is the middle coordinate when points exist', () => {
+    const { result } = renderHook(() => useWalkDetailViewModel(makeWalk()));
+    expect(result.current!.midpoint).toEqual({ latitude: 35.1, longitude: 139.1 });
+  });
+
+  it('midpoint falls back to Tokyo Station when there are no points', () => {
+    const { result } = renderHook(() =>
+      useWalkDetailViewModel(makeWalk({ points: [] })),
+    );
+    expect(result.current!.midpoint).toEqual(TOKYO_STATION_COORDINATE);
+  });
+
+  it('passes through walk.events', () => {
+    const event = {
+      id: 'e1',
+      walkId: 'w-1',
+      dogId: null,
+      eventType: 'pee' as const,
+      occurredAt: '',
+      lat: null,
+      lng: null,
+      photoUrl: null,
+    };
+    const { result } = renderHook(() =>
+      useWalkDetailViewModel(makeWalk({ events: [event] })),
+    );
+    expect(result.current!.events).toEqual([event]);
+  });
+});

--- a/apps/mobile/hooks/use-walk-detail-view-model.ts
+++ b/apps/mobile/hooks/use-walk-detail-view-model.ts
@@ -1,0 +1,50 @@
+import { useMemo } from 'react';
+import { TOKYO_STATION_COORDINATE } from '@/lib/walk/constants';
+import { formatClockTime } from '@/lib/walk/format';
+import type { Walk, WalkEvent } from '@/types/graphql';
+
+export interface WalkDetailViewModel {
+  coordinates: { latitude: number; longitude: number }[];
+  events: WalkEvent[];
+  durationMin: number;
+  distanceKm: string;
+  date: string;
+  dogNames: string;
+  startTime: string;
+  endTime: string | null;
+  midpoint: { latitude: number; longitude: number };
+}
+
+export function useWalkDetailViewModel(walk: Walk | null | undefined): WalkDetailViewModel | null {
+  return useMemo(() => {
+    if (!walk) return null;
+
+    const coordinates = (walk.points ?? []).map((p) => ({
+      latitude: p.lat,
+      longitude: p.lng,
+    }));
+    const events = walk.events ?? [];
+    const durationMin = walk.durationSec ? Math.round(walk.durationSec / 60) : 0;
+    const distanceKm = walk.distanceM ? (walk.distanceM / 1000).toFixed(2) : '0';
+    const date = new Date(walk.startedAt).toLocaleDateString();
+    const dogNames = walk.dogs.map((d) => d.name).join(', ');
+    const startTime = formatClockTime(walk.startedAt);
+    const endTime = walk.endedAt ? formatClockTime(walk.endedAt) : null;
+    const midpoint =
+      coordinates.length > 0
+        ? coordinates[Math.floor(coordinates.length / 2)]
+        : TOKYO_STATION_COORDINATE;
+
+    return {
+      coordinates,
+      events,
+      durationMin,
+      distanceKm,
+      date,
+      dogNames,
+      startTime,
+      endTime,
+      midpoint,
+    };
+  }, [walk]);
+}

--- a/apps/mobile/lib/walk/constants.test.ts
+++ b/apps/mobile/lib/walk/constants.test.ts
@@ -1,0 +1,11 @@
+import { TOKYO_STATION_COORDINATE } from './constants';
+
+describe('TOKYO_STATION_COORDINATE', () => {
+  it('has Tokyo Station latitude and longitude', () => {
+    expect(TOKYO_STATION_COORDINATE).toEqual({ latitude: 35.6812, longitude: 139.7671 });
+  });
+
+  it('is frozen so consumers cannot mutate the shared object', () => {
+    expect(Object.isFrozen(TOKYO_STATION_COORDINATE)).toBe(true);
+  });
+});

--- a/apps/mobile/lib/walk/constants.ts
+++ b/apps/mobile/lib/walk/constants.ts
@@ -1,0 +1,12 @@
+/**
+ * Tokyo Station fallback coordinate.
+ *
+ * Used when a walk has no recorded GPS points yet — the map needs an initial
+ * region to render. Tokyo Station is a central, recognizable landmark and is
+ * a neutral choice for domestic users. Callers should replace this with an
+ * actual walk coordinate as soon as one becomes available.
+ */
+export const TOKYO_STATION_COORDINATE: { latitude: number; longitude: number } = Object.freeze({
+  latitude: 35.6812,
+  longitude: 139.7671,
+});


### PR DESCRIPTION
## Summary

Phase 8 of `tasks/refactor/mobile/03-plan.md` — split `walks/[id].tsx` + `dogs/[id]/index.tsx`.

- `lib/walk/constants.ts` (new) — `TOKYO_STATION_COORDINATE` shared fallback for empty-track maps (reason comment documents why Tokyo Station).
- `hooks/use-walk-detail-view-model.ts` (new) — memoized derivation returning primitives only (duration/distance/date/dogNames/start/end time strings/midpoint). i18n string assembly stays in the screen.
- `hooks/use-dog-detail-authorization.ts` (new) — memoized `{ isOwner }` from `(dog, me)`.
- `app/walks/[id].tsx` — **206 → 176 lines**, delegates derivation.
- `app/dogs/[id]/index.tsx` — **209 → 208 lines**, uses auth hook (tiny but plan-mandated).
- `components/walk/WalkMap.tsx` — uses shared constant instead of inline literals.

Plan target was ≤150 lines per screen. Remaining bulk is JSX + styles that don't compress without component splits beyond Phase 8 scope.

## Test plan

- [x] `lib/walk/constants.test.ts` — 2 tests (value + frozen)
- [x] `hooks/use-walk-detail-view-model.test.ts` — 11 tests (null walk, coordinates, duration rounding + null, distance + null, dogNames, null endedAt, midpoint, Tokyo fallback, events passthrough)
- [x] `hooks/use-dog-detail-authorization.test.ts` — 6 tests (owner/member/non-member/no-members/no-me/no-dog)
- [x] Full `npx jest` — 306 passed / 54 suites
- [x] `npx tsc --noEmit` — no new errors in Phase 8 files
- [x] `npx expo lint` — no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)