### PR TITLE
docs(refactor): add mobile refactor plans + progress to main

### DIFF
--- a/tasks/refactor/mobile/01-scan.md
+++ b/tasks/refactor/mobile/01-scan.md
@@ -1,0 +1,99 @@
+# Scan: apps/mobile
+
+対象: `apps/mobile/{app,components,hooks,stores,lib,modules,theme,types}` (node_modules / ios / android / app-example / .expo / assets 除外)
+日付: 2026-04-17
+
+## 課題一覧
+
+### DRY — 重複
+
+- [DRY] `apps/mobile/hooks/use-me.ts:9` / `use-walks.ts:9,21` / `use-dog.ts` / `use-dog-encounters.ts:9` / `use-dog-friends.ts:9` / `use-friendship.ts:9` — `const isAuthenticated = useAuthStore((s) => s.isAuthenticated)` が6+フックに同一記述
+- [DRY] `apps/mobile/hooks/use-dog-mutations.ts:28-30,44-46,58-60` / `use-walk-mutations.ts:40` / `use-dog-member-mutations.ts:38-40,55-57` / `use-accept-invitation.ts:18-19` — `queryClient.invalidateQueries({ queryKey: meKeys.all })` + `queryClient.invalidateQueries({ queryKey: dogKeys.all })` の2本セットが8+箇所で重複
+- [DRY] `apps/mobile/app/(tabs)/dogs.tsx:99-105` / `(tabs)/settings.tsx:70-76` / `dogs/[id]/friends/index.tsx:64-69` / `dogs/[id]/encounters.tsx:60-65` / `walks/[id].tsx:81-94` — hero title スタイル (`fontSize: 40, fontWeight: 900, letterSpacing: -0.8, lineHeight: 44`) が4+画面で独立定義
+- [DRY] `apps/mobile/app/dogs/new.tsx:15-23` / `dogs/[id]/edit.tsx:31-41,44-54` / `dogs/[id]/members.tsx:46-52,57-65,69-75` / `dogs/[id]/index.tsx:33-38` — `try/catch + Alert.alert + error翻訳` パターンが3+画面・3+ハンドラで重複
+- [DRY] `apps/mobile/components/walk/WalkMap.tsx:9-13` と `WalkEventTimeline.tsx:11-15` — `EVENT_EMOJIS` マップが2ファイル重複 (`walks/[id].tsx:13-17` にも類似定義)
+- [DRY] `apps/mobile/components/dogs/DogListItem.tsx:24-29` / `EncounterCard.tsx:30-35` / `FriendCard.tsx:24-29` / `DogStatsCard.tsx:29-34` / `components/walks/WalkHistoryItem.tsx:32-37` — `theme.border + '33'` カードボーダーパターン5箇所重複
+- [DRY] `apps/mobile/components/settings/ProfileSection.tsx:42-48` / `AppearanceSection.tsx:51-58` / `EncounterDetectionSection.tsx:33-40` — `styles.card + styles.sectionTitle` 構造を3セクションで独立定義
+- [DRY] `apps/mobile/app/dogs/[id]/encounters.tsx:23-30` と `dogs/[id]/friends/index.tsx:24-31` — ヘッダー (sectionLabel + heroTitle + padding) が同構造
+- [DRY] `apps/mobile/app/(tabs)/dogs.tsx:67-72` / `dogs/[id]/friends/index.tsx:33-36` / `dogs/[id]/encounters.tsx:32-35` — EmptyState呼び出しが類似シグネチャで重複
+
+### KISS — 複雑さ過剰
+
+- [KISS] `apps/mobile/components/auth/ConfirmForm.tsx:26,31-45` — OTP入力が ref array + 手動 focus/backspace管理
+- [KISS] `apps/mobile/components/walk/WalkEventActions.tsx:58-109` — 写真アップロードの3段 choreography (presign→PUT→record) + phase error tracking + deep-link自動起動を1コンポーネントに
+- [KISS] `apps/mobile/components/walk/DogSelector.tsx:57-99` — FlatList renderItem 内の Pressable + 条件分岐で4段ネスト
+- [KISS] `apps/mobile/app/walks/[id].tsx:46-48` — Midpoint fallback に Tokyo 座標 (35.6812, 139.7671) ハードコード、根拠コメントなし
+- [KISS] `apps/mobile/app/invite/[token].tsx:41-52` — `mapInviteErrorMessage` が `includes('expired')` など文字列マッチでi18n前の英語前提
+
+### YAGNI — 未使用
+
+- [YAGNI] `apps/mobile/components/walk/WalkMap.tsx:15-18` — `followUser` prop 常に true、false パスなし
+- [YAGNI] `apps/mobile/components/walk/WalkControls.tsx:54-62` — pauseボタン disabled 表示のみで実体ロジックなし
+- [YAGNI] `apps/mobile/components/ui/Divider.tsx:1-20` — 1行の `<View/>` を返すだけのラッパー
+- [YAGNI] `apps/mobile/components/dogs/DogForm.tsx:24` — `gender` state 定義・描画のみで検証・送信未使用
+- [YAGNI] `apps/mobile/lib/graphql/keys.ts` — `dogKeys.members()` 定義あるが参照hookなし
+- [YAGNI] `apps/mobile/lib/ble/encounter-tracker.ts` — class定義だがhook経由の参照なし（要確認）
+
+### SRP — 責務肥大
+
+- [SRP] `apps/mobile/app/(tabs)/walk.tsx:1-201` — GPS追跡 + BLE scan/advertise + encounter検出 + 点バッチ送信 + permissionオーケストレーション + UI描画を1画面に
+- [SRP] `apps/mobile/app/invite/[token].tsx:1-230` — deeplink抽出 + state machine + Platform分岐SecureStore + 認証分岐 + errorマップ + 4状態UIを1画面に
+- [SRP] `apps/mobile/app/walks/[id].tsx:1-212` — データ変換 + Map描画 + timelineイベント描画 + walker section描画
+- [SRP] `apps/mobile/app/dogs/[id]/index.tsx:1-211` — 認可判定 + delete mutation + 条件付きUI + member/friends/stats描画
+- [SRP] `apps/mobile/app/dogs/[id]/members.tsx:45-75` — 3ハンドラ (invite/remove/leave) が同一try/catch+Alertパターンで独立実装
+- [SRP] `apps/mobile/components/walk/WalkEventActions.tsx:1-185` — pee/poo mutation + 写真upload choreography + deep-link自動起動 + haptics
+- [SRP] `apps/mobile/components/auth/ConfirmForm.tsx:1-169` — OTPフォーカス管理 + フォーム送信
+- [SRP] `apps/mobile/stores/auth-store.ts:25-56` — token取得 + auth verify + 401/Network分岐 + state更新をinitialize()1関数で
+- [SRP] `apps/mobile/stores/auth-store.ts:70-90` — `refreshAuth()` が retry (exp backoff) + refresh + storage更新を抱合
+- [SRP] `apps/mobile/lib/graphql/client.ts:18-42` — `authenticatedRequest()` が request + 401検出 + 動的import + refresh呼び出しを混在
+- [SRP] `apps/mobile/components/settings/ProfileSection.tsx:53-95` — edit mode と display mode を1コンポーネントに
+
+### OCP
+
+- [OCP] `apps/mobile/app/walks/[id].tsx:13-17` / `components/walk/WalkMap.tsx:9-13` / `WalkEventTimeline.tsx:11-15` — EVENT_EMOJIS が3箇所にハードコード、追加時に複数修正必要
+- [OCP] `apps/mobile/app/(tabs)/walk.tsx:28` — `MAX_POINTS_PER_BATCH = 200` ハードコード、configurable化されていない
+
+### 型安全性
+
+- [TYPE] `apps/mobile/hooks/use-encounter-mutations.ts:15-30` — `useRecordEncounter()` 戻り型 `RecordEncounterResponse` は実装と不一致（実際 `Encounter[]`）
+- [TYPE] `apps/mobile/hooks/use-encounter-mutations.ts:34-45` — `useUpdateEncounterDuration()` 戻り型 `UpdateEncounterDurationResponse` は実装と不一致（実際 `boolean`）
+- [TYPE] `apps/mobile/lib/ble/scanner.ts:22,23,25,39,74` — `BleManager`, `bleManagerInstance`, callbackパラメータ `(error: any, device: any)` など `any` 型が6箇所
+- [TYPE] `apps/mobile/lib/graphql/errors.ts:4` — `isNetworkError()` が `TypeError` で早期 true、誤分類の恐れ
+
+### 副作用の散在
+
+- [CONCERN] `apps/mobile/app/invite/[token].tsx:16-39` — `PENDING_INVITE_KEY` の Platform別 localStorage / SecureStore 実装が画面ファイル内
+- [CONCERN] `apps/mobile/lib/graphql/client.ts:29-37` — 動的import で `useAuthStore.getState().refreshAuth()` 呼び出し → 隠れ依存
+- [CONCERN] `apps/mobile/lib/auth/secure-storage.ts:53-67` — `migrateLegacyTokensIfNeeded()` が `getToken()` 毎回実行
+- [CONCERN] `apps/mobile/lib/providers.tsx:10-24` — Query/Mutation cache で `useAuthStore.getState().clearAuth()` を直呼び
+- [CONCERN] `apps/mobile/lib/i18n/index.ts:1-19` — i18n初期化と言語検出を混在
+- [CONCERN] `apps/mobile/components/settings/EncounterDetectionSection.tsx:20-30` — mutation をコンポーネント内で直定義
+- [CONCERN] `apps/mobile/components/walk/WalkEventActions.tsx:114-118` — deep-link (`cameraRequestedAt`) をコンポーネントのuseEffectで処理
+
+### Testability
+
+- [TEST] `apps/mobile/hooks/` 18ファイル中12ファイルがテストなし (`use-me`, `use-walks`, `use-dog`, `use-dog-encounters`, `use-dog-friends`, `use-friendship`, `use-dog-mutations`, `use-walk-mutations`, `use-profile-mutation`, `use-color-scheme`, `use-colors`, `use-color-scheme.web`)
+- [TEST] `apps/mobile/components/ui/{Button,Card,TextInput,SegmentedControl,ConfirmDialog,ErrorScreen,LoadingScreen,EmptyState,ThemedView,Divider}.tsx` 全てテストなし
+- [TEST] `apps/mobile/components/walk/WalkEventActions.test.tsx` 431行 vs 本体185行 (2.3倍) → tight coupling シグナル
+- [TEST] `apps/mobile/app/` 配下screenで unit test 皆無 (6 screenテストのみ `__tests__/app/`)
+- [TEST] `apps/mobile/components/auth/ConfirmForm.tsx` / `components/dogs/PhotoPicker.tsx` / `components/walk/DogSelector.tsx` / `components/settings/ProfileSection.tsx` テストなし
+
+### 可読性 / マジックナンバー
+
+- [READ] `apps/mobile/app/(tabs)/walk.tsx:28` — `MAX_POINTS_PER_BATCH = 200` 根拠不明
+- [READ] `apps/mobile/app/walks/[id].tsx:46-48` — Tokyo座標fallback ハードコード、根拠コメントなし
+- [READ] `apps/mobile/app/walks/[id].tsx:59-60` — `latitudeDelta/longitudeDelta = 0.01` ズーム根拠不明
+- [READ] `apps/mobile/components/walk/WalkMap.tsx:71` — `'rgba(239,68,68,0.9)'` ハードコード、theme.error 未使用
+- [READ] `apps/mobile/app/(tabs)/walk.tsx:72-132` — `handleStart` useCallback 依存11件 → 高結合
+- [READ] `apps/mobile/lib/graphql/mutations.ts:1-206` / `queries.ts:1-132` — ドメイン混在で長大
+- [READ] `apps/mobile/stores/walk-store.ts:15-19` — `cameraRequestedAt` タイムスタンプ戦略コメント冗長
+
+### 実行時重複 (upload helper)
+
+- [CONCERN] `apps/mobile/lib/upload.ts:16` — localstack ホスト置換がハードコード、環境ごと切り替えなし
+
+## 備考
+
+- スタイリング・a11y ・theme token 遵守は良好 (インライン styleなし、magic color少ない)
+- `components/ui/` に `StyleSheet.create` + token import 規律守られている
+- `lib/walk/{distance,format,gps-tracker}.ts` は既に純粋関数化済み、Phase対象外

