### PR TITLE
feat(mobile): Precise Dogs — pack rollup + full-bleed hero + walks history

### DIFF
--- a/.claude/plans/docs-design-walking-dog-readme-md-tab-1-peaceful-turing.md
+++ b/.claude/plans/docs-design-walking-dog-readme-md-tab-1-peaceful-turing.md
@@ -1,0 +1,109 @@
+# Tab 1 Dogs — Precise デザインへ pixel-perfect 移行
+
+## Context
+
+`docs/design/walking-dog/project/Precise Full App.html` の Tab 1 Dogs 配下、**01. Dogs (list)**（HTML L603–647）と **02. Dog detail**（HTML L650–719）は現状の React Native 実装と構造的に大きく乖離している。デザインに合わせて UI を作り直す。
+
+現状との主な差分：
+
+| 箇所 | デザイン | 現状実装 |
+| --- | --- | --- |
+| list の Today ロールアップ | 円形進捗（70%）+「3.52 / 5.0 km across your pack」 | 円アバター内に dog 数 |
+| list 行の右側情報 | 🔥 12d streak バッジ ＋「1.42 km today · 47 walks」 | `shared` バッジ ＋ 犬種のみ |
+| list の追加 CTA | ヘッダー右 `+ Add` | 右下 FAB |
+| detail hero | フルブリード 300px + 絵文字 + `group` 色への fade | 280px `surfaceContainer` 背景に中央寄せ写真 |
+| detail ナビバー | 写真にかぶさる透過「‹ Dogs / Edit」 | 通常の Stack ヘッダー |
+| detail stats 3列 | Walks / km / **Streak** | Walks / Distance / **Duration** |
+| detail メイン | Walks 履歴カード + `See all` | Members/Friends 行 + Edit/Delete ボタン |
+
+ユーザー確認済みの方針（実装を縛る）：
+
+1. 不足フィールド（streak、today km、pack today km）は **クライアント側で walks から算出** して完全一致させる。
+2. Today's walking goal は **固定 5 km** をデフォルトゴールに、進捗はクライアント集計。
+3. Dog detail の Members/Friends/Delete は **保持**。Edit は **ネイビバー右**、Members/Friends/Delete は Walks 履歴の下に配置。
+4. Hero 写真は **photoUrl をフルブリード** 表示し、下に fade-to-background を掛ける。
+
+## Files to modify
+
+### 変更
+- `apps/mobile/app/(tabs)/dogs.tsx` — rollup を新コンポーネントに差し替え、FAB 削除、ヘッダー右に `+ Add` を配置（`(tabs)/_layout.tsx` は `headerShown: false` なので、この画面内で `SafeArea` 上端に独自に配置する）
+- `apps/mobile/components/dogs/DogListItem.tsx` — 行の meta を streak バッジ + today km · walks に変更。`todayKm`, `walksTotal`, `streakDays` を props で受ける
+- `apps/mobile/app/dogs/[id]/_layout.tsx` — `index` 画面のみ `headerTransparent: true, headerTintColor: '#fff', headerBackTitle: 'Dogs', title: ''`、`headerRight` に Edit ボタンを追加
+- `apps/mobile/app/dogs/[id]/index.tsx` — hero を full-bleed photo + fade に、stats の 3 列目を Streak に、Walks 履歴を主役にし、Members/Friends/Delete を下に移動
+- `apps/mobile/components/dogs/DogStatsCard.tsx` — 3 列目を `Duration` → `Streak` に置換（props で `streakDays` を受け取る）
+- `apps/mobile/lib/graphql/queries/walk.ts` — `MY_WALKS_QUERY` に `events { eventType }` を追加（pee/poo カウント表示用）
+- `apps/mobile/locales/*/translation.json`（en を先に、ja は別 PR）
+
+### 新規
+- `apps/mobile/hooks/use-pack-progress.ts` — `useMyWalks` と `useMe` をラップし、`{ todayKm, goalKm: 5, progressPct, perDog: Record<dogId, { todayKm, totalWalks, streakDays }> }` を返す
+- `apps/mobile/components/dogs/PackRollupCard.tsx` — 円形進捗 + タイトル + サブタイトル + chevron
+- `apps/mobile/components/dogs/DogHero.tsx` — 300px photo + 下 60px LinearGradient で `theme.background` へ fade
+- `apps/mobile/components/dogs/DogWalksList.tsx` — 「Walks / See all」見出し + 履歴カード（空なら EmptyState）
+- `apps/mobile/components/dogs/DogWalkRow.tsx` — アイコン + 日付ラベル + `dist · time · pace` + `💧n 💩m` + chevron、`/walks/${id}` へ遷移
+- `apps/mobile/components/ui/RingProgress.tsx` — `react-native-svg` (導入済) で円形進捗リング + 中央に `70%`
+- `apps/mobile/lib/format/walk.ts` — `formatPace(distanceM, durationSec)`、`formatWalkDateLabel(startedAt)`（Today / Yesterday / 曜日 + 時刻）、`countEvents(events)`
+- `apps/mobile/constants/walk.ts` — `DEFAULT_DAILY_GOAL_KM = 5`
+
+## Reuse
+
+- `expo-linear-gradient` は `components/auth/AppMark.tsx:2,16` で導入済み — hero fade に使う
+- `react-native-svg` は `package.json:59` に存在 — RingProgress と walk row のチャートアイコンに使う
+- `useMyWalks` (`hooks/use-walks.ts:20`) — そのまま再利用、`limit=20` で足りる
+- `useMe` (`hooks/use-me.ts:8`) — dog 一覧ソース
+- `useColors` / `spacing` / `radius` / `typography` トークン — 既存 palette に準拠
+- `GroupedCard` / `GroupedRow` — detail 画面の Members/Friends/Delete 節で継続利用
+- Walk detail 画面 `app/walks/[id].tsx` — 既存。Walks 行のタップ先
+
+## Client-side computation ルール
+
+`use-pack-progress` 内で：
+- **today 判定**: 端末ローカルタイムゾーンで `startedAt` の YYYY-MM-DD が `new Date()` の当日と一致
+- **pack today km**: `todayWalks.reduce((a, w) => a + (w.distanceM ?? 0), 0) / 1000`
+- **dog today km**: 当該 dog id を含む walks のみ抽出して同上
+- **dog totalWalks**: `walkStats.totalWalks` (当該 dog を `useDog` で取得済み) を優先。list では `useMyWalks` で当該 dog を含む件数を暫定集計
+- **streak**: walks を日付集合にまとめ、当日または前日から連続する日付数。walks が 0 なら 0
+- **goalKm**: 定数 `DEFAULT_DAILY_GOAL_KM = 5`
+
+## i18n 追加キー（en 先行）
+
+```
+dogs.list.todayGoal = "Today's walking goal"
+dogs.list.acrossPack = "{{km}} / {{goal}} km across your pack"
+dogs.list.streak = "🔥 {{days}}d"
+dogs.list.todayStats = "{{km}} km today · {{count}} walks"
+dogs.list.addCta = "+ Add"
+dogs.detail.walks = "Walks"
+dogs.detail.seeAll = "See all"
+dogs.detail.streakLabel = "Streak"
+dogs.detail.streakDays = "{{days}}d"
+walk.date.today = "Today"
+walk.date.yesterday = "Yesterday"
+```
+
+## Accessibility
+
+- RingProgress に `accessibilityRole="progressbar"` と `accessibilityValue={{ now, min: 0, max: 100 }}`
+- Walks 行は `accessibilityRole="button"` + ラベルに日付と距離を含める
+- Edit ボタンは `hitSlop={12}`
+- streak バッジは装飾として親ラベルに含める
+
+## Verification
+
+1. `docker compose run --rm mobile npm test -- --testPathPattern='(pack-progress|walk-format|DogListItem|DogWalkRow)'` で新規ユニットテストが通る
+2. `docker compose run --rm mobile npm run lint` クリア
+3. `docker compose run --rm mobile npx tsc --noEmit` クリア
+4. iOS Simulator で手動確認（subagent に委譲せず直接 Bash で `npx expo start` → シミュレータ起動）
+   - Dogs タブ: タイトル「Dogs」+ 右上「+ Add」、円形進捗付き Today カード、行に 🔥 streak + today km 表示
+   - Dog を選択: hero がフルブリード写真、下端が背景へ fade、name + breed/age、stats に Streak
+   - Walks セクションに直近件、日付・距離・時間・ペース・💧💩、行タップで `/walks/[id]` へ遷移
+   - 下に Members/Friends 行と Edit/Delete が残っている
+   - ナビバー右の Edit で edit 画面へ
+5. walks が 0 件の dog で空表示（EmptyState の簡易版）を確認
+6. ダークモード切替で hero fade の色が `theme.background` に追従することを確認
+
+## Out of scope
+
+- サーバー側にゴール・streak・weight を持たせる変更
+- Walks 履歴画面（`See all` 先）の新規作成 — まずはリンクのみ、Phase 2
+- 日本語翻訳 — en キー先行、ja は別 PR
+- デザイン仕様にない編集機能刷新

