### PR TITLE
feat(mobile): Precise Sign In — grouped form + app mark + Apple CTA

### DIFF
--- a/apps/mobile/app/(auth)/login.tsx
+++ b/apps/mobile/app/(auth)/login.tsx
@@ -1,9 +1,10 @@
-import { StyleSheet, Text, View } from 'react-native';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
+import { AppMark } from '@/components/auth/AppMark';
 import { LoginForm } from '@/components/auth/LoginForm';
 import { useColors } from '@/hooks/use-colors';
-import { spacing } from '@/theme/tokens';
+import { spacing, typography } from '@/theme/tokens';
 
 export default function LoginScreen() {
   const router = useRouter();
@@ -12,31 +13,35 @@ export default function LoginScreen() {
 
   return (
     <View style={[styles.container, { backgroundColor: theme.background }]}>
-      <View style={styles.hero}>
-        {/* 68 px accent-colored app mark — the bright visual anchor per Precise SignIn */}
-        <View
-          style={[
-            styles.mark,
-            { backgroundColor: theme.interactive, shadowColor: theme.interactive },
-          ]}
-        >
-          <Text style={styles.markGlyph}>🐾</Text>
+      <View style={styles.content}>
+        <View style={styles.hero}>
+          <AppMark />
+          <Text style={[styles.heading, { color: theme.onSurface }]}>
+            {t('auth.login.heading')}
+          </Text>
+          <Text style={[styles.sub, { color: theme.onSurfaceVariant }]}>
+            {t('auth.login.subtitle')}
+          </Text>
         </View>
-        <Text style={[styles.heroText, { color: theme.onSurface }]}>
-          Welcome back
-        </Text>
-        <Text style={[styles.subText, { color: theme.onSurfaceVariant }]}>
-          {t('auth.login.subtitle', {
-            defaultValue: 'Sign in to keep walking with your companion.',
-          })}
-        </Text>
+        <LoginForm
+          onSuccess={() => {
+            // Navigation guard in _layout.tsx handles redirect to (tabs)
+          }}
+        />
       </View>
-      <LoginForm
-        onSuccess={() => {
-          // Navigation guard in _layout.tsx handles redirect to (tabs)
-        }}
-        onRegisterPress={() => router.push('/(auth)/register')}
-      />
+      <Pressable
+        onPress={() => router.push('/(auth)/register')}
+        accessibilityRole="link"
+        accessibilityLabel={t('auth.login.createAccountLink')}
+        style={styles.footer}
+      >
+        <Text style={[styles.footerText, { color: theme.onSurfaceVariant }]}>
+          {t('auth.login.newHere')}{' '}
+          <Text style={[styles.footerLink, { color: theme.interactive }]}>
+            {t('auth.login.createAccountLink')}
+          </Text>
+        </Text>
+      </Pressable>
     </View>
   );
 }
@@ -45,37 +50,31 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     paddingHorizontal: 32,
-    paddingTop: spacing.xxl,
+  },
+  content: {
+    flex: 1,
     justifyContent: 'center',
   },
   hero: {
     marginBottom: spacing.xl,
   },