--- a/tasks/refactor/mobile/02-solutions.md
+++ b/tasks/refactor/mobile/02-solutions.md
@@ -1,0 +1,99 @@
+# Solutions: apps/mobile
+
+各課題グループに対する採用解。既存コードで再利用可能な資産 (`theme/tokens.ts`, `hooks/use-themed-styles.ts`, `lib/walk/*`) を優先し、新規依存は追加しない。
+
+## [DRY] isAuthenticated 重複
+
+**候補**
+- A: `hooks/use-is-authenticated.ts` として1行ラッパー
+- B: 各 query hook の `enabled` オプション側に寄せて呼び出しを排除
+
+**採用**: **A** — 呼び出しパターンが query 以外 (providers, screens) にも波及する可能性があり、中央ラッパーの方がシンプルで将来の selector 変更 (`s.user !== null` など) に耐える。KISS。
+
+## [DRY] invalidate ペア重複
+
+**候補**
+- A: `hooks/use-invalidate-user-queries.ts` で `invalidateMeAndDogs()` helper
+- B: mutation hook 側に `meta.invalidates` 構造を持たせる
+
+**採用**: **A** — TanStack Query の標準に沿ったシンプルな helper。Bは過剰抽象 (YAGNI)。
+
+## [DRY] hero title style 重複
+
+**候補**
+- A: `theme/tokens.ts` に `typography.hero` を追加、画面側を token参照に
+- B: `components/ui/HeroTitle.tsx` として component 化
+
+**採用**: **A** — 既存の `typography.h1/h2/body/caption` パターンに一致。Bは余分なコンポーネントラッパー (YAGNI)。
+
+## [DRY] Alert エラーハンドリング重複
+
+**候補**
+- A: `hooks/use-mutation-with-alert.ts` で wrapper フック
+- B: 各 mutation の onError を `errorPresenter` util で統一
+
+**採用**: **A** — React フック内で `Alert` を翻訳+表示する責務は fetcher とは分離した方がテストしやすい。mutation自体は pure mutation hooks に残し、画面側 wrapper がalert表示を担う。
+
+**参照**: TanStack Query docs — `onError` callback per mutation vs global `QueryCache onError`
+
+## [DRY] EVENT_EMOJIS 重複
+
+**採用**: `lib/walk/event-emojis.ts` に1箇所集約。
+
+## [DRY] カードボーダー + settings section 重複
+
+**候補**
+- A: `components/ui/OutlinedCard.tsx` (border + opacity + radius + padding を prop 化)
+- B: `theme/tokens.ts` に `card` preset を追加してスタイル参照のみ共通化
+
+**採用**: **A + B ハイブリッド** — token に `colors.cardBorder` (既存 `theme.border + '33'` を alpha 込みで固定) を追加し、`OutlinedCard` コンポーネントで構造を共通化。settings section は `SettingsSection` 別コンポーネント (title + card slot)。
+
+## [KISS + SRP] ConfirmForm OTP / WalkEventActions 写真
+
+**候補**
+- A: カスタムフック抽出 (`useOtpInput`, `usePhotoUpload`)
+- B: ライブラリ採用 (`expo-otp-input` は存在しない、自前のまま)
+
+**採用**: **A** — 既存ライブラリ依存は追加せず、ロジックのみフックに切り出してコンポーネントは描画のみに。テストが大幅簡素化。
+
+## [SRP] 画面分割 (walk / invite / walks detail / dog detail)
+
+**採用**: 画面はdescriptionのみに戻し、ロジックをカスタムフック + lib ユーティリティに移す。
+
+- `app/(tabs)/walk.tsx` → `hooks/use-walk-session.ts` + `use-ble-session.ts` + `use-encounter-session.ts` + `use-walk-permissions.ts`
+- `app/invite/[token].tsx` → `lib/auth/pending-invite-token.ts` + `hooks/use-accept-invite-flow.ts` + `lib/errors/invite-error-map.ts`
+- `app/walks/[id].tsx` → `hooks/use-walk-detail-view-model.ts` + `lib/walk/constants.ts` (Tokyo fallback座標を理由コメント付き export)
+- `app/dogs/[id]/index.tsx` → `hooks/use-dog-detail-authorization.ts`
+
+**参照**: Expo Router + React の一般的な "container/presentational" 分離パターン。画面ファイルは router の layer に専念。
+
+## [TYPE] 戻り型不一致
+
+**採用**: `hooks/use-encounter-mutations.ts` の戻り型定義を実装に合わせ修正 (`Encounter[]`, `boolean`)。呼び出し側 (WalkScreenの recordEncounter / updateEncounterDuration 利用箇所) も合わせて調整。
+
+## [TYPE] BLE scanner any
+
+**採用**: `react-native-ble-plx` の公式型 (`BleManager`, `Device`, `Subscription`) を直接 import し `any` を排除。lazy-load のため dynamic import ではなく通常 import に変更してもバンドルサイズには影響なし (既に native module として含まれる)。
+
+## [CONCERN] secure-storage migration 毎回実行
+
+**採用**: migration を `auth-store.initialize()` の先頭で1回呼ぶ方式に変更。`getToken()` から migration を除去。auth-storeの初期化でのみ legacy → new へ移行される。
+
+## [CONCERN] GraphQL client refresh middleware 化
+
+**採用**: `lib/graphql/client.ts` の refresh 処理を `lib/graphql/middleware/refresh-on-401.ts` に分離。`authenticatedRequest()` は request 実行のみ、401 検出+リトライは middleware 層。副作用と通信を分離。
+
+## [CONCERN] GraphQL queries/mutations ドメイン分割
+
+**採用**: `lib/graphql/{dog,walk,me,friendship,encounter,auth}.{queries,mutations}.ts` にドメインで分け、`lib/graphql/index.ts` から re-export。既存importは段階的移行 (barrel は `no barrel file` ルールあるが GraphQL ドキュメント集約のみ例外として許容、要判断)。または直接ドメイン別にimport変更する。
+
+**参照**: Apollo公式 Fragment colocation パターンに近い — ドキュメントは利用者近くに置く思想もあるが、ここでは共有クライアント層に残し domain で分割するに留める。
+
+## [YAGNI] 未使用prop/component/フィールド
+
+**採用**: 削除ベース。迷うなら削除ではなく validation追加 (例: `DogForm.gender` は select UI を既に持つので、検証を追加してスキーマに沿うか、逆にUIも削除するかを実装時に user確認)。
+
+- `WalkMap.followUser` → 削除、`showsUserLocation={true}` ハードコード
+- `WalkControls` pauseボタン → 削除 (実装予定がない前提)
+- `Divider` → インライン置換で削除
+- `dogKeys.members()` → 削除

