### PR TITLE
feat(mobile): Precise Walk Detail screen — map card + 3-col metrics + grouped timeline

### DIFF
--- a/apps/mobile/app/walks/[id].tsx
+++ b/apps/mobile/app/walks/[id].tsx
@@ -1,10 +1,11 @@
-import { StyleSheet, Text, View, ActivityIndicator, ScrollView } from 'react-native';
+import { ActivityIndicator, ScrollView, StyleSheet, Text, View } from 'react-native';
 import MapView, { Polyline, Marker } from 'react-native-maps';
 import { Image } from 'expo-image';
 import { useLocalSearchParams } from 'expo-router';
 import { useTranslation } from 'react-i18next';
+import { GroupedCard } from '@/components/ui/GroupedCard';
 import { useColors } from '@/hooks/use-colors';
-import { spacing, radius, typography } from '@/theme/tokens';
+import { radius, spacing, typography } from '@/theme/tokens';
 import { useWalk } from '@/hooks/use-walks';
 import { useWalkDetailViewModel } from '@/hooks/use-walk-detail-view-model';
 import { WalkEventTimeline } from '@/components/walk/WalkEventTimeline';
@@ -30,10 +31,16 @@ export default function WalkDetailScreen() {
     ? `${t('walk.detail.startTime')} ${vm.startTime}${separator}${t('walk.detail.endTime')} ${vm.endTime}`
     : `${t('walk.detail.startTime')} ${vm.startTime}`;
 
+  const pace = formatPace(vm.durationMin, vm.distanceKm);
+  const durationDisplay = formatDuration(vm.durationMin);
+
   return (
     <View style={[styles.container, { backgroundColor: theme.background }]}>
-      <ScrollView contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
-        <View style={[styles.mapContainer, { borderColor: theme.border + '33' }]}>
+      <ScrollView
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+      >
+        <GroupedCard style={styles.mapCard}>
           <MapView
             style={styles.map}
             initialRegion={{
@@ -44,7 +51,13 @@ export default function WalkDetailScreen() {
             }}
           >
             {vm.coordinates.length >= 2 ? (
-              <Polyline coordinates={vm.coordinates} strokeColor={theme.interactive} strokeWidth={4} />
+              <Polyline
+                coordinates={vm.coordinates}
+                strokeColor={theme.success}
+                strokeWidth={5}
+                lineCap="round"
+                lineJoin="round"
+              />
             ) : null}
             {vm.events
               .filter((e) => e.lat != null && e.lng != null)
@@ -58,11 +71,15 @@ export default function WalkDetailScreen() {
                 </Marker>
               ))}
           </MapView>
-        </View>
+        </GroupedCard>
 
-        <View style={styles.info}>
-          <Text style={[styles.heroTitle, { color: theme.onSurface }]}>{t('walk.detail.title')}</Text>
-          <Text style={[styles.date, { color: theme.onSurface }]}>{vm.date}</Text>
+        <View style={styles.hero}>
+          <Text style={[styles.caption, { color: theme.onSurfaceVariant }]}>
+            {vm.date.toUpperCase()}
+          </Text>
+          <Text style={[styles.title, { color: theme.onSurface }]}>
+            {t('walk.detail.title')}
+          </Text>
           <Text style={[styles.dogs, { color: theme.onSurfaceVariant }]}>{vm.dogNames}</Text>
           <Text
             testID="walk-time"
@@ -72,105 +89,177 @@ export default function WalkDetailScreen() {
             {vm.startTime}
             {vm.endTime ? `${separator}${vm.endTime}` : null}
           </Text>
+        </View>
 
-          {walk.walker ? (
-            <View style={styles.walkerSection}>
-              <Text style={[styles.walkerLabel, { color: theme.onSurfaceVariant }]}>
-                {t('walk.detail.walker')}
-              </Text>
-              <View style={styles.walkerRow}>
-                {walk.walker.avatarUrl ? (
-                  <Image
-                    source={{ uri: walk.walker.avatarUrl }}
-                    style={styles.walkerAvatar}
-                    contentFit="cover"
-                    cachePolicy="memory-disk"
-                    accessibilityLabel={walk.walker.displayName ?? ''}
-                  />
-                ) : (
-                  <View
-                    style={[
-                      styles.walkerAvatar,
-                      styles.walkerInitialBg,
-                      { backgroundColor: theme.primaryContainer },
-                    ]}
-                  >
-                    <Text style={[styles.walkerInitialText, { color: theme.onInteractive }]}>
-                      {walk.walker.displayName?.charAt(0)?.toUpperCase() ?? '?'}
-                    </Text>
-                  </View>
-                )}
-                <Text style={[styles.walkerName, { color: theme.onSurface }]}>
-                  {walk.walker.displayName}
-                </Text>
-              </View>
-            </View>
-          ) : null}
+        <GroupedCard padding="lg" style={styles.metrics}>
+          <Metric
+            label={t('walk.recording.distance')}
+            value={vm.distanceKm}
+            unit="km"
+            labelColor={theme.onSurfaceVariant}
+            valueColor={theme.onSurface}
+          />
+          <Metric
+            label={t('walk.recording.time')}
+            value={durationDisplay.value}
+            unit={durationDisplay.unit}
+            labelColor={theme.onSurfaceVariant}
+            valueColor={theme.onSurface}
+          />
+          <Metric
+            label="Pace"
+            value={pace.value}
+            unit={pace.unit}
+            labelColor={theme.onSurfaceVariant}
+            valueColor={theme.onSurface}
+          />
+        </GroupedCard>
 
-          <View style={styles.stats}>
-            <View
-              style={[
-                styles.statCard,
-                { backgroundColor: theme.surfaceContainerLowest, borderColor: theme.border + '33' },
-              ]}
-            >
-              <Text style={[styles.statValue, { color: theme.onSurface }]}>
-                {t('walk.history.minutes', { count: vm.durationMin })}
-              </Text>
-              <Text style={[styles.statLabel, { color: theme.onSurfaceVariant }]}>
-                {t('walk.recording.time')}
-              </Text>
-            </View>
-            <View
-              style={[
-                styles.statCard,
-                { backgroundColor: theme.surfaceContainerLowest, borderColor: theme.border + '33' },
-              ]}
-            >
-              <Text style={[styles.statValue, { color: theme.onSurface }]}>
-                {t('walk.history.km', { value: vm.distanceKm })}
-              </Text>
-              <Text style={[styles.statLabel, { color: theme.onSurfaceVariant }]}>
-                {t('walk.recording.distance')}
+        {walk.walker ? (
+          <View style={styles.walkerSection}>
+            <Text style={[styles.walkerLabel, { color: theme.onSurfaceVariant }]}>
+              {t('walk.detail.walker')}
+            </Text>
+            <View style={styles.walkerRow}>
+              {walk.walker.avatarUrl ? (
+                <Image
+                  source={{ uri: walk.walker.avatarUrl }}
+                  style={styles.walkerAvatar}
+                  contentFit="cover"
+                  cachePolicy="memory-disk"
+                  accessibilityLabel={walk.walker.displayName ?? ''}
+                />
+              ) : (
+                <View
+                  style={[
+                    styles.walkerAvatar,
+                    styles.walkerInitialBg,
+                    { backgroundColor: theme.primaryContainer },
+                  ]}
+                >
+                  <Text style={[styles.walkerInitialText, { color: theme.onInteractive }]}>
+                    {walk.walker.displayName?.charAt(0)?.toUpperCase() ?? '?'}
+                  </Text>
+                </View>
+              )}
+              <Text style={[styles.walkerName, { color: theme.onSurface }]}>
+                {walk.walker.displayName}
               </Text>
             </View>
           </View>
-        </View>
+        ) : null}
 
-        {vm.events.length > 0 ? <WalkEventTimeline events={vm.events} /> : null}
+        {vm.events.length > 0 ? (
+          <GroupedCard style={styles.timelineCard}>
+            <WalkEventTimeline events={vm.events} />
+          </GroupedCard>
+        ) : null}
       </ScrollView>
     </View>
   );
 }
 
+function Metric({
+  label,
+  value,
+  unit,
+  labelColor,
+  valueColor,
+}: {
+  label: string;
+  value: string;
+  unit?: string;
+  labelColor: string;
+  valueColor: string;
+}) {
+  return (
+    <View style={styles.metric}>
+      <Text style={[styles.metricLabel, { color: labelColor }]}>{label}</Text>
+      <View style={styles.metricRow}>
+        <Text style={[styles.metricValue, { color: valueColor }]}>{value}</Text>
+        {unit ? <Text style={[styles.metricUnit, { color: labelColor }]}>{unit}</Text> : null}
+      </View>
+    </View>
+  );
+}
+
+function formatDuration(durationMin: number): { value: string; unit: string } {
+  if (durationMin < 60) return { value: `${durationMin}`, unit: 'min' };
+  const hh = Math.floor(durationMin / 60);
+  const mm = durationMin % 60;
+  return { value: `${hh}:${mm.toString().padStart(2, '0')}`, unit: 'hr' };
+}
+
+function formatPace(durationMin: number, distanceKm: string): { value: string; unit: string } {
+  const km = Number(distanceKm);
+  if (!Number.isFinite(km) || km < 0.1 || durationMin === 0) {
+    return { value: '—', unit: '/km' };
+  }
+  const secPerKm = (durationMin * 60) / km;
+  const mm = Math.floor(secPerKm / 60);
+  const ss = Math.floor(secPerKm % 60);
+  return { value: `${mm}'${ss.toString().padStart(2, '0')}"`, unit: '/km' };
+}
+
 const styles = StyleSheet.create({
   container: { flex: 1 },
-  scrollContent: { flexGrow: 1 },
+  scrollContent: { flexGrow: 1, paddingBottom: spacing.xl },
   center: { flex: 1, alignItems: 'center', justifyContent: 'center' },
-  mapContainer: { borderWidth: 1, borderRadius: radius.lg, overflow: 'hidden', margin: spacing.lg },
-  map: { height: 280 },
-  info: { paddingHorizontal: spacing.lg, paddingBottom: spacing.lg },
-  heroTitle: { fontSize: 32, fontWeight: '900', letterSpacing: -0.64, marginBottom: spacing.sm },
-  date: { ...typography.h3 },
-  dogs: { ...typography.body, marginTop: spacing.xs },
-  time: { ...typography.body, marginTop: spacing.xs },
-  walkerSection: { marginTop: spacing.md },
+
+  mapCard: { marginHorizontal: spacing.lg, marginTop: spacing.lg },
+  map: { height: 260, borderRadius: radius.xl },
+
+  hero: { paddingHorizontal: spacing.lg, marginTop: spacing.xl },
+  caption: {
+    fontSize: 13,
+    fontWeight: '600',
+    letterSpacing: 0.5,
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: '700',
+    letterSpacing: -0.5,
+    marginTop: spacing.xs,
+  },
+  dogs: { ...typography.subheadline, marginTop: spacing.xs },
+  time: { ...typography.footnote, marginTop: 2 },
+
+  metrics: {
+    marginHorizontal: spacing.lg,
+    marginTop: spacing.lg,
+    flexDirection: 'row',
+    gap: spacing.xs,
+  },
+  metric: { flex: 1, gap: 4 },
+  metricLabel: {
+    fontSize: 11,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    letterSpacing: 0.3,
+  },
+  metricRow: { flexDirection: 'row', alignItems: 'baseline' },
+  metricValue: {
+    fontSize: 26,
+    fontWeight: '700',
+    letterSpacing: -0.8,
+    fontVariant: ['tabular-nums'],
+    lineHeight: 30,
+  },
+  metricUnit: { fontSize: 12, fontWeight: '500', marginLeft: 2 },
+
+  walkerSection: { paddingHorizontal: spacing.lg, marginTop: spacing.lg },
   walkerLabel: { ...typography.label, marginBottom: spacing.xs },
   walkerRow: { flexDirection: 'row', alignItems: 'center', gap: spacing.sm },
   walkerAvatar: { width: 32, height: 32, borderRadius: radius.full },
   walkerInitialBg: { alignItems: 'center', justifyContent: 'center' },
   walkerInitialText: { fontSize: 14, fontWeight: '600' as const },
   walkerName: { ...typography.bodyMedium },
-  stats: { flexDirection: 'row', gap: spacing.md, marginTop: spacing.lg },
-  statCard: {
-    flex: 1,
-    alignItems: 'center',
-    paddingVertical: spacing.md,
-    paddingHorizontal: spacing.sm,
-    borderWidth: 1,
-    borderRadius: radius.lg,
+
+  timelineCard: {
+    marginHorizontal: spacing.lg,
+    marginTop: spacing.lg,
+    paddingVertical: spacing.xs,
   },
-  statValue: { ...typography.h3 },
-  statLabel: { ...typography.label, marginTop: spacing.xs },
+
   eventMarker: { fontSize: 20 },
 });


### PR DESCRIPTION
## Summary

Redesign the walk history detail view (`/walks/[id]`) per `docs/design/Precise Full App.html`. Same data, different layout rhythm — grouped surfaces, tabular numerics, accent-green route line.

### Changes

- **Map card** — MapView is now wrapped in a `GroupedCard` (radius 16, no border, soft shadow). 260 px tall. Polyline switches from blue to **Precise success green** (`#30d158`), 5 px, round caps + joins — matches the *"green = go / route trace"* semantic from Design System § 01.
- **Caption + title hero** — replace the 32 px "Walk Detail" hero-title with the Precise caption-plus-title pattern:
  - UPPERCASE 13 px / 600 / 0.5 letter-spacing date caption
  - 28 px / 700 / -0.5 title1 heading
  - Dogs (subheadline) + start/end time (footnote) as quiet metadata
- **3-column metric card** — replace the two-card Time/Distance stats with a single `GroupedCard` carrying **Distance / Time / Pace** in three columns. Values 26 px / 700 / tabular; units (km, min, hr, /km) sit as 12 px subtext next to them. New `formatPace(min, km)` returns `mm'ss"/km` once the walk covered ≥ 100 m (prevents GPS-warmup jitter).
- **Grouped timeline** — `WalkEventTimeline` now sits inside a `GroupedCard` so events land on the Precise white grouped surface instead of a bare container.

### Preserved

- `testID="walk-time"` + its `accessibilityLabel` kept exactly — existing 6 `WalkDetailScreen` tests continue to pass.
- View model (`useWalkDetailViewModel`) and data hook (`useWalk`) untouched.
- Walker section (avatar + name) retained.

## Test plan

- [x] `npx jest --no-coverage` → **372/372 pass**
- [x] No data-layer changes — `vm.durationMin`, `vm.distanceKm`, `vm.date`, `vm.dogNames`, `vm.startTime`, `vm.endTime`, `vm.midpoint`, `vm.coordinates`, `vm.events` all consumed as-is
- [ ] iOS Simulator: open a walk from the Dogs → dog detail → walks list → confirm green route, 3-column metrics, caption-style date, grouped timeline rendering

Depends on merged PRs #117–#121. With this, Phase 2 (Walk flow redesign) is complete. Next up is Phase 3 (Dogs list / Dog detail / Me / Auth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)