--- a/apps/mobile/__tests__/app/dogs/dog-detail.test.tsx
+++ b/apps/mobile/__tests__/app/dogs/dog-detail.test.tsx
@@ -90,10 +90,10 @@ describe('DogDetailScreen', () => {
     expect(screen.queryByText('Delete')).toBeNull();
   });
 
-  it('shows edit button for both owner and member', () => {
+  it('does not render edit button inside screen body (moved to nav header)', () => {
     mockMeData = { id: 'user-2' }; // member, not owner
     renderWithProviders(<DogDetailScreen />);
-    expect(screen.getByText('Edit')).toBeTruthy();
+    expect(screen.queryByText('Edit')).toBeNull();
   });
 
   it('hides delete button when user is not in members list', () => {

--- a/apps/mobile/__tests__/app/tabs/dogs.test.tsx
+++ b/apps/mobile/__tests__/app/tabs/dogs.test.tsx
@@ -22,6 +22,16 @@ jest.mock('@/hooks/use-me', () => ({
   }),
 }));
 
+jest.mock('@/hooks/use-pack-progress', () => ({
+  usePackProgress: () => ({
+    todayKm: 0,
+    goalKm: 5,
+    progressPct: 0,
+    perDog: {},
+    isLoading: false,
+  }),
+}));
+
 jest.mock('@/components/dogs/DogListItem', () => {
   const { Text } = jest.requireActual('react-native');
   return {
@@ -36,6 +46,11 @@ jest.mock('@/components/ui/EmptyState', () => ({
 jest.mock('@/components/ui/LoadingScreen', () => ({
   LoadingScreen: () => null,
 }));
+
+jest.mock('@/components/ui/RingProgress', () => {
+  const { View } = jest.requireActual('react-native');
+  return { RingProgress: () => <View /> };
+});
 
 jest.mock('@/components/themed-text', () => {
   const { Text } = jest.requireActual('react-native');
@@ -55,12 +70,12 @@ describe('DogsScreen', () => {
     expect(screen.getByText('My Dogs')).toBeTruthy();
   });
 
-  it('renders dog count stat', () => {
+  it('renders Today walking goal rollup title', () => {
     render(<DogsScreen />);
-    expect(screen.getByText('2')).toBeTruthy();
+    expect(screen.getByText("Today's walking goal")).toBeTruthy();
   });
 
-  it('renders add dog FAB', () => {
+  it('renders header + Add CTA', () => {
     render(<DogsScreen />);
     expect(screen.getByRole('button', { name: 'Add Dog' })).toBeTruthy();
   });

--- a/apps/mobile/app/(tabs)/dogs.tsx
+++ b/apps/mobile/app/(tabs)/dogs.tsx
@@ -3,58 +3,51 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useMe } from '@/hooks/use-me';
+import { usePackProgress } from '@/hooks/use-pack-progress';
 import { DogListItem } from '@/components/dogs/DogListItem';
+import { PackRollupCard } from '@/components/dogs/PackRollupCard';
 import { EmptyState } from '@/components/ui/EmptyState';
-import { GroupedCard } from '@/components/ui/GroupedCard';
 import { LoadingScreen } from '@/components/ui/LoadingScreen';
 import { SectionHeader } from '@/components/ui/SectionHeader';
 import { useColors } from '@/hooks/use-colors';
-import { spacing } from '@/theme/tokens';
+import { spacing, typography } from '@/theme/tokens';
 
 export default function DogsScreen() {
   const { t } = useTranslation();
   const router = useRouter();
   const theme = useColors();
   const { data: me, isLoading, refetch } = useMe();
+  const pack = usePackProgress();
 
   if (isLoading) return <LoadingScreen />;
 
-  const dogCount = me?.dogs?.length ?? 0;
+  const dogs = me?.dogs ?? [];
 
   const ListHeader = (
     <View style={styles.headerContainer}>
-      <Text style={[styles.heroTitle, { color: theme.onSurface }]}>
-        {t('dogs.list.title')}
-      </Text>
+      <View style={styles.titleRow}>
+        <Text style={[styles.heroTitle, { color: theme.onSurface }]}>
+          {t('dogs.list.title')}
+        </Text>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={t('dogs.list.addDog')}
+          onPress={() => router.push('/dogs/new')}
+          hitSlop={12}
+        >
+          <Text style={[styles.addCta, { color: theme.interactive }]}>
+            {t('dogs.list.addCta')}
+          </Text>
+        </Pressable>
+      </View>
 
-      {/* Today's roll-up — placeholder until goal-tracking lands. The dog
-          count is shown as the immediate indicator; "›" hints at a future
-          drill-down to a per-pack goal screen. */}
-      <GroupedCard style={styles.rollup}>
-        <View style={styles.rollupRow}>
-          <View
-            style={[
-              styles.rollupAvatar,
-              { backgroundColor: theme.surfaceContainer },
-            ]}
-          >
-            <Text style={[styles.rollupAvatarText, { color: theme.success }]}>
-              {dogCount}
-            </Text>
-          </View>
-          <View style={styles.rollupInfo}>
-            <Text style={[styles.rollupTitle, { color: theme.onSurface }]}>
-              Today&apos;s walking goal
-            </Text>
-            <Text
-              style={[styles.rollupSubtitle, { color: theme.onSurfaceVariant }]}
-            >
-              {dogCount} across your pack
-            </Text>
-          </View>
-          <Text style={[styles.chevron, { color: theme.textDisabled }]}>›</Text>
-        </View>
-      </GroupedCard>
+      <View style={styles.rollupWrap}>
+        <PackRollupCard
+          todayKm={pack.todayKm}
+          goalKm={pack.goalKm}
+          progressPct={pack.progressPct}
+        />
+      </View>
 
       <SectionHeader
         label={t('dogs.list.sectionLabel')}
@@ -64,14 +57,18 @@ export default function DogsScreen() {
   );
 
   return (
-    <SafeAreaView edges={['top']} style={[styles.container, { backgroundColor: theme.background }]}>
+    <SafeAreaView
+      edges={['top']}
+      style={[styles.container, { backgroundColor: theme.background }]}
+    >
       <FlatList
-        data={me?.dogs ?? []}
+        data={dogs}
         keyExtractor={(dog) => dog.id}
         renderItem={({ item }) => (
           <DogListItem
             dog={item}
             onPress={(id) => router.push(`/dogs/${id}`)}
+            progress={pack.perDog[item.id]}
           />
         )}
         ListHeaderComponent={ListHeader}
@@ -86,15 +83,6 @@ export default function DogsScreen() {
           />
         }
       />
-
-      <Pressable
-        accessibilityRole="button"
-        accessibilityLabel={t('dogs.list.addDog')}
-        style={[styles.fab, { backgroundColor: theme.interactive }]}
-        onPress={() => router.push('/dogs/new')}
-      >
-        <Text style={[styles.fabIcon, { color: theme.onInteractive }]}>+</Text>
-      </Pressable>
     </SafeAreaView>
   );
 }
@@ -103,69 +91,31 @@ const styles = StyleSheet.create({
   container: { flex: 1 },
   headerContainer: {
     paddingHorizontal: spacing.lg,
-    paddingTop: spacing.lg,
+    paddingTop: spacing.sm,
     paddingBottom: spacing.md,
   },
-  heroTitle: {
-    fontSize: 34,
-    fontWeight: '700',
-    letterSpacing: -0.6,
-    lineHeight: 41,
-    marginBottom: spacing.lg,
-  },
-  rollup: {
-    marginBottom: spacing.xl,
-  },
-  rollupRow: {
+  titleRow: {
     flexDirection: 'row',
     alignItems: 'center',
-    padding: 14,
-    gap: 14,
+    justifyContent: 'space-between',
+    marginBottom: spacing.lg,
   },
-  rollupAvatar: {
-    width: 44,
-    height: 44,
-    borderRadius: 22,
-    alignItems: 'center',
-    justifyContent: 'center',
+  heroTitle: {
+    ...typography.largeTitle,
   },
-  rollupAvatarText: {
+  addCta: {
     fontSize: 17,
-    fontWeight: '700',
+    fontWeight: '400',
   },
-  rollupInfo: { flex: 1 },
-  rollupTitle: {
-    fontSize: 15,
-    fontWeight: '600',
-  },
-  rollupSubtitle: {
-    fontSize: 13,
-    marginTop: 2,
+  rollupWrap: {
+    marginBottom: spacing.xl,
   },
   sectionHeader: {
     paddingHorizontal: 0,
   },
-  chevron: {
-    fontSize: 22,
-    marginLeft: spacing.xs,
-  },
   list: {
     paddingHorizontal: spacing.md,
     flexGrow: 1,
-    paddingBottom: spacing.xl + 56 + spacing.xl,
-  },
-  fab: {
-    position: 'absolute',
-    bottom: spacing.xl,
-    right: spacing.xl,
-    width: 56,
-    height: 56,
-    borderRadius: 28,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  fabIcon: {
-    fontSize: 28,
-    lineHeight: 32,
+    paddingBottom: spacing.xl,
   },
 });

--- a/apps/mobile/app/dogs/[id]/_layout.tsx
+++ b/apps/mobile/app/dogs/[id]/_layout.tsx
@@ -1,29 +1,33 @@
-import { Pressable } from 'react-native';
-import { Stack, useRouter } from 'expo-router';
+import { Pressable, Text } from 'react-native';
+import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
-import { IconSymbol } from '@/components/ui/icon-symbol';
 import { useColors } from '@/hooks/use-colors';
 
 export default function DogDetailLayout() {
   const { t } = useTranslation();
   const router = useRouter();
   const theme = useColors();
+  const { id } = useLocalSearchParams<{ id: string }>();
 
   return (
     <Stack>
       <Stack.Screen
         name="index"
         options={{
-          title: t('dogs.detail.title'),
-          headerStyle: { backgroundColor: theme.background },
-          headerLeft: () => (
+          title: '',
+          headerTransparent: true,
+          headerTintColor: '#ffffff',
+          headerBackTitle: t('dogs.detail.back'),
+          headerRight: () => (
             <Pressable
               accessibilityRole="button"
-              accessibilityLabel={t('dogs.list.title')}
-              onPress={() => router.back()}
+              accessibilityLabel={t('dogs.detail.edit')}
+              onPress={() => id && router.push(`/dogs/${id}/edit`)}
               hitSlop={12}
             >
-              <IconSymbol name="chevron.left" size={24} color={theme.onSurface} />
+              <Text style={{ color: '#ffffff', fontSize: 17, fontWeight: '400' }}>
+                {t('dogs.detail.edit')}
+              </Text>
             </Pressable>
           ),
         }}

--- a/apps/mobile/app/dogs/[id]/index.tsx
+++ b/apps/mobile/app/dogs/[id]/index.tsx
@@ -2,20 +2,44 @@ import { useState } from 'react';
 import { ScrollView, StyleSheet, Text, View } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
-import { Image } from 'expo-image';
 import { useDog } from '@/hooks/use-dog';
+import { useMyWalks } from '@/hooks/use-walks';
+import { usePackProgress } from '@/hooks/use-pack-progress';
 import { useDeleteDog } from '@/hooks/use-dog-mutations';
 import { useMe } from '@/hooks/use-me';
 import { useMutationWithAlert } from '@/hooks/use-mutation-with-alert';
 import { useDogDetailAuthorization } from '@/hooks/use-dog-detail-authorization';
+import { DogHero } from '@/components/dogs/DogHero';
 import { DogStatsCard } from '@/components/dogs/DogStatsCard';
+import { DogWalksList } from '@/components/dogs/DogWalksList';
 import { LoadingScreen } from '@/components/ui/LoadingScreen';
 import { Button } from '@/components/ui/Button';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { GroupedCard } from '@/components/ui/GroupedCard';
 import { GroupedRow } from '@/components/ui/GroupedRow';
 import { useColors } from '@/hooks/use-colors';
-import { radius, spacing } from '@/theme/tokens';
+import { spacing, typography } from '@/theme/tokens';
+import type { Dog, Walk } from '@/types/graphql';
+
+function computeAgeLabel(birthDate: Dog['birthDate'], now: Date = new Date()): string | null {
+  if (!birthDate?.year) return null;
+  const month = birthDate.month ?? 1;
+  const day = birthDate.day ?? 1;
+  const birth = new Date(birthDate.year, month - 1, day);
+  let age = now.getFullYear() - birth.getFullYear();
+  const md = now.getMonth() - birth.getMonth();
+  if (md < 0 || (md === 0 && now.getDate() < birth.getDate())) age -= 1;
+  return age >= 0 ? `${age}y` : null;
+}
+
+function buildMeta(dog: Dog): string {
+  const parts: string[] = [];
+  const age = computeAgeLabel(dog.birthDate);
+  if (age) parts.push(age);
+  if (dog.breed) parts.push(dog.breed);
+  else if (dog.gender) parts.push(dog.gender);
+  return parts.join(' · ');
+}
 
 export default function DogDetailScreen() {
   const { t } = useTranslation();
@@ -25,6 +49,8 @@ export default function DogDetailScreen() {
 
   const { data: dog, isLoading } = useDog(id, 'ALL');
   const { data: me } = useMe();
+  const { data: walks = [] } = useMyWalks(100);
+  const pack = usePackProgress();
   const { mutateAsync: deleteDog } = useDeleteDog();
   const runWithAlert = useMutationWithAlert();
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
@@ -37,37 +63,41 @@ export default function DogDetailScreen() {
     if (ok) router.replace('/(tabs)/dogs');
   }
 
-  const subtitle = [dog.breed, dog.gender].filter(Boolean).join(' · ');
+  const dogWalks: Walk[] = walks.filter((walk) =>
+    walk.dogs.some((walkDog) => walkDog.id === dog.id),
+  );
+  const streakDays = pack.perDog[dog.id]?.streakDays ?? 0;
+  const meta = buildMeta(dog);
   const memberCount = dog.members?.length ?? 0;
 
   return (
-    <ScrollView style={[styles.container, { backgroundColor: theme.background }]}>
-      {/* Hero — photo centered on a soft accent-gradient background */}
-      <View style={[styles.hero, { backgroundColor: theme.surfaceContainer }]}>
-        <Image
-          source={dog.photoUrl ?? require('@/assets/images/icon.png')}
-          style={styles.photo}
-          contentFit="cover"
-          cachePolicy="memory-disk"
-        />
-      </View>
+    <ScrollView
+      style={[styles.container, { backgroundColor: theme.background }]}
+      contentContainerStyle={styles.content}
+      contentInsetAdjustmentBehavior="never"
+    >
+      <DogHero photoUrl={dog.photoUrl} />
 
-      {/* Name + breed/gender metadata */}
-      <View style={styles.heroInfo}>
+      <View style={styles.nameBlock}>
         <Text style={[styles.dogName, { color: theme.onSurface }]}>{dog.name}</Text>
-        {subtitle ? (
-          <Text style={[styles.dogMeta, { color: theme.onSurfaceVariant }]}>{subtitle}</Text>
+        {meta ? (
+          <Text style={[styles.dogMeta, { color: theme.onSurfaceVariant }]}>{meta}</Text>
         ) : null}
       </View>
 
-      {/* Stats card */}
       {dog.walkStats ? (
         <View style={styles.statsSection}>
-          <DogStatsCard stats={dog.walkStats} />
+          <DogStatsCard stats={dog.walkStats} streakDays={streakDays} />
         </View>
       ) : null}
 
-      {/* Grouped navigation rows — Members (if any) + Friends */}
+      <View style={styles.walksSection}>
+        <DogWalksList
+          walks={dogWalks}
+          onPressWalk={(walkId) => router.push(`/walks/${walkId}`)}
+        />
+      </View>
+
       <GroupedCard style={styles.group}>
         {memberCount > 0 ? (
           <GroupedRow
@@ -84,23 +114,16 @@ export default function DogDetailScreen() {
         />
       </GroupedCard>
 
-      {/* Actions */}
-      <View style={styles.actions}>
-        <Button
-          label={t('dogs.detail.edit')}
-          variant="secondary"
-          onPress={() => router.push(`/dogs/${id}/edit`)}
-          style={styles.actionButton}
-        />
-        {isOwner ? (
+      {isOwner ? (
+        <View style={styles.actions}>
           <Button
             label={t('dogs.detail.delete')}
             variant="destructive"
             onPress={() => setShowDeleteConfirm(true)}
             style={styles.actionButton}
           />
-        ) : null}
-      </View>
+        </View>
+      ) : null}
 
       {isOwner ? (
         <ConfirmDialog
@@ -119,48 +142,38 @@ export default function DogDetailScreen() {
 
 const styles = StyleSheet.create({
   container: { flex: 1 },
-  hero: {
-    height: 280,
-    alignItems: 'center',
-    justifyContent: 'flex-end',
-    paddingBottom: spacing.xl,
+  content: {
+    paddingBottom: spacing.xxl,
   },
-  photo: {
-    width: 160,
-    height: 160,
-    borderRadius: radius.full,
-  },
-  heroInfo: {
-    alignItems: 'center',
-    paddingHorizontal: spacing.lg,
-    paddingTop: spacing.lg,
-    paddingBottom: spacing.md,
+  nameBlock: {
+    paddingHorizontal: spacing.step20,
+    paddingTop: spacing.sm,
   },
   dogName: {
-    fontSize: 28,
-    fontWeight: '700',
-    letterSpacing: -0.5,
-    lineHeight: 34,
-    textAlign: 'center',
+    ...typography.title1,
+    fontSize: 32,
+    letterSpacing: -0.6,
   },
   dogMeta: {
     fontSize: 14,
-    marginTop: 4,
-    textAlign: 'center',
+    marginTop: 2,
   },
   statsSection: {
-    paddingHorizontal: spacing.lg,
-    paddingBottom: spacing.lg,
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.lg,
+  },
+  walksSection: {
+    paddingHorizontal: spacing.xs,
   },
   group: {
     marginHorizontal: spacing.lg,
-    marginBottom: spacing.lg,
+    marginTop: spacing.lg,
   },
   actions: {
-    flexDirection: 'row',
-    gap: spacing.sm,
     paddingHorizontal: spacing.lg,
-    paddingBottom: spacing.xl,
+    paddingTop: spacing.lg,
   },
-  actionButton: { flex: 1 },
+  actionButton: {
+    width: '100%',
+  },
 });

--- a/apps/mobile/components/dogs/DogHero.tsx
+++ b/apps/mobile/components/dogs/DogHero.tsx
@@ -1,0 +1,51 @@
+import { StyleSheet, View } from 'react-native';
+import { Image } from 'expo-image';
+import { LinearGradient } from 'expo-linear-gradient';
+import { useColors } from '@/hooks/use-colors';
+
+interface DogHeroProps {
+  photoUrl: string | null | undefined;
+}
+
+const HERO_HEIGHT = 300;
+const FADE_HEIGHT = 60;
+
+export function DogHero({ photoUrl }: DogHeroProps) {
+  const theme = useColors();
+
+  return (
+    <View style={[styles.hero, { backgroundColor: theme.surfaceContainer }]}>
+      <Image
+        source={photoUrl ?? require('@/assets/images/icon.png')}
+        style={styles.photo}
+        contentFit="cover"
+        cachePolicy="memory-disk"
+        accessibilityIgnoresInvertColors
+      />
+      <LinearGradient
+        colors={['transparent', theme.background]}
+        style={styles.fade}
+        pointerEvents="none"
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  hero: {
+    height: HERO_HEIGHT,
+    width: '100%',
+    overflow: 'hidden',
+  },
+  photo: {
+    width: '100%',
+    height: '100%',
+  },
+  fade: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    height: FADE_HEIGHT,
+  },
+});

--- a/apps/mobile/components/dogs/DogListItem.tsx
+++ b/apps/mobile/components/dogs/DogListItem.tsx
@@ -5,15 +5,29 @@ import { useColors } from '@/hooks/use-colors';
 import { elevation, radius, spacing, typography } from '@/theme/tokens';
 import type { Dog } from '@/types/graphql';
 
+interface DogProgressSummary {
+  todayKm: number;
+  totalWalks: number;
+  streakDays: number;
+}
+
 interface DogListItemProps {
   dog: Dog;
   onPress: (id: string) => void;
+  progress?: DogProgressSummary;
 }
 
-export function DogListItem({ dog, onPress }: DogListItemProps) {
+export function DogListItem({ dog, onPress, progress }: DogListItemProps) {
   const { t } = useTranslation();
   const theme = useColors();
   const isShared = dog.role === 'member';
+  const showStreak = progress !== undefined && progress.streakDays > 0;
+  const metaLine = progress
+    ? t('dogs.list.todayStats', {
+        km: progress.todayKm.toFixed(2),
+        count: progress.totalWalks,
+      })
+    : dog.breed;
 
   return (
     <Pressable
@@ -35,6 +49,15 @@ export function DogListItem({ dog, onPress }: DogListItemProps) {
       <View style={styles.info}>
         <View style={styles.nameRow}>
           <Text style={[styles.name, { color: theme.onSurface }]}>{dog.name}</Text>
+          {showStreak ? (
+            <View
+              style={[styles.streakBadge, { backgroundColor: theme.surfaceContainer }]}
+            >
+              <Text style={[styles.streakText, { color: theme.warning }]}>
+                {t('dogs.list.streak', { days: progress!.streakDays })}
+              </Text>
+            </View>
+          ) : null}
           {isShared ? (
             <View style={[styles.badge, { backgroundColor: theme.surfaceContainer }]}>
               <Text style={[styles.badgeText, { color: theme.onSurfaceVariant }]}>
@@ -43,9 +66,9 @@ export function DogListItem({ dog, onPress }: DogListItemProps) {
             </View>
           ) : null}
         </View>
-        {dog.breed ? (
+        {metaLine ? (
           <Text style={[styles.breed, { color: theme.onSurfaceVariant }]}>
-            {dog.breed}
+            {metaLine}
           </Text>
         ) : null}
       </View>
@@ -88,6 +111,15 @@ const styles = StyleSheet.create({
   badgeText: {
     fontSize: 10,
     fontWeight: '600' as const,
+  },
+  streakBadge: {
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: radius.sm,
+  },
+  streakText: {
+    fontSize: 10,
+    fontWeight: '700' as const,
   },
   breed: {
     ...typography.footnote,

--- a/apps/mobile/components/dogs/DogStatsCard.tsx
+++ b/apps/mobile/components/dogs/DogStatsCard.tsx
@@ -7,6 +7,7 @@ import type { WalkStats } from '@/types/graphql';
 
 interface DogStatsCardProps {
   stats: WalkStats;
+  streakDays?: number;
 }
 
 function formatDistance(meters: number): string {
@@ -15,15 +16,9 @@ function formatDistance(meters: number): string {
     : `${meters} m`;
 }
 
-export function DogStatsCard({ stats }: DogStatsCardProps) {
+export function DogStatsCard({ stats, streakDays = 0 }: DogStatsCardProps) {
   const { t } = useTranslation();
   const theme = useColors();
-
-  const minutes = Math.floor(stats.totalDurationSec / 60);
-  const hours = Math.floor(minutes / 60);
-  const durationText = hours > 0
-    ? t('dogs.stats.hours', { hours, minutes: minutes % 60 })
-    : t('dogs.stats.minutes', { count: minutes });
 
   return (
     <OutlinedCard style={styles.card}>
@@ -39,9 +34,11 @@ export function DogStatsCard({ stats }: DogStatsCardProps) {
       </View>
       <View style={styles.stat}>
         <Text style={[styles.value, { color: theme.onSurface }]}>
-          {durationText}
+          {t('dogs.detail.streakDays', { days: streakDays })}
         </Text>
-        <Text style={[styles.label, { color: theme.onSurfaceVariant }]}>{t('dogs.stats.duration')}</Text>
+        <Text style={[styles.label, { color: theme.onSurfaceVariant }]}>
+          {t('dogs.detail.streakLabel')}
+        </Text>
       </View>
     </OutlinedCard>
   );

--- a/apps/mobile/components/dogs/DogWalkRow.tsx
+++ b/apps/mobile/components/dogs/DogWalkRow.tsx
@@ -1,0 +1,136 @@
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import Svg, { Circle, Path } from 'react-native-svg';
+import { useTranslation } from 'react-i18next';
+import { useColors } from '@/hooks/use-colors';
+import { radius, spacing, typography } from '@/theme/tokens';
+import {
+  countWalkEvents,
+  formatDistance,
+  formatPaceString,
+  formatTime,
+  formatWalkDateLabel,
+} from '@/lib/walk/format';
+import type { Walk } from '@/types/graphql';
+
+interface DogWalkRowProps {
+  walk: Walk;
+  onPress?: (id: string) => void;
+  separator?: boolean;
+}
+
+export function DogWalkRow({ walk, onPress, separator = true }: DogWalkRowProps) {
+  const { t } = useTranslation();
+  const theme = useColors();
+  const distanceM = walk.distanceM ?? 0;
+  const durationSec = walk.durationSec ?? 0;
+  const dateLabel = formatWalkDateLabel(walk.startedAt, new Date(), {
+    today: t('walk.date.today'),
+    yesterday: t('walk.date.yesterday'),
+  });
+  const metaParts = [
+    formatDistance(distanceM),
+    formatTime(durationSec),
+    formatPaceString(durationSec, distanceM),
+  ];
+  const meta = metaParts.join(' · ');
+  const { pee, poo } = countWalkEvents(walk.events);
+
+  return (
+    <>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={`${dateLabel} · ${meta}`}
+        onPress={() => onPress?.(walk.id)}
+        style={styles.row}
+      >
+        <View style={[styles.iconTile, { backgroundColor: theme.surfaceContainer }]}>
+          <Svg width={18} height={18} viewBox="0 0 18 18" fill="none">
+            <Path
+              d="M3 14 L7 9 L10 12 L15 5"
+              stroke={theme.interactive}
+              strokeWidth={2}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <Circle cx={15} cy={5} r={1.5} fill={theme.interactive} />
+          </Svg>
+        </View>
+        <View style={styles.info}>
+          <Text style={[styles.title, { color: theme.onSurface }]} numberOfLines={1}>
+            {dateLabel}
+          </Text>
+          <Text
+            style={[styles.meta, { color: theme.onSurfaceVariant }]}
+            numberOfLines={1}
+          >
+            {meta}
+          </Text>
+        </View>
+        {pee + poo > 0 ? (
+          <View style={styles.eventCounts}>
+            {pee > 0 ? (
+              <Text style={[styles.eventText, { color: theme.onSurfaceVariant }]}>
+                💧{pee}
+              </Text>
+            ) : null}
+            {poo > 0 ? (
+              <Text style={[styles.eventText, { color: theme.onSurfaceVariant }]}>
+                💩{poo}
+              </Text>
+            ) : null}
+          </View>
+        ) : null}
+        <Text style={[styles.chevron, { color: theme.textDisabled }]}>›</Text>
+      </Pressable>
+      {separator ? (
+        <View style={[styles.separator, { backgroundColor: theme.border }]} />
+      ) : null}
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.step12,
+    paddingHorizontal: spacing.md,
+    paddingVertical: 12,
+    minHeight: 44,
+  },
+  iconTile: {
+    width: 36,
+    height: 36,
+    borderRadius: radius.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  info: {
+    flex: 1,
+    minWidth: 0,
+  },
+  title: {
+    ...typography.subheadline,
+    fontWeight: '500',
+    fontSize: 15,
+  },
+  meta: {
+    ...typography.footnote,
+    fontSize: 12,
+  },
+  eventCounts: {
+    flexDirection: 'row',
+    gap: 4,
+  },
+  eventText: {
+    fontSize: 11,
+  },
+  chevron: {
+    fontSize: 20,
+    marginLeft: spacing.xs,
+  },
+  separator: {
+    height: StyleSheet.hairlineWidth,
+    marginLeft: 64,
+  },
+});

--- a/apps/mobile/components/dogs/DogWalksList.tsx
+++ b/apps/mobile/components/dogs/DogWalksList.tsx
@@ -1,0 +1,97 @@
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { useColors } from '@/hooks/use-colors';
+import { spacing, typography } from '@/theme/tokens';
+import { GroupedCard } from '@/components/ui/GroupedCard';
+import { DogWalkRow } from './DogWalkRow';
+import type { Walk } from '@/types/graphql';
+
+interface DogWalksListProps {
+  walks: Walk[];
+  onPressWalk?: (id: string) => void;
+  onSeeAll?: () => void;
+  maxRows?: number;
+}
+
+export function DogWalksList({
+  walks,
+  onPressWalk,
+  onSeeAll,
+  maxRows = 5,
+}: DogWalksListProps) {
+  const { t } = useTranslation();
+  const theme = useColors();
+  const visible = walks.slice(0, maxRows);
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <Text style={[styles.title, { color: theme.onSurface }]}>
+          {t('dogs.detail.walks')}
+        </Text>
+        {onSeeAll && walks.length > 0 ? (
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={t('dogs.detail.seeAll')}
+            onPress={onSeeAll}
+            hitSlop={8}
+          >
+            <Text style={[styles.seeAll, { color: theme.interactive }]}>
+              {t('dogs.detail.seeAll')}
+            </Text>
+          </Pressable>
+        ) : null}
+      </View>
+
+      {visible.length === 0 ? (
+        <GroupedCard elevated>
+          <View style={styles.empty}>
+            <Text style={[styles.emptyText, { color: theme.onSurfaceVariant }]}>
+              {t('walk.history.empty')}
+            </Text>
+          </View>
+        </GroupedCard>
+      ) : (
+        <GroupedCard elevated>
+          {visible.map((walk, idx) => (
+            <DogWalkRow
+              key={walk.id}
+              walk={walk}
+              onPress={onPressWalk}
+              separator={idx < visible.length - 1}
+            />
+          ))}
+        </GroupedCard>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginTop: spacing.md,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing.lg,
+    paddingTop: 4,
+    paddingBottom: spacing.sm,
+  },
+  title: {
+    ...typography.title2,
+    fontSize: 20,
+  },
+  seeAll: {
+    ...typography.subheadline,
+    fontSize: 15,
+  },
+  empty: {
+    padding: spacing.lg,
+    alignItems: 'center',
+  },
+  emptyText: {
+    ...typography.footnote,
+  },
+});

--- a/apps/mobile/components/dogs/PackRollupCard.tsx
+++ b/apps/mobile/components/dogs/PackRollupCard.tsx
@@ -1,0 +1,98 @@
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { useColors } from '@/hooks/use-colors';
+import { spacing, typography } from '@/theme/tokens';
+import { GroupedCard } from '@/components/ui/GroupedCard';
+import { RingProgress } from '@/components/ui/RingProgress';
+
+interface PackRollupCardProps {
+  todayKm: number;
+  goalKm: number;
+  progressPct: number;
+  onPress?: () => void;
+}
+
+export function PackRollupCard({
+  todayKm,
+  goalKm,
+  progressPct,
+  onPress,
+}: PackRollupCardProps) {
+  const { t } = useTranslation();
+  const theme = useColors();
+
+  const subtitle = t('dogs.list.acrossPack', {
+    km: todayKm.toFixed(2),
+    goal: goalKm.toFixed(1),
+  });
+
+  const content = (
+    <>
+      <RingProgress
+        size={44}
+        strokeWidth={4}
+        progress={progressPct}
+        color={theme.success}
+        trackColor={theme.surfaceContainer}
+        label={`${progressPct}%`}
+        labelFontSize={11}
+      />
+      <View style={styles.info}>
+        <Text style={[styles.title, { color: theme.onSurface }]}>
+          {t('dogs.list.todayGoal')}
+        </Text>
+        <Text
+          style={[styles.subtitle, { color: theme.onSurfaceVariant }]}
+          numberOfLines={1}
+        >
+          {subtitle}
+        </Text>
+      </View>
+      {onPress ? (
+        <Text style={[styles.chevron, { color: theme.textDisabled }]}>›</Text>
+      ) : null}
+    </>
+  );
+
+  return (
+    <GroupedCard elevated>
+      {onPress ? (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={t('dogs.list.todayGoal')}
+          onPress={onPress}
+          style={styles.row}
+        >
+          {content}
+        </Pressable>
+      ) : (
+        <View style={styles.row}>{content}</View>
+      )}
+    </GroupedCard>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.step12,
+    padding: 14,
+  },
+  info: {
+    flex: 1,
+  },
+  title: {
+    ...typography.headline,
+    fontWeight: '600',
+    fontSize: 15,
+  },
+  subtitle: {
+    ...typography.footnote,
+    marginTop: 2,
+  },
+  chevron: {
+    fontSize: 22,
+    marginLeft: spacing.xs,
+  },
+});

--- a/apps/mobile/components/ui/RingProgress.tsx
+++ b/apps/mobile/components/ui/RingProgress.tsx
@@ -1,0 +1,85 @@
+import { StyleSheet, Text, View } from 'react-native';
+import Svg, { Circle } from 'react-native-svg';
+
+interface RingProgressProps {
+  size: number;
+  strokeWidth: number;
+  progress: number;
+  color: string;
+  trackColor: string;
+  label?: string;
+  labelColor?: string;
+  labelFontSize?: number;
+  accessibilityLabel?: string;
+}
+
+export function RingProgress({
+  size,
+  strokeWidth,
+  progress,
+  color,
+  trackColor,
+  label,
+  labelColor,
+  labelFontSize = 11,
+  accessibilityLabel,
+}: RingProgressProps) {
+  const clamped = Math.max(0, Math.min(100, progress));
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const dashOffset = circumference * (1 - clamped / 100);
+
+  return (
+    <View
+      style={[styles.container, { width: size, height: size }]}
+      accessibilityRole="progressbar"
+      accessibilityLabel={accessibilityLabel}
+      accessibilityValue={{ now: Math.round(clamped), min: 0, max: 100 }}
+    >
+      <Svg width={size} height={size}>
+        <Circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          stroke={trackColor}
+          strokeWidth={strokeWidth}
+          fill="none"
+        />
+        <Circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          stroke={color}
+          strokeWidth={strokeWidth}
+          strokeDasharray={`${circumference}, ${circumference}`}
+          strokeDashoffset={dashOffset}
+          strokeLinecap="round"
+          fill="none"
+          transform={`rotate(-90 ${size / 2} ${size / 2})`}
+        />
+      </Svg>
+      {label ? (
+        <View style={styles.labelWrap} pointerEvents="none">
+          <Text style={[styles.label, { color: labelColor ?? color, fontSize: labelFontSize }]}>
+            {label}
+          </Text>
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  labelWrap: {
+    ...StyleSheet.absoluteFillObject,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  label: {
+    fontWeight: '700',
+  },
+});

--- a/apps/mobile/constants/walk.ts
+++ b/apps/mobile/constants/walk.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_DAILY_GOAL_KM = 5;

--- a/apps/mobile/hooks/use-pack-progress.test.ts
+++ b/apps/mobile/hooks/use-pack-progress.test.ts
@@ -1,0 +1,111 @@
+import { aggregatePackProgress } from './use-pack-progress';
+import type { Walk } from '@/types/graphql';
+
+function makeWalk(
+  id: string,
+  dogIds: string[],
+  startedAt: string,
+  distanceM: number | null,
+): Walk {
+  return {
+    id,
+    dogs: dogIds.map((dogId) => ({
+      id: dogId,
+      name: `dog-${dogId}`,
+      breed: null,
+      gender: null,
+      birthDate: null,
+      photoUrl: null,
+      createdAt: '2026-01-01T00:00:00Z',
+    })),
+    status: 'FINISHED',
+    distanceM,
+    durationSec: 1440,
+    startedAt,
+    endedAt: null,
+  };
+}
+
+describe('aggregatePackProgress', () => {
+  const now = new Date(2026, 3, 19, 12, 0, 0); // 2026-04-19 12:00 local
+
+  it('returns zeros when there are no walks', () => {
+    const result = aggregatePackProgress([], 5, now);
+    expect(result).toEqual({ todayKm: 0, goalKm: 5, progressPct: 0, perDog: {} });
+  });
+
+  it('sums today distance across all dogs for the pack card', () => {
+    const walks: Walk[] = [
+      makeWalk('w1', ['coco'], new Date(2026, 3, 19, 8, 0).toISOString(), 1420),
+      makeWalk('w2', ['momo'], new Date(2026, 3, 19, 9, 0).toISOString(), 2100),
+      makeWalk('w3', ['coco'], new Date(2026, 3, 18, 18, 0).toISOString(), 3000),
+    ];
+    const result = aggregatePackProgress(walks, 5, now);
+    expect(result.todayKm).toBeCloseTo(3.52, 2);
+    expect(result.progressPct).toBe(70);
+  });
+
+  it('computes per-dog today km and totals', () => {
+    const walks: Walk[] = [
+      makeWalk('w1', ['coco'], new Date(2026, 3, 19, 8, 0).toISOString(), 1420),
+      makeWalk('w2', ['coco'], new Date(2026, 3, 18, 18, 0).toISOString(), 2080),
+      makeWalk('w3', ['momo'], new Date(2026, 3, 19, 9, 0).toISOString(), 2100),
+    ];
+    const result = aggregatePackProgress(walks, 5, now);
+    expect(result.perDog.coco.todayKm).toBeCloseTo(1.42, 2);
+    expect(result.perDog.coco.totalWalks).toBe(2);
+    expect(result.perDog.momo.todayKm).toBeCloseTo(2.1, 2);
+    expect(result.perDog.momo.totalWalks).toBe(1);
+  });
+
+  it('counts walk that includes multiple dogs once per dog', () => {
+    const walks: Walk[] = [
+      makeWalk('w1', ['coco', 'momo'], new Date(2026, 3, 19, 8, 0).toISOString(), 1000),
+    ];
+    const result = aggregatePackProgress(walks, 5, now);
+    expect(result.todayKm).toBeCloseTo(1, 5);
+    expect(result.perDog.coco.todayKm).toBeCloseTo(1, 5);
+    expect(result.perDog.momo.todayKm).toBeCloseTo(1, 5);
+  });
+
+  it('streak counts consecutive days ending today', () => {
+    const walks: Walk[] = [
+      makeWalk('w1', ['coco'], new Date(2026, 3, 19, 8).toISOString(), 500),
+      makeWalk('w2', ['coco'], new Date(2026, 3, 18, 8).toISOString(), 500),
+      makeWalk('w3', ['coco'], new Date(2026, 3, 17, 8).toISOString(), 500),
+      makeWalk('w4', ['coco'], new Date(2026, 3, 15, 8).toISOString(), 500),
+    ];
+    expect(aggregatePackProgress(walks, 5, now).perDog.coco.streakDays).toBe(3);
+  });
+
+  it('streak counts from yesterday when today has no walk', () => {
+    const walks: Walk[] = [
+      makeWalk('w1', ['coco'], new Date(2026, 3, 18, 8).toISOString(), 500),
+      makeWalk('w2', ['coco'], new Date(2026, 3, 17, 8).toISOString(), 500),
+    ];
+    expect(aggregatePackProgress(walks, 5, now).perDog.coco.streakDays).toBe(2);
+  });
+
+  it('streak is zero if last walk was more than one day ago', () => {
+    const walks: Walk[] = [
+      makeWalk('w1', ['coco'], new Date(2026, 3, 15, 8).toISOString(), 500),
+    ];
+    expect(aggregatePackProgress(walks, 5, now).perDog.coco.streakDays).toBe(0);
+  });
+
+  it('caps progressPct at 100', () => {
+    const walks: Walk[] = [
+      makeWalk('w1', ['coco'], new Date(2026, 3, 19, 8).toISOString(), 20_000),
+    ];
+    expect(aggregatePackProgress(walks, 5, now).progressPct).toBe(100);
+  });
+
+  it('handles null distanceM as zero', () => {
+    const walks: Walk[] = [
+      makeWalk('w1', ['coco'], new Date(2026, 3, 19, 8).toISOString(), null),
+    ];
+    const result = aggregatePackProgress(walks, 5, now);
+    expect(result.todayKm).toBe(0);
+    expect(result.perDog.coco.totalWalks).toBe(1);
+  });
+});

--- a/apps/mobile/hooks/use-pack-progress.ts
+++ b/apps/mobile/hooks/use-pack-progress.ts
@@ -1,0 +1,111 @@
+import { useMemo } from 'react';
+import { DEFAULT_DAILY_GOAL_KM } from '@/constants/walk';
+import { useMyWalks } from './use-walks';
+import type { Walk } from '@/types/graphql';
+
+export interface DogProgress {
+  todayKm: number;
+  totalWalks: number;
+  streakDays: number;
+}
+
+export interface PackProgress {
+  todayKm: number;
+  goalKm: number;
+  progressPct: number;
+  perDog: Record<string, DogProgress>;
+  isLoading: boolean;
+}
+
+function toLocalDayKey(iso: string): string {
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return '';
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+function localDayKey(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+function shiftDay(date: Date, delta: number): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate() + delta);
+}
+
+function computeStreak(dayKeys: Set<string>, now: Date): number {
+  if (dayKeys.size === 0) return 0;
+  const today = localDayKey(now);
+  const yesterday = localDayKey(shiftDay(now, -1));
+  let cursor: Date;
+  if (dayKeys.has(today)) cursor = now;
+  else if (dayKeys.has(yesterday)) cursor = shiftDay(now, -1);
+  else return 0;
+  let streak = 0;
+  while (dayKeys.has(localDayKey(cursor))) {
+    streak += 1;
+    cursor = shiftDay(cursor, -1);
+  }
+  return streak;
+}
+
+export function aggregatePackProgress(
+  walks: Walk[],
+  goalKm: number = DEFAULT_DAILY_GOAL_KM,
+  now: Date = new Date(),
+): Omit<PackProgress, 'isLoading'> {
+  const todayKey = localDayKey(now);
+
+  let packTodayM = 0;
+  const dogDays = new Map<string, Set<string>>();
+  const dogTodayM = new Map<string, number>();
+  const dogTotalWalks = new Map<string, number>();
+
+  for (const walk of walks) {
+    const dayKey = toLocalDayKey(walk.startedAt);
+    const distanceM = walk.distanceM ?? 0;
+    if (dayKey === todayKey) packTodayM += distanceM;
+
+    for (const dog of walk.dogs ?? []) {
+      if (!dog?.id) continue;
+      let set = dogDays.get(dog.id);
+      if (!set) {
+        set = new Set();
+        dogDays.set(dog.id, set);
+      }
+      if (dayKey) set.add(dayKey);
+
+      dogTotalWalks.set(dog.id, (dogTotalWalks.get(dog.id) ?? 0) + 1);
+      if (dayKey === todayKey) {
+        dogTodayM.set(dog.id, (dogTodayM.get(dog.id) ?? 0) + distanceM);
+      }
+    }
+  }
+
+  const perDog: Record<string, DogProgress> = {};
+  for (const [dogId, days] of dogDays.entries()) {
+    perDog[dogId] = {
+      todayKm: (dogTodayM.get(dogId) ?? 0) / 1000,
+      totalWalks: dogTotalWalks.get(dogId) ?? 0,
+      streakDays: computeStreak(days, now),
+    };
+  }
+
+  const todayKm = packTodayM / 1000;
+  const progressPct =
+    goalKm > 0 ? Math.min(100, Math.round((todayKm / goalKm) * 100)) : 0;
+
+  return { todayKm, goalKm, progressPct, perDog };
+}
+
+export function usePackProgress(goalKm: number = DEFAULT_DAILY_GOAL_KM): PackProgress {
+  const { data, isLoading } = useMyWalks(100);
+  return useMemo(() => {
+    const walks = data ?? [];
+    return { ...aggregatePackProgress(walks, goalKm), isLoading };
+  }, [data, goalKm, isLoading]);
+}

--- a/apps/mobile/lib/graphql/queries/walk.ts
+++ b/apps/mobile/lib/graphql/queries/walk.ts
@@ -28,6 +28,7 @@ export const MY_WALKS_QUERY = gql`
       durationSec
       startedAt
       endedAt
+      events { id eventType }
     }
   }
 `;

--- a/apps/mobile/lib/i18n/locales/en.json
+++ b/apps/mobile/lib/i18n/locales/en.json
@@ -72,7 +72,12 @@
       "title": "My Dogs",
       "sectionLabel": "YOUR PACK",
       "empty": "No dogs registered yet",
-      "addDog": "Add Dog"
+      "addDog": "Add Dog",
+      "addCta": "+ Add",
+      "todayGoal": "Today's walking goal",
+      "acrossPack": "{{km}} / {{goal}} km across your pack",
+      "streak": "🔥 {{days}}d",
+      "todayStats": "{{km}} km today · {{count}} walks"
     },
     "new": {
       "title": "Register New Dog",
@@ -87,7 +92,12 @@
       "deleteError": "Failed to delete dog. Please try again.",
       "members": "Members",
       "membersCount": "{{count}} members",
-      "manageMembers": "Manage Members"
+      "manageMembers": "Manage Members",
+      "walks": "Walks",
+      "seeAll": "See all",
+      "streakLabel": "Streak",
+      "streakDays": "{{days}}d",
+      "back": "Dogs"
     },
     "members": {
       "title": "Members",
@@ -224,6 +234,10 @@
     "liveActivity": {
       "walking": "Walking",
       "walkingWithDogs": "Walking {{count}} dogs"
+    },
+    "date": {
+      "today": "Today",
+      "yesterday": "Yesterday"
     }
   },
   "invite": {

--- a/apps/mobile/lib/i18n/locales/ja.json
+++ b/apps/mobile/lib/i18n/locales/ja.json
@@ -72,7 +72,12 @@
       "title": "愛犬",
       "sectionLabel": "YOUR PACK",
       "empty": "まだ犬が登録されていません",
-      "addDog": "犬を追加"
+      "addDog": "犬を追加",
+      "addCta": "＋ 追加",
+      "todayGoal": "今日の散歩目標",
+      "acrossPack": "{{km}} / {{goal}} km（みんなの合計）",
+      "streak": "🔥 {{days}}日",
+      "todayStats": "今日 {{km}} km · {{count}}回"
     },
     "new": {
       "title": "新しい犬を登録",
@@ -87,7 +92,12 @@
       "deleteError": "犬の削除に失敗しました。もう一度お試しください。",
       "members": "メンバー",
       "membersCount": "{{count}}人のメンバー",
-      "manageMembers": "メンバー管理"
+      "manageMembers": "メンバー管理",
+      "walks": "散歩",
+      "seeAll": "すべて見る",
+      "streakLabel": "連続",
+      "streakDays": "{{days}}日",
+      "back": "愛犬"
     },
     "members": {
       "title": "メンバー",
@@ -224,6 +234,10 @@
     "liveActivity": {
       "walking": "散歩中",
       "walkingWithDogs": "{{count}}匹と散歩中"
+    },
+    "date": {
+      "today": "今日",
+      "yesterday": "昨日"
     }
   },
   "invite": {

--- a/apps/mobile/lib/walk/format.test.ts
+++ b/apps/mobile/lib/walk/format.test.ts
@@ -1,4 +1,10 @@
-import { formatTime, formatDistance, formatClockTime } from './format';
+import {
+  formatTime,
+  formatDistance,
+  formatClockTime,
+  formatWalkDateLabel,
+  countWalkEvents,
+} from './format';
 
 describe('formatTime', () => {
   it('formats seconds only', () => {
@@ -60,5 +66,54 @@ describe('formatClockTime', () => {
     } finally {
       Date.prototype.toLocaleTimeString = original;
     }
+  });
+});
+
+describe('formatWalkDateLabel', () => {
+  const now = new Date(2026, 3, 19, 12, 0, 0); // 2026-04-19 12:00 local
+
+  it('labels same local day as "Today"', () => {
+    const iso = new Date(2026, 3, 19, 8, 30).toISOString();
+    expect(formatWalkDateLabel(iso, now)).toMatch(/^Today · /);
+  });
+
+  it('labels previous local day as "Yesterday"', () => {
+    const iso = new Date(2026, 3, 18, 18, 12).toISOString();
+    expect(formatWalkDateLabel(iso, now)).toMatch(/^Yesterday · /);
+  });
+
+  it('labels older days with weekday short name', () => {
+    // 2026-04-13 was a Monday
+    const iso = new Date(2026, 3, 13, 6, 40).toISOString();
+    expect(formatWalkDateLabel(iso, now)).toMatch(/^Mon · /);
+  });
+
+  it('honours custom today/yesterday labels', () => {
+    const iso = new Date(2026, 3, 19, 8, 30).toISOString();
+    expect(
+      formatWalkDateLabel(iso, now, { today: '今日', yesterday: '昨日' }),
+    ).toMatch(/^今日 · /);
+  });
+
+  it('returns "--" for invalid date', () => {
+    expect(formatWalkDateLabel('garbage', now)).toBe('--');
+  });
+});
+
+describe('countWalkEvents', () => {
+  it('returns zeros for undefined or empty events', () => {
+    expect(countWalkEvents()).toEqual({ pee: 0, poo: 0 });
+    expect(countWalkEvents([])).toEqual({ pee: 0, poo: 0 });
+    expect(countWalkEvents(null)).toEqual({ pee: 0, poo: 0 });
+  });
+
+  it('counts pee and poo events and ignores photos', () => {
+    const events = [
+      { eventType: 'pee' as const },
+      { eventType: 'poo' as const },
+      { eventType: 'pee' as const },
+      { eventType: 'photo' as const },
+    ];
+    expect(countWalkEvents(events)).toEqual({ pee: 2, poo: 1 });
   });
 });

--- a/apps/mobile/lib/walk/format.ts
+++ b/apps/mobile/lib/walk/format.ts
@@ -42,3 +42,44 @@ export function formatClockTime(isoString: string, locale?: string): string {
     return `${h}:${m}`;
   }
 }
+
+const WEEKDAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const;
+
+function startOfLocalDay(date: Date): number {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
+}
+
+export function formatWalkDateLabel(
+  isoString: string,
+  now: Date = new Date(),
+  labels?: { today?: string; yesterday?: string },
+): string {
+  const d = new Date(isoString);
+  if (isNaN(d.getTime())) return '--';
+  const today = startOfLocalDay(now);
+  const target = startOfLocalDay(d);
+  const diffDays = Math.round((today - target) / 86_400_000);
+  let prefix: string;
+  if (diffDays === 0) prefix = labels?.today ?? 'Today';
+  else if (diffDays === 1) prefix = labels?.yesterday ?? 'Yesterday';
+  else prefix = WEEKDAY_LABELS[d.getDay()];
+  return `${prefix} · ${formatClockTime(isoString)}`;
+}
+
+interface CountableEvent {
+  eventType: 'pee' | 'poo' | 'photo';
+}
+
+export function countWalkEvents(events?: CountableEvent[] | null): {
+  pee: number;
+  poo: number;
+} {
+  if (!events || events.length === 0) return { pee: 0, poo: 0 };
+  let pee = 0;
+  let poo = 0;
+  for (const event of events) {
+    if (event.eventType === 'pee') pee += 1;
+    else if (event.eventType === 'poo') poo += 1;
+  }
+  return { pee, poo };
+}


### PR DESCRIPTION
## Summary
- Dogs list: replace the dog-count rollup with a circular pack progress ring (client-side today km vs fixed 5 km goal), move \"+ Add\" to the header, show streak + today km / walks meta on each row.
- Dog detail: full-bleed photoUrl hero with fade-to-background, transparent nav bar with Edit moved to \`headerRight\`, stats card shows Streak (client-side), Walks history card with per-walk pee/poo counts. Members/Friends/Delete retained beneath.
- New client-side aggregation: \`usePackProgress\` (pure + React Query wrapper) computes per-dog streak, today km, and pack total from \`myWalks\`.

## Test plan
- [x] \`npx jest\` — 70 suites / 441 tests pass (16 new)
- [x] \`npx tsc --noEmit\` — no new errors
- [x] \`npx expo lint\` — no new warnings
- [ ] iOS Simulator visual verification: list rollup, streak badge, detail hero fade, Edit in nav, walks history
- [ ] Dark mode hero fade colour follows \`theme.background\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)