--- a/tasks/refactor/mobile/03-plan.md
+++ b/tasks/refactor/mobile/03-plan.md
@@ -1,0 +1,173 @@
+# Plan: apps/mobile
+
+優先度 = `(impact × ease) / risk`。先頭ほど低リスク・高インパクト。**各フェーズは新セッションで実行**。
+
+## 共通検証 (全フェーズ適用)
+
+```
+docker compose run --rm mobile npm test
+docker compose run --rm mobile npx tsc --noEmit
+docker compose run --rm mobile npm run lint
+```
+
+変更行あるフェーズは iOS Simulator で影響画面をスモーク (`ios-simulator-skill` scripts 経由)。
+
+---
+
+## Phase 1: 共有フック/定数抽出 (優先度: 最高)
+
+- **対象課題**: DRY (isAuthenticated 6+重複, invalidate pair 8+重複, EVENT_EMOJIS 2+重複, hero style 4+重複)
+- **変更**:
+  - `apps/mobile/hooks/use-is-authenticated.ts` 新規 — `useAuthStore((s) => s.isAuthenticated)` wrapper
+  - `apps/mobile/hooks/use-invalidate-user-queries.ts` 新規 — `meKeys.all + dogKeys.all` invalidator
+  - `apps/mobile/lib/walk/event-emojis.ts` 新規 — emoji マップ統合
+  - `apps/mobile/theme/tokens.ts` に `typography.hero` 追加
+  - 対象ファイル (hooks 6件, mutation hooks 5件, screens 4件, walk components 2件) を置換
+- **完了条件**:
+  - 全既存テスト緑
+  - `rg "useAuthStore\(\(s\) => s\.isAuthenticated\)" apps/mobile/hooks` ≤ 1
+  - `rg "invalidateQueries\(\{ queryKey: meKeys\.all" apps/mobile/hooks` が helper 内のみ
+  - `rg "EVENT_EMOJIS" apps/mobile/{components,app}` が `event-emojis.ts` import のみ
+  - `rg "fontSize: 40," apps/mobile/app` が hero token 参照のみ
+- **依存**: なし
+- **推定規模**: S (60分)
+
+## Phase 2: YAGNI 除去 + 型不一致修正 (優先度: 高)
+
+- **対象課題**: WalkMap.followUser, WalkControls pause, Divider, DogForm.gender, dogKeys.members(), use-encounter-mutations 戻り型
+- **変更**:
+  - `components/walk/WalkMap.tsx` — `followUser` prop削除
+  - `components/walk/WalkControls.tsx` — pauseボタン削除
+  - `components/ui/Divider.tsx` — 利用箇所をインライン化後ファイル削除
+  - `components/dogs/DogForm.tsx` — `gender` 検証追加 / 削除は interview で確認 (デフォ: 検証追加)
+  - `hooks/use-encounter-mutations.ts` — 戻り型を `Encounter[]` / `boolean` に修正、呼び出し側調整
+  - `lib/graphql/keys.ts` — `dogKeys.members()` 削除
+- **完了条件**:
+  - `npx tsc --noEmit` エラーなし
+  - 全既存テスト緑
+  - grep で削除対象が消えている
+- **依存**: なし (Phase 1 と並行可)
+- **推定規模**: S (60分)
+
+## Phase 3: エラーハンドリング共通化 (優先度: 高)
+
+- **対象課題**: try/catch+Alert 画面3+ 重複, members.tsx 3ハンドラ同型
+- **変更**:
+  - `hooks/use-mutation-with-alert.ts` 新規 — mutation 実行 + i18n key + Alert.alert
+  - `app/dogs/{new,[id]/edit,[id]/members,[id]/index}.tsx` を置換
+- **完了条件**:
+  - 全既存テスト緑 + 新規 hook テスト
+  - `rg "Alert\.alert" apps/mobile/app` 削減 (確認済み例外のみ残す)
+- **依存**: Phase 1
+- **推定規模**: M (2時間)
+
+## Phase 4: カード系コンポーネント共通化 (優先度: 中)
+
+- **対象課題**: カードボーダー5箇所, settings section 3箇所
+- **変更**:
+  - `components/ui/OutlinedCard.tsx` 新規
+  - `components/settings/SettingsSection.tsx` 新規
+  - `theme/tokens.ts` に `colors.cardBorder` (alpha込み) 追加
+  - 対象コンポーネント5件をリファクタ
+- **完了条件**:
+  - 全既存テスト緑 + 新 unit test
+  - iOS Simulator で各画面視覚差分なし
+- **依存**: Phase 1
+- **推定規模**: M (2-3時間)
+
+## Phase 5: カスタムフック抽出 — WalkEventActions / ConfirmForm (優先度: 中)
+
+- **対象課題**: WalkEventActions 185行+テスト431行, ConfirmForm OTP
+- **変更**:
+  - `hooks/use-photo-upload.ts` 新規 — presign→PUT→record (phase error付き)
+  - `hooks/use-otp-input.ts` 新規 — digit state + focus/backspace
+  - `components/walk/WalkEventActions.tsx` を簡素化
+  - `components/auth/ConfirmForm.tsx` を簡素化
+- **完了条件**:
+  - `WalkEventActions.test.tsx` ≤ 200行
+  - フック単体テスト新規追加
+  - 全既存テスト緑
+- **依存**: Phase 3
+- **推定規模**: M (3時間)
+
+## Phase 6: 画面分割 — invite/[token] (優先度: 中)
+
+- **対象課題**: invite/[token].tsx 230行, Platform別SecureStore内包
+- **変更**:
+  - `lib/auth/pending-invite-token.ts` 新規 (Platform抽象化)
+  - `hooks/use-accept-invite-flow.ts` 新規 (state machine + 認証分岐)
+  - `lib/errors/invite-error-map.ts` 新規 (i18n key ベース)
+  - `app/invite/[token].tsx` を描画のみに
+- **完了条件**:
+  - 画面本体 ≤ 100行
+  - pending-invite-token / use-accept-invite-flow に unit test
+  - 深リンク手動テスト 4パス (auth済/未認証/期限切れ/使用済み)
+- **依存**: Phase 1, 3
+- **推定規模**: M (3-4時間)
+
+## Phase 7: 画面分割 — (tabs)/walk (優先度: 中 / risk:高)
+
+- **対象課題**: (tabs)/walk.tsx 201行
+- **変更**:
+  - `hooks/use-walk-session.ts` 新規 — start/finish + 点バッチ送信 (MAX_POINTS_PER_BATCH 理由コメント付き)
+  - `hooks/use-ble-session.ts` 新規 — BLE scan/advertise
+  - `hooks/use-encounter-session.ts` 新規 — encounter record/update
+  - `hooks/use-walk-permissions.ts` 新規 — 位置+BLE+通知 permission orchestration
+  - `app/(tabs)/walk.tsx` を合成のみに
+- **完了条件**:
+  - 画面本体 ≤ 100行
+  - 各フック unit test
+  - iOS Simulator で散歩開始→停止スモーク (GPS/BLE/encounter動作)
+- **依存**: Phase 1, 3
+- **推定規模**: L (半日〜1日)
+
+## Phase 8: 画面分割 — walks/[id] + dogs/[id] (優先度: 低)
+
+- **対象課題**: walks/[id].tsx 212行, dogs/[id]/index.tsx 211行
+- **変更**:
+  - `hooks/use-walk-detail-view-model.ts` 新規 (duration/distance/date/midpoint)
+  - `lib/walk/constants.ts` 新規 — Tokyo fallback座標を理由コメント付き export
+  - `hooks/use-dog-detail-authorization.ts` 新規
+  - 画面2件を presentational に
+- **完了条件**:
+  - 各画面 ≤ 150行
+  - view-model hook の unit test
+- **依存**: Phase 3
+- **推定規模**: M (3-4時間)
+
+## Phase 9: GraphQL 整理 + auth client改善 (優先度: 低)
+
+- **対象課題**: queries/mutations.ts ドメイン混在, client.ts refresh interleave, secure-storage 毎回 migration
+- **変更**:
+  - `lib/graphql/{dog,walk,me,friendship,encounter,auth}.{queries,mutations}.ts` にドメイン分割
+  - `lib/graphql/middleware/refresh-on-401.ts` 新規 — interceptor
+  - `lib/graphql/client.ts` — request 実行のみに
+  - `lib/auth/secure-storage.ts` — migration を `auth-store.initialize()` 先頭 1回に移動
+- **完了条件**:
+  - 全既存テスト緑
+  - auth-store.initialize で migration 実行の unit test
+- **依存**: Phase 3
+- **推定規模**: M (3時間)
+
+## Phase 10: BLE scanner 型安全化 + UI primitive テスト (優先度: 低 / risk:中)
+
+- **対象課題**: lib/ble/scanner.ts any×6, UI primitive テスト0
+- **変更**:
+  - `lib/ble/scanner.ts` — `react-native-ble-plx` 公式型を使用
+  - `components/ui/{Button,Card,TextInput,SegmentedControl,ConfirmDialog}.test.tsx` 新規
+- **完了条件**:
+  - `rg "any" apps/mobile/lib/ble/scanner.ts` = 0 (合理的例外除く)
+  - UI primitive テストで variant / state カバー
+  - iOS Simulator で BLE スキャン動作確認
+- **依存**: なし
+- **推定規模**: M (3-4時間)
+
+---
+
+## セッション起動テンプレ
+
+```
+tasks/refactor/mobile/03-plan.md の Phase <N> を実行して。
+TDD で進める (superpowers:test-driven-development)。
+完了したら tasks/refactor/mobile/progress.md の Phase <N> を完了に更新して。
+```

