### PR TITLE
feat(mobile): iOS 26 Liquid Glass floating tab bar

### DIFF
--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -1,46 +1,29 @@
 import { Tabs } from 'expo-router';
 import { useTranslation } from 'react-i18next';
-import { StyleSheet } from 'react-native';
 
-import { HapticTab } from '@/components/haptic-tab';
+import { LiquidGlassTabBar } from '@/components/navigation/liquid-glass-tab-bar';
 import { IconSymbol } from '@/components/ui/icon-symbol';
-import { useColors } from '@/hooks/use-colors';
 
 export default function TabLayout() {
-  const theme = useColors();
   const { t } = useTranslation();
 
   return (
     <Tabs
       initialRouteName="dogs"
-      screenOptions={{
-        tabBarActiveTintColor: theme.interactive,
-        tabBarInactiveTintColor: theme.onSurfaceVariant,
-        headerShown: false,
-        tabBarButton: HapticTab,
-        tabBarLabelStyle: {
-          fontSize: 10,
-          fontWeight: '500',
-          letterSpacing: 0.1,
-        },
-        tabBarStyle: {
-          backgroundColor: theme.material,
-          borderTopWidth: StyleSheet.hairlineWidth,
-          borderTopColor: theme.border,
-        },
-      }}>
+      screenOptions={{ headerShown: false }}
+      tabBar={(props) => <LiquidGlassTabBar {...props} />}>
       <Tabs.Screen
         name="dogs"
         options={{
           title: t('tabs.dogs'),
-          tabBarIcon: ({ color }) => <IconSymbol size={28} name="pawprint.fill" color={color} />,
+          tabBarIcon: ({ color }) => <IconSymbol size={24} name="pawprint.fill" color={color} />,
         }}
       />
       <Tabs.Screen
         name="walk"
         options={{
           title: t('tabs.walk'),
-          tabBarIcon: ({ color }) => <IconSymbol size={28} name="figure.walk" color={color} />,
+          tabBarIcon: ({ color }) => <IconSymbol size={24} name="figure.walk" color={color} />,
         }}
       />
       <Tabs.Screen
@@ -48,7 +31,7 @@ export default function TabLayout() {
         options={{
           title: t('tabs.me'),
           tabBarIcon: ({ color }) => (
-            <IconSymbol size={28} name="person.crop.circle" color={color} />
+            <IconSymbol size={24} name="person.crop.circle" color={color} />
           ),
         }}
       />

--- a/apps/mobile/components/navigation/liquid-glass-tab-bar.test.tsx
+++ b/apps/mobile/components/navigation/liquid-glass-tab-bar.test.tsx
@@ -1,0 +1,138 @@
+import type { BottomTabBarProps } from '@react-navigation/bottom-tabs';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import * as Haptics from 'expo-haptics';
+import { Text } from 'react-native';
+
+import { LiquidGlassTabBar } from './liquid-glass-tab-bar';
+
+jest.mock('@/hooks/use-color-scheme', () => ({
+  useColorScheme: () => 'light',
+}));
+
+jest.mock('expo-blur', () => {
+  const { View } = jest.requireActual('react-native');
+  return { BlurView: View };
+});
+
+jest.mock('expo-haptics', () => ({
+  impactAsync: jest.fn().mockResolvedValue(undefined),
+  ImpactFeedbackStyle: { Light: 'light' },
+}));
+
+jest.mock('react-native-safe-area-context', () => {
+  const actual = jest.requireActual('react-native-safe-area-context');
+  return {
+    ...actual,
+    useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 34, left: 0 }),
+  };
+});
+
+type RouteLike = { key: string; name: string; params?: object };
+
+type BuildOpts = {
+  activeIndex?: number;
+  hiddenRouteIndex?: number;
+  navigate?: jest.Mock;
+  emit?: jest.Mock;
+};
+
+function buildProps({
+  activeIndex = 0,
+  hiddenRouteIndex,
+  navigate = jest.fn(),
+  emit = jest.fn().mockReturnValue({ defaultPrevented: false }),
+}: BuildOpts = {}): BottomTabBarProps {
+  const routes: RouteLike[] = [
+    { key: 'dogs-1', name: 'dogs' },
+    { key: 'walk-1', name: 'walk' },
+    { key: 'settings-1', name: 'settings' },
+  ];
+  const titles = ['Dogs', 'Walk', 'Me'];
+
+  const descriptors = Object.fromEntries(
+    routes.map((route, index) => [
+      route.key,
+      {
+        options: {
+          title: titles[index],
+          tabBarIcon: ({ color }: { color: string }) => (
+            <Text>{`icon-${titles[index]}-${color}`}</Text>
+          ),
+          tabBarStyle: index === hiddenRouteIndex ? { display: 'none' as const } : undefined,
+        },
+      },
+    ]),
+  );
+
+  return {
+    state: {
+      index: activeIndex,
+      routes,
+      key: 'tabs',
+      routeNames: routes.map((r) => r.name),
+      history: [],
+      type: 'tab',
+      stale: false,
+    },
+    descriptors,
+    navigation: {
+      navigate,
+      emit,
+    },
+    insets: { top: 0, right: 0, bottom: 34, left: 0 },
+  } as unknown as BottomTabBarProps;
+}
+
+describe('LiquidGlassTabBar', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders a button for each route with its title as accessibility label', () => {
+    render(<LiquidGlassTabBar {...buildProps()} />);
+    expect(screen.getByRole('button', { name: 'Dogs' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Walk' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Me' })).toBeTruthy();
+  });
+
+  it('marks only the focused tab as selected', () => {
+    render(<LiquidGlassTabBar {...buildProps({ activeIndex: 1 })} />);
+    expect(screen.getByRole('button', { name: 'Dogs' }).props.accessibilityState).toEqual({
+      selected: false,
+    });
+    expect(screen.getByRole('button', { name: 'Walk' }).props.accessibilityState).toEqual({
+      selected: true,
+    });
+  });
+
+  it('navigates to the route name when an unfocused tab is pressed', () => {
+    const navigate = jest.fn();
+    const emit = jest.fn().mockReturnValue({ defaultPrevented: false });
+    render(<LiquidGlassTabBar {...buildProps({ activeIndex: 0, navigate, emit })} />);
+    fireEvent.press(screen.getByRole('button', { name: 'Walk' }));
+    expect(emit).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'tabPress', target: 'walk-1' }),
+    );
+    expect(navigate).toHaveBeenCalledWith('walk', undefined);
+  });
+
+  it('does not navigate when the focused tab is pressed again', () => {
+    const navigate = jest.fn();
+    render(<LiquidGlassTabBar {...buildProps({ activeIndex: 1, navigate })} />);
+    fireEvent.press(screen.getByRole('button', { name: 'Walk' }));
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it('renders nothing when the focused route sets tabBarStyle.display to "none"', () => {
+    const { toJSON } = render(
+      <LiquidGlassTabBar {...buildProps({ activeIndex: 1, hiddenRouteIndex: 1 })} />,
+    );
+    expect(toJSON()).toBeNull();
+  });
+
+  it('fires a light haptic on press-in on iOS', () => {
+    render(<LiquidGlassTabBar {...buildProps()} />);
+    fireEvent(screen.getByRole('button', { name: 'Walk' }), 'pressIn');
+    expect(Haptics.impactAsync).toHaveBeenCalledWith(Haptics.ImpactFeedbackStyle.Light);
+  });
+});

