### PR TITLE
feat(mobile): Precise Auth — app mark + largeTitle hero + softer voice

### DIFF
--- a/apps/mobile/app/(auth)/login.tsx
+++ b/apps/mobile/app/(auth)/login.tsx
@@ -3,7 +3,7 @@ import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { LoginForm } from '@/components/auth/LoginForm';
 import { useColors } from '@/hooks/use-colors';
-import { spacing, typography } from '@/theme/tokens';
+import { spacing } from '@/theme/tokens';
 
 export default function LoginScreen() {
   const router = useRouter();
@@ -13,11 +13,22 @@ export default function LoginScreen() {
   return (
     <View style={[styles.container, { backgroundColor: theme.background }]}>
       <View style={styles.hero}>
+        {/* 68 px accent-colored app mark — the bright visual anchor per Precise SignIn */}
+        <View
+          style={[
+            styles.mark,
+            { backgroundColor: theme.interactive, shadowColor: theme.interactive },
+          ]}
+        >
+          <Text style={styles.markGlyph}>🐾</Text>
+        </View>
         <Text style={[styles.heroText, { color: theme.onSurface }]}>
           Welcome back
         </Text>
         <Text style={[styles.subText, { color: theme.onSurfaceVariant }]}>
-          {t('auth.login.subtitle', { defaultValue: 'Sign in to access your companions\' archive.' })}
+          {t('auth.login.subtitle', {
+            defaultValue: 'Sign in to keep walking with your companion.',
+          })}
         </Text>
       </View>
       <LoginForm
@@ -33,18 +44,38 @@ export default function LoginScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    paddingHorizontal: spacing.lg,
+    paddingHorizontal: 32,
     paddingTop: spacing.xxl,
     justifyContent: 'center',
   },
   hero: {
     marginBottom: spacing.xl,
   },
+  mark: {
+    width: 68,
+    height: 68,
+    borderRadius: 22,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 24,
+    shadowOffset: { width: 0, height: 10 },
+    shadowOpacity: 0.3,
+    shadowRadius: 30,
+    elevation: 10,
+  },
+  markGlyph: {
+    fontSize: 36,
+  },
   heroText: {
-    ...typography.hero,
+    fontSize: 34,
+    fontWeight: '700',
+    letterSpacing: -0.8,
+    lineHeight: 38,
+    marginBottom: 8,
   },
   subText: {
-    ...typography.body,
-    marginTop: spacing.sm,
+    fontSize: 15,
+    fontWeight: '400',
+    lineHeight: 21,
   },
 });

--- a/apps/mobile/app/(auth)/register.tsx
+++ b/apps/mobile/app/(auth)/register.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { RegisterForm } from '@/components/auth/RegisterForm';
 import { ConfirmForm } from '@/components/auth/ConfirmForm';
 import { useColors } from '@/hooks/use-colors';
-import { spacing, typography } from '@/theme/tokens';
+import { spacing } from '@/theme/tokens';
 
 type Step = 'register' | 'confirm';
 
@@ -38,14 +38,14 @@ export default function RegisterScreen() {
       {step === 'register' ? (
         <>
           <View style={styles.hero}>
-            <Text style={[styles.brandLabel, { color: theme.onSurfaceVariant }]}>
-              WALKING DOG
-            </Text>
             <Text style={[styles.heroText, { color: theme.onSurface }]}>
-              {t('auth.register.title', { defaultValue: 'Create Account' })}
+              {t('auth.register.title', { defaultValue: "Let's meet\nyour dog." })}
             </Text>
             <Text style={[styles.subText, { color: theme.onSurfaceVariant }]}>
-              {t('auth.register.subtitle', { defaultValue: "Join the archive of your dog's journeys." })}
+              {t('auth.register.subtitle', {
+                defaultValue:
+                  "A few quick details and you'll be walking in a minute.",
+              })}
             </Text>
           </View>
           <RegisterForm
@@ -60,7 +60,10 @@ export default function RegisterScreen() {
               {t('auth.confirm.title', { defaultValue: 'Check your email' })}
             </Text>
             <Text style={[styles.subText, { color: theme.onSurfaceVariant }]}>
-              {t('auth.confirm.subtitle', { defaultValue: 'We sent a code to your email. Enter it below to verify your account.' })}
+              {t('auth.confirm.subtitle', {
+                defaultValue:
+                  'We sent a code to your email. Enter it below to verify your account.',
+              })}
             </Text>
           </View>
           <ConfirmForm email={pendingEmail} onSuccess={handleConfirmSuccess} />
@@ -73,22 +76,23 @@ export default function RegisterScreen() {
 const styles = StyleSheet.create({
   container: {
     flexGrow: 1,
-    paddingHorizontal: spacing.lg,
+    paddingHorizontal: 32,
     paddingTop: spacing.xxl,
     justifyContent: 'center',
   },
   hero: {
     marginBottom: spacing.xl,
   },
-  brandLabel: {
-    ...typography.label,
-    marginBottom: spacing.sm,
-  },
   heroText: {
-    ...typography.hero,
+    fontSize: 34,
+    fontWeight: '700',
+    letterSpacing: -0.8,
+    lineHeight: 38,
+    marginBottom: 8,
   },
   subText: {
-    ...typography.body,
-    marginTop: spacing.sm,
+    fontSize: 15,
+    fontWeight: '400',
+    lineHeight: 21,
   },
 });


### PR DESCRIPTION
## Summary

Phase 3d (final) — redesign the **Login** and **Register** screens per `docs/design/Precise Full App.html`. With this PR, **every screen from the Precise design — Walk, Dogs list, Dog detail, Me, Sign In, Sign Up — ships with the new tokens, primitives, and layout rhythm.**

### Login (`/(auth)/login`)

- Add a **68 px accent-colored app mark** with a 🐾 glyph and a soft blue halo shadow (`0 10px 30px` at 30 % alpha) — the "bright visual anchor" Precise prescribes for the sign-in hero.
- Heading promoted from `hero` (28/700/-0.5) to Precise **largeTitle** (34/700/-0.8) for real page-title presence. Subtitle drops to subheadline (15/400/21) — calm, never shouty.
- Soften the default subtitle from *"access your companions' archive"* to *"Sign in to keep walking with your companion."* Translators still win via `auth.login.subtitle` if provided.
- Horizontal padding bumped to 32 px to match Precise form rhythm.

### Register (`/(auth)/register`)

- **Drop the editorial `WALKING DOG` brand caption** — it was inverted from Precise ("captions go above groups, not titles").
- Heading is the Precise two-line **"Let's meet\\nyour dog."** with largeTitle typography; subtitle reads *"A few quick details and you'll be walking in a minute."*
- Confirm step uses the same largeTitle treatment for symmetry.

### Preserved

- `RegisterForm` / `LoginForm` / `ConfirmForm` bodies untouched — they were already field-based and own their own validation tests.
- All i18n override paths intact.

## Test plan

- [x] `npx jest --no-coverage` → **372/372 pass**
- [x] Auth form tests untouched and still green
- [ ] iOS Simulator: cold-launch → Login screen → verify blue app mark glow, largeTitle "Welcome back" + softer subtitle → Create account → Register screen with two-line "Let's meet your dog." and slimmer subtitle; submit a bogus form to confirm validation still works

Depends on merged PRs #117–#125. **This PR closes the Precise redesign initiative** (`.claude/plans/fetch-this-design-file-wiggly-crayon.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)