--- a/tasks/refactor/mobile/progress.md
+++ b/tasks/refactor/mobile/progress.md
@@ -1,0 +1,12 @@
+# Progress: apps/mobile
+
+- [x] Phase 1: 共有フック/定数抽出
+- [x] Phase 2: YAGNI 除去 + 型不一致修正
+- [x] Phase 3: エラーハンドリング共通化
+- [x] Phase 4: カード系コンポーネント共通化
+- [x] Phase 5: カスタムフック抽出 — WalkEventActions / ConfirmForm
+- [x] Phase 6: 画面分割 — invite/[token]
+- [x] Phase 7: 画面分割 — (tabs)/walk
+- [x] Phase 8: 画面分割 — walks/[id] + dogs/[id]
+- [x] Phase 9: GraphQL 整理 + auth client改善
+- [x] Phase 10: BLE scanner 型安全化 + UI primitive テスト


### PR DESCRIPTION
## Summary
Moves the 4-file mobile refactor scaffolding from the unmerged `docs/design-and-mobile-refactor` branch into `main` so the `@tasks/refactor/mobile/03-plan.md` reference that Phase 1–10 sessions quoted actually resolves on `main`.

- `01-scan.md` — issue inventory (DRY / KISS / YAGNI / SRP / OCP / TYPE / CONCERN / TEST)
- `02-solutions.md` — chosen solution per issue
- `03-plan.md` — 10-phase execution plan
- `progress.md` — checklist (all 10 phases checked from the completed work)

Docs-only. No source changes.

## Test plan
- [x] No source files touched; no CI suite to run
- [x] Plan file content verified against `docs/design-and-mobile-refactor` source commit `248cefd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)