### PR TITLE
feat(mobile): restore shared keychain (App Group + keychain-access-groups)

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -32,6 +32,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     },
     entitlements: {
       'com.apple.security.application-groups': [APP_GROUP],
+      'keychain-access-groups': [`$(AppIdentifierPrefix)${APP_GROUP}`],
     },
   },
   android: {

--- a/apps/mobile/lib/auth/secure-storage.ts
+++ b/apps/mobile/lib/auth/secure-storage.ts
@@ -16,9 +16,8 @@ const extras = (Constants.expoConfig?.extra ?? {}) as {
   keychainService?: string;
 };
 
-// When running on iOS with the shared keychain extras wired up, all reads and
-// writes go through the App Group / keychain service pair so the Widget
-// extension can read the same items via SecItemCopyMatching.
+// Tokens read/write through the App Group + keychain service so the Live
+// Activity widget can SecItemCopyMatching the same items via SharedKeychain.
 const sharedOptions: SecureStore.SecureStoreOptions | undefined =
   Platform.OS === 'ios' && extras.appGroup && extras.keychainService
     ? { accessGroup: extras.appGroup, keychainService: extras.keychainService }

--- a/apps/mobile/targets/walk-live-activity/expo-target.config.js
+++ b/apps/mobile/targets/walk-live-activity/expo-target.config.js
@@ -1,6 +1,7 @@
 /** @type {import('@bacons/apple-targets/app.plugin').ConfigFunction} */
 module.exports = (config) => {
   const group = config.ios?.entitlements?.['com.apple.security.application-groups'] ?? [];
+  const keychainGroups = config.ios?.entitlements?.['keychain-access-groups'] ?? [];
   return {
     type: 'widget',
     name: 'walk-live-activity',
@@ -9,6 +10,7 @@ module.exports = (config) => {
     deploymentTarget: '17.0',
     entitlements: {
       'com.apple.security.application-groups': group,
+      'keychain-access-groups': keychainGroups,
     },
   };
 };


### PR DESCRIPTION
## Summary

- Personal Team 署名の制約で暫定的に `sharedOptions = undefined` 固定にしていた `lib/auth/secure-storage.ts` を、有料 Apple Developer Program 加入を機に復元
- `app.config.ts` の `ios.entitlements` に `keychain-access-groups: ["\$(AppIdentifierPrefix)\${APP_GROUP}"]` を追加し、`expo prebuild` で生成される `.entitlements` plist に反映
- `targets/walk-live-activity/expo-target.config.js` も widget 側に `keychain-access-groups` を継承させ、Live Activity widget が `SharedKeychain.swift` 経由で同じトークンを `SecItemCopyMatching` 可能に

## Why

shared keychain なしでは widget が認証付き API を呼べず Live Activity の本来の役割が成立しない。Apple Developer Program の Keychain Sharing capability が provision 可能になったので恒久対応。

## Test plan

- [x] `npm test` 337/337 pass（`secure-storage.test.ts` の sharedOptions assertion 含む）
- [x] `npx expo prebuild --clean` 後に `ios/WalkingDoglocal/WalkingDoglocal.entitlements` と `targets/walk-live-activity/generated.entitlements` の両方に `application-groups` + `keychain-access-groups` が出力されることを確認
- [x] iOS Simulator (iPhone 16 Pro) でログインフロー実施 → 旧 `getValueWithKeyAsync` entitlement エラーが再発しないこと、walk タブ遷移とトークン永続化を確認
- [ ] 実機 (sakura 環境) で Live Activity 起動 → widget からの GraphQL リクエストが 401 を返さないこと
- [ ] 旧暫定版 (default scope) でログイン状態の端末に新版を上書きインストール → `migrateLegacyTokens` がデフォルトスコープから共有スコープへトークンを移行 → 再ログイン不要

## Deploy notes

- Xcode で WalkingDoglocal / walk-live-activity 両 target の Team を Personal Team から有料 Apple Developer Program team に切替済
- App Groups + Keychain Sharing capability が両 target に provision されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)