### PR TITLE
feat(mobile): Precise Dogs list — floating card rows + roll-up + SectionHeader

### DIFF
--- a/apps/mobile/app/(tabs)/dogs.tsx
+++ b/apps/mobile/app/(tabs)/dogs.tsx
@@ -5,9 +5,11 @@ import { useTranslation } from 'react-i18next';
 import { useMe } from '@/hooks/use-me';
 import { DogListItem } from '@/components/dogs/DogListItem';
 import { EmptyState } from '@/components/ui/EmptyState';
+import { GroupedCard } from '@/components/ui/GroupedCard';
 import { LoadingScreen } from '@/components/ui/LoadingScreen';
+import { SectionHeader } from '@/components/ui/SectionHeader';
 import { useColors } from '@/hooks/use-colors';
-import { spacing, typography, radius } from '@/theme/tokens';
+import { spacing } from '@/theme/tokens';
 
 export default function DogsScreen() {
   const { t } = useTranslation();
@@ -21,31 +23,43 @@ export default function DogsScreen() {
 
   const ListHeader = (
     <View style={styles.headerContainer}>
-      <Text style={[styles.sectionLabel, { color: theme.onSurfaceVariant }]}>
-        {t('dogs.list.sectionLabel')}
-      </Text>
       <Text style={[styles.heroTitle, { color: theme.onSurface }]}>
         {t('dogs.list.title')}
       </Text>
 
-      <View style={styles.bentoRow}>
-        <View
-          style={[
-            styles.bentoCard,
-            {
-              backgroundColor: theme.surfaceContainerLowest,
-              borderColor: theme.border + '33',
-            },
-          ]}
-        >
-          <Text style={[styles.bentoValue, { color: theme.onSurface }]}>
-            {dogCount}
-          </Text>
-          <Text style={[styles.bentoLabel, { color: theme.onSurfaceVariant }]}>
-            Dogs
-          </Text>
+      {/* Today's roll-up — placeholder until goal-tracking lands. The dog
+          count is shown as the immediate indicator; "›" hints at a future
+          drill-down to a per-pack goal screen. */}
+      <GroupedCard style={styles.rollup}>
+        <View style={styles.rollupRow}>
+          <View
+            style={[
+              styles.rollupAvatar,
+              { backgroundColor: theme.surfaceContainer },
+            ]}
+          >
+            <Text style={[styles.rollupAvatarText, { color: theme.success }]}>
+              {dogCount}
+            </Text>
+          </View>
+          <View style={styles.rollupInfo}>
+            <Text style={[styles.rollupTitle, { color: theme.onSurface }]}>
+              Today&apos;s walking goal
+            </Text>
+            <Text
+              style={[styles.rollupSubtitle, { color: theme.onSurfaceVariant }]}
+            >
+              {dogCount} across your pack
+            </Text>
+          </View>
+          <Text style={[styles.chevron, { color: theme.textDisabled }]}>›</Text>
         </View>
-      </View>
+      </GroupedCard>
+
+      <SectionHeader
+        label={t('dogs.list.sectionLabel')}
+        style={styles.sectionHeader}
+      />
     </View>
   );
 
@@ -92,32 +106,48 @@ const styles = StyleSheet.create({
     paddingTop: spacing.lg,
     paddingBottom: spacing.md,
   },
-  sectionLabel: {
-    ...typography.label,
-    marginBottom: spacing.xs,
-  },
   heroTitle: {
-    ...typography.hero,
-    marginBottom: spacing.md,
+    fontSize: 34,
+    fontWeight: '700',
+    letterSpacing: -0.6,
+    lineHeight: 41,
+    marginBottom: spacing.lg,
   },
-  bentoRow: {
+  rollup: {
+    marginBottom: spacing.xl,
+  },
+  rollupRow: {
     flexDirection: 'row',
-    gap: spacing.sm,
-    marginBottom: spacing.md,
-  },
-  bentoCard: {
-    flex: 1,
-    padding: spacing.md,
-    borderRadius: radius.lg,
-    borderWidth: 1,
     alignItems: 'center',
+    padding: 14,
+    gap: 14,
   },
-  bentoValue: {
-    ...typography.display,
-    marginBottom: spacing.xs,
+  rollupAvatar: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
-  bentoLabel: {
-    ...typography.label,
+  rollupAvatarText: {
+    fontSize: 17,
+    fontWeight: '700',
+  },
+  rollupInfo: { flex: 1 },
+  rollupTitle: {
+    fontSize: 15,
+    fontWeight: '600',
+  },
+  rollupSubtitle: {
+    fontSize: 13,
+    marginTop: 2,
+  },
+  sectionHeader: {
+    paddingHorizontal: 0,
+  },
+  chevron: {
+    fontSize: 22,
+    marginLeft: spacing.xs,
   },
   list: {
     paddingHorizontal: spacing.md,

--- a/apps/mobile/components/dogs/DogListItem.tsx
+++ b/apps/mobile/components/dogs/DogListItem.tsx
@@ -2,7 +2,7 @@ import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { Image } from 'expo-image';
 import { useTranslation } from 'react-i18next';
 import { useColors } from '@/hooks/use-colors';
-import { spacing, radius, typography } from '@/theme/tokens';
+import { elevation, radius, spacing, typography } from '@/theme/tokens';
 import type { Dog } from '@/types/graphql';
 
 interface DogListItemProps {
@@ -22,11 +22,8 @@ export function DogListItem({ dog, onPress }: DogListItemProps) {
       onPress={() => onPress(dog.id)}
       style={({ pressed }) => [
         styles.container,
-        {
-          backgroundColor: theme.surfaceContainerLowest,
-          borderColor: theme.border + '33',
-          opacity: pressed ? 0.7 : 1,
-        },
+        { backgroundColor: theme.surface, opacity: pressed ? 0.7 : 1 },
+        elevation.low,
       ]}
     >
       <Image
@@ -47,9 +44,12 @@ export function DogListItem({ dog, onPress }: DogListItemProps) {
           ) : null}
         </View>
         {dog.breed ? (
-          <Text style={[styles.breed, { color: theme.onSurfaceVariant }]}>{dog.breed}</Text>
+          <Text style={[styles.breed, { color: theme.onSurfaceVariant }]}>
+            {dog.breed}
+          </Text>
         ) : null}
       </View>
+      <Text style={[styles.chevron, { color: theme.textDisabled }]}>›</Text>
     </Pressable>
   );
 }
@@ -58,10 +58,9 @@ const styles = StyleSheet.create({
   container: {
     flexDirection: 'row',
     alignItems: 'center',
-    padding: spacing.md,
-    borderRadius: radius.lg,
-    borderWidth: 1,
-    marginBottom: spacing.sm,
+    padding: 14,
+    borderRadius: radius.xl,
+    marginBottom: spacing.md,
   },
   photo: {
     width: 56,
@@ -78,7 +77,8 @@ const styles = StyleSheet.create({
     gap: spacing.sm,
   },
   name: {
-    ...typography.h3,
+    ...typography.headline,
+    fontWeight: '600' as const,
   },
   badge: {
     paddingHorizontal: spacing.sm,
@@ -90,7 +90,11 @@ const styles = StyleSheet.create({
     fontWeight: '600' as const,
   },
   breed: {
-    ...typography.caption,
-    marginTop: spacing.xs,
+    ...typography.footnote,
+    marginTop: 2,
+  },
+  chevron: {
+    fontSize: 22,
+    marginLeft: spacing.sm,
   },
 });


### PR DESCRIPTION
## Summary

Phase 3b — redesign the **Dogs** tab per `docs/design/Precise Full App.html`.

### Dogs list screen

- Replace the bordered bento card with a `GroupedCard` **roll-up row**: 44 px accent-colored avatar carrying the dog-count, *"Today's walking goal"* headline, *"{count} across your pack"* subtitle, trailing `›` chevron hinting at a future pack-goal drill-down. When goal tracking lands, the avatar can swap to a conic-gradient progress ring without touching the row contract.
- Drop the editorial *"YOUR PACK"* caption that sat **above** the hero title and move it **below**, as a proper `SectionHeader` just above the list — matches Design System § 08.
- Hero title now uses the Precise largeTitle (34/700/-0.6).

### `DogListItem`

- Switch from bordered outline card to the Precise **floating card** — surface fill + `elevation.low` + radius 16, no border.
- Swap `h3` name for `headline` (17 / 600).
- Add a trailing `›` chevron so the tap target feels like a real row-to-detail link.
- Shared badge logic + photo rendering untouched.

### Preserved

- i18n strings: `dogs.list.title` (My Dogs / 愛犬), `dogs.list.sectionLabel` (YOUR PACK), `dogs.list.addDog` (Add Dog / 犬を追加).
- FAB `accessibilityRole="button"` + `accessibilityLabel="Add Dog"` so the existing DogsScreen test (`getByRole('button', { name: 'Add Dog' })`) stays green.
- All 6 `DogListItem.test.tsx` tests (name/breed, onPress, shared badge, null breed) continue to match via `getByText` / `getByRole`.

## Test plan

- [x] `npx jest --no-coverage` → **372/372 pass**
- [x] `__tests__/app/tabs/dogs.test.tsx` — YOUR PACK / My Dogs / `2` / Add Dog FAB all still queryable
- [x] `DogListItem.test.tsx` — 6/6 assertions still pass
- [x] No data-layer changes — `useMe` hook and `Dog` graphql type consumed as-is
- [ ] iOS Simulator: open Dogs tab → confirm large-title "My Dogs", roll-up card with count, YOUR PACK section header, each dog as a floating card with chevron, FAB still works

Depends on merged PRs #117–#123. Next PRs in Phase 3 will tackle the Dog detail (hero + stats card + grouped walks) and Auth screens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)