-  mark: {
-    width: 68,
-    height: 68,
-    borderRadius: 22,
+  heading: {
+    ...typography.largeTitle,
+    marginTop: spacing.lg,
+    marginBottom: spacing.xs,
+  },
+  sub: {
+    ...typography.subheadline,
+  },
+  footer: {
     alignItems: 'center',
-    justifyContent: 'center',
-    marginBottom: 24,
-    shadowOffset: { width: 0, height: 10 },
-    shadowOpacity: 0.3,
-    shadowRadius: 30,
-    elevation: 10,
+    paddingBottom: 50,
+    paddingTop: spacing.md,
   },
-  markGlyph: {
-    fontSize: 36,
+  footerText: {
+    ...typography.subheadline,
   },
-  heroText: {
-    fontSize: 34,
-    fontWeight: '700',
-    letterSpacing: -0.8,
-    lineHeight: 38,
-    marginBottom: 8,
-  },
-  subText: {
-    fontSize: 15,
-    fontWeight: '400',
-    lineHeight: 21,
+  footerLink: {
+    fontWeight: '500',
   },
 });

--- a/apps/mobile/components/auth/AppMark.test.tsx
+++ b/apps/mobile/components/auth/AppMark.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react-native';
+import { AppMark } from './AppMark';
+
+jest.mock('expo-linear-gradient', () => ({
+  LinearGradient: 'LinearGradient',
+}));
+
+jest.mock('react-native-svg', () => ({
+  __esModule: true,
+  default: 'Svg',
+  Path: 'Path',
+}));
+
+describe('AppMark', () => {
+  it('exposes an accessible image role with the app name as label', () => {
+    render(<AppMark />);
+    expect(screen.getByRole('image', { name: /walking dog/i })).toBeTruthy();
+  });
+});

--- a/apps/mobile/components/auth/AppMark.tsx
+++ b/apps/mobile/components/auth/AppMark.tsx
@@ -1,0 +1,48 @@
+import { StyleSheet, View } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import Svg, { Path } from 'react-native-svg';
+
+const PAW_PATH =
+  'M12 16c-2 0-3 2-3 4s1 3 2.5 3 2-1.5 2-3.5S13.5 16 12 16zm16 0c-1.5 0-2 1.5-2 3.5s.5 3.5 2 3.5 3-1.5 3-3-1.5-4-3-4zm-8 2c-2.5 0-4.5 2.5-4.5 4.5s-3 5.5-3 7.5 2.5 4 4 4 2.5-1.5 3.5-1.5 2.5 1.5 3.5 1.5 4-2 4-4-3-5.5-3-7.5-2-4.5-4.5-4.5z';
+
+export function AppMark() {
+  return (
+    <View
+      style={styles.halo}
+      accessible
+      accessibilityRole="image"
+      accessibilityLabel="Walking Dog"
+    >
+      <LinearGradient
+        colors={['#5eddb7', '#0a84ff']}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 1, y: 1 }}
+        style={styles.tile}
+      >
+        <Svg width={40} height={40} viewBox="0 0 40 40">
+          <Path d={PAW_PATH} fill="#ffffff" />
+        </Svg>
+      </LinearGradient>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  halo: {
+    width: 68,
+    height: 68,
+    borderRadius: 22,
+    shadowColor: '#0a84ff',
+    shadowOffset: { width: 0, height: 10 },
+    shadowOpacity: 0.3,
+    shadowRadius: 30,
+    elevation: 10,
+  },
+  tile: {
+    width: 68,
+    height: 68,
+    borderRadius: 22,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/apps/mobile/components/auth/LoginForm.test.tsx
+++ b/apps/mobile/components/auth/LoginForm.test.tsx
@@ -1,3 +1,4 @@
+import { Alert } from 'react-native';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react-native';
 import { LoginForm } from './LoginForm';
 
@@ -14,24 +15,24 @@ describe('LoginForm', () => {
   beforeEach(() => jest.clearAllMocks());
 
   it('renders email and password inputs', () => {
-    render(<LoginForm onSuccess={jest.fn()} onRegisterPress={jest.fn()} />);
+    render(<LoginForm onSuccess={jest.fn()} />);
     expect(screen.getByLabelText('Email')).toBeTruthy();
     expect(screen.getByLabelText('Password')).toBeTruthy();
   });
 
   it('disables submit button when fields are empty', () => {
-    render(<LoginForm onSuccess={jest.fn()} onRegisterPress={jest.fn()} />);
-    const button = screen.getByRole('button', { name: 'Login' });
+    render(<LoginForm onSuccess={jest.fn()} />);
+    const button = screen.getByRole('button', { name: 'Sign in' });
     expect(button).toBeDisabled();
   });
 
   it('calls signIn with email and password on submit', async () => {
     mockSignIn.mockResolvedValue(undefined);
-    render(<LoginForm onSuccess={jest.fn()} onRegisterPress={jest.fn()} />);
+    render(<LoginForm onSuccess={jest.fn()} />);
 
     fireEvent.changeText(screen.getByLabelText('Email'), 'test@example.com');
     fireEvent.changeText(screen.getByLabelText('Password'), 'password123');
-    fireEvent.press(screen.getByRole('button', { name: 'Login' }));
+    fireEvent.press(screen.getByRole('button', { name: 'Sign in' }));
 
     await waitFor(() => {
       expect(mockSignIn).toHaveBeenCalledWith('test@example.com', 'password123');
@@ -40,14 +41,35 @@ describe('LoginForm', () => {
 
   it('shows error message on sign-in failure', async () => {
     mockSignIn.mockRejectedValue(new Error('UserNotFoundException'));
-    render(<LoginForm onSuccess={jest.fn()} onRegisterPress={jest.fn()} />);
+    render(<LoginForm onSuccess={jest.fn()} />);
 
     fireEvent.changeText(screen.getByLabelText('Email'), 'wrong@example.com');
     fireEvent.changeText(screen.getByLabelText('Password'), 'wrongpass');
-    fireEvent.press(screen.getByRole('button', { name: 'Login' }));
+    fireEvent.press(screen.getByRole('button', { name: 'Sign in' }));
 
     await waitFor(() => {
       expect(screen.getByText('Invalid email or password')).toBeTruthy();
     });
+  });
+
+  it('renders Forgot password? link', () => {
+    render(<LoginForm onSuccess={jest.fn()} />);
+    expect(screen.getByText('Forgot password?')).toBeTruthy();
+  });
+
+  it('renders Continue with Apple button', () => {
+    render(<LoginForm onSuccess={jest.fn()} />);
+    expect(screen.getByRole('button', { name: 'Continue with Apple' })).toBeTruthy();
+  });
+
+  it('shows Coming soon Alert when Continue with Apple is pressed', () => {
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
+    render(<LoginForm onSuccess={jest.fn()} />);
+    fireEvent.press(screen.getByRole('button', { name: 'Continue with Apple' }));
+    expect(alertSpy).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringMatching(/coming soon/i),
+    );
+    alertSpy.mockRestore();
   });
 });

--- a/apps/mobile/components/auth/LoginForm.tsx
+++ b/apps/mobile/components/auth/LoginForm.tsx
@@ -1,18 +1,18 @@
 import { useState } from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { Alert, Pressable, StyleSheet, Text, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '@/hooks/use-auth';
 import { Button } from '@/components/ui/Button';
+import { GroupedCard } from '@/components/ui/GroupedCard';
 import { TextInput } from '@/components/ui/TextInput';
 import { useColors } from '@/hooks/use-colors';
 import { spacing, typography } from '@/theme/tokens';
 
 interface LoginFormProps {
   onSuccess: () => void;
-  onRegisterPress: () => void;
 }
 
-export function LoginForm({ onSuccess, onRegisterPress }: LoginFormProps) {
+export function LoginForm({ onSuccess }: LoginFormProps) {
   const { signIn } = useAuth();
   const { t } = useTranslation();
   const theme = useColors();
@@ -33,8 +33,12 @@ export function LoginForm({ onSuccess, onRegisterPress }: LoginFormProps) {
       onSuccess();
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : '';
-      if (message.includes('INVALID_CREDENTIALS') || message.includes('AUTH_ERROR') ||
-          message.includes('UserNotFoundException') || message.includes('NotAuthorizedException')) {
+      if (
+        message.includes('INVALID_CREDENTIALS') ||
+        message.includes('AUTH_ERROR') ||
+        message.includes('UserNotFoundException') ||
+        message.includes('NotAuthorizedException')
+      ) {
         setError(t('auth.login.error.invalidCredentials'));
       } else {
         setError(t('auth.login.error.generic'));
@@ -44,38 +48,74 @@ export function LoginForm({ onSuccess, onRegisterPress }: LoginFormProps) {
     }
   }
 
+  function handleForgotPassword() {
+    Alert.alert(t('auth.login.forgotPassword'), t('auth.login.comingSoonApple'));
+  }
+
+  function handleApple() {
+    Alert.alert(t('auth.login.continueWithApple'), t('auth.login.comingSoonApple'));
+  }
+
   return (
     <View style={styles.container}>
-      <TextInput
-        label={t('auth.login.email')}
-        value={email}
-        onChangeText={setEmail}
-        keyboardType="email-address"
-        autoCapitalize="none"
-        autoComplete="email"
-        textContentType="emailAddress"
-      />
-      <TextInput
-        label={t('auth.login.password')}
-        value={password}
-        onChangeText={setPassword}
-        secureTextEntry
-        textContentType="password"
-      />
+      <GroupedCard>
+        <TextInput
+          label={t('auth.login.email')}
+          labelPosition="inline"
+          separator
+          testID="login-email"
+          value={email}
+          onChangeText={setEmail}
+          keyboardType="email-address"
+          autoCapitalize="none"
+          autoComplete="email"
+          textContentType="emailAddress"
+        />
+        <TextInput
+          label={t('auth.login.password')}
+          labelPosition="inline"
+          testID="login-password"
+          value={password}
+          onChangeText={setPassword}
+          secureTextEntry
+          textContentType="password"
+        />
+      </GroupedCard>
+
+      <Pressable
+        onPress={handleForgotPassword}
+        accessibilityRole="link"
+        accessibilityLabel={t('auth.login.forgotPassword')}
+        style={styles.forgotWrapper}
+      >
+        <Text style={[styles.forgotText, { color: theme.interactive }]}>
+          {t('auth.login.forgotPassword')}
+        </Text>
+      </Pressable>
+
       {error ? (
         <Text style={[styles.error, { color: theme.error }]}>{error}</Text>
       ) : null}
+
       <Button
         label={t('auth.login.submit')}
         onPress={handleSubmit}
         loading={loading}
         disabled={!isValid}
       />
+
+      <View style={styles.orRow}>
+        <View style={[styles.orLine, { backgroundColor: theme.border }]} />
+        <Text style={[styles.orText, { color: theme.onSurfaceVariant }]}>
+          {t('auth.login.or')}
+        </Text>
+        <View style={[styles.orLine, { backgroundColor: theme.border }]} />
+      </View>
+
       <Button
-        label={t('auth.login.register')}
-        variant="secondary"
-        onPress={onRegisterPress}
-        style={styles.secondaryButton}
+        label={t('auth.login.continueWithApple')}
+        variant="apple"
+        onPress={handleApple}
       />
     </View>
   );
@@ -85,12 +125,30 @@ const styles = StyleSheet.create({
   container: {
     width: '100%',
   },
+  forgotWrapper: {
+    alignSelf: 'flex-end',
+    marginTop: 12,
+    marginBottom: spacing.lg,
+  },
+  forgotText: {
+    ...typography.subheadline,
+  },
   error: {
     ...typography.caption,
     marginBottom: spacing.md,
     textAlign: 'center',
   },
-  secondaryButton: {
-    marginTop: spacing.sm,
+  orRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    marginVertical: 20,
+  },
+  orLine: {
+    flex: 1,
+    height: StyleSheet.hairlineWidth,
+  },
+  orText: {
+    ...typography.footnote,
   },
 });

--- a/apps/mobile/components/ui/Button.test.tsx
+++ b/apps/mobile/components/ui/Button.test.tsx
@@ -65,6 +65,13 @@ describe('Button', () => {
     const flat = flattenStyle(node.props.style);
     expect(flat.height).toBe(50);
   });
+
+  it('renders apple variant with black fill in light mode', () => {
+    render(<Button label="Continue with Apple" variant="apple" />);
+    const node = screen.getByRole('button', { name: 'Continue with Apple' });
+    const flat = flattenStyle(node.props.style);
+    expect(flat.backgroundColor).toBe('#000000');
+  });
 });
 
 type Flat = Record<string, unknown>;

--- a/apps/mobile/components/ui/Button.tsx
+++ b/apps/mobile/components/ui/Button.tsx
@@ -15,7 +15,8 @@ type ButtonVariant =
   | 'secondary'
   | 'ghost'
   | 'destructive'
-  | 'success';
+  | 'success'
+  | 'apple';
 
 type ButtonSize = 'default' | 'circle';
 
@@ -65,6 +66,11 @@ export function Button({
       backgroundColor: theme.success,
       borderColor: 'transparent',
       textColor: theme.onInteractive,
+    },
+    apple: {
+      backgroundColor: colorScheme === 'dark' ? '#ffffff' : '#000000',
+      borderColor: 'transparent',
+      textColor: colorScheme === 'dark' ? '#000000' : '#ffffff',
     },
   }[variant];
 

--- a/apps/mobile/components/ui/TextInput.test.tsx
+++ b/apps/mobile/components/ui/TextInput.test.tsx
@@ -32,4 +32,26 @@ describe('TextInput', () => {
     render(<TextInput label="Email" value="initial" />);
     expect(screen.getByLabelText('Email').props.value).toBe('initial');
   });
+
+  it('renders inline labelPosition with label and input accessible', () => {
+    render(
+      <TextInput label="Email" labelPosition="inline" value="coco@walk.app" />,
+    );
+    expect(screen.getByText('Email')).toBeTruthy();
+    expect(screen.getByLabelText('Email').props.value).toBe('coco@walk.app');
+  });
+
+  it('inline variant renders separator when separator prop is true', () => {
+    render(
+      <TextInput label="Email" labelPosition="inline" separator testID="email-row" />,
+    );
+    expect(screen.getByTestId('email-row-separator')).toBeTruthy();
+  });
+
+  it('inline variant does not render separator when separator prop is false', () => {
+    render(
+      <TextInput label="Password" labelPosition="inline" testID="pwd-row" />,
+    );
+    expect(screen.queryByTestId('pwd-row-separator')).toBeNull();
+  });
 });

--- a/apps/mobile/components/ui/TextInput.tsx
+++ b/apps/mobile/components/ui/TextInput.tsx
@@ -2,14 +2,60 @@ import { StyleSheet, Text, TextInput as RNTextInput, View, type TextInputProps a
 import { useColors } from '@/hooks/use-colors';
 import { spacing, radius, typography } from '@/theme/tokens';
 
+type LabelPosition = 'top' | 'inline';
+
 interface TextInputProps extends Omit<RNTextInputProps, 'style'> {
   label: string;
   error?: string;
   style?: StyleProp<TextStyle>;
+  /**
+   * `top` (default) — UPPERCASE caption label above an outlined 52-px field.
+   * `inline` — iOS-settings-style row with label on the left and the field on
+   * the right, meant to sit inside a `GroupedCard`.
+   */
+  labelPosition?: LabelPosition;
+  /** Inline-only: draw a hairline separator below the row (for stacked GroupedCard rows). */
+  separator?: boolean;
 }
 
-export function TextInput({ label, error, style, ...props }: TextInputProps) {
+export function TextInput({
+  label,
+  error,
+  style,
+  labelPosition = 'top',
+  separator = false,
+  testID,
+  ...props
+}: TextInputProps) {
   const theme = useColors();
+
+  if (labelPosition === 'inline') {
+    return (
+      <>
+        <View style={inlineStyles.row}>
+          <Text style={[inlineStyles.label, { color: theme.onSurfaceVariant }]}>
+            {label}
+          </Text>
+          <RNTextInput
+            style={[inlineStyles.input, { color: theme.onSurface }, style]}
+            placeholderTextColor={theme.onSurfaceVariant}
+            accessibilityLabel={label}
+            testID={testID}
+            {...props}
+          />
+        </View>
+        {separator ? (
+          <View
+            testID={testID ? `${testID}-separator` : undefined}
+            style={[inlineStyles.separator, { backgroundColor: theme.border }]}
+          />
+        ) : null}
+        {error ? (
+          <Text style={[inlineStyles.error, { color: theme.error }]}>{error}</Text>
+        ) : null}
+      </>
+    );
+  }
 
   return (
     <View style={styles.container}>
@@ -31,6 +77,7 @@ export function TextInput({ label, error, style, ...props }: TextInputProps) {
         ]}
         placeholderTextColor={theme.onSurfaceVariant}
         accessibilityLabel={label}
+        testID={testID}
         {...props}
       />
       {error ? (
@@ -58,5 +105,34 @@ const styles = StyleSheet.create({
   error: {
     ...typography.caption,
     marginTop: spacing.xs,
+  },
+});
+
+const inlineStyles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    paddingHorizontal: spacing.md,
+    paddingVertical: 14,
+    minHeight: 44,
+  },
+  label: {
+    ...typography.subheadline,
+    width: 70,
+  },
+  input: {
+    flex: 1,
+    ...typography.body,
+    padding: 0,
+  },
+  separator: {
+    height: StyleSheet.hairlineWidth,
+    marginLeft: spacing.md,
+  },
+  error: {
+    ...typography.caption,
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.xs,
   },
 });

--- a/apps/mobile/lib/i18n/locales/en.json
+++ b/apps/mobile/lib/i18n/locales/en.json
@@ -11,11 +11,18 @@
   "auth": {
     "login": {
       "title": "Walking Dog",
-      "subtitle": "Cherish your dog walks and friendships",
+      "heading": "Welcome back",
+      "subtitle": "Sign in to keep walking with your companion.",
       "email": "Email",
       "password": "Password",
-      "submit": "Login",
+      "submit": "Sign in",
       "register": "Create Account",
+      "forgotPassword": "Forgot password?",
+      "or": "or",
+      "continueWithApple": "Continue with Apple",
+      "newHere": "New here?",
+      "createAccountLink": "Create an account",
+      "comingSoonApple": "Apple Sign-In is coming soon.",
       "error": {
         "invalidCredentials": "Invalid email or password",
         "generic": "Login failed"

--- a/apps/mobile/lib/i18n/locales/ja.json
+++ b/apps/mobile/lib/i18n/locales/ja.json
@@ -11,11 +11,18 @@
   "auth": {
     "login": {
       "title": "Walking Dog",
+      "heading": "おかえりなさい",
       "subtitle": "散歩の記録と犬の友情を大切に",
-      "email": "メールアドレス",
+      "email": "メール",
       "password": "パスワード",
-      "submit": "ログイン",
+      "submit": "サインイン",
       "register": "アカウントを作成",
+      "forgotPassword": "パスワードを忘れた場合",
+      "or": "または",
+      "continueWithApple": "Apple でサインイン",
+      "newHere": "はじめての方は",
+      "createAccountLink": "アカウント作成",
+      "comingSoonApple": "Apple でサインインは近日対応予定です",
       "error": {
         "invalidCredentials": "メールアドレスまたはパスワードが正しくありません",
         "generic": "ログインに失敗しました"

--- a/apps/mobile/package-lock.json
+++ b/apps/mobile/package-lock.json
@@ -23,6 +23,7 @@
         "expo-haptics": "~15.0.8",
         "expo-image": "~3.0.11",
         "expo-image-picker": "~17.0.10",
+        "expo-linear-gradient": "~15.0.8",
         "expo-linking": "~8.0.11",
         "expo-localization": "^55.0.9",
         "expo-location": "~19.0.8",
@@ -47,6 +48,7 @@
         "react-native-reanimated": "~4.1.1",
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
+        "react-native-svg": "15.12.1",
         "react-native-web": "~0.21.0",
         "react-native-worklets": "0.5.1",
         "zustand": "^5.0.12"
@@ -6593,6 +6595,12 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/bplist-creator": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.1.0.tgz",
@@ -7164,6 +7172,56 @@
         "hyphenate-style-name": "^1.0.3"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.0.14",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/css-tree/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/cssom": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
@@ -7511,6 +7569,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
     "node_modules/domexception": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
@@ -7533,6 +7629,35 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/dotenv-expand": {
@@ -8865,6 +8990,17 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*"
+      }
+    },
+    "node_modules/expo-linear-gradient": {
+      "version": "15.0.8",
+      "resolved": "https://registry.npmjs.org/expo-linear-gradient/-/expo-linear-gradient-15.0.8.tgz",
+      "integrity": "sha512-V2d8Wjn0VzhPHO+rrSBtcl+Fo+jUUccdlmQ6OoL9/XQB7Qk3d9lYrqKDJyccwDxmQT10JdST3Tmf2K52NLc3kw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-linking": {
@@ -15813,6 +15949,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
+      "license": "CC0-1.0"
+    },
     "node_modules/memoize-one": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
@@ -16423,6 +16565,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/nullthrows": {
@@ -17581,6 +17735,21 @@
         "react-freeze": "^1.0.0",
         "react-native-is-edge-to-edge": "^1.2.1",
         "warn-once": "^0.1.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-svg": {
+      "version": "15.12.1",
+      "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.12.1.tgz",
+      "integrity": "sha512-vCuZJDf8a5aNC2dlMovEv4Z0jjEUET53lm/iILFnFewa15b4atjVxU6Wirm6O9y6dEsdjDZVD7Q3QM4T1wlI8g==",
+      "license": "MIT",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "css-tree": "^1.1.3",
+        "warn-once": "0.1.1"
       },
       "peerDependencies": {
         "react": "*",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -31,6 +31,7 @@
     "expo-haptics": "~15.0.8",
     "expo-image": "~3.0.11",
     "expo-image-picker": "~17.0.10",
+    "expo-linear-gradient": "~15.0.8",
     "expo-linking": "~8.0.11",
     "expo-localization": "^55.0.9",
     "expo-location": "~19.0.8",
@@ -55,6 +56,7 @@
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
+    "react-native-svg": "15.12.1",
     "react-native-web": "~0.21.0",
     "react-native-worklets": "0.5.1",
     "zustand": "^5.0.12"


### PR DESCRIPTION
## Summary
Redesigns `/(auth)/login` to match the Precise design spec (`docs/design/sign-in/expect.html.png` / `docs/design/app.html:508-550`), bringing Sign In in line with PR #122–#126.

- **AppMark** — 68 px gradient tile (teal → blue) with white paw SVG + halo
- **Grouped form** — email / password rows stacked in a single `GroupedCard`; inline labels via new `TextInput labelPosition="inline"`
- **Forgot password?** link + **Sign in** primary CTA + **or** divider + **Continue with Apple** (UI only — Alert for now, real auth is a follow-up)
- **Footer** — "New here? Create an account" link
- i18n keys added to both `ja.json` and `en.json`

### Non-goals (follow-up PRs)
- Apple Sign-In functional implementation (`expo-apple-authentication`, Cognito federated identity, API OIDC)
- Forgot password screen + email reset flow

## Test plan
- [x] Unit tests — 380/380 passing (`npx jest`)
- [x] Typecheck — no new errors introduced (existing `lib/graphql/errors.test.ts` TS errors are unrelated and pre-existing)
- [ ] Visual verification on iOS Simulator — **blocked by local CocoaPods 1.16.2 + Xcode 26 objectVersion 70 incompatibility**. The JS changes are complete; once the environment is restored (`bundle exec pod install` with newer `xcodeproj`, or Ruby 3.3 + updated CocoaPods), re-run `npx expo run:ios` to rebuild the dev client — `react-native-svg` was added and needs native rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)