--- a/apps/mobile/components/navigation/liquid-glass-tab-bar.tsx
+++ b/apps/mobile/components/navigation/liquid-glass-tab-bar.tsx
@@ -1,0 +1,195 @@
+import type { BottomTabBarProps } from '@react-navigation/bottom-tabs';
+import { BlurView } from 'expo-blur';
+import * as Haptics from 'expo-haptics';
+import { Platform, Pressable, StyleSheet, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { useColors } from '@/hooks/use-colors';
+import { useColorScheme } from '@/hooks/use-color-scheme';
+
+const BAR_HEIGHT = 58;
+const BAR_RADIUS = 29;
+const BAR_INSET = 20;
+const BAR_BOTTOM_BASE = 22;
+const ACTIVE_PILL_INSET_V = 4;
+const ACTIVE_PILL_INSET_H_RATIO = 0.14;
+const ACTIVE_PILL_RADIUS = 18;
+
+export function LiquidGlassTabBar({ state, descriptors, navigation }: BottomTabBarProps) {
+  const insets = useSafeAreaInsets();
+  const scheme = useColorScheme() ?? 'light';
+  const isDark = scheme === 'dark';
+  const theme = useColors();
+
+  const focusedRoute = state.routes[state.index];
+  const focusedOptions = descriptors[focusedRoute.key]?.options;
+  const tabBarStyle = focusedOptions?.tabBarStyle as { display?: 'none' | 'flex' } | undefined;
+  if (tabBarStyle?.display === 'none') {
+    return null;
+  }
+
+  const bottomOffset = Math.max(insets.bottom, BAR_BOTTOM_BASE);
+
+  const gradientOverlay = isDark ? styles.gradientDark : styles.gradientLight;
+  const borderColor = isDark ? 'rgba(255,255,255,0.14)' : 'rgba(255,255,255,0.7)';
+  const shadowStyle = isDark ? styles.shadowDark : styles.shadowLight;
+  const activePillColor = isDark ? 'rgba(10,132,255,0.18)' : 'rgba(10,132,255,0.12)';
+  const androidFallbackBg = isDark ? 'rgba(30,30,34,0.9)' : 'rgba(250,250,252,0.9)';
+
+  return (
+    <View
+      pointerEvents="box-none"
+      style={[styles.wrapper, { bottom: bottomOffset }]}
+    >
+      <View
+        style={[
+          styles.bar,
+          shadowStyle,
+          { borderColor },
+          Platform.OS === 'android' && { backgroundColor: androidFallbackBg },
+        ]}
+      >
+        {Platform.OS === 'ios' && (
+          <BlurView
+            tint={isDark ? 'systemChromeMaterialDark' : 'systemChromeMaterialLight'}
+            intensity={80}
+            style={StyleSheet.absoluteFill}
+          />
+        )}
+        <View style={[StyleSheet.absoluteFill, gradientOverlay]} pointerEvents="none" />
+        <View style={styles.row}>
+          {state.routes.map((route, index) => {
+            const { options } = descriptors[route.key];
+            const label = typeof options.tabBarLabel === 'string'
+              ? options.tabBarLabel
+              : options.title ?? route.name;
+            const focused = state.index === index;
+            const color = focused ? theme.interactive : theme.onSurfaceVariant;
+
+            const onPress = () => {
+              const event = navigation.emit({
+                type: 'tabPress',
+                target: route.key,
+                canPreventDefault: true,
+              });
+              if (!focused && !event.defaultPrevented) {
+                navigation.navigate(route.name, route.params);
+              }
+            };
+
+            const onLongPress = () => {
+              navigation.emit({ type: 'tabLongPress', target: route.key });
+            };
+
+            const onPressIn = () => {
+              if (Platform.OS === 'ios') {
+                void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+              }
+            };
+
+            const renderIcon = options.tabBarIcon;
+
+            return (
+              <Pressable
+                key={route.key}
+                accessibilityRole="button"
+                accessibilityLabel={label}
+                accessibilityState={focused ? { selected: true } : { selected: false }}
+                onPress={onPress}
+                onLongPress={onLongPress}
+                onPressIn={onPressIn}
+                style={styles.tab}
+              >
+                {focused && (
+                  <View
+                    pointerEvents="none"
+                    style={[
+                      styles.activePill,
+                      { backgroundColor: activePillColor },
+                    ]}
+                  />
+                )}
+                <View style={styles.iconSlot}>
+                  {renderIcon ? renderIcon({ focused, color, size: 24 }) : null}
+                </View>
+                <Text
+                  numberOfLines={1}
+                  style={[styles.label, { color }]}
+                >
+                  {label}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    position: 'absolute',
+    left: BAR_INSET,
+    right: BAR_INSET,
+  },
+  bar: {
+    height: BAR_HEIGHT,
+    borderRadius: BAR_RADIUS,
+    overflow: 'hidden',
+    borderWidth: StyleSheet.hairlineWidth,
+    paddingHorizontal: 8,
+  },
+  row: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  tab: {
+    flex: 1,
+    alignSelf: 'stretch',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 1,
+    position: 'relative',
+  },
+  activePill: {
+    position: 'absolute',
+    top: ACTIVE_PILL_INSET_V,
+    bottom: ACTIVE_PILL_INSET_V,
+    left: `${ACTIVE_PILL_INSET_H_RATIO * 100}%`,
+    right: `${ACTIVE_PILL_INSET_H_RATIO * 100}%`,
+    borderRadius: ACTIVE_PILL_RADIUS,
+  },
+  iconSlot: {
+    width: 24,
+    height: 24,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  label: {
+    fontSize: 10,
+    fontWeight: '600',
+    letterSpacing: 0.1,
+  },
+  gradientLight: {
+    backgroundColor: 'rgba(255,255,255,0.62)',
+  },
+  gradientDark: {
+    backgroundColor: 'rgba(40,40,44,0.5)',
+  },
+  shadowLight: {
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 8 },
+    shadowOpacity: 0.12,
+    shadowRadius: 24,
+    elevation: 6,
+  },
+  shadowDark: {
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 8 },
+    shadowOpacity: 0.4,
+    shadowRadius: 24,
+    elevation: 8,
+  },
+});

--- a/apps/mobile/package-lock.json
+++ b/apps/mobile/package-lock.json
@@ -16,6 +16,7 @@
         "@react-navigation/native": "^7.1.8",
         "@tanstack/react-query": "^5.91.3",
         "expo": "~54.0.33",
+        "expo-blur": "~15.0.8",
         "expo-build-properties": "~1.0.10",
         "expo-constants": "~18.0.13",
         "expo-dev-client": "~6.0.20",
@@ -8765,6 +8766,17 @@
         "@expo/image-utils": "^0.8.8",
         "expo-constants": "~18.0.12"
       },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-blur": {
+      "version": "15.0.8",
+      "resolved": "https://registry.npmjs.org/expo-blur/-/expo-blur-15.0.8.tgz",
+      "integrity": "sha512-rWyE1NBRZEu9WD+X+5l7gyPRszw7n12cW3IRNAb5i6KFzaBp8cxqT5oeaphJapqURvcqhkOZn2k5EtBSbsuU7w==",
+      "license": "MIT",
       "peerDependencies": {
         "expo": "*",
         "react": "*",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -24,6 +24,7 @@
     "@react-navigation/native": "^7.1.8",
     "@tanstack/react-query": "^5.91.3",
     "expo": "~54.0.33",
+    "expo-blur": "~15.0.8",
     "expo-build-properties": "~1.0.10",
     "expo-constants": "~18.0.13",
     "expo-dev-client": "~6.0.20",


### PR DESCRIPTION
## Summary
- Swap the default docked tab bar for a floating pill Liquid Glass bar matching `docs/design/walking-dog/project/Precise Full App.html` (L464–500): translucent BlurView, soft shadow, subtle active-tab pill, 20pt side insets, safe-area aware bottom offset.
- Add `expo-blur` (SDK 54 compatible, ~15.0.8) and a new `LiquidGlassTabBar` component that preserves existing semantics — honors `navigation.emit('tabPress').defaultPrevented`, hides on `tabBarStyle.display: 'none'` (walk recording), and fires light haptics on press-in (iOS).
- Drop the old `HapticTab` / `tabBarStyle` config from `(tabs)/_layout.tsx` and pass the new bar via the `tabBar` prop. Tab icon size tuned 28 → 24 to match Precise spec.

## Test plan
- [x] `npm test -- --testPathPatterns=liquid-glass-tab-bar` — 6/6 green (labels, selected state, navigate, no-op on focused press, display:'none' hides, iOS haptic)
- [x] `npm test -- --testPathPatterns=__tests__/app/tabs` — 5/5 existing tab screen tests still green
- [x] `npx tsc --noEmit` — no new errors in changed files
- [x] `npx eslint` on changed files — clean
- [ ] iOS Simulator: rebuild required (`npx expo run:ios`) because expo-blur ships a native module; verify Light/Dark, active pill moves, walk recording hides bar, home indicator clearance

🤖 Generated with [Claude Code](https://claude.com/claude-code)