### PR TITLE
feat(mobile): Precise Me tab — SectionHeader outside GroupedCard, largeTitle hero

### DIFF
--- a/apps/mobile/app/(tabs)/settings.tsx
+++ b/apps/mobile/app/(tabs)/settings.tsx
@@ -2,7 +2,7 @@ import { ScrollView, StyleSheet, Text } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import { useColors } from '@/hooks/use-colors';
-import { spacing, typography } from '@/theme/tokens';
+import { spacing } from '@/theme/tokens';
 import { useMe } from '@/hooks/use-me';
 import { LoadingScreen } from '@/components/ui/LoadingScreen';
 import { ErrorScreen } from '@/components/ui/ErrorScreen';
@@ -30,9 +30,6 @@ export default function SettingsScreen() {
         style={styles.container}
         contentContainerStyle={styles.content}
       >
-        <Text style={[styles.sectionLabel, { color: theme.onSurfaceVariant }]}>
-          {t('settings.sectionLabel')}
-        </Text>
         <Text style={[styles.heroTitle, { color: theme.onSurface }]}>
           {t('settings.title')}
         </Text>
@@ -63,16 +60,15 @@ const styles = StyleSheet.create({
     padding: spacing.lg,
     paddingBottom: spacing.xxl,
   },
-  sectionLabel: {
-    ...typography.label,
-    marginBottom: spacing.xs,
-  },
   heroTitle: {
-    ...typography.hero,
+    fontSize: 34,
+    fontWeight: '700',
+    letterSpacing: -0.6,
+    lineHeight: 41,
     marginBottom: spacing.lg,
   },
   version: {
-    ...typography.caption,
+    fontSize: 12,
     textAlign: 'center',
     marginTop: spacing.xl,
   },

--- a/apps/mobile/components/settings/SettingsSection.tsx
+++ b/apps/mobile/components/settings/SettingsSection.tsx
@@ -1,8 +1,8 @@
 import type { ReactNode } from 'react';
-import { StyleSheet, Text } from 'react-native';
-import { useColors } from '@/hooks/use-colors';
-import { spacing, typography } from '@/theme/tokens';
-import { OutlinedCard } from '@/components/ui/OutlinedCard';
+import { StyleSheet, View } from 'react-native';
+import { GroupedCard } from '@/components/ui/GroupedCard';
+import { SectionHeader } from '@/components/ui/SectionHeader';
+import { spacing } from '@/theme/tokens';
 
 interface SettingsSectionProps {
   title: string;
@@ -10,21 +10,18 @@ interface SettingsSectionProps {
 }
 
 export function SettingsSection({ title, children }: SettingsSectionProps) {
-  const theme = useColors();
+  // Precise pattern: SectionHeader above the grouped card, not inside it.
+  // Uppercase the string (not just textTransform) so existing getByText
+  // matchers — including SettingsSection.test.tsx — keep matching "PROFILE".
   return (
-    <OutlinedCard style={styles.section}>
-      <Text style={[styles.title, { color: theme.onSurfaceVariant }]}>
-        {title.toUpperCase()}
-      </Text>
-      {children}
-    </OutlinedCard>
+    <View style={styles.wrapper}>
+      <SectionHeader label={title.toUpperCase()} style={styles.header} />
+      <GroupedCard padding="lg">{children}</GroupedCard>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
-  section: { marginBottom: spacing.md },
-  title: {
-    ...typography.label,
-    marginBottom: spacing.md,
-  },
+  wrapper: { marginBottom: spacing.lg },
+  header: { paddingHorizontal: 0 },
 });


### PR DESCRIPTION
## Summary

Phase 3a — redesign the **Me** (formerly Settings) tab per `docs/design/Precise Full App.html`.

The sub-section components (`ProfileSection`, `AppearanceSection`, `EncounterDetectionSection`) are **untouched**: all three wrap their content in `SettingsSection`, so changing just that one wrapper cascades the Precise layout through the whole screen.

### Changes

- **`SettingsSection`**: renders a `<SectionHeader>` above a `<GroupedCard>` instead of a title inside an `OutlinedCard`. Matches Design System § 08 — group labels live outside the card so the card itself is pure content. The title is uppercased via `title.toUpperCase()` rather than CSS `textTransform` so the existing `SettingsSection.test.tsx` — which queries by the literal `"PROFILE"` — continues to pass.
- **`(tabs)/settings.tsx` hero cleanup**: drop the inverted `"PREFERENCES"` caption that sat above the page title. Precise Me screen shows a plain **largeTitle** (34/700/-0.6); the caption belongs above each group, not above the page title.
- Version footer collapses to a plain 12 px center-aligned caption.

## Test plan

- [x] `npx jest --no-coverage` → **372/372 pass**
- [x] `SettingsSection.test.tsx` still green (the `"PROFILE"` uppercase assertion)
- [x] `__tests__/app/tabs/settings.test.tsx` still green (`getByText('Me')` passes via `settings.title` i18n)
- [x] No touch to `ProfileSection` / `AppearanceSection` / `EncounterDetectionSection` / `LogoutButton` — cascade through the wrapper
- [ ] iOS Simulator: open Me tab → verify large `Me` title, section headers sit above white grouped cards (not inside), light/dark contrast OK

Depends on merged PRs #117–#122. Next PRs in Phase 3 will redesign the Dogs list + Dog detail, then the Auth screens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)