### PR TITLE
feat: integrate Sentry for mobile + API error monitoring

### DIFF
--- a/apps/api/Cargo.lock
+++ b/apps/api/Cargo.lock
@@ -9,6 +9,169 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 
 [[package]]
+name = "actix-codec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "actix-http"
+version = "3.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93acb4a42f64936f9b8cae4a433b237599dd6eb6ed06124eb67132ef8cc90662"
+dependencies = [
+ "actix-codec",
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "bitflags",
+ "bytes",
+ "bytestring",
+ "derive_more",
+ "encoding_rs",
+ "foldhash 0.1.5",
+ "futures-core",
+ "http 0.2.12",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "language-tags",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "actix-router"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14f8c75c51892f18d9c46150c5ac7beb81c95f78c8b83a634d49f4ca32551fe7"
+dependencies = [
+ "bytestring",
+ "cfg-if",
+ "http 0.2.12",
+ "regex-lite",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "actix-rt"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92589714878ca59a7626ea19734f0e07a6a875197eec751bb5d3f99e64998c63"
+dependencies = [
+ "futures-core",
+ "tokio",
+]
+
+[[package]]
+name = "actix-server"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a65064ea4a457eaf07f2fba30b4c695bf43b721790e9530d26cb6f9019ff7502"
+dependencies = [
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "futures-core",
+ "futures-util",
+ "mio",
+ "socket2 0.5.10",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "actix-service"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e46f36bf0e5af44bdc4bdb36fbbd421aa98c79a9bce724e1edeb3894e10dc7f"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "actix-utils"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a1dcdff1466e3c2488e1cb5c36a71822750ad43839937f85d2f4d9f8b705d8"
+dependencies = [
+ "local-waker",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "actix-web"
+version = "4.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff87453bc3b56e9b2b23c1cc0b1be8797184accf51d2abe0f8a33ec275d316bf"
+dependencies = [
+ "actix-codec",
+ "actix-http",
+ "actix-router",
+ "actix-rt",
+ "actix-server",
+ "actix-service",
+ "actix-utils",
+ "bytes",
+ "bytestring",
+ "cfg-if",
+ "derive_more",
+ "encoding_rs",
+ "foldhash 0.1.5",
+ "futures-core",
+ "futures-util",
+ "impl-more",
+ "itoa",
+ "language-tags",
+ "log",
+ "mime",
+ "once_cell",
+ "pin-project-lite",
+ "regex-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "smallvec",
+ "socket2 0.6.3",
+ "time",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1035,6 +1198,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1104,6 +1282,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
 ]
 
 [[package]]
@@ -1181,6 +1368,15 @@ checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
 dependencies = [
  "bytes",
  "either",
+]
+
+[[package]]
+name = "bytestring"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "113b4343b5f6617e7ad401ced8de3cc8b012e73a594347c307b90db3e9271289"
+dependencies = [
+ "bytes",
 ]
 
 [[package]]
@@ -1309,6 +1505,15 @@ dependencies = [
  "getrandom 0.2.17",
  "once_cell",
  "tiny-keccak",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -1547,6 +1752,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "serde",
+ "uuid",
+]
+
+[[package]]
 name = "der"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1563,7 +1778,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
- "pem-rfc7468",
+ "pem-rfc7468 0.7.0",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+dependencies = [
+ "pem-rfc7468 1.0.0",
  "zeroize",
 ]
 
@@ -1623,6 +1848,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
+ "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -1640,6 +1866,16 @@ dependencies = [
  "const-oid",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "objc2",
 ]
 
 [[package]]
@@ -1783,6 +2019,18 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "flume"
@@ -1987,6 +2235,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2152,6 +2406,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link",
 ]
 
 [[package]]
@@ -2480,6 +2745,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-more"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a5a9a0ff0086c7a148acb942baaabeadf9504d10400b5a05645853729b9cd2"
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2591,6 +2862,12 @@ dependencies = [
  "serde_json",
  "simple_asn1",
 ]
+
+[[package]]
+name = "language-tags"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
 
 [[package]]
 name = "lazy_static"
@@ -2711,6 +2988,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "local-waker"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d873d7c67ce09b42110d801813efbc9364414e356be9935700d368351657487"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2749,7 +3032,7 @@ version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
 dependencies = [
- "nix",
+ "nix 0.29.0",
  "serde",
  "winapi",
 ]
@@ -2809,12 +3092,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -2864,6 +3157,18 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -2962,6 +3267,174 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+dependencies = [
+ "bitflags",
+ "block2",
+ "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-core-text",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3024,6 +3497,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "os_info"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4022a17595a00d6a369236fdae483f0de7f0a339960a53118b818238e132224"
+dependencies = [
+ "android_system_properties",
+ "log",
+ "nix 0.30.1",
+ "objc2",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "serde",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3116,6 +3605,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3171,6 +3669,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc58e2d255979a31caa7cabfa7aac654af0354220719ab7a68520ae7a91e8c0b"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3534,6 +4052,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-rustls 0.27.7",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3622,6 +4179,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc_version"
@@ -4007,6 +4570,142 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "sentry"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb25f439f97d26fea01d717fa626167ceffcd981addaa670001e70505b72acbb"
+dependencies = [
+ "cfg_aliases",
+ "httpdate",
+ "native-tls",
+ "reqwest 0.13.2",
+ "sentry-actix",
+ "sentry-backtrace",
+ "sentry-contexts",
+ "sentry-core",
+ "sentry-debug-images",
+ "sentry-panic",
+ "sentry-tracing",
+ "tokio",
+ "ureq",
+]
+
+[[package]]
+name = "sentry-actix"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9453d18fc9a45d841636004aad50288d80cc07c34a9e88cd4397cb66e6356f67"
+dependencies = [
+ "actix-http",
+ "actix-web",
+ "bytes",
+ "futures-util",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-backtrace"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a8c2c1bd5c1f735e84f28b48e7d72efcaafc362b7541bc8253e60e8fcdffc6"
+dependencies = [
+ "backtrace",
+ "regex",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-contexts"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b88a90baa654d7f0e1f4b667f6b434293d9f72c71bef16b197c76af5b7d5803"
+dependencies = [
+ "hostname",
+ "libc",
+ "os_info",
+ "rustc_version",
+ "sentry-core",
+ "uname",
+]
+
+[[package]]
+name = "sentry-core"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ac170a5bba8bec6e3339c90432569d89641fa7a3d3e4f44987d24f0762e6adf"
+dependencies = [
+ "rand 0.9.2",
+ "sentry-types",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "sentry-debug-images"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd9646a972b57896d4a92ed200cf76139f8e30b3cfd03b6662ae59926d26633c"
+dependencies = [
+ "findshlibs",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-panic"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6127d3d304ba5ce0409401e85aae538e303a569f8dbb031bf64f9ba0f7174346"
+dependencies = [
+ "sentry-backtrace",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-tower"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c5253dc4ad89863a866b93aeaaac1c9d60f2f774663b5024afe2d57e0a101c"
+dependencies = [
+ "http 1.4.0",
+ "pin-project",
+ "sentry-core",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "sentry-tracing"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27701acc51e68db5281802b709010395bfcbcb128b1d0a4e5873680d3b47ff0c"
+dependencies = [
+ "bitflags",
+ "sentry-backtrace",
+ "sentry-core",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "sentry-types"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56780cb5597d676bf22e6c11d1f062eb4def46390ea3bfb047bcbcf7dfd19bdb"
+dependencies = [
+ "debugid",
+ "hex",
+ "rand 0.9.2",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "time",
+ "url",
+ "uuid",
+]
 
 [[package]]
 name = "serde"
@@ -4955,6 +5654,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "uname"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4982,6 +5690,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4994,6 +5708,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64",
+ "der 0.8.0",
+ "log",
+ "native-tls",
+ "percent-encoding",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-root-certs",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64",
+ "http 1.4.0",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5003,6 +5746,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -5016,6 +5760,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -5088,14 +5838,18 @@ dependencies = [
  "jsonwebtoken",
  "migration",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.12.28",
  "sea-orm",
  "sea-orm-migration",
  "seaography",
+ "sentry",
+ "sentry-tower",
+ "sentry-tracing",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
+ "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber",
@@ -5242,6 +5996,15 @@ checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/apps/api/Cargo.toml
+++ b/apps/api/Cargo.toml
@@ -38,6 +38,10 @@ hex = "0.4"
 reqwest = { version = "0.12", features = ["json"] }
 base64 = "0.22"
 async-trait = "0.1"
+tower = "0.5"
+sentry = "0.47"
+sentry-tower = { version = "0.47", features = ["http"] }
+sentry-tracing = "0.47"
 
 [features]
 test-utils = []

--- a/apps/api/src/auth/mod.rs
+++ b/apps/api/src/auth/mod.rs
@@ -39,6 +39,13 @@ pub async fn auth_middleware(
         Err(_) => return Err(StatusCode::UNAUTHORIZED),
     };
 
+    sentry::configure_scope(|scope| {
+        scope.set_user(Some(sentry::User {
+            id: Some(cognito_sub.clone()),
+            ..Default::default()
+        }));
+    });
+
     request.extensions_mut().insert(AuthUser { cognito_sub });
     Ok(next.run(request).await)
 }

--- a/apps/api/src/config.rs
+++ b/apps/api/src/config.rs
@@ -14,6 +14,12 @@ pub struct Config {
     pub cognito_endpoint_url: Option<String>,
     pub cognito_client_id: String,
     pub port: u16,
+    /// Sentry DSN. 未設定なら Sentry は無効化される。
+    pub sentry_dsn: Option<String>,
+    /// Sentry environment タグ (例: local / development / production)
+    pub sentry_environment: String,
+    /// パフォーマンス計測のサンプリング率 (0.0 - 1.0)
+    pub sentry_traces_sample_rate: f32,
 }
 
 impl Config {
@@ -46,6 +52,12 @@ impl Config {
                 .unwrap_or_else(|_| "3000".to_string())
                 .parse()
                 .expect("PORT must be a number"),
+            sentry_dsn: std::env::var("SENTRY_DSN").ok().filter(|s| !s.is_empty()),
+            sentry_environment: std::env::var("SENTRY_ENVIRONMENT").unwrap_or(app_env),
+            sentry_traces_sample_rate: std::env::var("SENTRY_TRACES_SAMPLE_RATE")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(0.1),
         }
     }
 }

--- a/apps/api/src/error.rs
+++ b/apps/api/src/error.rs
@@ -28,6 +28,11 @@ impl AppError {
     /// Convert to async_graphql::Error with extension code.
     pub fn into_graphql_error(self) -> async_graphql::Error {
         use async_graphql::ErrorExtensions;
+        // Report unexpected failures to Sentry. Expected user-facing errors
+        // (NotFound, Unauthorized, BadRequest, ValidationErrors) are skipped.
+        if matches!(&self, AppError::Internal(_) | AppError::Database(_)) {
+            sentry::capture_error(&self);
+        }
         match self {
             AppError::BadRequest(msg) => async_graphql::Error::new(msg).extend_with(|_, ext| {
                 ext.set("code", "BAD_USER_INPUT");

--- a/apps/api/src/lib.rs
+++ b/apps/api/src/lib.rs
@@ -20,6 +20,7 @@ use axum::{
 };
 use sea_orm::DatabaseConnection;
 use std::sync::Arc;
+use tower::ServiceBuilder;
 use tower_http::cors::CorsLayer;
 
 pub struct AppState {
@@ -49,12 +50,22 @@ pub fn build_app(
     });
     let schema = graphql::build_schema(state);
 
+    // Sentry middleware: NewSentryLayer creates a fresh Hub per request so user
+    // context, breadcrumbs and transactions do not leak between concurrent requests.
+    // SentryHttpLayer attaches HTTP request data (method, URL) to each event.
+    // ServiceBuilder composes them into a single Layer that satisfies the
+    // Send + Sync bounds required by Router::layer on axum 0.8.
+    let sentry_layer = ServiceBuilder::new()
+        .layer(sentry_tower::NewSentryLayer::new_from_top())
+        .layer(sentry_tower::SentryHttpLayer::new().enable_transaction());
+
     Router::new()
         .route("/graphql", post(graphql_handler))
         .layer(middleware::from_fn_with_state(
             verifier,
             auth::auth_middleware,
         ))
+        .layer(sentry_layer)
         .layer(CorsLayer::permissive())
         .route("/health", get(|| async { "ok" }))
         .with_state(schema)

--- a/apps/api/src/main.rs
+++ b/apps/api/src/main.rs
@@ -1,14 +1,49 @@
 use migration::{Migrator, MigratorTrait};
 use std::sync::Arc;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
 use walking_dog_api::auth::jwt::CognitoJwtVerifier;
 use walking_dog_api::config::Config;
 
-#[tokio::main]
-async fn main() {
-    tracing_subscriber::fmt::init();
+fn main() {
     dotenvy::dotenv().ok();
     let config = Config::from_env();
 
+    // Sentry must be initialized from a synchronous context so the ClientInitGuard
+    // lives across the full tokio runtime and flushes events on drop.
+    let _sentry_guard = init_sentry(&config);
+    init_tracing();
+
+    let runtime = tokio::runtime::Runtime::new().expect("Failed to build tokio runtime");
+    runtime.block_on(run(config));
+}
+
+fn init_sentry(config: &Config) -> Option<sentry::ClientInitGuard> {
+    let dsn = config.sentry_dsn.clone()?;
+    let guard = sentry::init((
+        dsn,
+        sentry::ClientOptions {
+            release: sentry::release_name!(),
+            environment: Some(config.sentry_environment.clone().into()),
+            traces_sample_rate: config.sentry_traces_sample_rate,
+            send_default_pii: false,
+            ..Default::default()
+        },
+    ));
+    Some(guard)
+}
+
+fn init_tracing() {
+    let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
+    tracing_subscriber::registry()
+        .with(env_filter)
+        .with(tracing_subscriber::fmt::layer())
+        .with(sentry_tracing::layer())
+        .init();
+}
+
+async fn run(config: Config) {
     let db = walking_dog_api::db::connect(&config.database_url)
         .await
         .expect("Failed to connect to database");

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -93,6 +93,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
       },
     ],
     '@bacons/apple-targets',
+    '@sentry/react-native',
   ],
   experiments: {
     typedRoutes: true,
@@ -103,5 +104,6 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     appEnv: APP_ENV,
     appGroup: APP_GROUP,
     keychainService: KEYCHAIN_SERVICE,
+    sentryDsn: process.env.EXPO_PUBLIC_SENTRY_DSN ?? null,
   },
 });

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -2,6 +2,7 @@ import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native
 import { Stack, useRouter, useSegments } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { useEffect } from 'react';
+import * as Sentry from '@sentry/react-native';
 import 'react-native-reanimated';
 import '@/lib/i18n';
 import { useTranslation } from 'react-i18next';
@@ -10,12 +11,16 @@ import { useColorScheme } from '@/hooks/use-color-scheme';
 import { AppProviders } from '@/lib/providers';
 import { useAuthStore } from '@/stores/auth-store';
 import { useSettingsStore } from '@/stores/settings-store';
+import { useSentryUser } from '@/hooks/use-sentry-user';
 import { LoadingScreen } from '@/components/ui/LoadingScreen';
 import { ErrorScreen } from '@/components/ui/ErrorScreen';
+import { initSentry } from '@/lib/monitoring/sentry';
 import {
   getPendingInviteToken,
   deletePendingInviteToken,
 } from '@/lib/auth/pending-invite-token';
+
+initSentry();
 
 function NavigationGuard() {
   const { isAuthenticated, isLoading } = useAuthStore();
@@ -49,7 +54,7 @@ export const unstable_settings = {
   anchor: '(tabs)',
 };
 
-export default function RootLayout() {
+function RootLayout() {
   const colorScheme = useColorScheme();
   const isLoading = useAuthStore((s) => s.isLoading);
   const initialize = useAuthStore((s) => s.initialize);
@@ -72,6 +77,7 @@ export default function RootLayout() {
 
   return (
     <AppProviders>
+      <AuthenticatedSentryScope />
       <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
         <NavigationGuard />
         <Stack>
@@ -86,3 +92,10 @@ export default function RootLayout() {
     </AppProviders>
   );
 }
+
+function AuthenticatedSentryScope() {
+  useSentryUser();
+  return null;
+}
+
+export default Sentry.wrap(RootLayout);

--- a/apps/mobile/hooks/use-sentry-user.ts
+++ b/apps/mobile/hooks/use-sentry-user.ts
@@ -1,0 +1,16 @@
+import { useEffect } from 'react';
+import { useMe } from './use-me';
+import { setSentryUser } from '@/lib/monitoring/sentry';
+
+export function useSentryUser(): void {
+  const { data: me } = useMe();
+  const id = me?.id;
+
+  useEffect(() => {
+    if (id) {
+      setSentryUser({ id });
+    } else {
+      setSentryUser(null);
+    }
+  }, [id]);
+}

--- a/apps/mobile/jest.setup.ts
+++ b/apps/mobile/jest.setup.ts
@@ -1,3 +1,14 @@
+// Mock @sentry/react-native globally so test runs do not initialize the SDK
+// or send events. Individual test files can still override with jest.mock() calls.
+jest.mock('@sentry/react-native', () => ({
+  init: jest.fn(),
+  wrap: <T,>(component: T): T => component,
+  setUser: jest.fn(),
+  captureException: jest.fn(),
+  captureMessage: jest.fn(),
+  ErrorBoundary: ({ children }: { children: unknown }) => children,
+}));
+
 // Workaround for Jest 30 + jest-expo 55 + Expo SDK 54 compatibility.
 //
 // jest-expo 55 targets Jest 29. In Jest 30, calling require() from lazy getters

--- a/apps/mobile/lib/monitoring/sentry.test.ts
+++ b/apps/mobile/lib/monitoring/sentry.test.ts
@@ -1,0 +1,90 @@
+import * as Sentry from '@sentry/react-native';
+
+import { captureGraphQLError, redactSensitive, setSentryUser } from './sentry';
+
+jest.mock('@sentry/react-native', () => ({
+  setUser: jest.fn(),
+  captureException: jest.fn(),
+}));
+
+const setUserMock = Sentry.setUser as jest.MockedFunction<typeof Sentry.setUser>;
+const captureExceptionMock = Sentry.captureException as jest.MockedFunction<typeof Sentry.captureException>;
+
+describe('redactSensitive', () => {
+  it('masks accessToken and refreshToken inside request body', () => {
+    const event = {
+      request: {
+        data: {
+          accessToken: 'secret-access',
+          refreshToken: 'secret-refresh',
+          other: 'ok',
+        },
+      },
+    } as never;
+    const result = redactSensitive(event) as unknown as {
+      request: { data: Record<string, string> };
+    };
+    expect(result.request.data.accessToken).toBe('[Redacted]');
+    expect(result.request.data.refreshToken).toBe('[Redacted]');
+    expect(result.request.data.other).toBe('ok');
+  });
+
+  it('masks tokens inside breadcrumb data but keeps unrelated fields', () => {
+    const event = {
+      breadcrumbs: [
+        { data: { accessToken: 'leak' }, message: 'first' },
+        { data: { foo: 'bar' }, message: 'second' },
+      ],
+    } as never;
+    const result = redactSensitive(event) as unknown as {
+      breadcrumbs: Array<{ data: Record<string, string>; message: string }>;
+    };
+    expect(result.breadcrumbs[0].data.accessToken).toBe('[Redacted]');
+    expect(result.breadcrumbs[1].data.foo).toBe('bar');
+  });
+
+  it('returns events without sensitive fields unchanged', () => {
+    const event = { message: 'hello' } as never;
+    expect(redactSensitive(event)).toEqual({ message: 'hello' });
+  });
+});
+
+describe('setSentryUser', () => {
+  beforeEach(() => {
+    setUserMock.mockClear();
+  });
+
+  it('forwards id and username when user is provided', () => {
+    setSentryUser({ id: 'user-1', username: 'alice' });
+    expect(setUserMock).toHaveBeenCalledWith({ id: 'user-1', username: 'alice' });
+  });
+
+  it('calls Sentry.setUser with null to clear scope when user is null', () => {
+    setSentryUser(null);
+    expect(setUserMock).toHaveBeenCalledWith(null);
+  });
+
+  it('omits username when not provided', () => {
+    setSentryUser({ id: 'user-2' });
+    expect(setUserMock).toHaveBeenCalledWith({ id: 'user-2', username: undefined });
+  });
+});
+
+describe('captureGraphQLError', () => {
+  beforeEach(() => {
+    captureExceptionMock.mockClear();
+  });
+
+  it('reports Error instances with context as extras', () => {
+    const err = new Error('boom');
+    captureGraphQLError(err, { operation: 'ListDogs' });
+    expect(captureExceptionMock).toHaveBeenCalledWith(err, { extra: { operation: 'ListDogs' } });
+  });
+
+  it('ignores non-Error inputs to avoid noise', () => {
+    captureGraphQLError('plain string');
+    captureGraphQLError(null);
+    captureGraphQLError(undefined);
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/lib/monitoring/sentry.ts
+++ b/apps/mobile/lib/monitoring/sentry.ts
@@ -1,0 +1,75 @@
+import * as Sentry from '@sentry/react-native';
+import Constants from 'expo-constants';
+
+export interface SentryUser {
+  id: string;
+  username?: string;
+}
+
+const SENSITIVE_KEYS = ['accessToken', 'refreshToken', 'authorization', 'cookie'] as const;
+
+type ExpoExtra = {
+  sentryDsn?: string | null;
+  appEnv?: string;
+};
+
+type MutableEvent = {
+  request?: { data?: unknown };
+  breadcrumbs?: Array<{ data?: Record<string, unknown> }>;
+};
+
+export function initSentry(): void {
+  const extra = (Constants.expoConfig?.extra ?? {}) as ExpoExtra;
+  const dsn = extra.sentryDsn ?? null;
+  if (!dsn) return;
+
+  const version = Constants.expoConfig?.version ?? '0.0.0';
+  const name = Constants.expoConfig?.name ?? 'walking-dog';
+
+  Sentry.init({
+    dsn,
+    environment: extra.appEnv ?? 'local',
+    release: `${name}@${version}`,
+    tracesSampleRate: 0.1,
+    enableAutoSessionTracking: true,
+    beforeSend: (event) => redactSensitive(event as MutableEvent) as typeof event,
+  });
+}
+
+export function setSentryUser(user: SentryUser | null): void {
+  if (user === null) {
+    Sentry.setUser(null);
+    return;
+  }
+  Sentry.setUser({ id: user.id, username: user.username });
+}
+
+export function captureGraphQLError(error: unknown, context?: Record<string, unknown>): void {
+  if (!(error instanceof Error)) return;
+  Sentry.captureException(error, context ? { extra: context } : undefined);
+}
+
+export function redactSensitive<T extends MutableEvent>(event: T): T {
+  const body = event.request?.data;
+  if (body && typeof body === 'object' && !Array.isArray(body)) {
+    const data = body as Record<string, unknown>;
+    for (const key of SENSITIVE_KEYS) {
+      if (key in data) {
+        data[key] = '[Redacted]';
+      }
+    }
+  }
+
+  if (event.breadcrumbs) {
+    for (const bc of event.breadcrumbs) {
+      if (!bc.data) continue;
+      for (const key of SENSITIVE_KEYS) {
+        if (key in bc.data) {
+          bc.data[key] = '[Redacted]';
+        }
+      }
+    }
+  }
+
+  return event;
+}

--- a/apps/mobile/lib/providers.tsx
+++ b/apps/mobile/lib/providers.tsx
@@ -2,16 +2,26 @@ import { MutationCache, QueryCache, QueryClient, QueryClientProvider } from '@ta
 import { ClientError } from 'graphql-request';
 import { PropsWithChildren } from 'react';
 import { useAuthStore } from '@/stores/auth-store';
+import { captureGraphQLError } from '@/lib/monitoring/sentry';
+import { isNetworkError } from '@/lib/graphql/errors';
 
 function isUnauthorized(error: unknown): boolean {
   return error instanceof ClientError && error.response.status === 401;
+}
+
+function reportIfInteresting(error: unknown, kind: 'query' | 'mutation'): void {
+  if (isUnauthorized(error)) return;
+  if (isNetworkError(error) && !(error instanceof ClientError)) return;
+  captureGraphQLError(error, { kind });
 }
 
 const queryCache = new QueryCache({
   onError: (error) => {
     if (isUnauthorized(error)) {
       useAuthStore.getState().clearAuth();
+      return;
     }
+    reportIfInteresting(error, 'query');
   },
 });
 
@@ -19,7 +29,9 @@ const mutationCache = new MutationCache({
   onError: (error) => {
     if (isUnauthorized(error)) {
       useAuthStore.getState().clearAuth();
+      return;
     }
+    reportIfInteresting(error, 'mutation');
   },
 });
 

--- a/apps/mobile/package-lock.json
+++ b/apps/mobile/package-lock.json
@@ -14,6 +14,7 @@
         "@react-navigation/bottom-tabs": "^7.4.0",
         "@react-navigation/elements": "^2.6.3",
         "@react-navigation/native": "^7.1.8",
+        "@sentry/react-native": "~7.2.0",
         "@tanstack/react-query": "^5.91.3",
         "expo": "~54.0.33",
         "expo-blur": "~15.0.8",
@@ -4907,6 +4908,336 @@
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.12.0.tgz",
+      "integrity": "sha512-dozbx389jhKynj0d657FsgbBVOar7pX3mb6GjqCxslXF0VKpZH2Xks0U32RgDY/nK27O+o095IWz7YvjVmPkDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.12.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.12.0.tgz",
+      "integrity": "sha512-0+7ceO6yQPPqfxRc9ue/xoPHKcnB917ezPaehGQNfAFNQB9PNTG1y55+8mRu0Fw+ANbZeCt/HyoCmXuRdxmkpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.12.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.12.0.tgz",
+      "integrity": "sha512-/1093gSNGN5KlOBsuyAl33JkzGiG38kCnxswQLZWpPpR6LBbR1Ddb18HjhDpoQNNEZybJBgJC3a5NKl43C2TSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.12.0",
+        "@sentry/core": "10.12.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.12.0.tgz",
+      "integrity": "sha512-W/z1/+69i3INNfPjD1KuinSNaRQaApjzwb37IFmiyF440F93hxmEYgXHk3poOlYYaigl2JMYbysGPWOiXnqUXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/replay": "10.12.0",
+        "@sentry/core": "10.12.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/babel-plugin-component-annotate": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-4.3.0.tgz",
+      "integrity": "sha512-OuxqBprXRyhe8Pkfyz/4yHQJc5c3lm+TmYWSSx8u48g5yKewSQDOxkiLU5pAk3WnbLPy8XwU/PN+2BG0YFU9Nw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.12.0.tgz",
+      "integrity": "sha512-lKyaB2NFmr7SxPjmMTLLhQ7xfxaY3kdkMhpzuRI5qwOngtKt4+FtvNYHRuz+PTtEFv4OaHhNNbRn6r91gWguQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.12.0",
+        "@sentry-internal/feedback": "10.12.0",
+        "@sentry-internal/replay": "10.12.0",
+        "@sentry-internal/replay-canvas": "10.12.0",
+        "@sentry/core": "10.12.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli": {
+      "version": "2.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.55.0.tgz",
+      "integrity": "sha512-cynvcIM2xL8ddwELyFRSpZQw4UtFZzoM2rId2l9vg7+wDREPDocMJB9lEQpBIo3eqhp9JswqUT037yjO6iJ5Sw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "progress": "^2.0.3",
+        "proxy-from-env": "^1.1.0",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "sentry-cli": "bin/sentry-cli"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@sentry/cli-darwin": "2.55.0",
+        "@sentry/cli-linux-arm": "2.55.0",
+        "@sentry/cli-linux-arm64": "2.55.0",
+        "@sentry/cli-linux-i686": "2.55.0",
+        "@sentry/cli-linux-x64": "2.55.0",
+        "@sentry/cli-win32-arm64": "2.55.0",
+        "@sentry/cli-win32-i686": "2.55.0",
+        "@sentry/cli-win32-x64": "2.55.0"
+      }
+    },
+    "node_modules/@sentry/cli-darwin": {
+      "version": "2.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.55.0.tgz",
+      "integrity": "sha512-jGHE7SHHzqXUmnsmRLgorVH6nmMmTjQQXdPZbSL5tRtH8d3OIYrVNr5D72DSgD26XAPBDMV0ibqOQ9NKoiSpfA==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm": {
+      "version": "2.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.55.0.tgz",
+      "integrity": "sha512-ATjU0PsiWADSPLF/kZroLZ7FPKd5W9TDWHVkKNwIUNTei702LFgTjNeRwOIzTgSvG3yTmVEqtwFQfFN/7hnVXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm64": {
+      "version": "2.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.55.0.tgz",
+      "integrity": "sha512-jNB/0/gFcOuDCaY/TqeuEpsy/k52dwyk1SOV3s1ku4DUsln6govTppeAGRewY3T1Rj9B2vgIWTrnB8KVh9+Rgg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-i686": {
+      "version": "2.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.55.0.tgz",
+      "integrity": "sha512-8LZjo6PncTM6bWdaggscNOi5r7F/fqRREsCwvd51dcjGj7Kp1plqo9feEzYQ+jq+KUzVCiWfHrUjddFmYyZJrg==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-x64": {
+      "version": "2.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.55.0.tgz",
+      "integrity": "sha512-5LUVvq74Yj2cZZy5g5o/54dcWEaX4rf3myTHy73AKhRj1PABtOkfexOLbF9xSrZy95WXWaXyeH+k5n5z/vtHfA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-arm64": {
+      "version": "2.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-2.55.0.tgz",
+      "integrity": "sha512-cWIQdzm1pfLwPARsV6dUb8TVd6Y3V1A2VWxjTons3Ift6GvtVmiAe0OWL8t2Yt95i8v61kTD/6Tq21OAaogqzA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-i686": {
+      "version": "2.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.55.0.tgz",
+      "integrity": "sha512-ldepCn2t9r4I0wvgk7NRaA7coJyy4rTQAzM66u9j5nTEsUldf66xym6esd5ZZRAaJUjffqvHqUIr/lrieTIrVg==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-x64": {
+      "version": "2.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.55.0.tgz",
+      "integrity": "sha512-4hPc/I/9tXx+HLTdTGwlagtAfDSIa2AoTUP30tl32NAYQhx9a6niUbPAemK2qfxesiufJ7D2djX83rCw6WnJVA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/@sentry/cli/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.12.0.tgz",
+      "integrity": "sha512-Jrf0Yo7DvmI/ZQcvBnA0xKNAFkJlVC/fMlvcin+5IrFNRcqOToZ2vtF+XqTgjRZymXQNE8s1QTD7IomPHk0TAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.12.0.tgz",
+      "integrity": "sha512-TpqgdoYbkf5JynmmW2oQhHQ/h5w+XPYk0cEb/UrsGlvJvnBSR+5tgh0AqxCSi3gvtp82rAXI5w1TyRPBbhLDBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.12.0",
+        "@sentry/core": "10.12.0",
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
+    },
+    "node_modules/@sentry/react-native": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react-native/-/react-native-7.2.0.tgz",
+      "integrity": "sha512-rjqYgEjntPz1sPysud78wi4B9ui7LBVPsG6qr8s/htLMYho9GPGFA5dF+eqsQWqMX8NDReAxNkLTC4+gCNklLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/babel-plugin-component-annotate": "4.3.0",
+        "@sentry/browser": "10.12.0",
+        "@sentry/cli": "2.55.0",
+        "@sentry/core": "10.12.0",
+        "@sentry/react": "10.12.0",
+        "@sentry/types": "10.12.0"
+      },
+      "bin": {
+        "sentry-expo-upload-sourcemaps": "scripts/expo-upload-sourcemaps.js"
+      },
+      "peerDependencies": {
+        "expo": ">=49.0.0",
+        "react": ">=17.0.0",
+        "react-native": ">=0.65.0"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/types": {
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-10.12.0.tgz",
+      "integrity": "sha512-sKGj3l3V8ZKISh2Tu88bHfnm5ztkRtSLdmpZ6TmCeJdSM9pV+RRd6CMJ0RnSEXmYHselPNUod521t2NQFd4W1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.12.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.10",
@@ -17385,6 +17716,12 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
     },
     "node_modules/psl": {

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -22,6 +22,7 @@
     "@react-navigation/bottom-tabs": "^7.4.0",
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",
+    "@sentry/react-native": "~7.2.0",
     "@tanstack/react-query": "^5.91.3",
     "expo": "~54.0.33",
     "expo-blur": "~15.0.8",


### PR DESCRIPTION
## Summary
- Wire `@sentry/react-native` (Expo config plugin) into the mobile app. Global error boundary via `Sentry.wrap`, TanStack Query/Mutation error capture with 401 + offline filtered out, user scope synced from `useMe` via a new `useSentryUser` hook.
- Add `sentry` 0.47 + `sentry-tower` + `sentry-tracing` to the Rust API. Synchronous `main` holds `ClientInitGuard` across the tokio runtime so events flush on shutdown. `NewSentryLayer` + `SentryHttpLayer` composed via `ServiceBuilder` between CORS and auth so each request gets a fresh Hub with HTTP context before auth runs. `AppError::Internal` / `AppError::Database` reported via `sentry::capture_error`; `cognito_sub` attached to scope in `auth_middleware`.
- DSNs are opt-in via `EXPO_PUBLIC_SENTRY_DSN` and `SENTRY_DSN`; when unset, both SDKs are no-ops so local dev and tests are unaffected. `beforeSend` in the mobile SDK redacts `accessToken` / `refreshToken` / `authorization` / `cookie` from request bodies and breadcrumb data.

## Design choices worth calling out
- Used a `useSentryUser` hook bound to `useMe` instead of mutating `auth-store.ts` (plan had the latter). The hook is lighter because `useMe` is already the canonical me-fetcher and kept as TanStack Query cache.
- Upgraded from sentry 0.34 → 0.47 during build. 0.34's `SentryService` carries `PhantomData<Request<Body>>` which is not `Sync` on axum 0.8's `Body`; 0.47 fixes the auto-trait bound so `Router::layer` accepts the composed service.
- `SentryHttpLayer::new().enable_transaction()` is the non-deprecated builder form in 0.47 (`with_transaction` is now deprecated).

## Test Plan
- [x] `npm test` in `apps/mobile` — 455 tests passing (includes 8 new tests for `redactSensitive`, `setSentryUser`, `captureGraphQLError`)
- [x] `cargo check --features test-utils` — clean on apps/api
- [x] `cargo test --lib` — 63 unit tests passing on apps/api
- [ ] `cargo test --features test-utils` full integration suite — requires stopping other compose stacks to free ports 5432/8000/4566/9229. Run locally before merge.
- [ ] Manual smoke with a real DSN: set `EXPO_PUBLIC_SENTRY_DSN` and `SENTRY_DSN`, trigger a test error, confirm the event arrives in the Sentry dashboard with user scope populated after sign-in.

## Follow-ups (not in scope)
- Source map upload via EAS Build (add when EAS is introduced).
- Performance dashboards / alert routing (configure in Sentry UI after DSN provisioned).
- Update top-level `CLAUDE.md` rule "git worktree を使わない" — the current `apps/compose.yml` has no mobile service and api uses a relative bind mount, so worktrees now work with `COMPOSE_PROJECT_NAME` isolation. Proposing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)