### PR TITLE
Add planning documents and agent aliases

### DIFF
--- a/.claude/plans/api-sentry-synthetic-owl.md
+++ b/.claude/plans/api-sentry-synthetic-owl.md
@@ -1,0 +1,149 @@
+# Sentry 導入計画（Mobile + Rust API）
+
+## Context
+モバイルアプリ（Expo/React Native）と Rust/Axum API で発生したエラー・パニック・未キャッチ例外を Sentry に集約通知したい。現状：
+- Mobile: グローバル Error Boundary なし、GraphQL エラーは `console.log` すら無い
+- API: `tracing_subscriber::fmt::init()` の stdout ログのみ、エラーは async-graphql 経由で返るだけ
+
+Sentry を選定した理由は、Mobile (`@sentry/react-native`) と Rust (`sentry` crate + `sentry-tower`) の両方に公式 SDK があり、release/user でクロスリンクできるため。無料プラン 5K errors/月で MVP には十分。
+
+## Scope（分離した Sentry プロジェクト 2 つ）
+- `walking-dog-mobile` (Platform: React Native)
+- `walking-dog-api` (Platform: Rust)
+
+DSN は環境ごとに分けず、`environment` タグで `local` / `development` / `production` を区別する。
+
+---
+
+## Worktree 運用
+
+### 前提の再確認
+- `apps/compose.yml` に `mobile` サービスは**存在しない** — Mobile は host 上で Expo CLI 直接起動
+- `api` サービスの bind mount は `./api:/app`（`apps/compose.yml:46`）で compose ファイル相対パス → worktree 内から compose を起動すれば worktree 側ソースが自動で反映される
+- したがって CLAUDE.md の「worktree を使わない」ルールの根拠（Mobile バインドマウント問題）は現行 Compose には該当しない
+
+### セットアップ手順
+```bash
+git worktree add -b feat/sentry-integration .claude/worktrees/sentry-integration main
+cd .claude/worktrees/sentry-integration
+```
+
+### Compose 並行実行の衝突回避
+main リポジトリの compose が動いている場合に備え、worktree 側で起動するときは **project name を分離**する：
+```bash
+COMPOSE_PROJECT_NAME=walking-dog-sentry docker compose -f apps/compose.yml up api
+```
+ただし host port（3000, 5432, 8000, 4566, 9229）は衝突するため、実動作確認時は main 側 compose を `docker compose down` で停止してから worktree 側を起動する。`compose.override.yml` 追加は不要。
+
+### PR 作成後
+```bash
+git worktree remove .claude/worktrees/sentry-integration
+```
+
+---
+
+## Mobile 側（apps/mobile）
+
+### パッケージ
+- 追加: `@sentry/react-native`（`sentry-expo` は deprecated、RN 公式 SDK が Expo config plugin を内蔵）
+- インストール: `cd apps/mobile && npm install --save @sentry/react-native`（host 実行、CLAUDE.md に従い Docker 経由ではなく直接）
+
+> 注: memory `feedback_npm_docker.md` は npm を Docker 経由と指定しているが、`apps/compose.yml` に mobile サービスが無く Expo は host 実行のため、mobile の npm は host 側で扱う。セッション終了時に該当 memory を更新する。
+
+### 新規ファイル
+- **`apps/mobile/lib/monitoring/sentry.ts`** — `initSentry()`、`setSentryUser(user | null)`、`captureGraphQLError(err, ctx)` を export。`Sentry.init` の `dsn` / `environment` / `release` / `dist` / `tracesSampleRate: 0.1` / `enableAutoSessionTracking: true` / `beforeSend`（ペイロードから `accessToken` `refreshToken` を redact）を構成
+- **`apps/mobile/lib/monitoring/sentry.test.ts`** — `beforeSend` の redact ロジックと `setSentryUser(null)` の scope クリアを検証
+
+### 変更ファイル
+| ファイル | 変更内容 |
+|---|---|
+| `apps/mobile/app.config.ts` (lines 52–106) | `plugins` 配列に `['@sentry/react-native/expo', { organization, project, url: 'https://sentry.io/' }]` を追加。`extra.sentryDsn = process.env.EXPO_PUBLIC_SENTRY_DSN ?? null` を追加 |
+| `apps/mobile/app/_layout.tsx` | `initSentry()` をモジュールトップレベルで呼ぶ（既存 `useEffect` 外）。`export default Sentry.wrap(RootLayout)` で wrap（公式推奨、ErrorBoundary + TouchEventBoundary を自動注入） |
+| `apps/mobile/stores/auth-store.ts` | `setUser` / `clearAuth` 時に `setSentryUser({ id, username })` / `setSentryUser(null)` を呼ぶ。`displayName` は PII 扱いを避けるため送らない |
+| `apps/mobile/lib/providers.tsx` (QueryCache/MutationCache onError) | `captureGraphQLError` を呼ぶ。既存の 401 → `clearAuth` ロジックは保持、401 自体はキャプチャしない |
+| `apps/mobile/jest.setup.ts` | `jest.mock('@sentry/react-native', () => ({ init: jest.fn(), wrap: (c) => c, setUser: jest.fn(), captureException: jest.fn(), ErrorBoundary: ({ children }) => children }))` を追加 |
+| `apps/mobile/.env.local` / `.env.development` / `.env.production` | `EXPO_PUBLIC_SENTRY_DSN=...`（local は空文字で無効化） |
+
+### 既存資産の再利用
+- `apps/mobile/lib/graphql/errors.ts:3` `isNetworkError()` → `captureGraphQLError` で 5xx のみレポート、ネットワーク断は除外
+- `apps/mobile/stores/auth-store.ts` の `user` は `{ id, username }` を保持済み → setUser へ直接渡せる
+- `apps/mobile/lib/graphql/client.ts` の `refresh-on-401.ts` ミドルウェア → 401 は Sentry に送らない判断材料
+
+### リリース追跡
+- EAS Build 未導入のため source map アップロードは**今回はスキップ**。`release` は `app.config.ts` の `version` + `runtimeVersion` から合成。EAS 導入時に `@sentry/react-native/expo` plugin が自動アップロードする想定を README に注記
+
+---
+
+## API 側（apps/api）
+
+### Cargo dependencies 追加（`apps/api/Cargo.toml`）
+```toml
+sentry = { version = "0.34", default-features = false, features = ["backtrace", "contexts", "panic", "tower", "tracing", "reqwest", "rustls"] }
+sentry-tower = { version = "0.34", features = ["http"] }
+sentry-tracing = "0.34"
+```
+※ `default-features = false` + `rustls` 指定は Docker image での openssl リンク回避
+
+### 変更ファイル
+| ファイル | 変更内容 |
+|---|---|
+| `apps/api/src/config.rs` (L19–51) | `Config` に `sentry_dsn: Option<String>`, `sentry_environment: String`, `sentry_traces_sample_rate: f32` を追加。`SENTRY_DSN` 未設定なら `None` で Sentry 無効化 |
+| `apps/api/src/main.rs` (L6–46) | `#[tokio::main]` を外し、`fn main() -> anyhow::Result<()>` に変更。`let _sentry = init_sentry(&config);` を同期コンテキストで呼び、戻り値 `ClientInitGuard` を main 末尾までスコープ保持。その後 `tokio::runtime::Runtime::new()?.block_on(async { run(config).await })` |
+| `apps/api/src/main.rs`（tracing 初期化） | `tracing_subscriber::fmt::init()` を廃止、`tracing_subscriber::registry().with(fmt_layer).with(EnvFilter).with(sentry_tracing::layer()).init()` に置換 |
+| `apps/api/src/lib.rs` (`build_app()` L34–61) | `NewSentryLayer::new_from_top()` と `SentryHttpLayer::with_transaction()` を CORS の直後、auth middleware の前に挿入（Sentry scope が auth より外側になるように） |
+| `apps/api/src/error.rs` (L11–56) | `AppError::Internal(e)` の `into_graphql_error` で `sentry::capture_error(&e)` を呼ぶ。`NotFound`, `Unauthorized`, `BadRequest`, `ValidationErrors` は送らない |
+| `apps/api/src/auth/mod.rs` (`auth_middleware`) | 認証成功時に `sentry::configure_scope(|s| s.set_user(Some(User { id: Some(cognito_sub), ..Default::default() })))` |
+| `apps/api/.env.local` / `.env.development` | `SENTRY_DSN=`、`SENTRY_ENVIRONMENT=local`、`SENTRY_TRACES_SAMPLE_RATE=0.1` |
+
+### 既存資産の再利用
+- `apps/api/src/error.rs` の `AppError::Internal` バリアント → そのまま capture 対象
+- `apps/api/src/auth/mod.rs` の `cognito_sub` context 注入ロジック → Sentry user.id に流用
+
+### テスト
+- `apps/api/tests/support/client.rs` は `SENTRY_DSN` 未設定環境で動作するため変更不要（DSN 空時 `sentry::init` は no-op）
+- 新規 `apps/api/tests/sentry_layer_test.rs`: `SentryHttpLayer` 付き Router で `/health` が 200 を返すことのみ確認
+
+---
+
+## 検証手順（E2E、worktree 内で実行）
+
+### 事前準備
+```bash
+cd .claude/worktrees/sentry-integration
+# main 側の compose が動いていれば停止
+# 本物の DSN を .env.local に一時注入
+```
+
+### Mobile
+1. `cd apps/mobile && npm start`（host 実行、worktree 側ソースで起動）
+2. 一時的に throw ボタンを `app/(tabs)/dogs.tsx` に追加して発火
+3. Sentry ダッシュボードで `walking-dog-mobile` / `environment: local` にイベント到着を確認
+4. サインイン → イベントに `user.id` が付く
+5. サインアウト → 後続イベントに `user` が付かない
+6. スモークテスト用コードを削除
+
+### API
+1. `COMPOSE_PROJECT_NAME=walking-dog-sentry docker compose -f apps/compose.yml up api`
+2. 一時的な panic resolver を追加して 500 発生
+3. Sentry ダッシュボードで `walking-dog-api` にスタックトレース到着
+4. 認証後リクエストでは `user.id` が Cognito sub で付く
+5. スモークテスト用 resolver を削除
+
+### 自動テスト
+- Mobile: `cd apps/mobile && npm test`（Sentry モック化、副作用なし）
+- API: `COMPOSE_PROJECT_NAME=walking-dog-sentry docker compose -f apps/compose.yml run --rm api cargo test --features test-utils`（DSN 空で no-op）
+
+### 片付け
+```bash
+cd /Users/matsuokashuhei/Development/walking-dog
+git worktree remove .claude/worktrees/sentry-integration
+```
+
+---
+
+## 非対応（明示的に今回やらない）
+- EAS Build + source map アップロード（EAS 導入時に別タスク）
+- Performance monitoring のダッシュボード整備（`tracesSampleRate: 0.1` のみ設定）
+- Release health / deploy tracking の CI 連携
+- Slack/Email 通知ルーティング（Sentry 側で alert rule を手動設定）
+- CLAUDE.md の「git worktree を使わない」ルール改訂（別 PR で提案）

--- a/.claude/plans/apps-mobile-ticklish-rossum.md
+++ b/.claude/plans/apps-mobile-ticklish-rossum.md
@@ -1,0 +1,258 @@
+# Refactor Plan: apps/mobile/
+
+**対象**: `apps/mobile/` 全体
+**作成日**: 2026-04-19
+**スコープ**: Phase A–J 全部（ユーティリティ集約 → 責務分離 → ViewModel 抽出 → テスト補強）
+**関連**: `.claude/plans/apps-mobile-valiant-lagoon.md`（前回スナップショット、残す）
+
+---
+
+## Context
+
+**なぜこの変更が必要か**:
+直近で walk recording (iOS 26 Liquid Glass)、Me タブリデザイン、Sentry 統合、写真アップロード、家族共有機能、犬のパックロールアップなど、短期間で大きな機能追加が続いた。結果として apps/mobile/ に以下の負債が蓄積している:
+
+- `WalkEventActions.tsx` (340行)・`WalkControls.tsx` (300行) など 1 コンポーネント 6 責務化したファイル
+- `formatDuration` / `formatDistance` がローカルで 3–5 箇所に再実装され、精度（`.toFixed(1)` vs `.toFixed(2)`）も不一致
+- `toLocaleString()` が 4+ 箇所で直呼ばれ、ロケール/単位処理が一貫しない
+- `hooks/use-walk-session.ts` にモジュールスコープの `activeTrackingCleanup` / `activeTrackingGeneration` があり、テストが複雑化
+- `app/` 配下 19 ファイル中テスト 0 件（画面ロジックが UI に埋まっているため）
+- `auth-store` / `walk-store` のテストが 282–293 行に肥大
+
+**目標**: 機能追加をゼロにしたまま、共通ユーティリティ集約 → 責務分離 → ViewModel 抽出 → テスト補強を段階的に進める。スコープは `apps/mobile/` のみ。API・infra は触らない。
+
+**非目標**: 新機能追加、UI デザイン変更、ネイティブモジュール改修、性能最適化。
+
+---
+
+## Phase 1 Scan — 課題一覧
+
+凡例: `[原則]` `ファイル:行` — 症状
+
+### DRY（重複）
+
+- `[DRY]` `components/dogs/DogStatsCard.tsx:13-16` — `formatDistance` をローカル再実装、`lib/walk/format.ts` の同名関数と精度不一致（`.toFixed(1)` vs `.toFixed(2)`）
+- `[DRY]` `components/dogs/EncounterCard.tsx:14-19` — `formatDuration(sec)` ローカル定義
+- `[DRY]` `app/walks/[id].tsx:186-191` — `formatDuration(min)` ローカル定義（入力単位が min で別シグネチャ）
+- `[DRY]` `app/dogs/[id]/friends/[friendDogId].tsx:12-17` — `formatDuration` 3 回目の再実装
+- `[DRY]` `app/walks/[id].tsx:193-200` — `formatPace` ローカル定義、`lib/walk/format.ts` の同名関数と別シグネチャ
+- `[DRY]` `components/walk/WalkControls.tsx` — `splitDistance`, `contextualWalkLabel` がファイル内 private
+- `[DRY]` `components/walk/WalkHistoryItem.tsx:19` / `FriendCard.tsx:18` / `EncounterCard.tsx:40` / `app/dogs/[id]/friends/[friendDogId].tsx:75,83` — `toLocaleDateString()` / `toLocaleString()` が 4 ファイル 5 箇所で直呼び
+- `[DRY]` `components/walk/WalkEventActions.tsx:132` / `WalkQuickActions.tsx:182` — `console.error('walk event record failed', err)` が 2 箇所で同一
+- `[DRY]` `components/walk/WalkControls.tsx:34-43` / `WalkMinimizedControls.tsx:28-36` — 毎秒 `Date.now() - startedAt.getTime()` の useEffect 重複
+- `[DRY]` `components/auth/LoginForm.tsx:36-41` / `RegisterForm.tsx:38-41` / `ConfirmForm.tsx:34-40` — 認証エラーの `message.includes(...)` 文字列判定が 3 箇所
+
+### SRP（単一責任）
+
+- `[SRP]` `components/walk/WalkEventActions.tsx:1-221` (340行) — UI 分岐（single/multi dog）+ カメラ起動 + アップロード + Live Activity リクエスト監視 + AppState 購読の 6 責務
+- `[SRP]` `components/walk/WalkControls.tsx:29-204` (300行) — タイマー useEffect + ポーズ状態 + 4 フォーマッタ + 時間帯判定 + UI レイアウト
+- `[SRP]` `hooks/use-walk-session.ts:1-107` — GPS トラッキング + バッチフラッシュ + Live Activity 連携 + API mutation + **モジュールスコープのグローバル変数**
+- `[SRP]` `app/walk-recording-controls.tsx:15-81` — 3 session hook orchestration + API stop + bottom-sheet レイアウト計算 + ナビゲーション
+- `[SRP]` `app/(tabs)/walk.tsx:40-66` — GPS 権限 → session.start → encounter flag → Bluetooth 権限 → BLE init が 1 useCallback
+- `[SRP]` `stores/auth-store.ts:34-69` — store メソッド内で legacy migration + SecureStore I/O + ME_QUERY + エラー判別
+- `[SRP]` `stores/settings-store.ts:29-49` — store メソッド内で AsyncStorage 3 並列読み + i18n 言語変更
+- `[SRP]` `components/walk/WalkSummaryCard.tsx:18-71` (229行) — 5 派生状態計算 + 保存ノート生成 + router.push
+- `[SRP]` `components/auth/ConfirmForm.tsx:17-45` / `LoginForm.tsx:27-49` / `RegisterForm.tsx:29-48` — フォーム状態 + API + エラー文字列マッチ混在
+- `[SRP]` `hooks/use-accept-invite-flow.ts:31-58` — token 読取 + 認証判定 + 保存 + mutation + ナビゲーションを 1 effect
+
+### KISS / YAGNI / その他
+
+- `[OCP]` `components/walk/WalkEventActions.tsx` — `EVENT_ORDER` / `tallyByType` でイベント種別を 3 ヶ所ハードコード
+- `[YAGNI]` `app-example/` — Expo Router デモ残骸、参照ゼロ
+- `[KISS]` `AppMark.tsx:34` `borderRadius: 22`, `Tag.tsx:64` `borderRadius: 100`, `shadowColor: '#0a84ff'`, `color: '#fff'` — theme/tokens 未集約
+- `[関心分離]` `settings-store.ts` は AsyncStorage 直呼び、`auth-store.ts` は secure-storage wrapper 経由で抽象レベル不統一
+
+### テスト
+
+- `[Test]` `app/` 19 ファイル / テスト 0 件
+- `[Test]` `components/dogs/` 11 ファイル中 3 テスト（`DogWalkRow`, `DogWalksList`, `EncounterCard`, `PackRollupCard` 未カバー）
+- `[Test]` `lib/walk/live-activity.ts` (105行) / `stores/settings-store.ts` — テストなし
+- `[Test]` `auth-store.test.ts` (282行) / `walk-store.test.ts` (293行) — store 肥大で regression 面大
+
+---
+
+## Phase 2 Solutions — 採用案
+
+### S1. `lib/walk/format.ts` に共通フォーマッタ集約
+
+**採用**: 既存 `lib/walk/format.ts` を拡張、外部依存追加なし（KISS + DRY）。
+
+- `formatDuration(totalSec: number): string` — `mm:ss` / `h時間m分` 統一
+- `formatDistance(meters: number, units: 'km'|'mile', precision?: number)` — precision デフォルト 2
+- `formatShortDate(d: Date, locale: string)`, `formatDateTime(d: Date, locale: string)` — i18n 対応
+
+### S2. エラーハンドリング統一
+
+**採用**: 既存 `hooks/use-mutation-with-alert.ts` を活用。`WalkEventActions` / `WalkQuickActions` の直 `.catch()` を置換。`console.warn`/`error` のタグ付きログは `lib/monitoring/logger.ts` に薄く集約（Sentry は既に `lib/monitoring/` で連携）。
+
+### S3. 認証エラーを型化
+
+**採用**: `lib/auth/errors.ts` に `AuthError` discriminated union（`'invalid-credentials' | 'user-exists' | 'code-mismatch' | 'network' | 'unknown'`）。`lib/auth/api.ts` でマッピング、フォームは `switch(err.kind)` で i18n キー。
+
+### S4. WalkEventActions の分解
+
+**採用** (段階分割):
+1. `components/walk/EventPill.tsx`（pee/poo/photo 1 ボタン分 UI）
+2. `hooks/use-walk-event-recorder.ts`（mutation + error map）
+3. `hooks/use-camera-event-trigger.ts`（AppState + Live Activity）
+4. 残った `WalkEventActions.tsx` は UI orchestration のみ（目標 120 行以下）
+
+### S5. タイマー hook 共通化
+
+**採用**: `hooks/use-walk-elapsed.ts` を新設。入力 `{ startedAt, isPaused, totalPausedMs }`、出力 `elapsedSec`。`WalkControls` / `WalkMinimizedControls` で共有。
+
+### S6. walk-session グローバル変数除去
+
+**採用**: `activeTrackingCleanup` / `activeTrackingGeneration` を `walk-store.ts` のインスタンス状態へ。`lib/walk/tracking-manager.ts` を新設し GPS + バッチフラッシュを分離。hook は state/effect 配線のみ。
+
+### S7. 設定ストア wrapper 統一
+
+**採用**: `lib/storage/async-storage.ts`（薄い wrapper、typed key + try/catch）を新設し `settings-store.ts` を置換。
+
+### S8. app-example/ 削除
+
+**採用**: 削除して `tsconfig.json` / `app.config.ts` / `.gitignore` 参照を除去。
+
+### S9. ViewModel 抽出 + テスト
+
+**採用**: 画面ごとに `hooks/use-*-view-model.ts` を抽出。画面は props 受け取り + render のみ。ViewModel に Jest 単体テスト。E2E（Detox）は将来別作業。
+
+### S10. テーマトークン統合
+
+**採用**: `theme/tokens.ts` に `radius.xl = 22`, `radius.pill = 100`, `colors.shadow.primary = '#0a84ff'` を追加。ハードコード値を参照に置換。
+
+---
+
+## Phase 3 Implementation Plan — フェーズ分割
+
+優先度は `(impact × ease) / risk` 降順。**各フェーズは独立した新セッションで実装**する前提。
+
+### Phase A: 共通フォーマッタ集約（優先度: 最高 / 規模 S）
+
+- **対象課題**: DRY 7 件
+- **変更ファイル**:
+  - `lib/walk/format.ts` — `formatDuration`, `formatShortDate`, `formatDateTime`, `formatDistance` に precision 引数
+  - 置換: `components/dogs/DogStatsCard.tsx`, `EncounterCard.tsx`, `app/walks/[id].tsx`, `app/dogs/[id]/friends/[friendDogId].tsx`, `components/walk/WalkHistoryItem.tsx`, `components/dogs/FriendCard.tsx`, `components/walk/WalkControls.tsx`
+- **完了条件**:
+  - `rg "toLocaleDateString|toLocaleString\(" apps/mobile/{app,components,hooks}` がテスト以外で 0 件
+  - `rg "^function format(Duration|Distance|Pace)" apps/mobile/{app,components}` が 0 件
+  - `npm test -- lib/walk/format` 緑
+- **依存**: なし
+- **推定**: S（60分）
+
+### Phase B: 認証エラー型化（優先度: 高 / 規模 S）
+
+- **対象課題**: LoginForm/RegisterForm/ConfirmForm の文字列マッチ
+- **変更ファイル**:
+  - 新規 `lib/auth/errors.ts`
+  - `lib/auth/api.ts`
+  - `components/auth/{LoginForm,RegisterForm,ConfirmForm}.tsx`
+- **完了条件**: `rg "message.includes\(" apps/mobile/components/auth` 0 件、各 AuthError kind に新規テスト 1 本
+- **依存**: なし
+- **推定**: S（60分）
+
+### Phase C: app-example/ 削除（優先度: 高 / 規模 XS）
+
+- **変更**: `apps/mobile/app-example/` 削除、`tsconfig.json` / `app.config.ts` / `.gitignore` 参照を外す
+- **完了条件**: `rg "app-example" apps/mobile` 0 件、typecheck 緑
+- **推定**: XS（15分）
+
+### Phase D: walk event エラーハンドリング統一（優先度: 高 / 規模 S）
+
+- **対象課題**: `WalkEventActions` / `WalkQuickActions` の `.catch(console.error)` 重複
+- **変更**: `useMutationWithAlert` か新規 `useWalkEventRecorder` を使用
+- **完了条件**: `rg "walk event record failed" apps/mobile` 0 件、オフライン状態で記録エラーダイアログ表示（iOS Simulator）
+- **依存**: Phase A
+- **推定**: S（60分）
+
+### Phase E: タイマー hook 共通化（優先度: 中 / 規模 S）
+
+- **対象課題**: WalkControls / WalkMinimizedControls タイマー重複
+- **変更**: `hooks/use-walk-elapsed.ts` 新設、2 コンポーネントで共用
+- **完了条件**: hook に fake timer 単体テスト、useEffect タイマー処理が両コンポーネントから消える
+- **依存**: Phase A
+- **推定**: S（60分）
+
+### Phase F: WalkEventActions.tsx 分解（優先度: 中 / 規模 M）
+
+- **対象課題**: SRP 340行 6 責務
+- **変更**: `EventPill.tsx`, `use-walk-event-recorder.ts`, `use-camera-event-trigger.ts` 新設、本体を 120 行以下に
+- **完了条件**: 各 hook に最低 3 ケース単体テスト、iOS Simulator で single/multi dog 両方で動作確認
+- **依存**: Phase D 必須
+- **推定**: M（2–3時間）
+
+### Phase G: walk-session グローバル除去（優先度: 中 / 規模 M）
+
+- **対象課題**: `use-walk-session.ts` のモジュールスコープ変数
+- **変更**: `lib/walk/tracking-manager.ts` 新設、`walk-store.ts` に tracking generation 移動
+- **完了条件**: `let activeTrackingCleanup` が消える、マルチセッション重複起動を防ぐ新規テスト、iOS Simulator で start→中断→再start
+- **依存**: Phase A, E
+- **推定**: M（2–3時間）
+
+### Phase H: WalkControls.tsx 分解（優先度: 中 / 規模 M）
+
+- **対象課題**: SRP 300行
+- **変更**: フォーマッタは lib へ、タイマーは Phase E の hook、`<Metric />` を `components/ui/Metric.tsx` に抽出
+- **完了条件**: `WalkControls.tsx` が 150 行以下
+- **依存**: Phase A, E
+- **推定**: M（2時間）
+
+### Phase I: stores の責務分離（優先度: 低 / 規模 M）
+
+- **対象課題**: `auth-store` 初期化 orchestration、`settings-store` AsyncStorage 直呼び
+- **変更**:
+  - `lib/auth/bootstrap.ts` に initialize 処理、store は setter のみ
+  - `lib/storage/async-storage.ts` wrapper で `settings-store` 置換
+- **完了条件**: store テストが半分以下に縮小、bootstrap の単体テスト
+- **依存**: Phase B
+- **推定**: M（3時間）
+
+### Phase J: app/ ViewModel 抽出とテスト補強（優先度: 低 / 規模 L）
+
+- **対象課題**: app/ 画面テスト 0 件
+- **変更**: 主要 5 画面（`(tabs)/walk`, `walks/[id]`, `(tabs)/dogs`, `dogs/[id]/index`, `(tabs)/me`）の ViewModel を `hooks/use-*-view-model.ts` に抽出、画面は render と props のみに
+- **完了条件**: 5 画面分の ViewModel 単体テストが通る、`components/dogs/` 未カバーコンポーネントにもテスト追加
+- **依存**: Phase F, H, I（画面が依存する hook/store 整備後）
+- **推定**: L（5時間以上、複数セッションに分割）
+
+### Phase K: テーマトークン統合（優先度: 低 / 規模 S）
+
+- **対象課題**: borderRadius/color ハードコード
+- **変更**: `theme/tokens.ts` に `radius.xl`, `radius.pill`, `colors.shadow.primary` 追加、参照置換
+- **完了条件**: `rg "borderRadius:\s*(22|100)" apps/mobile` 0 件、`rg "'#0a84ff'|'#fff'" apps/mobile/components` が token 参照に置換
+- **推定**: S（45分）
+
+---
+
+## 重要な参照先（既存資産）
+
+- `lib/walk/format.ts` — 共通フォーマッタ（Phase A で拡張）
+- `hooks/use-mutation-with-alert.ts` — 既存エラーハンドラ（Phase D で流用）
+- `lib/auth/secure-storage.ts` — SecureStore wrapper（Phase I で参考）
+- `theme/tokens.ts` — テーマ定義（Phase K で拡張）
+- `lib/monitoring/` — Sentry 連携（Phase D で流用）
+
+---
+
+## Verification（全体の受け入れ条件）
+
+各フェーズ完了時:
+
+1. **Build**: `docker compose run --rm mobile npm run typecheck` 緑
+2. **Test**: `docker compose run --rm mobile npm test` 緑、既存カバレッジ維持
+3. **Lint**: `docker compose run --rm mobile npm run lint` 警告ゼロ増
+4. **iOS Simulator 手動確認**:
+   - 散歩開始 → GPS・BLE 起動 → pee/poo/photo 記録 → 終了 → サマリ
+   - 単一犬・複数犬の両ケース
+   - バックグラウンド復帰時のカメラトリガー
+5. **Progress ログ**: `tasks/refactor/mobile-cleanup/progress.md` を各フェーズ完了時に更新（plan mode 解除後に作成可能）
+
+---
+
+## 実行時ルール
+
+- **git worktree 使わない** — Docker Compose マウント不整合を避ける（CLAUDE.md 準拠）
+- **エラー隠蔽禁止** — try/catch 追加を「修正」扱いしない
+- **Phase 4 実行は新セッションで** — 本計画を Read で読み込ませて `executing-plans` or `tdd-workflow` で
+- **フェーズ間スコープ厳守** — ついでの変更は別フェーズへ
+- **Docker 経由で実行** — `npm` は必ず `docker compose run --rm mobile npm …`（CLAUDE.md 準拠）

--- a/.claude/plans/apps-mobile-valiant-lagoon.md
+++ b/.claude/plans/apps-mobile-valiant-lagoon.md
@@ -1,0 +1,312 @@
+# Refactor Plan: apps/mobile
+
+## Context
+
+`apps/mobile` は機能追加を重ねた結果、画面・フック・ストア・lib にまたがって重複・責務肥大・型安全性の低下が蓄積している。ビルドは通るが、以下の痛みが顕在化：
+
+- 同じ `const isAuthenticated = useAuthStore((s) => s.isAuthenticated)` が 6+ フック、同じ invalidate 2本セットが 8+ 箇所に散在
+- `app/(tabs)/walk.tsx` / `app/invite/[token].tsx` / `app/walks/[id].tsx` / `app/dogs/[id]/index.tsx` が 200行超で GPS・BLE・ストレージ・ナビゲーション・UI を1ファイルで抱える
+- `components/walk/WalkEventActions.tsx` が tight coupling で、テストが本体 185行に対し 431行
+- `hooks/use-encounter-mutations.ts` の戻り型 (`RecordEncounterResponse` / `UpdateEncounterDurationResponse`) が実装と不一致
+- `lib/ble/scanner.ts` に `any` が6箇所
+- Hero title スタイル (`fontSize: 40, fontWeight: 900, letterSpacing: -0.8, lineHeight: 44`) が4画面で独立定義
+
+リファクタの目的：**機能変更ゼロ**で重複と責務逸脱を解消し、テスト容易性と6ヶ月後の可読性を確保する。実装は新セッションで1フェーズずつ走らせる。
+
+## 成果物置き場
+
+`tasks/refactor/mobile/` に集約：
+
+- `01-scan.md` — Phase 1 Scan (本計画の Findings セクション)
+- `02-solutions.md` — Phase 2 候補解 (採用案まとめ)
+- `03-plan.md` — Phase 3 実装フェーズ一覧 (下の Implementation Phases)
+- `progress.md` — Phase 4 実行トラッカー
+
+承認後に上記ファイルを作成し、実装セッションを起動する。
+
+## Findings サマリ (Phase 1)
+
+**対象**: `apps/mobile/{app,components,hooks,stores,lib,modules,theme,types}` (node_modules/ios/android/app-example除外)
+
+### Top-level 重複 (DRY)
+
+| 場所 | 症状 |
+|---|---|
+| `hooks/use-{me,walks,dog,dog-encounters,dog-friends,friendship}.ts` | `const isAuthenticated = useAuthStore((s) => s.isAuthenticated)` が6+フックで同一 |
+| `hooks/use-{dog,dog-member,accept-invitation}-mutations.ts` + `use-walk-mutations.ts` | `invalidateQueries(meKeys.all)` + `invalidateQueries(dogKeys.all)` の2本セットが8+箇所 |
+| `app/(tabs)/{dogs,settings}.tsx` + `app/dogs/[id]/{friends/index,encounters}.tsx` + `app/walks/[id].tsx` | hero title style (40/900/-0.8/44) が4+画面で独立定義 |
+| `app/dogs/{new,[id]/edit,[id]/members,[id]/index}.tsx` | `try/catch + Alert.alert + errorTranslation` が3+箇所 |
+| `components/walk/{WalkMap,WalkEventTimeline}.tsx` | `EVENT_EMOJIS` マップが2ファイルで重複 |
+| `components/{dogs/DogListItem,dogs/EncounterCard,dogs/FriendCard,dogs/DogStatsCard,walks/WalkHistoryItem}` | `theme.border + '33'` のカードボーダー+opacityパターン5箇所 |
+| `components/settings/{Profile,Appearance,EncounterDetection}Section.tsx` | `styles.card + styles.sectionTitle` 構造が3セクションで重複 |
+
+### 責務肥大 (SRP)
+
+| 場所 | 症状 | 行数 |
+|---|---|---|
+| `app/(tabs)/walk.tsx` | GPS追跡 + BLEスキャン/広告 + encounter検出 + バッチ送信 + パーミッション + UI | 201 |
+| `app/invite/[token].tsx` | deeplink処理 + state machine + platform別SecureStore + 認証分岐 + errorマップ + 4状態UI | 230 |
+| `app/walks/[id].tsx` | データ変換 + Map描画 + タイムライン描画 + walkerセクション描画 | 212 |
+| `app/dogs/[id]/index.tsx` | 認可ロジック + delete + 条件付きUI + member/friends/statsレンダリング | 211 |
+| `components/walk/WalkEventActions.tsx` | pee/pooボタン + 写真upload choreography (presign→PUT→record) + 深リンク自動起動 | 185 |
+| `components/auth/ConfirmForm.tsx` | OTPフォーカス管理 + form submission | 169 |
+| `stores/auth-store.ts:initialize()` | token取得 + auth verify + 401/Network分岐 + state更新 | L25-56 |
+
+### 型安全性
+
+- `hooks/use-encounter-mutations.ts:15-45` — 戻り型が実装と不一致 (`RecordEncounterResponse` 実際は `Encounter[]`、`UpdateEncounterDurationResponse` 実際は `boolean`)
+- `lib/ble/scanner.ts:22-77` — `any` が6箇所 (BleManager lazy-load、callback params)
+
+### Testability
+
+- `hooks/` 18個中12個テストなし
+- `components/ui/{Button,Card,TextInput,SegmentedControl,ConfirmDialog,ErrorScreen,LoadingScreen,EmptyState,ThemedView,Divider}` 全てテストなし
+- `components/walk/WalkEventActions.test.tsx` 431行 (本体の2.3倍) ← tight coupling のシグナル
+
+### YAGNI
+
+- `components/walk/WalkMap.tsx:16` — `followUser` prop 常に true、falseパスなし
+- `components/walk/WalkControls.tsx:54-62` — pauseボタン disabled だけで実体なし、誤解招く
+- `components/ui/Divider.tsx` — 本体1行の wrapper、インライン化可能
+- `components/dogs/DogForm.tsx:24` — `gender` state 検証なく描画のみ
+- `lib/graphql/keys.ts` — `dogKeys.members()` 定義あるが参照なし
+
+### 副作用の散在
+
+- `app/invite/[token].tsx:16-39` — Platform分岐 `localStorage` vs `SecureStore` が画面ファイル内
+- `lib/graphql/client.ts:29-37` — `authenticatedRequest()` 内で動的import+`useAuthStore.getState().refreshAuth()` 直呼び (隠れ依存)
+- `lib/auth/secure-storage.ts:53-67` — `migrateLegacyTokensIfNeeded()` が毎回の `getToken()` で実行
+
+### 可読性 / マジックナンバー
+
+- `app/(tabs)/walk.tsx:28` — `MAX_POINTS_PER_BATCH = 200` 根拠コメントなし
+- `app/walks/[id].tsx:46-48` — fallback 座標 Tokyo (35.6812, 139.7671) ハードコード
+- `components/walk/WalkMap.tsx:71` — `'rgba(239,68,68,0.9)'` ハードコード (theme.error 未使用)
+- `lib/graphql/{queries,mutations}.ts` — ドメイン混在で 132行/206行
+
+---
+
+## Implementation Phases (Phase 3)
+
+優先度は `(impact × ease) / risk` で並べた。前のフェーズほど低リスク・高インパクト。各フェーズは1セッション完結。
+
+### Phase 1: 共有フック/定数抽出 (優先度: 最高 / S)
+
+**対象課題**: `isAuthenticated` 重複6+、`EVENT_EMOJIS` 重複2、hero title style 重複4、invalidate ペア重複8+
+
+**変更**:
+- `hooks/use-is-authenticated.ts` 新規 — `useAuthStore((s) => s.isAuthenticated)` を1箇所に
+- `hooks/use-invalidate-user-queries.ts` 新規 — `meKeys.all + dogKeys.all` invalidate helper
+- `lib/walk/event-emojis.ts` 新規 — 2箇所の `EVENT_EMOJIS` 統合
+- `theme/tokens.ts` に `typography.hero` 追加、4画面の hero style を置換
+
+**完了条件**:
+- 全既存テスト緑 (`docker compose run --rm mobile npm test`)
+- `rg "useAuthStore\(\(s\) => s\.isAuthenticated\)" apps/mobile/hooks` が 1件以下
+- `rg "invalidateQueries\(\{ queryKey: meKeys\.all" apps/mobile/hooks` が 1箇所(helper内)のみ
+- `rg "EVENT_EMOJIS" apps/mobile/components` が `event-emojis.ts` のimportのみ
+- `rg "fontSize: 40," apps/mobile/app` がhero token使用のみ
+
+**依存**: なし
+**推定規模**: S (60分以内)
+
+### Phase 2: YAGNI 除去 + 型不一致修正 (優先度: 高 / S)
+
+**対象課題**: `WalkMap.followUser`、`WalkControls` pauseボタン、`Divider` wrapper、`DogForm.gender` 未検証、`dogKeys.members()` 未使用、`use-encounter-mutations.ts` 戻り型
+
+**変更**:
+- `components/walk/WalkMap.tsx` — `followUser` prop 削除、`showsUserLocation` ハードコード
+- `components/walk/WalkControls.tsx` — pauseボタン削除（実装予定なし確認後）
+- `components/ui/Divider.tsx` — 利用箇所をインライン `<View style={styles.divider}/>` に置換して削除
+- `components/dogs/DogForm.tsx` — `gender` 検証追加 or フィールド削除 (interview で確認)
+- `hooks/use-encounter-mutations.ts:15-45` — 戻り型を `Encounter[]` / `boolean` に修正、呼び出し側も更新
+- `lib/graphql/keys.ts` — `dogKeys.members()` 削除
+
+**完了条件**:
+- `docker compose run --rm mobile npx tsc --noEmit` エラーなし
+- 全既存テスト緑
+- grepで削除対象が消えている
+
+**依存**: なし (Phase 1 と並行可能だがレビュー簡素化のため順次)
+**推定規模**: S (60分以内)
+
+### Phase 3: エラーハンドリング共通化 (優先度: 高 / M)
+
+**対象課題**: `try/catch + Alert.alert + i18n` 3+画面重複、`dogs/[id]/members.tsx:45-75` 3ハンドラ同型
+
+**変更**:
+- `hooks/use-mutation-with-alert.ts` 新規 — mutation実行 + エラーを i18n key + Alert.alert に変換する共通フック
+- `app/dogs/{new,[id]/edit,[id]/members,[id]/index}.tsx` を置換
+- `components/walk/WalkEventActions.tsx` のエラー phase ロジックも検証 (別フェーズで対応するなら保留)
+
+**完了条件**:
+- 全既存テスト緑 + 新規 hook テスト追加
+- `rg "Alert\.alert" apps/mobile/app` が削減 (直接呼び出しは確認済み例外のみ)
+
+**依存**: Phase 1, 2
+**推定規模**: M (2時間以内)
+
+### Phase 4: カード系コンポーネント共通化 (優先度: 中 / M)
+
+**対象課題**: `theme.border + '33'` カードパターン5箇所、settings section 3箇所
+
+**変更**:
+- `components/ui/OutlinedCard.tsx` 新規 — border + opacity + radius + padding を prop 化
+- `components/settings/SettingsSection.tsx` 新規 — card + title + children 構造
+- `DogListItem`, `EncounterCard`, `FriendCard`, `DogStatsCard`, `WalkHistoryItem` を `OutlinedCard` 化
+- `ProfileSection`, `AppearanceSection`, `EncounterDetectionSection` を `SettingsSection` 化
+
+**完了条件**:
+- 全既存テスト緑 + `OutlinedCard` / `SettingsSection` の unit test
+- iOS Simulator で各画面の視覚差分なしを確認 (ios-sim-test でスクリーンショット比較)
+
+**依存**: Phase 1
+**推定規模**: M (2-3時間)
+
+### Phase 5: カスタムフック抽出 (優先度: 中 / M)
+
+**対象課題**: `WalkEventActions.tsx` 185行+テスト431行、`ConfirmForm.tsx` OTP logic
+
+**変更**:
+- `hooks/use-photo-upload.ts` 新規 — presign → PUT → record の3段を1フック化 (phase error付き)
+- `hooks/use-otp-input.ts` 新規 — digit state + focus/backspace imperative 管理
+- `components/walk/WalkEventActions.tsx` は `usePhotoUpload()` 呼び出しのみに
+- `components/auth/ConfirmForm.tsx` は `useOtpInput()` 呼び出しのみに
+
+**完了条件**:
+- `WalkEventActions.test.tsx` が 200行以下に削減
+- フック単体テスト新規追加 (use-photo-upload / use-otp-input)
+- 全既存テスト緑
+
+**依存**: Phase 3 (mutation-with-alert を使う可能性)
+**推定規模**: M (3時間)
+
+### Phase 6: 画面分割 — invite/[token] (優先度: 中 / M)
+
+**対象課題**: `app/invite/[token].tsx` 230行、Platform別SecureStore内包
+
+**変更**:
+- `lib/auth/pending-invite-token.ts` 新規 — Platform抽象化 (`save/get/delete`)
+- `hooks/use-accept-invite-flow.ts` 新規 — state machine + 認証分岐を切り出し
+- `lib/errors/invite-error-map.ts` 新規 — `mapInviteErrorMessage` を i18n keyベースに
+- `app/invite/[token].tsx` はUIレンダリングのみ
+
+**完了条件**:
+- 画面本体 100行以下
+- pending-invite-token / use-accept-invite-flow に unit test
+- 深リンク手動テスト (auth済/未認証/期限切れ/使用済み の4パス)
+
+**依存**: Phase 1, 3
+**推定規模**: M (3-4時間)
+
+### Phase 7: 画面分割 — (tabs)/walk (優先度: 中 / L / risk:高)
+
+**対象課題**: `app/(tabs)/walk.tsx` 201行、GPS + BLE + encounter + UI 全部入り
+
+**変更**:
+- `hooks/use-walk-session.ts` 新規 — startWalk/finishWalk + 点バッチ送信 (MAX_POINTS_PER_BATCH 定数化理由コメント付き)
+- `hooks/use-ble-session.ts` 新規 — BLE scan/advertise のライフサイクル
+- `hooks/use-encounter-session.ts` 新規 — encounter tracker の record/update
+- `hooks/use-walk-permissions.ts` 新規 — 位置情報+BLE+通知 パーミッションオーケストレーション
+- `app/(tabs)/walk.tsx` は上記の合成のみ
+
+**完了条件**:
+- 画面本体 100行以下
+- 各フックに unit test
+- iOS Simulator で散歩開始→停止のスモーク試験 (GPS取得、BLE広告、encounter記録が動く)
+- 既存 `__tests__/app/tabs/walk.test.tsx` が緑 (あれば)
+
+**依存**: Phase 1, 3
+**推定規模**: L (半日〜1日)
+
+### Phase 8: 画面分割 — walks/[id] + dogs/[id] (優先度: 低 / M)
+
+**対象課題**: `app/walks/[id].tsx` 212行、`app/dogs/[id]/index.tsx` 211行
+
+**変更**:
+- `hooks/use-walk-detail-view-model.ts` 新規 — duration/distance/date/midpoint 計算
+- `app/walks/[id].tsx` はMap + Timeline + WalkerSection の合成のみ
+- `hooks/use-dog-detail-authorization.ts` 新規 — isOwner/isCurrentMember 判定
+- `app/dogs/[id]/index.tsx` は presentational のみ
+- walks側の Tokyo fallback 座標は `lib/walk/constants.ts` に理由コメント付きで切り出し
+
+**完了条件**:
+- 各画面 150行以下
+- view-model hook の unit test
+
+**依存**: Phase 3
+**推定規模**: M (3-4時間)
+
+### Phase 9: GraphQL 整理 + auth client改善 (優先度: 低 / M)
+
+**対象課題**: `lib/graphql/{queries,mutations}.ts` ドメイン混在、`lib/graphql/client.ts` の refresh middleware 化、`lib/auth/secure-storage.ts` 毎回 migration
+
+**変更**:
+- `lib/graphql/{dog,walk,me,friendship,encounter}.{queries,mutations}.ts` にドメイン分割、`index.ts` から re-export
+- `lib/graphql/client.ts` — refresh ロジックを `middleware/refresh-on-401.ts` に切り出し (interceptor pattern)
+- `lib/auth/secure-storage.ts` — migration を app 起動時1回 (auth-store.initialize) に移動
+
+**完了条件**:
+- 全既存テスト緑
+- 起動時マイグレーション確認 (auth-store test)
+
+**依存**: Phase 3
+**推定規模**: M (3時間)
+
+### Phase 10: BLE scanner 型安全化 + テスト追加 (優先度: 低 / M / risk:中)
+
+**対象課題**: `lib/ble/scanner.ts` `any` 6箇所、UI primitive テスト0
+
+**変更**:
+- `lib/ble/scanner.ts` — `react-native-ble-plx` の型を直接import、`any` を排除
+- `components/ui/{Button,Card,TextInput,SegmentedControl,ConfirmDialog}.test.tsx` 新規
+
+**完了条件**:
+- `rg "any" apps/mobile/lib/ble/scanner.ts` が 0 (または合理的な例外のみ)
+- UI primitive テストで各 variant/state カバー
+- iOS Simulator で BLE スキャン動作確認
+
+**依存**: なし
+**推定規模**: M (3-4時間)
+
+---
+
+## 検証戦略
+
+各フェーズ共通：
+1. `docker compose run --rm mobile npm test` 緑
+2. `docker compose run --rm mobile npx tsc --noEmit` エラーなし
+3. `docker compose run --rm mobile npm run lint` 警告なし
+4. 画面変更あるフェーズは iOS Simulator でスモーク (`ios-simulator-skill` の scripts 経由)
+
+**機能変更の禁止**: 各フェーズで `git diff --stat` を確認し、計画外のファイル変更がないかチェック。
+
+## セッション起動テンプレ (Phase 4 Execute時)
+
+```
+tasks/refactor/mobile/03-plan.md の Phase <N> を実行して。
+TDD で進める (superpowers:test-driven-development)。
+完了したら progress.md の Phase <N> を完了に更新して。
+```
+
+## Critical Files
+
+- `apps/mobile/hooks/` — Phase 1, 3, 5, 7, 8 で変更
+- `apps/mobile/app/(tabs)/walk.tsx` — Phase 7
+- `apps/mobile/app/invite/[token].tsx` — Phase 6
+- `apps/mobile/app/walks/[id].tsx` — Phase 8
+- `apps/mobile/app/dogs/[id]/index.tsx` — Phase 8
+- `apps/mobile/components/walk/WalkEventActions.tsx` — Phase 5
+- `apps/mobile/components/auth/ConfirmForm.tsx` — Phase 5
+- `apps/mobile/lib/graphql/` — Phase 1, 9
+- `apps/mobile/lib/ble/scanner.ts` — Phase 10
+- `apps/mobile/lib/auth/secure-storage.ts` — Phase 9
+- `apps/mobile/theme/tokens.ts` — Phase 1
+
+## 既存の再利用可能ユーティリティ
+
+- `theme/tokens.ts` (colors/spacing/radius/typography) — Phase 1 で hero 追加
+- `hooks/use-themed-styles.ts` — 既にある memoized StyleSheet ヘルパー
+- `hooks/use-colors.ts` — theme アクセス
+- `lib/walk/{distance,format,gps-tracker}.ts` — 既にドメイン分離済み、変更不要
+- `lib/graphql/keys.ts` — query key definition (Phase 2 で未使用 key 削除のみ)

--- a/.claude/plans/crispy-sniffing-hanrahan.md
+++ b/.claude/plans/crispy-sniffing-hanrahan.md
@@ -1,0 +1,205 @@
+# 散歩ログ分析: 健康アラート機能 v1
+
+## Context
+
+現状、walking-dog は散歩記録（距離・時間・GPS・pee/poo/photo イベント）を蓄積しているが、蓄積データを活用した「犬の健康変化の気づき」が得られていない。飼い主が散歩ログから犬の異変に気づくには、自力でグラフを見比べる必要がある。
+
+この機能は **蓄積データから異常を自動検知して飼い主に通知** し、「犬への貢献心」軸（Product Vision）を強化する。v1 はアプリ内通知に絞り、運用して有効性を検証してから push・閾値設定 UI に拡張する。
+
+## スコープ（v1）
+
+**対象アラート 3 種**（全犬ごとに判定）:
+
+| ID | 名前 | 判定ロジック |
+|----|------|------|
+| `DISTANCE_DROP` | 散歩量の急減 | 直近 7 日の平均 `distance_m` が直近 30 日（除: 直近7日）平均の **20% 以上減少** |
+| `DURATION_DROP` | 散歩時間の急減 | 同上を `duration_sec` で判定 |
+| `PACE_DROP` | ペース低下 | `distance_m / duration_sec`（m/s）の直近7日平均が直近30日平均の **15% 以上低下** |
+| `ELIMINATION_ANOMALY` | 排泄異常 | 散歩あたりの pee / poo 回数（直近7日 vs 直近30日）が **平均±2σ を外れる** |
+
+**全アラート共通の前提条件**:
+- 直近30日のサンプル数 `finished` walks が **8 件以上**（統計的に意味のある比較のため）
+- 対象 `status = 'finished'` の walks のみ
+
+**UI**:
+- 犬詳細画面（`apps/mobile/app/dogs/[id]/index.tsx`）の `DogStatsCard` 下に `DogHealthAlertsCard` を追加
+- アラートありの場合: 黄色（warning）または赤（critical）バッジ + 件数
+- タップで展開し、各アラートの説明・該当値・期間を表示
+- ボトムタブの犬アイコンに「未読アラートありバッジ」（赤ドット）
+
+**非対象（v2 以降）**:
+- 運動不足（連続N日散歩なし）アラート
+- push 通知（`expo-notifications` 導入）
+- 閾値のユーザー設定
+- 犬種・年齢補正
+- アラート既読管理のサーバー永続化（v1 はクライアント AsyncStorage）
+
+## アーキテクチャ
+
+### バックエンド（Rust / Axum / async-graphql / SeaORM）
+
+**新規 GraphQL query**:
+
+```graphql
+type DogHealthAlert {
+  id: String!            # "DISTANCE_DROP" | "DURATION_DROP" | "PACE_DROP" | "ELIMINATION_ANOMALY"
+  severity: String!      # "warning" | "critical"
+  title: String!         # 日本語表示用（例: "散歩量が減っています"）
+  description: String!   # 詳細（例: "直近7日の平均距離が 30日平均より 28% 減少"）
+  recentValue: Float!    # 直近7日の値
+  baselineValue: Float!  # 直近30日（除直近7日）の値
+  deltaPercent: Float!   # (recent - baseline) / baseline * 100
+  windowDays: Int!       # 7
+  detectedAt: DateTime!  # query 実行時刻
+}
+
+extend type Query {
+  dogHealthAlerts(dogId: ID!): [DogHealthAlert!]!
+}
+```
+
+**実装場所**:
+- `apps/api/src/graphql/custom_queries.rs` — query 追加
+- `apps/api/src/services/health_alert_service.rs` — 新規サービス（判定ロジック）
+- `apps/api/src/services/walk_service.rs` — 既存の集計ヘルパー再利用
+
+**判定ロジック（`health_alert_service.rs`）**:
+
+1. `walks` テーブルから対象犬の直近30日 `finished` walk を取得（`walk_dogs` JOIN）
+2. サンプル数 < 8 → 空配列を返す（判定不可）
+3. 直近7日ウィンドウ / 直近30日ベースライン（除直近7日）で集計
+4. 各アラートの閾値と比較し、該当するもののみ返す
+5. severity: deltaPercent の絶対値が 30% 以上なら `critical`、それ未満なら `warning`
+6. 排泄異常は `walk_events` を JOIN して `event_type IN ('pee', 'poo')` でカウント
+
+**パフォーマンス**:
+- 1 回の query あたり 30 日分の walks + events スキャン
+- 1 犬 1 日 ~2 walks、30 日 = ~60 行、events ~200 行 → 十分小さい
+- 犬詳細画面表示時のみ呼ばれるので N+1 懸念なし
+
+### フロントエンド（React Native / Expo / Apollo）
+
+**新規コンポーネント**:
+- `apps/mobile/components/dog/DogHealthAlertsCard.tsx`
+  - アラートなし: 「特に異変はありません」（緑チェック）
+  - アラートあり: severity ごとに色分けし、タップで各アラート詳細を展開
+- `apps/mobile/hooks/useDogHealthAlerts.ts` — Apollo `useQuery` ラッパ
+
+**統合**:
+- `apps/mobile/app/dogs/[id]/index.tsx` の `DogStatsCard` 直下に `DogHealthAlertsCard` 配置
+- 犬タブアイコン: 自分の全ての犬について alert 件数を合算し、> 0 ならバッジ表示（`apps/mobile/app/(tabs)/_layout.tsx` で `useMyDogs` → 各犬の alerts を合算）
+
+**クライアント既読管理（AsyncStorage）**:
+- `dog_alert_read:{dogId}` に最後に開いたタイムスタンプを保存
+- `DogHealthAlert.detectedAt > stored_timestamp` なら「未読」扱い
+- 犬詳細画面を開くと自動で既読化
+
+## データフロー
+
+```mermaid
+sequenceDiagram
+  participant M as Mobile
+  participant API as Rust API
+  participant DB as PostgreSQL
+  participant DDB as DynamoDB
+
+  M->>API: query dogHealthAlerts(dogId)
+  API->>DB: SELECT walks (last 30d, finished) JOIN walk_dogs
+  API->>DB: SELECT walk_events (last 30d, pee/poo) JOIN walks
+  Note over API: 判定ロジック実行
+  API-->>M: [DogHealthAlert]
+  M->>M: AsyncStorage 既読比較
+  M->>M: DogHealthAlertsCard 描画
+```
+
+**注: DynamoDB (`walk_points`) は v1 では参照しない**（GPS trace はペース計算に不要、`walks.distance_m / duration_sec` で十分）。
+
+## エラーハンドリング
+
+| ケース | 挙動 |
+|-------|------|
+| サンプル不足（< 8 walks / 30d） | 空配列返却、UI は「データ蓄積中」表示 |
+| 対象犬が存在しない / 権限なし | `DogNotFound` / `Forbidden` エラー（既存パターン踏襲） |
+| DB エラー | 既存の `AppError` → GraphQL error extension 経由 |
+| モバイル: query 失敗 | カード非表示 + 「再試行」ボタン（`refetch`） |
+
+## テスト戦略
+
+**API 単体テスト**（`apps/api/src/services/health_alert_service.rs` に `#[cfg(test)]`）:
+- サンプル不足 → 空配列
+- 距離30%減 → `DISTANCE_DROP` severity=critical
+- 距離15%減 → 空配列（閾値未満）
+- pee 回数 +3σ → `ELIMINATION_ANOMALY`
+- 排泄データゼロ犬 → 排泄アラート出さない
+
+**API 統合テスト**（`apps/api/tests/test_health_alert.rs` 新規）:
+- 既存 test fixture（user/dog/walks 作成）を再利用
+- GraphQL query 経由でエンドツーエンド検証
+- 他ユーザーの犬へのアクセス拒否
+
+**モバイル単体テスト**（Jest）:
+- `DogHealthAlertsCard`: 空・warning・critical 各状態のスナップショット
+- `useDogHealthAlerts`: mock Apollo で正常/エラー分岐
+
+**手動検証**:
+- iOS Simulator で犬詳細画面を開き、カードが正しく表示されること
+- 既存の散歩記録で実データでの表示確認
+
+## 移行/ロールバック
+
+- 新規 query / コンポーネント追加のみ、既存スキーマ変更なし
+- DB マイグレーション不要
+- クライアント後方互換: 旧クライアントは新 query を呼ばないので影響なし
+- ロールバック: コンポーネントのフィーチャーフラグは不要（失敗時は query エラー → カード非表示で自然に無害化）
+
+## 実装順序（TDD）
+
+1. **API: health_alert_service**（赤→緑）
+   - 単体テスト先行、判定ロジック実装
+2. **API: GraphQL query 配線**
+   - 統合テスト先行、`dogHealthAlerts` resolver を実装
+3. **Mobile: useDogHealthAlerts hook**
+   - Jest mock テスト先行
+4. **Mobile: DogHealthAlertsCard**
+   - スナップショット + 表示テスト
+5. **Mobile: 犬詳細画面統合 + タブバッジ**
+   - Simulator 動作確認
+
+## 主要ファイル
+
+**新規**:
+- `apps/api/src/services/health_alert_service.rs`
+- `apps/api/tests/test_health_alert.rs`
+- `apps/mobile/components/dog/DogHealthAlertsCard.tsx`
+- `apps/mobile/hooks/useDogHealthAlerts.ts`
+- `apps/mobile/components/dog/__tests__/DogHealthAlertsCard.test.tsx`
+- `docs/design/health_alerts/DESIGN.md`（仕様書をコミット）
+
+**変更**:
+- `apps/api/src/graphql/custom_queries.rs` — query / schema 追加
+- `apps/api/src/services/mod.rs` — `health_alert_service` 公開
+- `apps/mobile/app/dogs/[id]/index.tsx` — カード統合
+- `apps/mobile/app/(tabs)/_layout.tsx` — 犬タブバッジ
+- `apps/mobile/gql/*.graphql` — query 定義（codegen 実行）
+
+**再利用**:
+- `apps/api/src/services/walk_service.rs` — walks 集計ヘルパー
+- `apps/api/src/entities/{walks,walk_dogs,walk_events,dogs}.rs` — SeaORM entities
+- `apps/mobile/components/DogStatsCard.tsx` — UI 配置参考
+
+## 検証方法（Verification）
+
+1. **API 単体/統合テスト**: `docker compose exec api cargo test health_alert` で全通過
+2. **モバイル単体テスト**: `docker compose exec mobile npm test -- DogHealthAlerts` で全通過
+3. **E2E 動作確認**:
+   - ローカル API + DynamoDB Local 起動
+   - 既存 seed で犬 + 30日分の walks を生成（必要なら test fixture を手動投入スクリプト化）
+   - iOS Simulator で犬詳細画面を開き、アラートカードを目視確認
+   - 閾値を意図的に越えるデータを投入し、warning / critical 両方の表示を確認
+4. **リグレッション**: 既存の `test_walk.rs`, `test_dog.rs` が緑のまま
+
+## 未決事項（後続 PR）
+
+- 排泄標準偏差 σ 計算のサンプル不足時のフォールバック（現状は 8 件必須）
+- アラート消失の扱い（例: 翌日復調したら即カード消す or 3日 grace period）
+- 運動不足（連続未散歩）アラートは v2 で追加

--- a/.claude/plans/docs-design-walk-actual-png-docs-design-recursive-storm.md
+++ b/.claude/plans/docs-design-walk-actual-png-docs-design-recursive-storm.md
@@ -1,0 +1,213 @@
+# Precise Walk Ready — spec 準拠リデザイン
+
+## Context
+
+`docs/design/walk/walk-1.png` / `walk-1.html` の Precise 仕様に対し、現状の
+Walk 画面 (`app/(tabs)/walk.tsx` の `phase === 'ready'`) は以下がズレている。
+
+- **大見出し "Walk" が無い**（現状は START が最上段）
+- **犬選択 UI がモーダルシート（`DogSelectorSheet`）に隠れている** — 仕様では画面本体にグループ化カードで常時表示
+- **START までの導線**：現状は「START → モーダル → 犬選択 → Start Walk」の 2 ステップ。仕様は「犬選択 → START」の 1 画面
+- **Group walk サマリカード（複数選択時）が無い**
+- **補助テキスト**：現状 "Tap to begin. We'll follow your route." / 仕様 "We'll log pees, poops and photos for each dog separately."
+- **RECENT WALKS 履歴リスト** — 仕様外。Walk タブからは削除する（ユーザー確認済み）
+
+Walk 画面の主役を「これから誰と散歩するかを選ぶ準備台」に戻すことで、
+*犬の体験*（個別ログ）・*データによる散歩の最大化*（頭数に応じた分離記録の
+意図が UI で可視化）・*飼い主の貢献心*（1タップで散歩開始）の3軸を満たす。
+
+この PR は Precise redesign シリーズの次エピソード (Walk ready)。直前の
+Dogs list / Dog detail / Auth / Sign In / Sign Up と同じ粒度で、既存の
+`GroupedCard` / `SectionHeader` / `Tag` / `Button` プリミティブを再利用する。
+
+タブアイコンは SF Symbols のまま（ユーザー確認済み・スコープ外）。
+
+---
+
+## Scope
+
+### 画面として残す / 変える / 捨てる
+
+| 要素 | 処置 |
+|---|---|
+| largeTitle "Walk" | **新規**。左寄せ 34pt/700、`letterSpacing: -0.6` |
+| "WHO'S COMING?" セクション + "Select all" アクション | **新規** |
+| 犬選択カード（GroupedCard + 行） | **新規**。`DogSelectorSheet` / 旧 `DogSelector` を置き換え |
+| Group walk サマリカード | **新規**。選択が 2 頭以上で表示 |
+| START 円形ボタン (200×200) | **再利用**。配置だけ中段へ移す |
+| 補助テキスト | **文言差し替え**（i18n キー追加） |
+| RECENT WALKS セクション + 履歴リスト | **削除** |
+| モーダル経由の Cancel / Start Walk | **削除**（インライン化で不要） |
+
+### ユーザー確認済みの前提
+
+1. 履歴リストは Walk タブから完全に削除（将来 Me タブで再利用する選択肢は残す）
+2. タブバーアイコンは SF Symbols のまま（Precise SVG 差し替えは別 PR）
+
+---
+
+## 実装手順（TDD: RED → GREEN → REFACTOR）
+
+### 1. UI プリミティブ拡張
+
+**`apps/mobile/components/ui/SectionHeader.tsx`**
+- `trailing?: ReactNode` を追加。存在すれば `flexDirection: 'row'` /
+  `justifyContent: 'space-between'` で右端に配置
+- 既存の呼び出し側は破壊しない（trailing 省略時の見た目を現状維持）
+- テスト: trailing なしで従来表示、trailing ありで trailing が描画されるか
+
+### 2. 犬選択カード
+
+**新規 `apps/mobile/components/walk/DogPickerCard.tsx`**
+- `GroupedCard` を surface に採用
+- 行 = `Pressable` (accessibilityRole="checkbox" / accessibilityState.checked)
+  - 左 44×44 `expo-image` アバター（photoUrl / placeholder）
+  - 中央 `name` (16/600) + `breedSubtitle` (12pt, 60% onSurface)
+  - 右 26×26 チェック：選択時は `backgroundColor: theme.interactive` の丸 + 白 `✓`、
+    未選択は `borderWidth: 1.5` / `borderColor: onSurfaceVariant 30%` の空リング
+  - 行間は `height: StyleSheet.hairlineWidth` セパレータ、`marginLeft: 72`
+- props: `dogs: Dog[]`, `selectedIds: string[]`, `onToggle(id)`
+- **サブタイトル文言**: 仕様では "Toy Poodle · last walk 2h ago"。`Dog` 型に
+  `lastWalkAt` が無い場合は犬種のみ表示。将来 `lastWalkAt` 追加時に相対時刻
+  表示できるよう `buildSubtitle(dog)` ヘルパーを関数外に切り出す
+- テスト: 未選択/選択の切替、アクセシビリティ state、犬種のみ/ありの分岐
+
+**新規 `apps/mobile/components/walk/GroupWalkSummaryCard.tsx`**
+- 選択が 2 頭以上のときだけ描画
+- 左: 36×36 アバターを `marginLeft: -10` で 2 枚重ね（最大 3 枚まで、残りは数字バッジ）
+- 中央: "{count} dogs walking together"。count を bold テキストで前置し、
+  続く "dogs walking together" は通常ウェイト。`<Text>` 内の `<Text>` で
+  スタイル分岐（`fontWeight: '700'`）
+- 右: `<Tag tone="success" label={t('walk.ready.groupWalk')} />`
+- テスト: 1 頭 → 非描画、2 頭 → 2 avatar + count 2、3 頭 → avatar 3 + count 3
+
+### 3. WalkReadyView 刷新
+
+**`apps/mobile/components/walk/WalkReadyView.tsx`** を全面書き換え
+- 構造 (上から):
+  1. largeTitle "Walk" — `paddingHorizontal: spacing.lg` / `paddingTop: spacing.md`
+  2. `SectionHeader` `label={t('walk.ready.whosComing')}` + trailing に
+     "Select all" Pressable（`color: theme.interactive`、`textTransform: none`）
+  3. `DogPickerCard`（上の新規）
+  4. `GroupWalkSummaryCard`（選択 2 頭以上のみ）
+  5. 中央 `Button size="circle" variant="success" label="START"`
+     - disabled: `selectedDogIds.length === 0 || isStarting`
+     - onPress は `onStart` prop → 親 `app/(tabs)/walk.tsx` の `handleStart` を直接呼ぶ
+  6. 補助テキスト `t('walk.ready.hint')` — `footnote` / 60% / `textAlign: 'center'` / `maxWidth: 300`
+- `FlatList` は使わず `ScrollView`（犬数は通常 1〜数頭で列挙で十分）。履歴は描画しない
+- dogs が 0 のときは選択カード枠内に `noDogs` 空状態メッセージ + 登録導線（既存文言再利用）
+- `Select all` は `dogs.every(d => selected)` ならトグルで全解除、そうでなければ全選択
+
+**`apps/mobile/app/(tabs)/walk.tsx`**
+- `DogSelectorSheet` 周りと `isSheetOpen` state を削除
+- `<WalkReadyView onStart={handleStart} isStarting={walkSession.isStarting} />` に変更
+- `handleStart` 呼び出しタイミングは現状維持（GPS / BLE 権限フロー / Live Activity）
+- `phase !== 'ready'` の分岐は**触らない**（recording / finished は別画面）
+
+### 4. 削除するコード
+
+- `apps/mobile/components/walk/DogSelectorSheet.tsx` 本体と test（存在すれば）
+- `apps/mobile/components/walk/DogSelector.tsx` 本体と test（旧モーダル内 UI）
+- `WalkReadyView.tsx` 内の `useMyWalks` import と履歴描画ロジック
+- `components/walk/WalkHistoryItem.*` / `hooks/use-walks.ts` は**削除しない**
+  （将来 Me タブ等で再利用する余地を残す。未使用 import のみ除去）
+- 参照が他に無いことを `grep -r "DogSelectorSheet\|DogSelector[^P]"` で確認
+
+### 5. i18n
+
+`apps/mobile/lib/i18n/locales/en.json` / `ja.json` に追加：
+
+```
+walk.ready.largeTitle      "Walk" / "散歩"
+walk.ready.whosComing      "Who's coming?" / "今日の散歩メンバー"
+walk.ready.selectAll       "Select all" / "すべて選択"
+walk.ready.dogsWalkingBold "{{count}} dogs" / "{{count}} 頭"
+walk.ready.dogsWalkingTail "walking together" / "でおでかけ"
+walk.ready.groupWalk       "Group walk" / "グループ散歩"
+walk.ready.hint            "We'll log pees, poops and photos for each dog
+                           separately." / "おしっこ・うんち・写真は犬ごと
+                           に記録されます"
+```
+
+既存の `walk.ready.title` / `walk.ready.subtitle` / `walk.ready.start` /
+`walk.home.hero` / `walk.history.*` は、他から参照されていなければ削除。
+`grep -r "walk\.home\.hero\|walk\.history\."` で確認してから消す。
+
+### 6. テスト
+
+- `DogPickerCard.test.tsx` — RNTL、queryByRole("checkbox") で state 検証
+- `GroupWalkSummaryCard.test.tsx` — 1/2/3 頭の分岐、Tag 表示、avatar 枚数
+- `WalkReadyView.test.tsx` — (a) "Walk" 見出し、(b) START が disabled when no dog,
+  (c) "Select all" で全選択、(d) 選択 0→1→2 で GroupWalkSummaryCard が現れる、
+  (e) 履歴関連 DOM が存在しないこと
+- `SectionHeader.test.tsx` — trailing prop（既存テストがあれば拡張）
+- `walk.tsx` は integration で `useWalkSession` をモックし、START 押下で
+  `permissions.requestGpsPermission` / `walkSession.start` が呼ばれるか確認
+
+---
+
+## Critical Files
+
+**変更**
+- `apps/mobile/app/(tabs)/walk.tsx` — sheet 排除
+- `apps/mobile/components/walk/WalkReadyView.tsx` — 全面書き換え
+- `apps/mobile/components/ui/SectionHeader.tsx` — trailing prop
+- `apps/mobile/lib/i18n/locales/en.json` / `ja.json`
+
+**新規**
+- `apps/mobile/components/walk/DogPickerCard.tsx`
+- `apps/mobile/components/walk/DogPickerCard.test.tsx`
+- `apps/mobile/components/walk/GroupWalkSummaryCard.tsx`
+- `apps/mobile/components/walk/GroupWalkSummaryCard.test.tsx`
+
+**削除**
+- `apps/mobile/components/walk/DogSelectorSheet.tsx` (+test)
+- `apps/mobile/components/walk/DogSelector.tsx` (+test)
+
+**再利用（無変更）**
+- `apps/mobile/components/ui/GroupedCard.tsx`
+- `apps/mobile/components/ui/Tag.tsx` (`tone="success"`)
+- `apps/mobile/components/ui/Button.tsx` (`variant="success" size="circle"`)
+- `apps/mobile/hooks/use-me.ts` (`me.dogs`)
+- `apps/mobile/stores/walk-store.ts` (`selectedDogIds`, `selectDog`)
+
+---
+
+## Verification
+
+**自動**
+```
+cd apps/mobile
+npm run lint
+npm run typecheck
+npm test -- --watchAll=false
+```
+- 追加したテストはもちろん、既存テストが回帰していないこと
+- `DogSelectorSheet` / `DogSelector` / `walk.history.*` の参照が 0 件
+
+**手動（iOS Simulator）**
+```
+npm run ios
+```
+1. Walk タブを開く → largeTitle "Walk" が左上
+2. "WHO'S COMING?" の右に "Select all" が表示、タップで全選択トグル
+3. 犬行をタップすると青塗りチェック ↔ 空リングが切り替わる
+4. 2 頭以上選択 → Group walk カードがアニメーションなしで現れる
+5. 選択 0 頭で START ボタンが disabled（`theme.border` 色、opacity）
+6. START → GPS 権限ダイアログ → 許可で recording 画面へ遷移
+7. recording / finished 画面は一切変更なし（リグレッション確認）
+8. 履歴リストが画面のどこにも存在しないこと
+
+**アクセシビリティ**
+- VoiceOver でカード行が "Coco, 未選択, ボタン" と読み上げられる
+- START disabled 時に announcement で無効が伝わる
+- タップターゲット ≥ 44pt（行高さ 60pt / チェック hitSlop 込み）
+
+---
+
+## Out of Scope (明示)
+
+- タブバー SVG の差し替え（SF Symbols のまま維持）
+- `WalkHistoryItem` / `useMyWalks` の削除（後続 PR で Me タブへ移す余地を残す）
+- ダークモードの色調整（既存トークンに従うのみ、別途再検証は Precise 全体の別タスク）
+- `lastWalkAt` の表示（`Dog` 型への追加が必要、別 PR で API 変更が要る）

--- a/.claude/plans/docs-design-walking-dog-readme-md-ios26-zesty-biscuit.md
+++ b/.claude/plans/docs-design-walking-dog-readme-md-ios26-zesty-biscuit.md
@@ -1,0 +1,115 @@
+# Plan: iOS 26 Liquid Glass Floating Tab Bar
+
+## Context
+
+`docs/design/walking-dog/project/Precise Full App.html` の `TabBar` (L464–500) は iOS 26 の Liquid Glass 仕様で描かれており、画面下部にフロートする丸ピル型・半透明ブラー・選択時の薄いチントピル背景が特徴。現行 `apps/mobile/app/(tabs)/_layout.tsx` は Expo Router `<Tabs>` のデフォルトに `tabBarStyle.backgroundColor = theme.material` を被せただけの「画面幅いっぱい・上辺ボーダー・矩形」で、デザインと乖離している。本変更で視覚のみを Precise 仕様に揃え、タブ構成・ナビゲーション・ハプティクス・`walk` 画面での非表示制御など現行挙動は維持する。
+
+## User Request (verbatim)
+
+> 「@docs/design/walking-dog/README.md タブバーのデザインをiOS26の見た目にしてください。詳細は @docs/design/walking-dog/project/Precise Full App.html をご確認ください。」
+
+## Target Design Spec (from `Precise Full App.html:477–498`)
+
+| 項目 | 値 |
+|---|---|
+| 位置 | 絶対配置、画面下から `bottom: 22 + safeInset.bottom` 相当、左右 inset 20 |
+| サイズ | height 58、borderRadius 29（完全ピル） |
+| 内側 padding | 横 8 |
+| ブラー | `blur(30px) saturate(180%)` 相当 — iOS は `BlurView tint="systemChromeMaterial"` |
+| Light 背景 | `linear-gradient(180deg, rgba(255,255,255,0.7)→rgba(245,245,250,0.55))` |
+| Dark 背景 | `linear-gradient(180deg, rgba(60,60,65,0.55)→rgba(30,30,34,0.65))` |
+| Hairline border | 0.5px — light `rgba(255,255,255,0.7)` / dark `rgba(255,255,255,0.14)` |
+| 影（Light） | `0 8px 24px rgba(0,0,0,0.12), 0 2px 6px rgba(0,0,0,0.06)` |
+| 影（Dark） | `0 8px 24px rgba(0,0,0,0.4)` |
+| アクティブピル | `inset 4px 14%`、borderRadius 18、color `rgba(10,132,255,0.12)` (light) / `0.18` (dark) |
+| アイコン | 24×24、アクティブ時 `#0a84ff` / 非アクティブ `onSurfaceVariant` |
+| ラベル | 10px、fontWeight 600、letterSpacing 0.1 |
+| アイコン↔ラベル gap | 1px |
+
+## Scope
+
+**In scope**
+- `(tabs)/_layout.tsx` のタブバー視覚差し替え（Dogs / Walk / Me の 3 タブ、アイコン、ハプティクスは現状維持）
+- 新コンポーネント `components/navigation/liquid-glass-tab-bar.tsx` 作成
+- `expo-blur` 依存追加
+- `walk.tsx` の記録中非表示 (`tabBarStyle: { display: 'none' }`) 互換維持
+- スナップショット/スモークテスト追加
+
+**Out of scope**
+- 画面側コンテンツの paddingBottom 調整（フロートバー化で重なる領域は発生するが、既存 `paddingBottom: xxl` で実害がないことを目視確認したうえで、必要時は別タスク）
+- アイコン意匠の差し替え（SF Symbols のまま。HTML は inline SVG だがピクセル換算で同等）
+- その他画面のリデザイン
+
+## Files to Modify / Create
+
+| 種類 | パス | 役割 |
+|---|---|---|
+| NEW | `apps/mobile/components/navigation/liquid-glass-tab-bar.tsx` | iOS 26 仕様のフロートタブバー本体 |
+| NEW | `apps/mobile/components/navigation/liquid-glass-tab-bar.test.tsx` | アクティブ指標・ハプティクス・`display:'none'` 非表示の単体テスト |
+| EDIT | `apps/mobile/app/(tabs)/_layout.tsx` | `tabBarStyle` 設定を廃し、`tabBar={(props) => <LiquidGlassTabBar {...props} />}` へ差し替え |
+| EDIT | `apps/mobile/package.json` | `expo-blur` を追加（`npx expo install expo-blur` 経由、バージョンは SDK 整合） |
+
+既存の `HapticTab` (`apps/mobile/components/haptic-tab.tsx`) はタブバーボタン単位のハプティクスだが、カスタム `tabBar` 側でも同等の `Haptics.impactAsync(Light)` を `onPressIn` で呼ぶため、`tabBarButton` 経由の呼び出しは不要になる。コンポーネント自体は他用途がない場合にのみ削除。
+
+## Component Contract — `LiquidGlassTabBar`
+
+```tsx
+import type { BottomTabBarProps } from '@react-navigation/bottom-tabs';
+
+export function LiquidGlassTabBar(props: BottomTabBarProps): ReactElement | null;
+```
+
+主な責務
+1. `props.descriptors[route.key].options.tabBarStyle?.display === 'none'` なら `null` を返す（walk 記録中対応）
+2. `useSafeAreaInsets().bottom` を加味し、外側コンテナを `position: 'absolute', left: 20, right: 20, bottom: Math.max(insets.bottom - 12, 10) + 12` などで配置（最低 22px 確保）
+3. `BlurView`（iOS: `tint="systemChromeMaterial"`, intensity 80 / Android: 半透明 fallback 背景）+ 二段グラデ用の半透明オーバーレイ View
+4. 各ボタンは `Pressable` で `onPress={() => navigation.emit + navigate}`, `onPressIn` でハプティクス、アクティブ判定で青ピル + tint を切替
+5. `accessibilityRole="button"`, `accessibilityLabel` に現在の `options.title`（i18n 済）, `accessibilityState={{ selected: focused }}`
+
+デザインに合わせた固有値は component 内 `StyleSheet` に集約。色は `useColors()` の `interactive` / `onSurfaceVariant` / `onSurface` を使い、グラス特有の rgba 値（白 0.7 等）は token 化せずインラインで持つ（用途限定のため）。
+
+## `_layout.tsx` 変更概要
+
+```tsx
+import { LiquidGlassTabBar } from '@/components/navigation/liquid-glass-tab-bar';
+
+<Tabs
+  initialRouteName="dogs"
+  screenOptions={{ headerShown: false }}
+  tabBar={(props) => <LiquidGlassTabBar {...props} />}
+>
+  <Tabs.Screen name="dogs" options={{ title: t('tabs.dogs'), tabBarIcon: ... }} />
+  <Tabs.Screen name="walk" options={{ title: t('tabs.walk'), tabBarIcon: ... }} />
+  <Tabs.Screen name="settings" options={{ title: t('tabs.me'), tabBarIcon: ... }} />
+</Tabs>
+```
+
+`tabBarStyle` / `tabBarLabelStyle` / `tabBarActiveTintColor` / `tabBarInactiveTintColor` / `tabBarButton: HapticTab` は削除（カスタムバー内で再現）。`tabBarIcon` の `size` は 24、color は `LiquidGlassTabBar` が渡す `props.descriptors[...].options.tabBarIcon({ focused, color, size })` の `color` 経由で切替。
+
+## Tests
+
+`apps/mobile/components/navigation/liquid-glass-tab-bar.test.tsx` — React Native Testing Library で:
+1. 3 タブのラベル（i18n モック）と role=button がレンダーされる
+2. 選択中タブの `accessibilityState.selected === true`、他は false
+3. 非選択タブ押下で `navigation.navigate` が該当 route 名で呼ばれる
+4. `options.tabBarStyle = { display: 'none' }` の状態で `null` を返す（`container` query empty）
+5. `Haptics.impactAsync` が iOS 環境で `onPressIn` 時に呼ばれる（`process.env.EXPO_OS === 'ios'` をモック）
+
+既存の `__tests__/app/tabs/dogs.test.tsx` 等はタブバー視覚に依存しないため変更不要見込み。影響があれば最小限で追従。
+
+## Verification
+
+1. `cd apps/mobile && npm test -- liquid-glass-tab-bar` で単体テスト 緑
+2. `cd apps/mobile && npx tsc --noEmit` 型エラーなし
+3. `cd apps/mobile && npm run lint` パス
+4. iOS Simulator で起動し、Light / Dark の両モードで以下を目視:
+   - タブバーがフロートしピル型になっている
+   - ブラー越しに背面コンテンツが透けて見える
+   - Dogs/Walk/Me いずれかを選択すると薄い青ピルが移動しアイコン tint が `#0a84ff` に変わる
+   - Walk → 散歩開始（recording 遷移）でタブバーが非表示になり、Finish で戻ったら再表示される
+   - ホームインジケータと被らない（bottom inset を消化できている）
+5. Android エミュレータでブラー fallback が破綻していないこと（半透明背景で代替）
+
+## Rollback
+
+単一コンポーネント追加 + `_layout.tsx` の一点変更 + `expo-blur` 追加のみ。`_layout.tsx` を git revert、`components/navigation/liquid-glass-tab-bar.tsx` を削除、`expo-blur` を `package.json` から外せば従前のタブバーに復帰できる。

--- a/.claude/plans/docs-design-walking-dog-readme-md-tab-3-adaptive-flurry.md
+++ b/.claude/plans/docs-design-walking-dog-readme-md-tab-3-adaptive-flurry.md
@@ -1,0 +1,134 @@
+# Tab 3 (Me 画面) を設計書通りに再構成
+
+## Context
+
+ユーザー指示（逐語）: 「@docs/design/walking-dog/README.md Tab 3 - Me 画面を設計書にとおりのUIに変更してください。」
+
+設計書の正解は `docs/design/walking-dog/project/screens/precise-app.jsx:481-533` の `OwnerScreen`。
+現状 `apps/mobile/app/(tabs)/settings.tsx` と乖離:
+
+| 項目 | 現状 | 設計書 |
+| --- | --- | --- |
+| Profile | Display Name + Edit（インライン編集） | グラデーションアバター + 氏名 + email + `View profile` |
+| Preferences | Theme segmented + Language dropdown | `Language / Units / Notifications / Appearance` の drill-down 行 |
+| Encounter Detection | トグル | **なし（削除）** |
+| Legal | なし | `Terms of Service / Privacy Policy / About` 行 |
+| Sign out | destructive Button | GroupedCard に 1 行、赤字センタリング |
+| Version | 画面下テキスト | `About` 行の value に統合 |
+
+ユーザー選択（AskUserQuestion）:
+- Encounter Detection: 削除
+- Language / Appearance: ActionSheet で切替（画面遷移なし）
+- Units / Notifications / email / View profile: 静的表示、Terms/Privacy だけ外部リンク
+- Sign out: 赤字センタリング行
+
+## Files
+
+### 新規
+- `apps/mobile/components/settings/ProfileCard.tsx` + `.test.tsx`
+- `apps/mobile/components/settings/PreferencesSection.tsx` + `.test.tsx`
+- `apps/mobile/components/settings/LegalSection.tsx` + `.test.tsx`
+- `apps/mobile/components/settings/SignOutRow.tsx` + `.test.tsx`
+
+### 更新
+- `apps/mobile/app/(tabs)/settings.tsx` — 新コンポーネントで差替、version テキスト削除
+- `apps/mobile/components/ui/GroupedRow.tsx` — `showChevron?: boolean` 追加（非 pressable でも chevron を描画）
+- `apps/mobile/components/ui/GroupedRow.test.tsx` — 新ケース追加
+- `apps/mobile/lib/i18n/locales/en.json` / `ja.json` — 新キー追加、未使用キー削除
+
+### 削除
+- `apps/mobile/components/settings/EncounterDetectionSection.tsx`
+- `apps/mobile/components/settings/AppearanceSection.tsx`
+- `apps/mobile/components/settings/ProfileSection.tsx`
+- `apps/mobile/components/settings/LogoutButton.tsx`
+- `apps/mobile/components/settings/SettingsSection.tsx`
+- `apps/mobile/components/settings/SettingsSection.test.tsx`
+
+## Implementation
+
+### 1. `GroupedRow` 拡張
+`apps/mobile/components/ui/GroupedRow.tsx` に `showChevron?: boolean`。デフォルトは `isPressable`。既存呼び出しは無影響。
+
+### 2. `ProfileCard.tsx`（TDD）
+- props: `displayName: string | null`
+- `expo-linear-gradient` で 60×60 サークル `#bf5af2 → #0a84ff` + initial (先頭1文字、なければ `?`)
+- 氏名 17pt 600 / email 13pt onSurfaceVariant（固定 `mio@walk.app`） / `View profile` 12pt `theme.interactive`
+- ラッパーは `GroupedCard padding="lg"` 相当、下マージン 24
+- 未導入なら `expo-linear-gradient` を `package.json` 経由で追加（`npx expo install expo-linear-gradient`）
+
+### 3. `PreferencesSection.tsx`
+- `SectionHeader label="PREFERENCES"` + `GroupedCard padding="none"` に 4 `GroupedRow`
+- 行 (leading: 絵文字 Text を 16pt で描画):
+  - 🌐 Language — value = 現言語ラベル、onPress = 既存 ActionSheetIOS 経由で `setLanguage`（`AppearanceSection.tsx:31-49` のロジックを移植）
+  - 📏 Units — value `km, min`、静的、`showChevron`
+  - 🔔 Notifications — value `On`、静的、`showChevron`
+  - 🌙 Appearance — value 現テーマラベル、onPress = ActionSheetIOS → `setTheme`
+- 最終行は `separator={false}`
+
+### 4. `LegalSection.tsx`
+- ヘッダー `LEGAL`、行:
+  - 📄 Terms of Service — `Linking.openURL('https://walk.app/terms')`
+  - 🔒 Privacy Policy — `Linking.openURL('https://walk.app/privacy')`
+  - ℹ︎ About — value `Constants.expoConfig?.version ?? '1.0.0'`、静的、`showChevron`
+
+### 5. `SignOutRow.tsx`
+- `GroupedCard padding="none"` + 1 `Pressable`、中央寄せ 17pt 500、色 `theme.error`
+- `ConfirmDialog` + `useAuth().signOut`（`LogoutButton.tsx` の挙動を移植）
+
+### 6. `settings.tsx` 再構成
+```
+<Text largeTitle>Me</Text>
+<ProfileCard displayName={me.displayName} />
+<PreferencesSection />
+<LegalSection />
+<SignOutRow />
+```
+version / appEnv / apiUrl の追加テキストブロックは削除（About 行に包含）。
+
+### 7. i18n キー追加（en / ja）
+```
+settings.sectionLabel.preferences  = PREFERENCES / 環境設定
+settings.sectionLabel.legal        = LEGAL / 法的情報
+settings.units                     = Units / 単位
+settings.unitsValue                = km, min / km、分
+settings.notifications             = Notifications / 通知
+settings.notificationsValue        = On / オン
+settings.viewProfile               = View profile / プロフィールを見る
+settings.emailPlaceholder          = mio@walk.app
+settings.terms                     = Terms of Service / 利用規約
+settings.privacy                   = Privacy Policy / プライバシーポリシー
+settings.about                     = About / このアプリについて
+```
+既存流用: `settings.title`, `settings.language`, `settings.appearance`, `settings.themeLight/Dark/Auto`, `settings.signOut`, `settings.signOutConfirm`, `settings.cancel`, `settings.loadError`。
+削除: `settings.profile`, `settings.displayName`, `settings.edit`, `settings.save`, `settings.updateError`, `settings.sectionLabel`, `settings.version`。
+
+### 8. テスト
+- `ProfileCard.test.tsx` — 氏名・emailPlaceholder・initial レンダリング
+- `PreferencesSection.test.tsx` — 4 ラベル、Language/Appearance タップで `ActionSheetIOS.showActionSheetWithOptions` がモック呼び出し
+- `LegalSection.test.tsx` — 3 ラベル、Terms/Privacy タップで `Linking.openURL` 呼び出し
+- `SignOutRow.test.tsx` — タップ → Confirm → `signOut` 呼び出し
+- `GroupedRow.test.tsx` — `showChevron` 単独で `›` が描画
+
+### 9. 後処理
+未使用化した `hooks/use-profile-mutation`、`UPDATE_ENCOUNTER_DETECTION_MUTATION` の参照を grep し、他で未使用なら削除。落ちるテストがあれば該当 i18n / mutation 依存を解消。
+
+## Reusable
+
+- `components/ui/GroupedCard.tsx`、`GroupedRow.tsx`、`SectionHeader.tsx`、`ConfirmDialog.tsx`
+- `hooks/use-auth.ts` / `signOut`、`hooks/use-me.ts`、`hooks/use-colors.ts`
+- `stores/settings-store.ts` の `setTheme` / `setLanguage`
+
+## Risks
+
+- `expo-linear-gradient` 未導入の可能性。未導入なら追加インストール。
+- email は `User` スキーマ未提供のため固定値。API 追加は別タスク。
+- Terms/Privacy URL 未定。定数化して後差替可能に。
+- `GroupedRow.showChevron` は新規 optional なので既存呼び出しに無影響。
+
+## Verification
+
+1. `docker compose exec mobile npm test -- --watch=false` 新規テスト全通過
+2. iOS Simulator で Me タブを開き `docs/design/me/expect.html.png` と比較（アバター・氏名/email/View profile・2 セクション・赤字 Sign out 行）
+3. Language/Appearance 行タップで ActionSheet 表示、Terms/Privacy タップで Linking
+4. Sign out タップで確認 → サインアウト完了
+5. `docker compose exec mobile npm run lint` / `typecheck` 通過

--- a/.claude/plans/e-id-e-vps-amazon-greedy-brook.md
+++ b/.claude/plans/e-id-e-vps-amazon-greedy-brook.md
@@ -1,0 +1,99 @@
+# Eメール送信機能（SES + Custom Email Sender Lambda）
+
+## Context
+
+現在、アカウント作成時の確認コードは Cognito の `COGNITO_DEFAULT` 送信で配信されている（`infra/aws/cognito.tf:60`）。本番運用ではドメインから統一的にメールを送り、将来的にテンプレート・到達率をコントロールできる構成に切り替えたい。
+
+今回の変更でローカル環境は対象外。さくらVPS環境（AWS dev）に Amazon SES を組み込み、Cognito の CustomEmailSender Lambda 経由で SES からドメイン `walkingdogdev.dpdns.org` を送信元として確認コードを送る。
+
+### 決定事項（ユーザー確認済み）
+
+- SES 送信元: **ドメイン検証** `walkingdogdev.dpdns.org`（DKIM/SPF は dpdns.org 側で手動追加）
+- Cognito 連携: **Custom Email Sender Lambda + KMS**（Cognito の email テンプレートを完全制御）
+- SES サンドボックス: **今回は解除申請しない**（開発中は検証済みアドレスにのみ送信）
+
+## アーキテクチャ
+
+```
+[Mobile] signUp → [API /graphql signUp] → [Cognito SignUp]
+                                               ↓ CustomEmailSender_SignUp event
+                                          [Lambda (Node.js)]
+                                               ↓ KMS decrypt(code) + SES send
+                                          [Amazon SES] → ユーザーEメール
+```
+
+Cognito SignUp 時の動作:
+1. Cognito が確認コードを生成
+2. CustomEmailSender_SignUp イベントを Lambda に送信（コードは KMS で envelope 暗号化）
+3. Lambda が AWS Encryption SDK でコードを復号
+4. SES で日本語テンプレートのメールを組み立てて送信
+
+## 変更対象ファイル
+
+### Terraform 新規/変更（`infra/aws/`）
+
+| ファイル | 操作 | 内容 |
+|---|---|---|
+| `ses.tf` | 新規 | `aws_ses_domain_identity`, `aws_ses_domain_dkim`, `aws_ses_email_identity`（sandbox 中の検証済みテスト宛先用） |
+| `kms.tf` | 新規 | CustomEmailSender 用 KMS カスタマーマスターキー（symmetric）、Cognito サービス向け利用許可 policy |
+| `lambda_custom_email_sender.tf` | 新規 | Lambda 関数定義（`archive_file` で zip 化）、IAM role（`ses:SendEmail`, `kms:Decrypt`, CloudWatch Logs）、Cognito 呼び出し許可 |
+| `cognito.tf` | 変更 | `lambda_config.custom_email_sender` + `kms_key_id` を追加（`email_sending_account` は `COGNITO_DEFAULT` のまま — Custom Email Sender を使う場合 Cognito 自身は email を送らない） |
+| `variables.tf` | 変更 | `ses_from_address`（例: `noreply@walkingdogdev.dpdns.org`）, `ses_from_name`（例: `WalkingDog`）, `email_domain` 変数を追加 |
+| `outputs.tf` | 変更 | SES ドメイン検証トークン、DKIM CNAME、Lambda ARN を出力（手動DNS作業の参照用） |
+
+### Lambda ソース新規（`infra/aws/lambda/custom-email-sender/`）
+
+| ファイル | 内容 |
+|---|---|
+| `index.mjs` | ハンドラ。`triggerSource` で `CustomEmailSender_SignUp` / `CustomEmailSender_ResendCode` / `CustomEmailSender_ForgotPassword` を分岐。AWS Encryption SDK (`@aws-crypto/client-node`) でコード復号後、SES v2 (`@aws-sdk/client-sesv2`) で `SendEmail` |
+| `package.json` | 依存: `@aws-crypto/client-node`, `@aws-sdk/client-sesv2` |
+| `templates/signup-ja.mjs` | 件名・本文テンプレート（HTML + text）。コードと失効目安を埋め込み |
+| `README.md` | ビルド・デプロイ手順（`npm ci --omit=dev && zip`） |
+
+### Cargo/Rust 側
+
+APIコードは**変更不要**。Cognito の `SignUp` / `ConfirmSignUp` 呼び出しは既存のまま（`apps/api/src/auth/service.rs:52`, `apps/api/src/auth/service.rs:85`）。送信経路のみインフラで差し替わる。
+
+### ドキュメント
+
+| ファイル | 操作 | 内容 |
+|---|---|---|
+| `docs/design/2026-04-18-ses-custom-email-sender.md` | 新規 | 設計概要、DNS 手動追加手順、SES サンドボックス下でテスト宛先を検証する運用、将来の本番申請・テンプレート拡張ロードマップ |
+| `infra/sakura/README.md` | 変更 | さくらVPS側は変更不要である旨を追記（SES送信は Lambda 経由のため VPS IAM 権限は追加不要） |
+
+## 実装手順
+
+1. **SES domain identity を Terraform で作成**（`ses.tf`）。`terraform apply` 出力から DKIM CNAME 3本と SPF/verification TXT を取得
+2. **DNS 手動追加**（dpdns.org 側ダッシュボード）。ユーザー作業
+3. **KMS キー作成**（`kms.tf`）。key policy で Cognito サービスプリンシパル `cognito-idp.amazonaws.com` に `Encrypt` 許可
+4. **Lambda ソース実装**（`infra/aws/lambda/custom-email-sender/index.mjs`）。`@aws-crypto/client-node` の `buildClient(CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT)` + `KmsKeyringNode` で復号
+5. **Lambda Terraform 定義**（`lambda_custom_email_sender.tf`）。`archive_file` data source で zip 生成 → `aws_lambda_function` → `aws_lambda_permission` で Cognito 呼び出し許可
+6. **Cognito 更新**（`cognito.tf`）。`lambda_config { custom_email_sender { lambda_arn, lambda_version = "V1_0" } kms_key_id = ... }` を追加
+7. **SES 検証済み宛先を追加**（開発テスト用）。`aws_ses_email_identity` で自分のメールアドレスを登録、確認クリック
+8. **E2E テスト**。モバイルで signUp → 実機/検証済みメールで受信確認 → confirmSignUp 成功
+9. **ドキュメント整備**
+
+## 検証方法
+
+- `terraform plan` でリソース差分確認（dev workspace）
+- `terraform apply` 後、AWS Console で SES identity が `Pending verification` → DNS 追加後 `Verified` になること
+- `aws lambda invoke` でサンプルイベント（`event.triggerSource = "CustomEmailSender_SignUp"`）を投げてエラーなし
+- モバイルアプリで新規登録 → 検証済みアドレスにコードが届く（差出人が `noreply@walkingdogdev.dpdns.org`）
+- コードで `confirmSignUp` が成功する（`apps/api/src/graphql/mutations/auth.rs:275`）
+- CloudWatch Logs で Lambda のエラーなし、送信先/MessageId がログに残る
+
+## 前提・制約
+
+- **SES サンドボックス**: 送信先も検証済みでないと届かない。開発中はユーザー（自分）のテストアドレスを `aws_ses_email_identity` で登録。本番申請は別タスク
+- **Cognito region**: SES は同リージョンで verify 必要（既存Cognito と同リージョンを前提）
+- **dpdns.org の DNS 制約**: TXT/CNAME が追加できない場合、ドメイン検証戦略の見直しが必要（代替: 取得済み別ドメイン）
+- Lambda のコールドスタックで signup レスポンスが数百ms遅延する可能性（許容範囲）
+
+## 重要な参照
+
+- 既存 Cognito 定義: `infra/aws/cognito.tf:60-66`
+- signUp サービス: `apps/api/src/auth/service.rs:52`
+- confirmSignUp サービス: `apps/api/src/auth/service.rs:85`
+- モバイル登録画面: `apps/mobile/app/(auth)/register.tsx`
+- 確認コード入力: `apps/mobile/components/auth/ConfirmForm.tsx`
+- Terraform 実行ルール: `feedback_terraform_docker.md`（Docker 経由で実行）

--- a/.claude/plans/fetch-this-design-file-wiggly-crayon.md
+++ b/.claude/plans/fetch-this-design-file-wiggly-crayon.md
@@ -1,0 +1,219 @@
+# Precise デザインシステムへのモバイルアプリ移行計画
+
+## Context
+
+`docs/design/Design System.html` と `docs/design/Precise Full App.html` で定義された **Precise** デザイン（Apple HIG 哲学を踏襲したオリジナル体系 — 抑制・グルーピング・大見出し・テーブル数字・ガラス素材）に、`apps/mobile` を再設計して揃える。
+
+現行 UI はトークン (`theme/tokens.ts`) や primitives (`components/ui/`) に整理済みなので、まずトークン層を Precise 仕様に差し替えてから画面を順次書き換える。タブ構成は **Dogs / Walk / Me** に並べ替え、Settings を Me に改名する。
+
+---
+
+## 進め方（3 段 PR）
+
+| # | 目的 | ブランチ例 |
+|---|---|---|
+| 1 | デザイントークン + UI primitives 差し替え | `feat/mobile-precise-tokens` |
+| 2 | Walk フロー（Start / Active / Finish / Detail）再設計 | `feat/mobile-precise-walk` |
+| 3 | Dogs 系 + Me + Auth 再設計 | `feat/mobile-precise-remaining` |
+
+各 PR は TDD（既存テストを緑に保つ）で、コミット前に Docker Compose で iOS Simulator 起動＋スクショ検証。
+
+---
+
+## Phase 1 — トークンと Primitives
+
+### 1.1 `apps/mobile/theme/tokens.ts`
+
+- **colors (light / dark)** を Precise パレットへ
+  - `background` → `#f2f2f7` / `#000`
+  - `surface` → `#ffffff` / `#1c1c1e`
+  - `surfaceContainer`（= 行の fill） → `rgba(118,118,128,0.12)` / `rgba(118,118,128,0.24)`
+  - `onSurface` → `#000` / `#fff`
+  - `onSurfaceVariant` → `rgba(60,60,67,0.6)` / `rgba(235,235,245,0.6)`
+  - `textDisabled` → `rgba(60,60,67,0.3)` / `rgba(235,235,245,0.3)`
+  - `border` → `rgba(60,60,67,0.18)` / `rgba(84,84,88,0.6)` （0.5 px セパレータ）
+  - `interactive` → `#0a84ff`
+  - `success`(new) → `#30d158`・`warning`(new) → `#ff9f0a`・`error` → `#ff453a`
+  - `material` (new) → `rgba(249,249,249,0.85)` / `rgba(22,22,23,0.85)`（タブバー・シート）
+- **typography** を SF/iOS スタイルへ入れ替え（`Display/Hero` は破棄し、`Inter` を system-ui スタックへ変更）
+  - `largeTitle` 34/41 · 700 · -0.6
+  - `title1` 28 · 700 · -0.5／`title2` 22 · 700 · -0.4
+  - `headline` 17 · 600／`body` 17 · 400／`subheadline` 15 · 400
+  - `footnote` 13 · 400／`caption` 12 · 600 · 0.4 (uppercase)
+  - `numericBig` 32 · 700 · tabular-nums（Walk タイマー用）
+- **spacing** を 4-point グリッドに正規化: `xs4 / sm8 / md12 / lg16 / xl20 / xxl24 / xxxl32 / xxxxl44 / huge60`
+- **radius**: `chip4 / small8 / row12 / card16 / sheet24 / phone44`
+- **elevation** を 3 段に: `low`（0 1 3 + 0 4 12）／`mid`（0 4 12 + 0 20 40）／`accentStart`（0 20 60 緑, START ボタン専用）
+
+### 1.2 UI primitives（`apps/mobile/components/ui/`）
+
+- `Button`: 高さ 50 / radius 14 / `font-size 17 / weight 600`。variants `primary`（tint 塗り）・`ghost`（fill 塗り）・`destructive`（red 塗り）。`size="circle"` を追加して Walk Start の 200×200 円形ボタン（緑 + accentStart shadow）に使用。
+- `OutlinedCard` → **`GroupedCard`** に刷新。白サーフェス＋`card16` radius＋`low` 影。`border` は廃止（Precise は境界線でなく余白とラジアスで分離）。
+- **新規** `GroupedRow`: leading 30×30 アイコンタイル / タイトル / trailing value / `›` chevron。兄弟行間は 0.5 px の `border` 色、leading アイコンの右端から開始。
+- **新規** `SectionHeader`: caption スタイル uppercase、グループ前に置く。
+- **新規** `Tag` / `PillTag`: 低不透明度背景＋フル発色テキスト、radius 100。Live 用に 6 px ドット付きバリアント。
+- **新規** `LargeTitleHeader` / `TopAppBar`: 54 safe + 44 nav + 52 large title ブロック。`left` / `right` に tint アクション、スクロールで大見出しが小見出しに折りたたむ（MVP では折りたたみなしでも可）。
+- `IconSymbol`: stroke 1.8 px / 26 px のアウトラインセットに置換（現行 SF Symbols マッピングを維持しつつ線画を再描画）。
+- `TextInput`: カード内行スタイル（左ラベル + 右値）に刷新、下線 0.5 px セパレータ。
+
+### 1.3 `hooks/use-colors.ts`
+
+新トークン（`success` / `warning` / `material` / `onSurfaceVariant` / `textDisabled`）を露出。
+
+### 1.4 既存テスト
+
+`components/ui/**.test.tsx` と `components/walk/*.test.tsx` を最低限パスさせる。スナップショットは更新、意味テスト（active/disabled の色・押下挙動）は維持。
+
+---
+
+## Phase 2 — Walk フロー
+
+### 2.1 タブ再構成 — `apps/mobile/app/(tabs)/_layout.tsx`
+
+- 順序を `dogs` → `walk` → `settings`（→ `me` にリネーム）に入れ替え。
+- ラベル: Dogs / Walk / **Me**（`settings.tabTitle` → `me.tabTitle` に i18n キーを移動。`en.json` = "Me", `ja.json` = "マイページ"）。
+- `tabBarStyle` にぼかしマテリアル（`material` トークン）と 0.33 px 上ボーダーを適用。高さ 83、上パディング 6、下パディング 28。
+- アイコンは Precise Full App `TabBar` に合わせたアウトライン SVG を `IconSymbol` 側に追加（Dogs=脚＋顔、Walk=チェック入り丸、Me=人物）。
+
+### 2.2 Walk Start — `components/walk/WalkReadyView.tsx` ＋ `app/(tabs)/walk.tsx`
+
+- レイアウト：Large Title "Walk" → "Walking with" キャプション → `DogSelectorSheet` トリガー（`GroupedCard` + ⌄） → "Today's goal" スライダーカード（5–60 分、現状の `SegmentedControl` は廃止し一次元スライダに差し替え） → **200×200 緑 START 円形ボタン** → キャプション「Tap to begin. We'll follow your route.」。
+- `Button size="circle" variant="success"` を新設して流用。
+- i18n: `walk.ready.*` のコピーを Precise voice に合わせて整える（穏やか・命令形を避ける）。
+
+### 2.3 Walk Active — `components/walk/Walk{Map,Controls,EventActions}.tsx`
+
+- マップを全画面背景へ。上部に 3 要素の floating glass bar（`✕` 閉じる／中央タイトル "Walk with Coco"／右上レイヤー切替）。各は radius 20 の `material` カード。
+- 下部に Live Activity 風ボトムシート (`radius 32`, `material` ブラー, 上に 36×5 grabber):
+  - 犬アバター ＋ 名前・副題 ＋ 右に `tag-live`（● LIVE）。
+  - 3 カラム大数字 `Time / Distance / Pace`（`numericBig` + tabular, 単位はサブフォントで隣）。
+  - Pee / Poop / Photo のクイック行（`fill` 背景 + 絵文字 + ラベル + count）。これは現行 `WalkEventActions` の拡張。
+  - `Pause`（ghost）＋ `End Walk`（destructive）。
+- タイマー表示はシート内 `Time` に統合し、`WalkControls` の独立カードは削除。
+- 既存のマップ polyline 描画・ピン（pee/poo/photo マーカー）は維持、色は accent green 5 px stroke＋0.3 opacity 白 highlight にアップデート。
+
+### 2.4 Walk Finish — `components/walk/WalkSummaryCard.tsx`
+
+- 構成を全面差し替え:
+  1. `caption` 緑 "WALK COMPLETE" ＋ 36 px heading「いいね、Coco!」 ＋ サブ「昨日のペースを 14 秒更新」。
+  2. 同心リングカード（Distance=green / Time=orange / Pace=red, stroke 10 / linecap round / `rotate(-90 55 55)`）と右に凡例＋値。
+  3. ミニマップ（140 高）— ルート縮小表示。
+  4. Tag ピル群「💩 1 / 💧 2 / 📷 3 / 🐾 友達に会った / ☀️ 晴れ」— 現行 `walk.finishTags` は未実装なので新 `TagGroup` で追加、オンは `tint` 塗り、オフは `surface`。
+  5. 底部アクション: `Add note`（ghost）＋ `Save walk`（primary, flex:1.4）。
+- 「Done で walk.tsx に戻れない」625c688 の症状は、Finish 画面からの復帰経路を `onClose` コールバック → `router.navigate("/(tabs)/walk")` ＋ phase リセットに固定して確実化する（Walk 画面が `finished` phase に貼り付く現象の根本原因: phase リセットが conditional）。
+- 「詳細」は Save 後に walk detail へ push し、Finish 画面は stack から pop。
+
+### 2.5 Walk Detail — `app/walks/[id].tsx`
+
+- ヘッダーを transparent glass の `‹ Coco` / `⋯`。
+- マップを 260 高 `card16` カードへ。polyline + start/end ピン + 写真ピン（白ドット＋青枠＋📷）。
+- `caption` uppercase 日付 → `title1` "朝の散歩"。
+- 3 カラム大数字カード（Distance / Duration / Pace）。
+- イベントタイムラインを `GroupedCard` + `GroupedRow` に置換（絵文字 22 幅 / 時刻 tabular 44 幅 / 本文）。
+
+### 2.6 i18n 調整
+
+`walk.*` キーを Precise voice に合わせて見直し：
+- `walk.ready.title` → "散歩"（英: "Walk"）
+- `walk.ready.startHint` → "タップして開始。道のりはこちらで記録します。"
+- `walk.finished.heroLine` → "{{dog}}、おつかれさま"
+- `walk.finished.beatPace` → "昨日より {{seconds}} 秒速いペース"
+- `walk.active.live` → "LIVE"
+- `walk.events.pee/poop/photo` はアイコン＋ラベルのまま維持
+
+---
+
+## Phase 3 — Dogs / Me / Auth
+
+### 3.1 Dogs list — `app/(tabs)/dogs.tsx` + `DogListItem`
+
+- Large Title "Dogs" ＋ 右に `+ Add`（tint テキストボタン）。
+- 先頭に "Today's walking goal" ロールアップカード（conic-gradient の進捗リング 44 + タイトル + `3.52 / 5.0 km across your pack` + ›）。現行 `BentoCard` を流用しレイアウトだけ差し替え。
+- セクションヘッダー `YOUR PACK`。
+- 行カード: 56 円形アバター / 名前 ＋ `🔥12d` streak チップ / 副題 `breed · age` / `stats`（`1.42 km today · 47 walks`, tabular） / `›`。
+
+### 3.2 Dog detail — `app/dogs/[id]/index.tsx`
+
+- 0–300 に hero グラデ背景 ＋ 大型絵文字/写真（drop-shadow 強）。下に `bg` へのフェード。
+- 250 付近に name（title1）＋ breed/age/weight 行。
+- 320 に 3 セル stats カード（`Walks` / `km` / `Streak`, 縦 0.5 px セパレータ）。
+- 416 に Section title "Walks" ＋ `See all`。
+- Walks を `GroupedCard` + `GroupedRow`（36 青マーク / 日付 + 速度 / `💧n 💩m` / ›）。
+
+### 3.3 Me（旧 Settings）— `app/(tabs)/settings.tsx`
+
+- プロフィールカード: 60 円形イニシャル（accent グラデ）＋ 名前 / email / `View profile`（tint）。
+- 3 グループ: **Preferences**（Language / Units / Notifications / Appearance）・**Legal**（Terms / Privacy / About） ・**Sign out**（単独カード、赤中央）。
+- 行は `GroupedRow`（icon 30 tile + label + value + ›）。
+- 既存 `EncounterDetectionSection` は Preferences グループ内に "Nearby dogs"（仮）として組み込む。
+
+### 3.4 Auth — `app/(auth)/login.tsx`, `register.tsx`
+
+- 上部 68 角丸 22 のアプリマーク（緑→青グラデ + 中に脚型 SVG）。
+- Large heading "Welcome back" / "Let's meet your dog."
+- 入力は `GroupedCard` の行スタイル（左ラベル 70–96 / 右値・`TextInput`）。
+- Primary CTA は 50 高／radius 14 ／tint。SNS ログインは黒ボタン（`Continue with Apple`）として Cognito HostedUI への既存フローを流用（feedback_auth_via_api に従い API 経由）。
+
+### 3.5 Dog new / edit / members / encounters
+
+- 同じ `GroupedCard + GroupedRow + LargeTitleHeader + Button` の組み合わせで書き換え。特別な新規コンポーネントは不要。
+
+---
+
+## 修正対象ファイル
+
+### Phase 1
+- `apps/mobile/theme/tokens.ts`
+- `apps/mobile/hooks/use-colors.ts`
+- `apps/mobile/components/ui/Button.tsx` (+ test)
+- `apps/mobile/components/ui/OutlinedCard.tsx` → `GroupedCard.tsx`（リネーム＋書き換え）
+- `apps/mobile/components/ui/GroupedRow.tsx`（新規）
+- `apps/mobile/components/ui/SectionHeader.tsx`（新規）
+- `apps/mobile/components/ui/Tag.tsx`（新規）
+- `apps/mobile/components/ui/LargeTitleHeader.tsx`（新規）
+- `apps/mobile/components/ui/IconSymbol.tsx`
+- `apps/mobile/components/ui/TextInput.tsx`
+
+### Phase 2
+- `apps/mobile/app/(tabs)/_layout.tsx`
+- `apps/mobile/app/(tabs)/walk.tsx`
+- `apps/mobile/components/walk/WalkReadyView.tsx` (+ test)
+- `apps/mobile/components/walk/DogSelectorSheet.tsx`
+- `apps/mobile/components/walk/WalkMap.tsx`
+- `apps/mobile/components/walk/WalkControls.tsx`（縮小・統合）
+- `apps/mobile/components/walk/WalkEventActions.tsx`
+- `apps/mobile/components/walk/WalkSummaryCard.tsx`（全面差し替え）
+- `apps/mobile/app/walks/[id].tsx`
+- `apps/mobile/lib/i18n/locales/en.json`, `ja.json`
+
+### Phase 3
+- `apps/mobile/app/(tabs)/dogs.tsx`
+- `apps/mobile/components/dogs/DogListItem.tsx`, `DogStatsCard.tsx`
+- `apps/mobile/app/dogs/[id]/index.tsx`, `edit.tsx`, `new.tsx`, `members.tsx`, `encounters.tsx`, `friends/[friendDogId].tsx`
+- `apps/mobile/app/(tabs)/settings.tsx`（ディレクトリ名は保持、画面タイトル/tabTitle のみ `me` へ）
+- `apps/mobile/app/(auth)/login.tsx`, `register.tsx`
+- i18n：`settings.*` → `me.*`（下位互換のため旧キーを残すか、全面切替かは Phase 3 着手時に判断）
+
+---
+
+## 再利用する既存機能
+
+- `useColors()` / `useTheme()` — トークン参照の集約点。トークン拡張だけで Primitive は自動追従。
+- `OutlinedCard` → `GroupedCard` リネームは shim を 1 リリース挟む（名前衝突の import を一括置換）。
+- 既存 i18n キー大半は保持し、文言のみ差し替え。
+- Walk 計測ロジック（`useWalkRecording` 等）は触らず、表示コンポーネントのみ再設計。
+- Cognito 認証フロー（`feedback_auth_via_api`）は API 経由のまま、UI だけ差し替え。
+
+---
+
+## 検証手順
+
+1. **ユニットテスト**：`docker compose run --rm mobile npm test -- --run` が緑（snapshot 更新後も含む）。
+2. **型**：`docker compose run --rm mobile npm run typecheck`。
+3. **Lint**：`docker compose run --rm mobile npm run lint`。
+4. **iOS Simulator ビジュアル検証**（`ios-sim-test` skill）：
+   - Phase 1 後: Button / GroupedCard / GroupedRow のテストハーネス画面で light/dark を確認。
+   - Phase 2 後: Walk Start → START → Active シートで Pee/Poo/Photo をタップ → End Walk → Finish → Save → Walk Detail。625c688 で出た「Walk Complete に貼り付く」症状が解消し `Walk` タブに戻れることを確認。
+   - Phase 3 後: Dogs / Dog detail / Me / Login / Register の全画面スクショを light・dark で比較。
+5. **統合**：1 台の実機（Personal Team 署名）で散歩を 1 周し、保存まで到達することを確認。
+6. **アクセシビリティ**：最小行高 44 px、コントラスト比 4.5:1 以上（黒テキスト on `#f2f2f7`、白テキスト on `#1c1c1e`）を spot-check。

--- a/.claude/plans/lib-auth-secure-storage-ts-hashed-meteor.md
+++ b/.claude/plans/lib-auth-secure-storage-ts-hashed-meteor.md
@@ -1,0 +1,123 @@
+# Plan: shared keychain (App Group) 復活
+
+## Context
+
+Apple Personal Team 署名では `keychain-access-groups` entitlement を provision できないため、`apps/mobile/lib/auth/secure-storage.ts:17` で `sharedOptions = undefined` 固定にして暫定回避していた。これにより:
+
+- Live Activity widget (`targets/walk-live-activity/SharedKeychain.swift`) がトークンを読めない
+- `migrateLegacyTokens` (`auth-store.ts:41` から呼ばれる) は no-op 状態
+
+ユーザーが有料 Apple Developer Program に加入したため、shared keychain (App Group + keychain access group) を恒久的に復活させる。復活後は widget からも同じトークンを `SecItemCopyMatching` で読み出せるようになり、Live Activity の認証付き API 呼び出しが成立する。
+
+## 修正対象ファイル
+
+| ファイル | 修正内容 |
+|---|---|
+| `apps/mobile/app.config.ts` | `ios.entitlements` に `keychain-access-groups` を追加 |
+| `apps/mobile/lib/auth/secure-storage.ts` | `sharedOptions` を `extras.appGroup` + `extras.keychainService` から復元（コミット `63e7540` 以前のロジックを復活） |
+| `apps/mobile/lib/auth/secure-storage.test.ts` | `sharedOptions` が設定されるケースの assertion を追加 |
+| `apps/mobile/targets/walk-live-activity/expo-target.config.js` | 必要に応じ widget 側 entitlements に `keychain-access-groups` 継承を明示（既に `application-groups` を継承しているため要確認） |
+| `apps/mobile/ios/**/*.entitlements` | `expo prebuild --clean` で再生成（手編集しない） |
+
+## 実装手順
+
+### 1. `app.config.ts` の entitlements 拡張
+
+現在 (`app.config.ts:33-35`):
+```ts
+entitlements: {
+  'com.apple.security.application-groups': [APP_GROUP],
+},
+```
+
+変更後:
+```ts
+entitlements: {
+  'com.apple.security.application-groups': [APP_GROUP],
+  'keychain-access-groups': [`$(AppIdentifierPrefix)${APP_GROUP}`],
+},
+```
+
+`$(AppIdentifierPrefix)` は Xcode/codesign が Team ID に展開するプレースホルダ。`expo-secure-store` は `accessGroup` オプション値（= `APP_GROUP`）を `kSecAttrAccessGroup` にそのまま渡し、iOS が自動で `$(AppIdentifierPrefix)` プレフィックスと突合する。
+
+### 2. `secure-storage.ts` の `sharedOptions` 復元
+
+`apps/mobile/lib/auth/secure-storage.ts:1-17` を以下に差し戻す（コミット `63e7540` の構造）:
+
+```ts
+import * as SecureStore from 'expo-secure-store';
+import Constants from 'expo-constants';
+import { Platform } from 'react-native';
+
+// ... keys ...
+
+const extras = (Constants.expoConfig?.extra ?? {}) as {
+  appGroup?: string;
+  keychainService?: string;
+};
+
+const sharedOptions: SecureStore.SecureStoreOptions | undefined =
+  Platform.OS === 'ios' && extras.appGroup && extras.keychainService
+    ? { accessGroup: extras.appGroup, keychainService: extras.keychainService }
+    : undefined;
+```
+
+`migrateLegacyTokens` 本体 (`secure-storage.ts:46-60`) は変更不要 — `!sharedOptions` ガードが false に変わるだけで既存ロジックがそのまま走る。
+
+### 3. テスト更新
+
+`apps/mobile/lib/auth/secure-storage.test.ts:14-17` の `expo-constants` モックで `extra.appGroup` / `extra.keychainService` を固定し、
+
+- `setItemAsync` / `getItemAsync` 呼び出し時の第2引数に `{ accessGroup: 'group.com.walkingdog.dev', keychainService: 'com.walkingdog.shared' }` が渡ることを assertion 追加
+- `migrateLegacyTokens` が `MIGRATION_DONE_KEY` を共有スコープ側に書くケース（既存テスト 72-99 行）が引き続き green
+
+### 4. Xcode signing 設定
+
+`expo prebuild --clean` 実行後:
+
+1. `apps/mobile/ios/WalkingDoglocal.xcworkspace` を開く
+2. WalkingDoglocal target → Signing & Capabilities タブ
+3. Team を Personal Team から有料 Apple Developer Program team に切り替え
+4. `Keychain Sharing` capability が自動追加され `group.com.walkingdog.dev` が表示されることを確認
+5. `App Groups` capability に `group.com.walkingdog.dev` がチェックされていることを確認
+6. walk-live-activity target についても同様に Team / capability 確認
+7. Apple Developer Portal で App ID `com.walkingdog.dev` および `com.walkingdog.dev.WalkLiveActivity` (widget) に App Groups + Keychain Sharing が enabled になっていることを確認（Xcode 自動 provisioning が処理）
+
+### 5. prebuild と pod install
+
+```bash
+cd apps/mobile
+npx expo prebuild --clean
+cd ios && pod install
+```
+
+`ios/WalkingDoglocal/WalkingDoglocal.entitlements` が空 `<dict/>` から `application-groups` + `keychain-access-groups` を含む状態に再生成されることを diff で確認。
+
+## 検証
+
+### 単体
+```bash
+cd apps/mobile
+npm test -- secure-storage auth-store
+```
+
+### 実機 e2e (sakura環境)
+```bash
+API_URL=https://walkingdogdev.dpdns.org APP_ENV=dev \
+  npx expo run:ios --device --configuration Release
+```
+
+確認項目:
+1. **新規ログイン**: Welcome → Login → トークン取得 → walk タブ遷移
+2. **永続化**: アプリを kill → 再起動 → 自動ログイン状態
+3. **Live Activity**: 散歩開始 → ロック画面の Live Activity 表示 → widget からの API リクエスト（GraphQL）が 401 を返さない（widget が共有 keychain からトークン取得できている証跡）
+4. **既存ユーザー migration**: 旧暫定版 (default scope) でログイン状態のまま新版にビルド差し替え → `migrateLegacyTokens` がデフォルトスコープから共有スコープへ移行 → 再ログイン不要
+5. **simulator**: `npm run ios` で iPhone 16 Pro sim 起動 → ログインフローで `getValueWithKeyAsync` の entitlement エラーが再発しないこと
+
+### 既存メモリ更新
+
+`~/.claude/projects/-Users-matsuokashuhei-Development-walking-dog/memory/project_iphone_dev_setup.md` の以下を改訂:
+
+- 「`sharedOptions` は `undefined` 固定」→ shared keychain 復活済みに変更
+- Personal Team 制約セクションを「過去の記録」として簡略化
+- 新たに有料 Apple Developer team の Team ID と provisioning profile 名を記載

--- a/.claude/plans/linked-yawning-hickey.md
+++ b/.claude/plans/linked-yawning-hickey.md
@@ -1,0 +1,56 @@
+# Fix CI on PR #89 (feat/ios-live-activity-walk)
+
+## Context
+
+PR #89 の CI `Cargo Test` が失敗（`Jest` はpass）。原因は
+`apps/api/src/graphql/mod.rs` の 3 関数 `walk_status_enum` /
+`walk_event_type_enum` / `period_enum` が **2重定義** されている
+こと（rustc E0428 "defined multiple times"）。
+
+経緯:
+- `main` の PR #87 (`0c9b3b1` refactor) がこの 3 関数を追加
+- ブランチコミット `f3311b0` (Phase 2 enums) が同じ 3 関数を追加
+- マージコミット `17c183a` でコンフリクト解消時に両方残したため
+  行 11–32 と行 35–56 に連結複製された
+
+両コピーは完全に同一。片方を削除すれば解消。
+
+## Workspace
+
+新規 worktree を作成済み:
+`/Users/matsuokashuhei/Development/walking-dog/.claude/worktrees/fix-pr89-ci`
+
+- worktree ブランチ `worktree-fix-pr89-ci` を `origin/feat/ios-live-activity-walk`
+  の tip (17c183a) に hard reset 済み。
+- 既存の worktree `.worktrees/feat/ios-live-activity` には
+  ユーザーの iOS Live Activity の WIP があるため触らない。
+
+## Fix Steps
+
+1. `apps/api/src/graphql/mod.rs` の 行 33（空行）〜行 56（2つ目の
+   `period_enum` 閉じ括弧）を削除する。1つ目の 10–32 行はそのまま。
+   削除後は行 32 の `}` の直後に行 33（現行57）の空行が続く形。
+2. `docker compose -f apps/compose.yml run --rm api cargo build` で
+   ローカル build 確認。
+3. `apps/api/src/graphql/mod.rs` だけ `git add` してコミット:
+   ```
+   fix(api): remove duplicate enum helpers from bad merge
+
+   Merging main (#87) into feat/ios-live-activity-walk concatenated
+   the enum helpers instead of dedup. Drop the second copy to
+   resolve E0428.
+   ```
+4. `git push origin worktree-fix-pr89-ci:feat/ios-live-activity-walk`
+   で PR ブランチに fast-forward push。
+5. `gh pr checks 89 --watch` で Cargo Test が緑になるのを確認。
+
+## Verification
+
+- ローカル: `cargo build` (Docker経由) が成功
+- CI: `Cargo Test` の conclusion が SUCCESS
+- `git diff origin/feat/ios-live-activity-walk~1..HEAD` が
+  `apps/api/src/graphql/mod.rs` の削除のみ
+
+## Files Touched
+
+`apps/api/src/graphql/mod.rs` のみ。

--- a/.claude/plans/pee-poo-iterative-balloon.md
+++ b/.claude/plans/pee-poo-iterative-balloon.md
@@ -1,0 +1,115 @@
+# Lock Screen Widget: pee/poo 無反応 + カメラ シャッター無反応 修正計画
+
+## Context
+
+ユーザー報告（逐語）: 「ロック画面に表示されるウィジェットでpeeやpooを押しても、データが記録されませんでした。またカメラを起動してもシャッターボタンが無効でした。」
+
+最新コミット `1b60162 feat(mobile): restore shared keychain (App Group + keychain-access-groups)` で、Live Activity（ロック画面ウィジェット）の pee / poo / camera ボタン機能を正式に有効化した。ところが実機（iPhone）＋さくら VPS の API 構成で以下 2 件の不具合が確認された。
+
+- **Bug A: pee / poo** — ロック画面ウィジェットで pee / poo を押しても、`WalkEvent` が DB に記録されない。ユーザーには失敗理由が一切見えない。
+- **Bug B: カメラ シャッター** — ウィジェットの 📷 ボタンを押すと iOS 標準カメラは起動するが、シャッターボタンが反応しない（ライブプレビューは動く、× / フリップは効く、白い丸ボタンだけ押しても何も起きない）。
+
+散歩は継続中（Live Activity 表示中）で、`walkId` は App Group に書き込まれている前提。両者とも最近追加されたウィジェット連携のコードパスに固有の問題で、既存のアプリ内 Pee/Poo/Photo ボタン操作には影響していない。
+
+根本原因は確定していない。Bug A の AppIntent は失敗時も `throw` するだけでユーザーも開発者もエラー理由が分からないため、**まず Bug A は原因特定の仕組みを入れる → 特定 → 直す** の順で進める。Bug B は UIKit の presenter タイミング起因の典型パターンであり、独立して修正できる。
+
+## 方針
+
+### Bug A: pee / poo 無反応 — 失敗原因を可視化してから根本修正する
+
+AppIntent が失敗している理由を現状 **まったくユーザー側でも開発者側でも把握できない**。4 つの失敗モード（`missingContext` / `missingToken` / `network` / `graphQLError`）のうちどれが起きているか分からないので、ブラインドで直す前に診断情報を出す。
+
+#### Step A-1: AppIntent の失敗を Live Activity で可視化する
+
+最小侵襲の設計：`WalkAttributes.ContentState` に `lastEventError: String?` を追加し、失敗時はそれを書き込む。ロック画面側には赤バッジで数秒表示する。
+
+- 対象ファイル
+  - `apps/mobile/targets/walk-live-activity/WalkAttributes.swift`
+  - `apps/mobile/modules/walk-activity/ios/WalkAttributes.swift` — ウィジェットと **byte-identical** にする規約（ファイル頭コメントで宣言済み）
+  - `apps/mobile/targets/walk-live-activity/WalkEventIntents.swift` — catch して `lastEventError` を書き込む
+  - `apps/mobile/targets/walk-live-activity/WalkLiveActivity.swift` — `lastEventError` があれば pee/poo ボタン上に小さく `⚠ <reason>` を重ねる
+- `WalkEventClient` 側は既に `WalkEventClientError` を enum で持っているので、`rawDescription` を付けて string 化する（`missingContext` / `missingToken` / `unauthorized` / `network(code)` / `graphQL(msg)` / `invalidURL` / `invalidResponse`）。
+
+これで次回ユーザーが pee/poo を押すと、どのフェーズで失敗しているかが即座に見える。
+
+#### Step A-2: 特定した原因に応じて根本修正
+
+先に可能性が高い順に整理しておく。
+
+1. **`missingToken`（最有力）** — 共有キーチェーンから access token が読めない。考えられる原因:
+   - `1b60162` 以前にログイン済みで、`migrateLegacyTokens` がまだ走っていない。対応: アプリ側 `lib/auth/auth-store.ts` の起動シーケンスで必ず `migrateLegacyTokens` 完了後に初回 `getToken` が走ることを確認する。走っていれば次起動で解消。走っていなければ auth 初期化を修正。
+   - `expo-target.config.js:13` の `'keychain-access-groups': keychainGroups` が実際のビルドで空配列になっている。対応: `generated.entitlements` を読んでビルド成果物に `keychain-access-groups` が含まれるか確認。含まれていなければ `expo-target.config.js` で fallback を持たせる。
+   - Apple Developer Portal 側で Widget 拡張の App ID に Keychain Sharing Capability が付いていない（Personal Team 時代の残骸）。対応: `eas build` 時に provisioning profile を再生成するか、Apple Developer Portal で手動確認。
+
+2. **`unauthorized`（次点）** — token は読めているが期限切れ。ウィジェットは refresh token 経由で更新する機能を持たない（`WalkEventClient.swift:68-70` は 401 を投げるだけ）。対応: **最小対応** として `WalkEventClientError.unauthorized` を `lastEventError` に載せて「再ログインしてください」と案内する。**理想対応** としてウィジェット側でも `SharedKeychain.readRefreshToken()` を使って `/auth/refresh` を叩き、新しい access token を shared keychain に書き戻す（`SharedKeychain` に書き込み API を追加）。今回はユーザー要望に応じて最小対応を採用し、理想対応は別タスクにする。
+
+3. **`network`** — さくら VPS が HTTPS であることを確認。`extras.apiUrl`（`app.config.ts:102`）が `http://...` だと ATS でブロックされる。対応: `.env.production` / `.env.development` で `API_URL=https://...` を設定。
+
+4. **`graphQLError`** — 入力バリデーション失敗。サーバー側 `apps/api/src/graphql/mutations/walk_event.rs:125-140` を読むと `walkId` / `eventType` / `occurredAt` のみ必須で、ウィジェットが送る `{walkId, eventType, occurredAt, dogId?}` は schema に合致している。このパスは可能性が低い。
+
+5. **`missingContext`** — 散歩継続中なのでほぼあり得ないが、App Group の bundle prefix 解決（`SharedConstants.swift:10-16`）が失敗するケースでは起きる。診断の第一ラウンドで除外できる。
+
+#### Step A-3: 再発防止
+
+- `WalkEventClient.swift` の URLSession タスクで `HTTPURLResponse` の `statusCode` と response body を OSLog に残す（`Logger(subsystem: "com.walkingdog.liveactivity", category: "Network")`）。Console.app で `subsystem == com.walkingdog.liveactivity` でフィルタすれば iPhone 実機からでも確認できる。
+- テスト: `apps/mobile/targets/walk-live-activity/*Tests.swift` は現状存在しない。Widget Extension 単体のユニットテストは環境整備が重いので、`WalkEventClient` の GraphQL ボディ組み立てだけ手動で Curl 比較する（別タスク化）。
+
+### Bug B: カメラ シャッター無反応
+
+スクリーンショットから iOS 標準カメラは起動しておりプレビューも動いているが、シャッターボタンだけタップに反応しない。このパターンは **`UIImagePickerController` を deep link のハンドラ内で present した場合**、UIKit のウィンドウ遷移が完了しきる前にモーダルが押し込まれてタッチハンドリングが壊れる、という既知挙動に合致する。
+
+現在のフロー（`app/(tabs)/walk.tsx:44-48` → `walk-store.cameraRequestedAt` → `components/walk/WalkEventActions.tsx:102-106` → `handlePhoto`）では、deep link 受信→Zustand 更新→effect 発火→`ImagePicker.launchCameraAsync` が **数フレーム以内** に連鎖する。アプリが cold start／backgrounded 状態から起動した直後だとここが詰まりがち。
+
+#### Step B-1: 起動後のアイドルを待ってから launchCameraAsync する
+
+- 対象ファイル: `apps/mobile/components/walk/WalkEventActions.tsx`
+- 変更: Live Activity 経由の effect (L102-106) 内で `handlePhoto()` を呼ぶ前に、`InteractionManager.runAfterInteractions` と `AppState` が `'active'` になるのを待つ。両方を満たした後、さらに 150ms 程度の遅延を挟んでから `handlePhoto()`。
+- 併せて `handlePhoto` 側（L58-97）は unchanged。アプリ内 📷 ボタンから直接呼ぶ経路は今まで通りに動く。
+
+#### Step B-2: Deep link の cold start 取りこぼしを直す
+
+関連バグ：`app/(tabs)/walk.tsx:44-48` は `phase === 'recording' && walkId` が条件だが、cold start 直後はまだ `phase === 'ready'` かつ `walkId === null`。にもかかわらず `router.setParams({ action: undefined })` で action が消されるため、後で store が hydrate されても effect は再発火しない。
+
+- 変更案: `if (params.action !== 'camera') return;` で early return した後、条件を満たさない場合は `router.setParams` を呼ばずに待機する。条件が満たされた時点で初めて `requestCamera()` と `setParams(undefined)` を呼ぶ。これで hydrate 完了後に取りこぼさず発火する。
+- この Phase の修正は Bug B と独立に効くので、まとめて一つの PR で出す。
+
+#### Step B-3: 手動検証
+
+- ロック画面で Live Activity の 📷 をタップ → Face ID → カメラ起動 → シャッター反応を確認。
+- 散歩開始前（`phase === 'ready'`）に Live Activity を出すケースは存在しない（startActivity は walk 開始時のみ）ので、cold start の race は「散歩中にアプリを kill → ロック画面 → 📷」で再現。
+
+### 修正対象ファイル一覧
+
+**Bug A**
+- `apps/mobile/targets/walk-live-activity/WalkAttributes.swift` — `ContentState.lastEventError: String?` を追加
+- `apps/mobile/modules/walk-activity/ios/WalkAttributes.swift` — 同上（byte-identical）
+- `apps/mobile/targets/walk-live-activity/WalkEventIntents.swift` — catch → ContentState 更新
+- `apps/mobile/targets/walk-live-activity/WalkEventClient.swift` — OSLog の詳細ログ追加
+- `apps/mobile/targets/walk-live-activity/WalkLiveActivity.swift` — `lastEventError` の赤バッジ表示
+- Step A-2 の結果により追加（例: `apps/mobile/lib/auth/auth-store.ts`、`app.config.ts` の env、`expo-target.config.js`）
+
+**Bug B**
+- `apps/mobile/components/walk/WalkEventActions.tsx` — InteractionManager / AppState / setTimeout ガード追加
+- `apps/mobile/app/(tabs)/walk.tsx` — `router.setParams({ action: undefined })` を条件満足時のみ呼ぶ
+
+### 再利用する既存関数・構造体
+
+- `WalkEventClientError`（`WalkEventClient.swift:3-11`）— そのまま `lastEventError` の source として使う
+- `SharedWalkContext.write/clear`（`modules/walk-activity/ios/SharedWalkContext.swift`）— 既存、変更なし
+- `useWalkStore.requestCamera/clearCameraRequest`（`stores/walk-store.ts:68`）— 既存、変更なし
+- `InteractionManager` / `AppState`（React Native 標準）
+
+### 検証手順
+
+1. **ビルド**: `cd apps/mobile && npx expo prebuild --clean` → Xcode で Run（実機接続）
+2. **Bug A 診断ラン**: ロック画面 Live Activity で pee をタップ。Live Activity に `⚠ missingToken` など理由表示されることを確認。Console.app で `subsystem == com.walkingdog.liveactivity` をフィルタしてログ確認。
+3. **Bug A 根本修正後**: pee/poo をタップ → Live Activity の `lastEventKind` が "pee" / "poo" に更新される／アプリを前面に戻すと DB にイベントが反映されていることを `apps/api` の GraphQL で確認。
+4. **Bug B**: 散歩中にアプリを完全 kill → ロック画面 📷 → Face ID → カメラ起動 → シャッター反応を確認。撮影後アプリに戻り、`WalkEvent.photo_url` が S3 の key で保存されることを確認。
+5. **回帰**: アプリ内 Pee/Poo/📷 ボタンが従来通り動作すること（変更は deep link 経由 effect のみ）。
+6. **ユニットテスト**: `apps/mobile` で `npm test`（Docker 経由）を通す。変更した React コンポーネントは既存テストの assertion が壊れないことを確認。
+
+### 想定外のリスク
+
+- Step A-1 で `WalkAttributes.ContentState` を拡張するとシリアライズ互換性のため、既存の進行中 Live Activity は一度終了して再作成する必要がある。対応: デプロイ後に古いまま動いている Live Activity は散歩終了時に自動で clear される。ユーザーにリスクは無い。
+- Step A-2 の「理想対応（widget で refresh token 利用）」は今回スコープ外。
+- Step B-1 の `setTimeout(150ms)` はアプリ内 📷 ボタン経路（通常 hot path）には影響しない（effect ではなく `handlePress` 直接呼び）。

--- a/.claude/plans/peppy-percolating-hartmanis.md
+++ b/.claude/plans/peppy-percolating-hartmanis.md
@@ -1,0 +1,185 @@
+# Plan: #2 CI disk 圧迫対策 + Dockerfile.dev に rustfmt 追加
+
+## Context
+
+`tasks/refactor/api/04-followup.md` 項目 #2 (Medium): Phase 6/7 CI で `Compiling walking-dog-api` の linker 段階で "No space left on device" 失敗が発生。ubuntu-latest runner の 14GB disk 境界が原因。rerun で通る不安定状態、本質的対策が必要。
+
+合流項目: Dockerfile.dev に `rustup component add rustfmt` 追加 (前セッションで agent が `cargo-fmt is not installed` で fmt 検証 fail、dev container で直接 `cargo fmt` 実行可能化する需要あり)。
+
+ユーザー選択: **D = A+B+C 全て** を **2 PR に分割** 実施。
+
+## 分割方針
+
+- **PR 1: CI disk 対策** — `.github/workflows/test-api.yml` (free-disk-space + rust-cache) + `apps/api/Cargo.toml` (`[profile.test]` tweak)
+- **PR 2: dev container rustfmt 追加** — `apps/api/Dockerfile.dev`
+
+分割理由: PR 1 は CI インフラ変更 (影響範囲 = CI runner のみ)、PR 2 は dev container rebuild 要件 (影響範囲 = 開発者環境)。CI 成功確認を PR 2 より先に得る。
+
+---
+
+## PR 1: CI disk 対策
+
+### 変更ファイル
+
+#### `/Users/matsuokashuhei/Development/walking-dog/.github/workflows/test-api.yml`
+
+現状 (L22-L24): `Checkout` の直後に `Create DynamoDB table and S3 bucket` step。
+
+**変更**:
+1. `Checkout` step の直後に `jlumbroso/free-disk-space@main` step 挿入 (~30GB 解放)
+2. その直後に `Swatinem/rust-cache@v2` step 挿入 (`workspaces` key を `apps/api` に設定、`shared-key` で cache scope 統一)
+
+挿入例 (docker compose の compose.yml L26 の `up -d dynamodb-local localstack` より前):
+
+```yaml
+- name: Free disk space
+  uses: jlumbroso/free-disk-space@main
+  with:
+    tool-cache: true
+    android: false
+    dotnet: false
+    haskell: false
+    large-packages: false
+    swap-storage: false
+
+- name: Rust cache
+  uses: Swatinem/rust-cache@v2
+  with:
+    workspaces: apps/api -> target
+    shared-key: test-api
+```
+
+注: rust-cache の `workspaces: apps/api -> target` は「`apps/api` workspace の `target` ディレクトリをキャッシュ」という意味。docker compose 経由実行では host 側の `apps/api/target` が named volume に紐づくため、rust-cache が正しく拾えるか要検証 (検証手順は下記)。万一 compose の named volume と競合する場合は rust-cache を PR 1 から除外して PR 1B (別 PR) に切り出す。
+
+#### `/Users/matsuokashuhei/Development/walking-dog/apps/api/Cargo.toml`
+
+現状: `[profile.*]` セクション無し (`[features]`, `[dependencies]`, `[dev-dependencies]` のみ)。
+
+**変更**: ファイル末尾に以下を追加:
+
+```toml
+[profile.test]
+debug = "line-tables-only"
+```
+
+効果: debug symbol size 30-50% 削減 → linker phase disk spike 軽減 (A の margin 増加)。
+
+### 完了条件 / 検証
+
+1. CI で `Test API` workflow PASS
+2. workflow log 上で `Free disk space` step が `Total reclaimed: ~30 GB` 相当表示
+3. `cargo test --features test-utils -- --test-threads=1` 全緑維持
+4. rust-cache が期待通り cache hit or miss して compile 時間短縮確認 (初回は miss で OK)
+5. rust-cache の `workspaces: apps/api -> target` が docker compose named volume と衝突していない (step succeeds without warnings)
+
+### リスク / mitigation
+
+| リスク | mitigation |
+|---|---|
+| rust-cache が docker compose target_cache named volume と競合 → cache 書き込み失敗 | compose volume が host 側 path にマウントされているか確認。競合時は rust-cache を PR 1 から除外し、PR 1B として後日検討 |
+| free-disk-space が timeout / failure | `continue-on-error: true` で fallback 可能。ただし CI 不安定化を避けるため初期は false で確実に検証 |
+| `[profile.test] debug = "line-tables-only"` が既存 test 挙動を変える | debug info のみ影響。test pass/fail には無関係。既存 test の全緑で担保 |
+
+---
+
+## PR 2: Dockerfile.dev に rustfmt 追加
+
+### 変更ファイル
+
+#### `/Users/matsuokashuhei/Development/walking-dog/apps/api/Dockerfile.dev`
+
+現状 (L4): `RUN rustup component add clippy`
+
+**変更**: L4 直後に以下を追加:
+
+```dockerfile
+RUN rustup component add rustfmt
+```
+
+または既存 clippy と合流:
+
+```dockerfile
+RUN rustup component add clippy rustfmt
+```
+
+(後者の方が layer 数少なく image size 最適)
+
+### 完了条件 / 検証
+
+1. `docker compose -f apps/compose.yml build api` でイメージ rebuild 成功
+2. `docker compose -f apps/compose.yml run --rm api cargo fmt --check` が実行可能 (rustfmt not installed エラーが出ない)
+3. `.claude/agents/inspector_ja.md` の `cargo fmt --check` checkbox が機能する (将来的な inspector 検査の blocker 解消)
+
+### リスク / mitigation
+
+| リスク | mitigation |
+|---|---|
+| image size 増加 (~20MB) | 単独 layer より clippy との合流で削減 |
+| 既存 cargo fmt 違反が発覚 | PR 2 前に `chore(api): fix pre-existing cargo fmt violations` を別コミットで対応 (今回 PR #102 の chore と同様パターン)。事前 scan 必要 |
+
+---
+
+## 実施順序
+
+1. **PR 1 先行** — CI disk 対策が最優先、項目 #2 解消の主目的
+2. **PR 1 merge 確認後 PR 2** — dev container rebuild は PR 1 の CI 結果に影響しないが、順次で不具合切り分け容易化
+3. 両 PR merge 後、`tasks/refactor/api/04-followup.md` 項目 #2 に DONE ステータス追記 (PR 2 の末尾コミット or 別 small PR)
+
+---
+
+## 既存資産の再利用
+
+- **既存 workflow** `.github/workflows/test-api.yml` の構造 (docker compose 依存) 維持
+- **既存 Dockerfile.dev** の `rustup component add clippy` パターンに rustfmt 合流
+- **PR #102 の手法** (chore commit で pre-existing 違反修正) を PR 2 の fmt 違反対応で踏襲
+
+## Critical Files
+
+- PR 1:
+  - `/Users/matsuokashuhei/Development/walking-dog/.github/workflows/test-api.yml`
+  - `/Users/matsuokashuhei/Development/walking-dog/apps/api/Cargo.toml`
+- PR 2:
+  - `/Users/matsuokashuhei/Development/walking-dog/apps/api/Dockerfile.dev`
+- 参照のみ (変更なし):
+  - `/Users/matsuokashuhei/Development/walking-dog/.github/workflows/deploy-api.yml` (対策不要、既に GHA cache 使用)
+  - `/Users/matsuokashuhei/Development/walking-dog/apps/compose.yml` (named volume 設定確認用)
+  - `/Users/matsuokashuhei/Development/walking-dog/tasks/refactor/api/04-followup.md` 項目 #2 (出発点)
+
+## Verification (PR 1)
+
+```bash
+# CI 実行を trigger (push 後)
+gh pr checks <pr-1-number>
+
+# 成功時の log 確認 (例)
+gh run view --log-failed <run-id>  # 失敗時
+gh run view <run-id>  # 成功時
+
+# rust-cache の cache hit/miss 確認
+# workflow log 内 "Cache hit" or "Cache not found" message を grep
+```
+
+## Verification (PR 2)
+
+```bash
+# local で image rebuild
+docker compose -f apps/compose.yml build --no-cache api
+
+# rustfmt 動作確認
+docker compose -f apps/compose.yml run --rm api cargo fmt --check
+# 期待: 違反無しなら no output、あればリスト出力
+
+# 既存 integration test が rebuild 後も緑維持
+docker compose -f apps/compose.yml run --rm api cargo test --features test-utils -- --test-threads=1
+```
+
+---
+
+## OOS (本プランの対象外)
+
+- self-hosted runner 導入 (Option D)
+- sccache / cargo-chef 等の advanced caching
+- `cargo test --no-run` 分割 (効果無い判定)
+- `.github/workflows/deploy-api.yml` 変更 (既に cache 有効)
+- test-mobile.yml / e2e 配下の disk 対策 (リスク低)
+- `tests/support/` の fmt 違反自動検知 (既に PR #102 の chore で対処済)

--- a/.claude/plans/reactnative-ios26-ui-eager-rainbow.md
+++ b/.claude/plans/reactnative-ios26-ui-eager-rainbow.md
@@ -1,0 +1,152 @@
+# Plan: 歩行記録画面の下部パネルを Expo 公式 formSheet (iOS 26 Liquid Glass) 化
+
+## User Request (verbatim)
+
+> 「歩行記録画面の下部のフローティングパネルもExpo公式のUIに変えれるか？」
+
+## Context
+
+**なぜこの変更をするか**
+
+前回の NativeTabs 移行（`apps/mobile/app/(tabs)/_layout.tsx`）で iOS 26 Liquid Glass タブバーは公式 API 化できた（コミット未）。
+
+しかし `apps/mobile/app/walk-recording.tsx` の下部フローティングパネル（統計・イベントボタン・Pause/End）は**完全自作**で、React Native の `<View>` + 絶対位置 + 丸角 + 手動 grabber（WalkControls.tsx:226-234）で構成されている。
+
+これを **Expo Router の `formSheet` 公式プレゼンテーション**に置き換えれば：
+- iOS 26 で **UIGlassEffect が自動適用**（ネイティブ sheet なので Liquid Glass 対応）
+- 手動の grabber・角丸・影が不要になる
+- Apple Maps / 純正「フィットネス」「マップ」アプリと同じ挙動（検出・ドラッグ・detent）
+- `sheetAllowedDetents` でネイティブに minimized/expanded をドラッグで切替
+
+**トレードオフ**
+- 既知の iOS 26 不具合（[react-native-screens #3235](https://github.com/software-mansion/react-native-screens/issues/3235)、[expo #42066](https://github.com/expo/expo/issues/42066)）で formSheet が小さく描画される報告あり → 発生時は detent 数値調整で回避
+- ルーティング構造の再編が必要（walk-recording.tsx 単一ファイル → グループ）
+- 既存の `isMinimized` ストア状態は detent で置き換え可能（または detent change event と同期）
+
+## Approach
+
+### ルート構造の再編
+
+**Before**: `app/walk-recording.tsx`（単一ファイル）
+
+**After**: `app/walk-recording/` グループ
+```
+app/walk-recording/
+├── _layout.tsx     # Stack 層
+├── index.tsx       # 背景 Map + TopChip（push で controls を自動オープン）
+└── controls.tsx    # 下部パネル（formSheet プレゼンテーション）
+```
+
+- Root `_layout.tsx` の `<Stack.Screen name="walk-recording">` 登録はそのまま（`presentation: 'fullScreenModal'` も維持 → タブバー非表示）
+- `(tabs)/walk.tsx` 内の `router.push('/walk-recording')` も変更不要（index.tsx が受ける）
+
+### formSheet 設定（`walk-recording/_layout.tsx` 内）
+
+```tsx
+<Stack.Screen
+  name="controls"
+  options={{
+    presentation: 'formSheet',
+    sheetAllowedDetents: [0.28, 0.62],   // minimized / expanded の 2 detent
+    sheetInitialDetentIndex: 1,          // 初期は expanded
+    sheetGrabberVisible: true,           // ネイティブ grabber
+    sheetCornerRadius: 24,               // iOS 26 はシステム既定も綺麗
+    gestureEnabled: false,               // スワイプで閉じさせない（End Walk 必須）
+    headerShown: false,
+  }}
+/>
+```
+
+### 各ファイルの役割
+
+**`walk-recording/index.tsx`**（背景 map、新規）
+- `<WalkMap />` + `<WalkTopChip />`
+- `useEffect` で `phase === 'recording'` 確認、非ならば `router.back()`
+- 初回マウント時に `router.push('/walk-recording/controls')` で sheet 起動
+- deep link `action=camera` の転送（現状と同じロジックを保持）
+
+**`walk-recording/controls.tsx`**（新規、formSheet 内容）
+- 現行 `walk-recording.tsx` の `WalkControls` / `WalkMinimizedControls` / `WalkEventActions` / `WalkQuickActions` 部分を移植
+- handleStop の実装もこちらに集約
+- detent change event で `isMinimized` を store に反映（または `isMinimized` 自体を廃止し、detent index で content 切替）
+
+**`walk-recording/_layout.tsx`**（新規）
+- `Stack` で index と controls を束ねる
+
+### 既存コンポーネントの変更
+
+- `components/walk/WalkControls.tsx` — 自作 sheet 装飾を削除（`borderRadius`, `borderWidth`, 手動 grabber、`theme.surface` 背景）。formSheet が提供するので不要
+- `components/walk/WalkMinimizedControls.tsx` — 同上（pill 背景・border を削除、または detent 0（小）時のみ表示する content に再利用）
+- 他コンポーネント（`WalkEventActions`, `WalkQuickActions`, `WalkTopChip`）は変更なし
+
+### `isMinimized` ストア状態の扱い
+
+**推奨**: 残す。ただし setter は detent change event で呼ぶ
+```tsx
+<Stack.Screen
+  name="controls"
+  listeners={{
+    sheetDetentChanged: (e) => setMinimized(e.data.index === 0),
+  }}
+/>
+```
+これで既存の WalkQuickActions/WalkMinimizedControls の表示切替ロジックを保持しつつ、detent はネイティブドラッグで動かせる。
+
+## Files to Modify / Add / Remove
+
+### 追加
+- `apps/mobile/app/walk-recording/_layout.tsx`
+- `apps/mobile/app/walk-recording/index.tsx`
+- `apps/mobile/app/walk-recording/controls.tsx`
+
+### 削除
+- `apps/mobile/app/walk-recording.tsx` — フォルダに置き換わる
+
+### 変更
+- `apps/mobile/components/walk/WalkControls.tsx` — 自作 sheet 装飾（border, radius, grabber, background）の削除
+- `apps/mobile/components/walk/WalkMinimizedControls.tsx` — pill 背景削除（sheet 内に埋まるため）
+- 既存テスト（`WalkControls.test.tsx`, `WalkMinimizedControls.test.tsx`）のアサーション調整（削除した style の期待値を更新）
+
+### 変更不要
+- `apps/mobile/app/(tabs)/walk.tsx` — `router.push('/walk-recording')` はそのまま有効
+- `apps/mobile/app/_layout.tsx` — root Stack 登録は変更なし
+
+## Re-used Utilities
+
+- `useWalkStore`, `useWalkSession`, `useBleSession`, `useEncounterSession` — そのまま（ロジック変更なし）
+- `useSafeAreaInsets` — index.tsx の TopChip 配置で使用
+- `useTranslation` — ラベル i18n
+- SF Symbol / MaterialIcons via existing `IconSymbol` — 変更なし
+- `apps/mobile/components/walk/WalkMap.tsx`, `WalkTopChip.tsx`, `WalkEventActions.tsx`, `WalkQuickActions.tsx` — そのまま再利用
+
+## Risks & Open Questions
+
+1. **iOS 26 formSheet 描画バグ**: 報告あり（detent が期待通り表示されない）。発生時は `sheetAllowedDetents` の数値を実機計測して調整。最悪 `fitToContents` でも可
+2. **Android での見た目**: Android でも formSheet は動くが、Liquid Glass は iOS 26 専用。Android は Material BottomSheetDialog 相当で描画される
+3. **Stack 入れ子**: root → `walk-recording` (fullScreenModal) → 内部 Stack (index + formSheet controls)。この入れ子構成を expo-router が正しくハンドルするか、実機確認要
+4. **detent change event**: `sheetDetentChanged` listener が iOS/Android 両方で発火するか確認（types.tsx:60-64 に記述あり）
+5. **camera deep link**: index.tsx → controls.tsx への params 受け渡しを正しく実装する必要あり
+6. **既存テスト**: `WalkControls.test.tsx` / `WalkMinimizedControls.test.tsx` 内のスタイル・レイアウトアサーションを更新する必要あり
+7. **見た目調整**: formSheet 内コンテンツは padding を native sheet のルールに合わせる必要あり（iOS 26 sheet の safe inset を考慮）
+
+## Verification
+
+1. **Type check**: `npx tsc --noEmit` — 新規エラー 0 を確認
+2. **Unit test**: `npm test` — 既存 457 件が緑、テスト更新部分も緑
+3. **iOS 26.4 Simulator（iPhone 17 Pro）**:
+   - 歩行 START → walk-recording/index にマップ表示、controls sheet が下から expanded detent で自動提示
+   - **sheet 背景が Liquid Glass**（マップが透けて見える、スクロール/パンで屈折）
+   - grabber をドラッグして minimized detent → 小さいサイズでも stats 見える（または minimized pill に切替）
+   - End Walk ボタン → sheet 閉じる → map 画面経由で /(tabs)/walk に戻る → Summary 表示
+   - Live Activity 「Camera」ボタンタップ → deep link が controls sheet にまで届き撮影フロー起動
+4. **iOS 18 / Android**: Liquid Glass は出ないが、通常の formSheet として正常動作（クラッシュなし）
+5. **回帰**: 既存の WalkControls/WalkEventActions の個別テスト（pee/poop/photo ボタン、stats 表示）が緑
+
+## Rollback
+
+変更は新規 3 ファイル追加 + 1 ファイル削除 + 2 ファイル微修正（WalkControls 系スタイル）。問題時は：
+```bash
+git checkout -- apps/mobile/app/walk-recording.tsx apps/mobile/components/walk/WalkControls.tsx apps/mobile/components/walk/WalkMinimizedControls.tsx
+rm -rf apps/mobile/app/walk-recording/
+```
+で復元可能。

--- a/.claude/plans/sign-in-docs-design-sign-in-actual-png-purrfect-octopus.md
+++ b/.claude/plans/sign-in-docs-design-sign-in-actual-png-purrfect-octopus.md
@@ -1,0 +1,142 @@
+# Sign In 画面 Precise リデザイン計画
+
+## Context
+
+`docs/design/sign-in/expect.html.png`（`docs/design/app.html:508-550` が一次ソース）で示された Precise デザインと、現行実装 `apps/mobile/app/(auth)/login.tsx` + `components/auth/LoginForm.tsx` の見た目が大きく乖離している。PR #122-#126 で他画面（Walk Detail / Me / Dogs list / Dog detail / Auth hero）は Precise スタイル化済み。Sign In だけ Precise 化が不完全で、app mark・フォームレイアウト・CTA 周り・secondary 認証導線が未対応。
+
+本変更により Sign In 画面を他画面と同等の Precise 仕上げに揃え、視覚的一貫性とプレミアム感を確立する。Apple Sign-In は UI のみ先行（機能は後続 PR）。
+
+## 採用するスコープ（AskUserQuestion 結果）
+
+1. **Apple Sign-In**: UI のみ先行。ボタンは出すが onPress は Alert「近日対応」表示。`expo-apple-authentication` 依存追加・API 改修なし。
+2. **Subtitle コピー**: 現状維持。en `"Sign in to keep walking with your companion."` / ja `"散歩の記録と犬の友情を大切に"`。
+3. **入力 UI**: 既存 `TextInput` を改修。`labelPosition?: 'top' | 'inline'` を opt-in で追加、デフォルトは `'top'` で後方互換維持。
+
+## 目標デザイン仕様（expect ソース準拠）
+
+| 要素 | 仕様 |
+|---|---|
+| App mark | 68×68, radius 22, `LinearGradient(135deg, #5eddb7, #0a84ff)`, 中央に白い paw SVG, shadow `offset(0,10) opacity 0.3 radius 30` |
+| Hero title | `largeTitle` (34/700/-0.8), `Welcome back` ハードコーディング → i18n キー `auth.login.heading` に移行 |
+| Subtitle | `subheadline` (15/400/21), `onSurfaceVariant` |
+| Form | `GroupedCard` 1 枚 = Email 行 + separator(hairline, marginLeft 16) + Password 行。各行 `paddingHorizontal 16 / paddingVertical 14`, gap 10, label 幅 70 / 15px text2, value 17px flex 1 |
+| Forgot password | フォーム直下右寄せ, 15px tint, marginTop 12 / marginBottom 24 |
+| Primary CTA | `Button variant="primary"` `Sign in` (height 50, radius 16[既存 `radius.xl`]) |
+| Divider | 中央 `or`（13px text2）+ 左右 hairline separator, `margin 20px 0` |
+| Apple CTA | height 50, radius 16, light=#000 bg / 白 text (dark=#fff bg / 黒 text), 新規 `variant="apple"` 追加 or inline 実装 |
+| Footer | 画面下部に `New here? Create an account` 14px + tint link |
+
+## 変更ファイル一覧
+
+### 新規 / 改修コンポーネント
+
+1. **`apps/mobile/components/ui/TextInput.tsx`** — 改修
+   - props に `labelPosition?: 'top' | 'inline'` 追加（デフォルト `'top'`）
+   - `inline` 時: 行内横並び (label 70px 幅 / 15px `onSurfaceVariant` / value flex:1 17px)、border なし、padding 14/16 固定
+   - `top` 時: 現状のまま
+   - `separator?: boolean` 追加（GroupedCard 内で最後以外に hairline を下側に描画、`GroupedRow` に合わせる）
+   - **後方互換**: 既存 RegisterForm / ConfirmForm 呼び出しはデフォルト `top` で変化なし
+
+2. **`apps/mobile/components/ui/Button.tsx`** — 改修
+   - `ButtonVariant` に `'apple'` 追加
+   - Light: black bg / white text、Dark: white bg / black text（`useColorScheme` で分岐）
+   - サイズは `default`（既存 50 height / radius.xl）を共有
+   - Apple ロゴ glyph は SF Symbol `applelogo`（`IconSymbol` 経由）or `` 文字を leading に配置
+
+3. **`apps/mobile/components/auth/AppMark.tsx`** — **新規**
+   - 68×68 グラデーションタイル + 白 paw SVG + halo shadow
+   - グラデーション依存: `expo-linear-gradient` を `package.json` に追加（Expo SDK 標準モジュール、ガイドラインに合致）
+   - Paw SVG は `expect.html:516` のパスをそのまま React Native `react-native-svg` で描画（`react-native-svg` は既存依存想定、なければ追加）
+   - `login.tsx` と `register.tsx` で再利用可能な形に（将来）
+
+4. **`apps/mobile/components/auth/LoginForm.tsx`** — 大幅改修
+   - `TextInput` を `GroupedCard` 内 2 行レイアウトに（`labelPosition="inline"` + 1 行目 `separator`）
+   - `Forgot password?` リンクを追加（onPress は一旦 Alert「近日対応」or 空関数 + コメント、機能実装は後続 PR）
+   - Primary Button `Sign in` のみ残す（`Create Account` の secondary Button は削除）
+   - `or` divider 追加
+   - `Continue with Apple` Button（variant=`apple`）追加、onPress は `Alert.alert('Coming soon')`
+   - エラー表示位置: フォーム上部 or フォーム直下（hairline なし、`caption` サイズ維持）
+
+5. **`apps/mobile/app/(auth)/login.tsx`** — 軽微改修
+   - 絵文字 🐾 app mark を新 `AppMark` コンポーネントに置換
+   - `Welcome back` を i18n キー `t('auth.login.heading')` に
+   - hero と `LoginForm` の間のレイアウト調整
+   - 画面下部に「New here? Create an account」フッター追加（`position: absolute, bottom: 50`）
+   - 既存の `onRegisterPress={() => router.push('/(auth)/register')}` はフッターリンクの onPress に付け替え
+
+### i18n 追加
+
+6. **`apps/mobile/lib/i18n/locales/en.json`** と **`ja.json`**
+   - `auth.login.heading` 追加: en `"Welcome back"` / ja `"おかえりなさい"`
+   - `auth.login.forgotPassword` 追加: en `"Forgot password?"` / ja `"パスワードを忘れた場合"`
+   - `auth.login.or` 追加: en `"or"` / ja `"または"`
+   - `auth.login.continueWithApple` 追加: en `"Continue with Apple"` / ja `"Apple でサインイン"`
+   - `auth.login.newHere` 追加: en `"New here?"` / ja `"はじめての方は"`
+   - `auth.login.createAccountLink` 追加: en `"Create an account"` / ja `"アカウント作成"`
+   - `auth.login.comingSoonApple` 追加: en `"Apple Sign-In is coming soon."` / ja `"Apple でサインインは近日対応予定です"`
+   - 既存 `auth.login.subtitle` / `auth.login.register` はそのまま（register は未使用化）
+
+### テスト追加・更新
+
+7. **`apps/mobile/components/ui/TextInput.test.tsx`** — 新規 or 既存に
+   - `labelPosition="top"` デフォルト動作（従来と同じ）
+   - `labelPosition="inline"` 時のレイアウト検証（label / value の role ベース取得）
+   - `separator={true}` 時に hairline が描画されることを検証
+
+8. **`apps/mobile/components/ui/Button.test.tsx`** — 既存更新
+   - `variant="apple"` 時の背景色（light/dark）を検証
+
+9. **`apps/mobile/components/auth/LoginForm.test.tsx`** — 既存更新 or 新規
+   - Sign in / Forgot password / Continue with Apple が描画されること
+   - Apple タップで Alert が出ること（`jest.spyOn(Alert, 'alert')`）
+   - 既存: email/password 入力 → Sign in 押下で signIn が呼ばれる、エラー文言表示
+
+10. **`apps/mobile/components/auth/AppMark.test.tsx`** — 新規
+    - レンダリングのスナップショット or glyph の accessibilityHidden 確認
+
+## 依存追加
+
+- `expo-linear-gradient` — gradient 背景（Expo 公式モジュール、ガイドライン `feedback_` なし）
+- `react-native-svg` — paw アイコン SVG（既存依存あるか要確認、なければ追加）
+
+両方とも `Docker Compose 経由 npm` で追加（memory: feedback_npm_docker.md）:
+```
+docker compose exec mobile npm install expo-linear-gradient react-native-svg
+```
+
+## 検証方法
+
+1. **型チェック**: `docker compose exec mobile npx tsc --noEmit`
+2. **テスト**: `docker compose exec mobile npm test -- components/ui/TextInput components/ui/Button components/auth/LoginForm components/auth/AppMark`
+3. **iOS Simulator 実機確認**（memory: feedback_no_agent_for_simulator.md → Bash で直接実行）:
+   - `apps/mobile` で `npx expo start` 起動
+   - Simulator で `/(auth)/login` を表示
+   - expect.html.png と actual.png を並べてピクセル差を確認:
+     - App mark グラデーション + halo
+     - Grouped form レイアウト（label 幅 70, value 右側）
+     - Forgot password 右寄せ
+     - Primary Sign in ボタンの色（disabled/enabled）
+     - OR divider
+     - Continue with Apple 黒ボタン
+     - 画面下部 footer
+   - Email / Password 入力 → Sign in タップで既存フローが動くこと
+   - Continue with Apple タップで Alert 表示
+   - Dark mode でも視覚崩れがないこと
+4. **既存画面回帰**: RegisterForm / ConfirmForm（`TextInput` 既定 `top` 利用）が見た目・挙動とも不変
+5. **i18n**: デバイス言語を ja / en で切り替え、両方表示を確認
+
+## 再利用する既存資産
+
+- `components/ui/GroupedCard.tsx:1-44` — フォーム行のコンテナ（radius.xl + elevation.low）
+- `components/ui/Button.tsx:30-101` — primary / apple（新規追加）
+- `theme/tokens.ts:146-213` — largeTitle / subheadline / body / caption typography
+- `theme/tokens.ts:5-58` — interactive / onSurfaceVariant / border カラー
+- `hooks/use-colors.ts` — light/dark 対応
+- `hooks/use-auth.ts` — signIn 呼び出し（変更なし）
+- `docs/design/app.html:515-516` — gradient + paw SVG パスの一次ソース
+
+## 非スコープ（後続 PR）
+
+- Apple Sign-In 機能実装（`expo-apple-authentication` + Cognito federated identity + API Apple OIDC）
+- Forgot password 画面の実装（リンク先ルート作成、リセットメール送信）
+- Register 画面の同系統 Precise リデザイン（別途必要なら別 PR で）

--- a/.claude/plans/sign-up-docs-design-sign-up-redesign.md
+++ b/.claude/plans/sign-up-docs-design-sign-up-redesign.md
@@ -1,0 +1,82 @@
+# Sign Up 画面 Precise リデザイン計画
+
+## Context
+
+`docs/design/sign-up/expect.html.png`（一次ソース `docs/design/app.html:553-590`）と現行 `apps/mobile/app/(auth)/register.tsx` の見た目が乖離。直前の Sign In リデザイン（PR #127 マージ済み）と同じ設計言語で整える。
+
+変更対象は Register 画面の **register ステップのみ**（`step === 'register'`）。Confirm ステップは PR #126 で largeTitle 統一済みなので範囲外。Register → Confirm の 2 ステップフロー自体は変更しない。
+
+## 方針の既定値（Auto mode、Sign In と同一ポリシー）
+
+- **Terms / Privacy Policy**: UI のみ先行。タップで `Alert` 「近日対応予定」（Apple CTA と同パターン）。実 URL や外部ブラウザ呼び出しは別 PR。
+- **"You can add your dog's profile on the next step." ヘルパー文言**: 追加するが、実フローは変更しない（confirm 後は login にリダイレクト、という既存挙動維持）。デザインの狙いを i18n 文言で示すに留める。
+- **Back ボタン**: `router.back()` を呼ぶ `Pressable`（青 tint の `‹ Back`）を hero 上部に配置。`_layout.tsx` のネイティブヘッダーは触らない（現状 auth stack はヘッダー非表示）。
+- **Confirm ステップの見た目**: 現状維持（PR #126 で Precise 化済み）。
+
+## 目標仕様（expect ソース準拠）
+
+| 要素 | 仕様 |
+|---|---|
+| Back | top:60, left:16。`‹ Back` 17px, `theme.interactive` 色、`accessibilityRole="link"` |
+| Hero title | `largeTitle` 2行: "Let's meet\nyour dog."（既存実装と一致、維持） |
+| Subtitle | `subheadline` "A few quick details and you'll be walking in a minute." |
+| Form | `GroupedCard` 1 枚 = Display Name / Email / Password の 3 行、各行 `TextInput labelPosition="inline"`、1・2 行目に `separator` |
+| Helper text | フォーム直下に `footnote` "You can add your dog's profile on the next step. We'll remember paw-size, pace, and photo." |
+| Primary CTA | `Button variant="primary"` label `Continue` |
+| Footer | center-aligned `caption`: "By continuing you agree to the Terms and Privacy Policy."（Terms / Privacy は青 `interactive`、Pressable で Alert） |
+
+## 変更ファイル一覧
+
+1. **`apps/mobile/components/auth/RegisterForm.tsx`** — 大幅改修
+   - TextInput 3 つを `GroupedCard` + `labelPosition="inline"` に置換
+   - `separator` は 1・2 行目に付与
+   - secondary Button（loginLink）削除 → Back ボタンに役割移行（画面側で実装）
+   - submit Button label を `Continue` に（i18n 値変更）
+   - Helper text 追加
+   - Terms / Privacy フッター追加（Pressable × 2 + Alert）
+   - Props 変更: `onLoginPress` 削除（Back は画面側が持つ）
+
+2. **`apps/mobile/app/(auth)/register.tsx`** — 改修
+   - register ステップで hero 上に Back Pressable を描画（`router.back()`）
+   - RegisterForm の `onLoginPress` prop 渡しを削除
+   - Confirm ステップは変更なし
+
+3. **`apps/mobile/components/auth/RegisterForm.test.tsx`** — 既存テスト更新
+   - `onLoginPress` prop 廃止に合わせて呼び出し修正
+   - 新 CTA ラベル `Continue` に更新
+   - Terms / Privacy Alert、helper text 表示の新規テスト追加
+
+4. **`apps/mobile/lib/i18n/locales/ja.json`** と **`en.json`** — キー追加・値変更
+   - `auth.register.subtitle` 追加
+   - `auth.register.submit` の値を en: "Continue" / ja: "次へ" に更新
+   - `auth.register.displayName` の値を en: "Your name" / ja: "お名前" に変更（expect 通りの柔らかい表現）
+   - `auth.register.dogProfileHint` 追加（"You can add your dog's profile on the next step..." の多言語文言）
+   - `auth.register.terms` / `auth.register.privacyPolicy` / `auth.register.termsPrefix` / `auth.register.termsAnd` 追加（"By continuing you agree to the {terms} and {privacy}." を文字列分割 or 補間で構築）
+   - `auth.register.back` (en: "Back", ja: "戻る") — 表示 + accessibilityLabel 用
+   - `auth.register.comingSoonTerms` 追加（or 既存 `auth.login.comingSoonApple` 相当を汎用キー化して再利用）
+
+## 既存資産の再利用
+
+- `components/ui/TextInput.tsx` の `labelPosition="inline"` + `separator`（PR #127 で追加済み）
+- `components/ui/GroupedCard.tsx`
+- `components/ui/Button.tsx`（`variant="primary"`）
+- `theme/tokens.ts` の `largeTitle`, `subheadline`, `footnote`, `caption`
+- Sign In で定着した「Alert で UI のみ先行」パターン
+
+## 検証方法
+
+1. **ユニットテスト**: `npx jest components/auth/ lib/i18n/` — RegisterForm + translations の key 対称性
+2. **型チェック**: `npx tsc --noEmit`（事前存在の `lib/graphql/errors.test.ts` エラーは対象外）
+3. **視覚確認**（CocoaPods 環境復旧後）: `npx expo run:ios` → Sign In 画面で "Create an account" タップ → Register 画面で目視確認:
+   - Back が左上に表示・タップで戻る
+   - GroupedCard に 3 行（Your name / Email / Password）
+   - Helper text がフォーム直下
+   - Continue ボタン（青）、空欄時は disabled
+   - Terms / Privacy フッターの青リンク部分タップで Alert
+4. **挙動確認**: 有効な値で Continue 押下 → signUp 呼び出し → userConfirmed の分岐でそれぞれ login / confirm へ遷移（既存テスト通り）
+
+## 非スコープ（後続 PR）
+
+- Terms / Privacy Policy の実 URL と外部ブラウザ表示
+- Register → Confirm → 犬プロフィール誘導のフル実装（現状は login リダイレクトのまま）
+- Confirm ステップの更なる UI 調整

--- a/.claude/plans/tasks-refactor-mobile-03-plan-md-phase-1-keen-kazoo.md
+++ b/.claude/plans/tasks-refactor-mobile-03-plan-md-phase-1-keen-kazoo.md
@@ -1,0 +1,151 @@
+# Phase 1: 共有フック/定数抽出 (apps/mobile)
+
+## Context
+
+`tasks/refactor/mobile/03-plan.md` Phase 1 の実行。`apps/mobile` に 4 種類の DRY 違反が蓄積している:
+
+1. `useAuthStore((s) => s.isAuthenticated)` — 6 ファイル 7 箇所で重複
+2. `invalidateQueries({ queryKey: meKeys.all })` + `dogKeys.all` のペア — 8 箇所で類似パターン
+3. `EVENT_EMOJIS` 定数マップ — `components/walk/WalkMap.tsx` と `app/walks/[id].tsx` に同一リテラル
+4. Hero テキスト inline style — 8 画面で `fontSize: 40, fontWeight: '900', letterSpacing: -0.8, lineHeight: 44` を重複
+
+共通フック/トークン/定数モジュールに抽出し、呼び出し側を置換する。TDD で進める (RED → GREEN → REFACTOR)。
+
+## Worktree Setup
+
+Docker Compose は `./apps/*` をマウントする想定だが、mobile サービスは現在 compose に無く、npm/jest はホスト or `docker run -v` 直接実行。worktree と main repo で Metro を同時起動しないよう注意。
+
+```bash
+cd /Users/matsuokashuhei/Development/walking-dog
+git worktree add .worktrees/refactor-mobile-phase-1 -b refactor/mobile-phase-1
+cd .worktrees/refactor-mobile-phase-1
+```
+
+## Files to Create
+
+| Path | Purpose |
+|------|---------|
+| `apps/mobile/hooks/use-is-authenticated.ts` | `useAuthStore((s) => s.isAuthenticated)` wrapper |
+| `apps/mobile/hooks/use-is-authenticated.test.ts` | hook 単体テスト |
+| `apps/mobile/hooks/use-invalidate-user-queries.ts` | `meKeys.all + dogKeys.all` 並列 invalidator |
+| `apps/mobile/hooks/use-invalidate-user-queries.test.ts` | hook 単体テスト |
+| `apps/mobile/lib/walk/event-emojis.ts` | `EVENT_EMOJIS: Record<WalkEventType, string>` 統合 export |
+| `apps/mobile/lib/walk/event-emojis.test.ts` | emoji マップ shape テスト |
+
+## Files to Modify
+
+### typography.hero トークン追加
+- `apps/mobile/theme/tokens.ts` — `typography.hero: { fontSize: 40, fontWeight: '900', lineHeight: 44, letterSpacing: -0.8 }` 追加
+- `apps/mobile/theme/tokens.test.ts` — hero token の値検証テスト追加
+
+### use-is-authenticated 置換対象 (7箇所)
+- `apps/mobile/hooks/use-dog-friends.ts:9`
+- `apps/mobile/hooks/use-dog-encounters.ts:9`
+- `apps/mobile/hooks/use-me.ts:9`
+- `apps/mobile/hooks/use-friendship.ts:9`
+- `apps/mobile/hooks/use-walks.ts:9,21`
+- `apps/mobile/app/invite/[token].tsx:59`
+
+### use-invalidate-user-queries 置換対象 (8箇所)
+- `apps/mobile/hooks/use-dog-mutations.ts:28-30, 44-47, 58-61` (3 mutation)
+- `apps/mobile/hooks/use-dog-member-mutations.ts:38-41, 55-58` (2 mutation)
+- `apps/mobile/hooks/use-accept-invitation.ts:17-20`
+- `apps/mobile/hooks/use-profile-mutation.ts:17-19`
+- `apps/mobile/components/settings/EncounterDetectionSection.tsx:27-29`
+
+**設計判断**: `meKeys.all` 単独のサイト (use-dog-mutations:useCreateDog, use-profile-mutation, EncounterDetectionSection) も新 helper に統合する。dog queries の余分な refetch は許容 (Phase 1 plan の grep 基準: `hooks` 配下から `meKeys.all` 直接呼び出し消失)。
+
+### event-emojis 置換対象 (2箇所)
+- `apps/mobile/components/walk/WalkMap.tsx:9-13` — ローカル定義削除 → import
+- `apps/mobile/app/walks/[id].tsx:13-17` — 同上
+
+### typography.hero 置換対象 (8箇所)
+- `apps/mobile/components/walk/WalkReadyView.tsx:70`
+- `apps/mobile/app/(auth)/register.tsx:88`
+- `apps/mobile/app/(auth)/login.tsx:44`
+- `apps/mobile/app/(tabs)/dogs.tsx:100`
+- `apps/mobile/app/(tabs)/settings.tsx:71`
+- `apps/mobile/app/dogs/[id]/encounters.tsx:61`
+- `apps/mobile/app/dogs/[id]/friends/index.tsx:65`
+- `apps/mobile/app/dogs/[id]/friends/[friendDogId].tsx:113`
+
+各 style を `{ ...typography.hero, marginBottom: spacing.md }` 形式にリファクタ。既存 `bentoValue: { ...typography.display, ... }` (dogs.tsx:119) と同じスプレッド+オーバーライドパターンを踏襲。
+
+## TDD 実行順 (superpowers:test-driven-development)
+
+**注**: 各ステップは RED (失敗するテスト) → GREEN (最小実装) → REFACTOR (呼び出し側置換) の順。
+
+### Step 1 — `use-is-authenticated`
+1. RED: `use-is-authenticated.test.ts` 作成 — auth store の `isAuthenticated` フラグを返すことを検証 (Zustand store を mock)
+2. GREEN: hook 実装
+3. REFACTOR: 7 箇所を置換
+
+### Step 2 — `use-invalidate-user-queries`
+1. RED: test 作成 — `invalidateQueries` が `meKeys.all` と `dogKeys.all` の両方で呼ばれることを検証 (QueryClientProvider wrapper + spy)
+2. GREEN: hook 実装 (`useCallback` + `Promise.all` で並列 invalidate)
+3. REFACTOR: 8 箇所を置換
+
+### Step 3 — `lib/walk/event-emojis.ts`
+1. RED: test 作成 — `EVENT_EMOJIS.pee / poo / photo` の値検証
+2. GREEN: `export const EVENT_EMOJIS: Record<WalkEventType, string> = { pee: '🚽', poo: '💩', photo: '📷' };`
+3. REFACTOR: WalkMap + walks/[id] から local 定義削除 → import
+
+### Step 4 — `typography.hero` トークン
+1. RED: `tokens.test.ts` に hero token 検証 追加
+2. GREEN: `tokens.ts` に hero 追加
+3. REFACTOR: 8 style entries をスプレッド形式に置換
+
+## 既存ユーティリティの再利用
+
+- `useQueryClient()` from `@tanstack/react-query` — 既存 mutation hook と同じ access pattern (ref: `use-dog-mutations.ts:21-31`)
+- `meKeys.all`, `dogKeys.all` — `apps/mobile/lib/graphql/keys.ts:1-27` の既存 exports
+- `typography.display` spread pattern — `app/(tabs)/dogs.tsx:119` を踏襲
+- Hook test convention — `apps/mobile/hooks/use-accept-invitation.test.ts` のパターン (Jest + `@testing-library/react-native` + `QueryClientProvider` wrapper)
+
+## 完了条件 (plan §Phase 1)
+
+- 全既存テスト緑 + 新規テスト緑
+- `rg "useAuthStore\(\(s\) => s\.isAuthenticated\)" apps/mobile/hooks` が `use-is-authenticated.ts` 1 件のみ
+- `rg "invalidateQueries\(\{ queryKey: meKeys\.all" apps/mobile/hooks` が `use-invalidate-user-queries.ts` 内のみ
+- `rg "EVENT_EMOJIS" apps/mobile/{components,app}` が import 行のみ (local 定義なし)
+- `rg "fontSize: 40," apps/mobile/app apps/mobile/components` が 0 件 (hero token 参照のみ)
+
+## 検証コマンド
+
+worktree ディレクトリで実行:
+
+```bash
+cd apps/mobile
+npm test                      # jest suite 全緑
+npx tsc --noEmit              # 型エラーなし
+npm run lint                  # ESLint 通過
+```
+
+完了条件 grep 確認:
+
+```bash
+cd /Users/matsuokashuhei/Development/walking-dog/.worktrees/refactor-mobile-phase-1
+rg "useAuthStore\(\(s\) => s\.isAuthenticated\)" apps/mobile/hooks
+rg "invalidateQueries\(\{ queryKey: meKeys\.all" apps/mobile/hooks
+rg "EVENT_EMOJIS" apps/mobile/components apps/mobile/app
+rg "fontSize: 40," apps/mobile/app apps/mobile/components
+```
+
+iOS Simulator スモーク (`ios-simulator-skill`):
+- 起動 → login 画面 (hero style)
+- dogs tab → settings tab (hero title)
+- 犬詳細 → friends / encounters 遷移 (hero title)
+- 散歩開始 → WalkMap にイベントマーカーが表示されるか (EVENT_EMOJIS)
+
+## 完了後処理
+
+1. Conventional Commit: `refactor(mobile): extract shared hooks and tokens for DRY cleanup`
+2. `tasks/refactor/mobile/progress.md` の Phase 1 行を `- [x]` に更新 (worktree 側で編集 → main に反映は最終コミット or PR 後)
+3. `finishing-a-development-branch` skill で PR 作成検討
+
+## 依存 / リスク
+
+- **依存**: なし (Phase 1 は他フェーズに blocking)
+- **リスク**: 低
+  - invalidate helper で `meKeys.all` 単独サイトも both invalidate になる (意図的トレードオフ)
+  - hero token 置換時に `marginBottom` / `textAlign` の override 忘れでレイアウト崩れの可能性 → Simulator スモークで検出

--- a/.claude/plans/typed-tinkering-castle.md
+++ b/.claude/plans/typed-tinkering-castle.md
@@ -1,0 +1,166 @@
+# 散歩中 iPhone ロック画面ウィジェット
+
+## Context
+
+散歩中にアプリを開かずロック画面から操作したい。表示要素：経過時間・距離・おしっこボタン・うんこボタン・カメラボタン。
+
+**重要な技術的再定義**: iOS の仕様上、ユーザーが「ロック画面ウィジェット」と呼ぶ表示は、実際には **Live Activity (ActivityKit)** で実現する必要がある。
+
+- Lock Screen Widget (WidgetKit) は `TimelineProvider` ベースで数分〜数時間単位の更新しかできず、秒単位のタイマー表示には不向き。インタラクティブボタンも限定的。
+- **Live Activity** は散歩のような「進行中のセッション」専用に設計されており、ロック画面・Dynamic Island・StandBy に同時に表示される。`Text(timerInterval:)` で自己更新する経過時間、iOS 17+ の `AppIntent` ボタンをサポート。
+
+よって本計画は **Live Activity ベースの実装** とする。
+
+## 採用アーキテクチャ
+
+### メカニズム
+- **Live Activity (ActivityKit)**: `@bacons/apple-targets` で Widget Extension ターゲットを Expo 管理プロジェクトに追加し、SwiftUI でレイアウトを書く
+- **経過時間**: `Text(timerInterval: startDate...)` — 自己ティック、プッシュ不要
+- **距離**: `ContentState` に `distanceM` を持たせ、JS から GPS 更新ごとに `Activity.update()` を呼ぶ
+- **pee / poo ボタン**: `AppIntent` with `openAppWhenRun = false` — ロック解除せずバックグラウンドで GraphQL `recordWalkEvent` を Swift から直接叩く
+- **camera ボタン**: `AppIntent` with `openAppWhenRun = true` + ディープリンク `walking-dog://walk?action=camera` — アプリをカメラ起動状態で開く（Face ID 解除が走る）
+
+### iOS バージョン戦略
+- **最低 iOS 17.0**（ユーザー確認済み）。インタラクティブ `AppIntent` ボタン前提のため iOS 16 は切り捨て
+- app.config.ts の `ios.deploymentTarget: '17.0'` を明示設定
+- iOS 16 デバイスでは Live Activity 自体を起動しない（JS 側で guard）
+
+### 認証トークン共有
+- App ↔ Extension 間で **App Group Keychain (Keychain Access Groups)** を使って access / refresh token を共有
+- `expo-secure-store` のキーチェーン保存先をカスタム access group に変更する必要あり（native 設定）
+- Extension 側（Swift）は Keychain から token を読んで `URLSession` で GraphQL を叩く
+- 401 時は refresh token で再取得、失敗したら Live Activity に「再サインイン必要」表示
+
+### データフロー
+```
+Walk 開始 (JS)
+  → startWalk mutation → walkId 取得
+  → ActivityManager.startActivity({walkId, dogIds, startedAt}) ─── RN Native Module
+  → App Group UserDefaults に walkId 書き込み
+  → Live Activity 表示 (Lock Screen + Dynamic Island)
+
+GPS 更新 (JS, 5s 間隔)
+  → walkStore.addPoint → totalDistanceM 更新
+  → ActivityManager.updateActivity({distanceM}) ─── デバウンス 10s
+
+pee ボタン (AppIntent, バックグラウンド)
+  → App Group から walkId + auth token 取得
+  → GraphQL recordWalkEvent 直接 POST
+  → Activity.update で lastEvent バッジ表示
+
+camera ボタン (AppIntent, ディープリンク)
+  → アプリ起動 → Expo Router が /(tabs)/walk?action=camera を処理
+  → WalkEventActions の handlePhoto を自動実行
+
+Walk 終了 (JS)
+  → finishWalk → ActivityManager.endActivity()
+```
+
+## 新規ファイル
+
+### iOS ネイティブ（`apps/mobile/targets/walk-live-activity/`）
+- `WalkAttributes.swift` — ActivityAttributes（walkId, dogName, startedAt）+ ContentState（distanceM, lastEvent）
+- `WalkLiveActivity.swift` — SwiftUI レイアウト（ロック画面 + Dynamic Island compact/expanded/minimal）
+- `PeeIntent.swift`, `PooIntent.swift` — `AppIntent` バックグラウンド実行
+- `CameraIntent.swift` — `AppIntent` with `openAppWhenRun = true`
+- `WalkEventClient.swift` — GraphQL ミニマル HTTP クライアント（URLSession）
+- `SharedKeychain.swift` — Access Group 対応 Keychain 読み取り
+- `Info.plist`, `walk-live-activity.entitlements`
+
+### Expo config plugin（`apps/mobile/plugins/`）
+- `with-live-activity.ts` — Info.plist に `NSSupportsLiveActivities=true`, `NSSupportsLiveActivitiesFrequentUpdates=true` を追加、App Group と Keychain Access Group を entitlements に設定
+- `@bacons/apple-targets` の target 定義（config plugin が参照）
+
+### RN Native Module（`apps/mobile/modules/walk-activity/`）
+- Expo Module として作成（`create-expo-module` の形式）
+- `ios/WalkActivityModule.swift` — `startActivity`, `updateActivity`, `endActivity` を公開
+- `src/index.ts` — TypeScript 型定義 + wrapper
+
+### JS 統合
+- `apps/mobile/lib/walk/live-activity.ts` — Native Module の薄いラッパー（フラグで iOS 16.1+ のみ呼ぶ）
+- `apps/mobile/stores/walk-store.ts` の **修正**:
+  - `startRecording` 内で `liveActivity.start(...)` 呼び出し
+  - `addPoint` 後にデバウンスで `liveActivity.update({distanceM})` 呼び出し
+  - `finish` / `reset` で `liveActivity.end()`
+- `apps/mobile/app/(tabs)/walk.tsx` の **修正**: `useLocalSearchParams` で `action=camera` を受け取ったら自動で `handlePhoto` を起動
+
+### Keychain アクセスグループ設定
+- `apps/mobile/plugins/with-secure-store-access-group.ts` — `expo-secure-store` の保存先を App Group Keychain にするカスタム plugin（既存 plugin には該当オプションがないので自作 / アップデート要）
+
+## 既存ファイル修正
+
+| ファイル | 変更内容 |
+|---|---|
+| `apps/mobile/app.config.ts` | `ios.deploymentTarget: '16.1'`, App Group `group.com.walkingdog.app`, `plugins` に `@bacons/apple-targets`, `with-live-activity`, `with-secure-store-access-group` を追加 |
+| `apps/mobile/package.json` | `@bacons/apple-targets`, `expo-modules-core` 依存を追加 |
+| `apps/mobile/stores/walk-store.ts` | Live Activity ライフサイクル呼び出しを追加 |
+| `apps/mobile/lib/walk/gps-tracker.ts` | 距離変化閾値を満たしたら Activity update トリガー |
+| `apps/mobile/components/walk/WalkEventActions.tsx` | deep link 経由の自動 `handlePhoto` 発火は walk.tsx 側で行うためここは変更なし（確認のみ） |
+| `apps/mobile/app/(tabs)/walk.tsx` | `useLocalSearchParams.action === 'camera'` のハンドリング追加 |
+| `apps/mobile/eas.json` | 新規作成 — development / preview / production プロファイル。Expo Go 非対応機能のため dev-client 必須 |
+
+## 再利用する既存コード
+- `apps/mobile/hooks/use-walk-event-mutations.ts` — JS 側の pee/poo/photo ロジックはそのまま使える（deep link から呼ぶ）
+- `apps/mobile/lib/walk/distance.ts` — `haversineDistance` — 距離計算ロジックは Swift に複製せず、JS 側で計算して Activity に push
+- `apps/api/src/services/walk_event_service.rs` — `recordWalkEvent` mutation はそのまま使う。Swift 側から同じ GraphQL を叩く
+- `apps/mobile/lib/api/client.ts`（要確認）— GraphQL エンドポイント URL を Swift に定数として渡す（config plugin で Info.plist に書く）
+
+## API 側の変更
+- **基本は変更なし**。既存 `recordWalkEvent` と `generateWalkEventPhotoUploadUrl` を Swift から叩くだけ
+- ただし Swift 側は Apollo を使わず手書きの GraphQL POST にするため、エラー契約・認証ヘッダ形式（`Authorization: Bearer`）のみドキュメント化
+
+## スコープ外（今回やらない）
+- Android ホーム画面ウィジェット — iOS 専用機能として開始
+- バックグラウンド GPS 追跡（フォアグラウンドで walk 中のみ想定）— 現状 `isBackgroundEnabled: false`
+- 写真ボタンから **直接** カメラ UI をロック画面に表示 — iOS 制約で不可能、アプリ起動経由
+- StandBy / Apple Watch
+- Live Activity 用プッシュ通知チャネル — Phase 1 は端末内更新のみ
+
+## 段階的実装（phase 分け）
+
+### Phase 1: 骨組みと表示（インタラクションなし）
+1. `@bacons/apple-targets` セットアップ、空の Widget Extension ターゲットを prebuild で生成できる状態に
+2. `WalkAttributes` + `WalkLiveActivity` の SwiftUI（時間・距離の表示のみ、ボタンはダミー）
+3. Expo Module で `startActivity` / `updateActivity` / `endActivity` 実装
+4. `walk-store` のライフサイクル統合、実機で経過時間・距離がロック画面に出ることを確認
+
+### Phase 2: AppIntent ボタン（iOS 17+）
+5. App Group + Keychain Access Group 設定、`expo-secure-store` を access group 対応に
+6. `WalkEventClient.swift` — GraphQL ミニクライアント、認証ヘッダ付き POST
+7. `PeeIntent`, `PooIntent` 実装 + SwiftUI に `Button(intent:)` 配置
+8. 401 時の refresh token フロー
+
+### Phase 3: カメラディープリンク
+9. `CameraIntent` with `openAppWhenRun = true` + `walking-dog://walk?action=camera`
+10. `walk.tsx` で deep link ハンドリング、`handlePhoto` 自動呼び出し
+
+### Phase 4: Dynamic Island + 仕上げ
+11. Dynamic Island compact / expanded / minimal レイアウト
+12. アクセシビリティラベル、VoiceOver 検証
+13. iOS 16 デバイスは Live Activity を起動しない guard を JS 側に追加
+
+## 検証方法
+- **実機必須**（シミュレータは Live Activity 動作するが AppIntent 挙動の一部が異なる）
+- `eas build --profile development --platform ios` でビルド、iPhone にインストール
+- 犬選択 → 散歩開始 → iPhone をロック
+- ロック画面で経過時間が秒単位で進むこと確認
+- 5〜10 秒歩いて距離が更新されること確認
+- pee ボタンタップ → 画面遷移せず、アプリ内イベント一覧に「pee」が追加されていること（アプリを開いて確認）
+- poo ボタンも同様
+- camera ボタン → Face ID → カメラ起動 → 撮影 → walk に photo イベント追加
+- 散歩終了 → Live Activity 消滅
+- iOS 16 実機では Live Activity が出ないこと（silent skip）確認
+
+## リスクと未解決事項
+1. **Keychain Access Group 共有**: `expo-secure-store` は現状 access group 指定オプションがない。カスタム plugin で Objective-C レベルのビルド設定注入が必要。規模次第で refresh token だけ別経路で共有する妥協案もあり
+2. **Token refresh の排他制御**: アプリ本体と Extension が同時に refresh を走らせた場合の競合
+3. **Live Activity の頻繁更新制限**: iOS は 1 時間あたりの update 回数を制限。距離更新は最低 10s デバウンス必須
+4. **`@bacons/apple-targets` 成熟度**: 2026 時点でのメンテ状況を確認する必要あり。代替は bare workflow 化
+5. **既存の `isBackgroundEnabled: false`（BLE）との整合性**: Live Activity 自体は BG 不要だが、散歩中に画面が消えたときの GPS 追跡は別途 UIBackgroundModes 設定が必要（今回スコープ外だが UX 上ほぼ必須）
+
+## 見積もりの目安
+- Phase 1: 2-3 日（Expo Module 初回セットアップ込み）
+- Phase 2: 3-4 日（Keychain 共有が最大リスク）
+- Phase 3: 0.5 日
+- Phase 4: 1-2 日
+- 合計: 約 1.5 週間（実機検証含む）

--- a/.claude/plans/walk-docs-design-walk-walk-start-with-mu-goofy-quokka.md
+++ b/.claude/plans/walk-docs-design-walk-walk-start-with-mu-goofy-quokka.md
@@ -1,0 +1,299 @@
+# Walk Finished Screen — Precise Redesign
+
+## Context
+
+現状の終了画面 (`apps/mobile/components/walk/WalkSummaryCard.tsx`) は「WALK COMPLETE ヘッダ → dot 付きメトリクスリスト → イベントチップ行 → Add note / Save walk ボタン」という抽象的な構造で、犬の識別・ルート可視化・犬ごとの活動量の可視化が欠けている。
+
+ユーザーは添付モックアップ（複数頭 Coco + Momo のケース）のように、**静的ルートマップ + 3 つの表示専用メトリクスピル + 犬ごとのサマリ**を中心に据えたレイアウトに差し替えたい。単頭時は「Per dog」カードと「Saved to both…」ノートを省く分岐が必要。
+
+目的：
+- 飼い主に「今日の散歩の成果」を即座に伝える（距離・時間・ペース・犬ごとのイベント件数）
+- 共同散歩を可視化する（「together」感、犬ごとの内訳）
+- Precise UI 言語（大見出し・丸みカード・重畳ピル）を終了画面に適用する
+
+## Target Layout
+
+```
+WALK COMPLETE  (green caption)
+Nice walk, everyone.         (large title, 2行想定)
+🐶🐶 Coco and Momo · 24 min together
+
+┌ static map card ─────────────┐
+│      ╭─●  (end, red)         │
+│    ╭─╯                        │
+│ ●──╯     (start, green)       │
+│ [1.42 km] [24:18] [4'18"/km]  │  ← 左下重畳の 3 ピル
+└───────────────────────────────┘
+
+Per dog                 View each
+┌ grouped card ─────────────┐
+│ 🐶 Coco  💧2 · 💩1 · 📷3  >│
+│ ─────                      │
+│ 🐶 Momo  💧1 · 💩0 · 📷1  >│
+└────────────────────────────┘
+
+Saved to both Coco's and Momo's history   (center, muted)
+
+[ Add note ]   [ Save walk ]
+
+Dogs  Walk  Me   (既存タブバー — recording で消して finished で復帰済み)
+```
+
+## Files
+
+### 新規
+- `apps/mobile/components/walk/WalkRoutePreview.tsx`
+- `apps/mobile/components/walk/PerDogSummaryCard.tsx`
+- `apps/mobile/components/walk/WalkRoutePreview.test.tsx`
+- `apps/mobile/components/walk/PerDogSummaryCard.test.tsx`
+
+### 変更
+- `apps/mobile/components/walk/WalkSummaryCard.tsx` — 上記 2 つを組み合わせた新構成に書き直し、単頭/多頭分岐
+- `apps/mobile/components/walk/WalkSummaryCard.test.tsx` — 構造変更に合わせて書き直し
+- `apps/mobile/lib/walk/format.ts` — `formatPace(elapsedSec, totalM)` と `formatPaceString(...)` を追加し共通化
+- `apps/mobile/components/walk/WalkControls.tsx` — 既存 `formatPace` を `format.ts` 経由に置換（動作変更なし）
+- `apps/mobile/lib/i18n/locales/en.json` / `ja.json` — 新規キー追加
+
+### 変更なし
+- `apps/mobile/stores/walk-store.ts` — `finish()` は `points / events / startedAt / totalDistanceM / selectedDogIds` を既に保持しているため変更不要
+- `apps/mobile/app/(tabs)/walk.tsx` — `phase === 'finished'` 時のタブバー復帰は実装済み
+- `apps/mobile/types/graphql.ts` — 既存 `Dog` / `WalkEvent` で足りる
+
+## 実装詳細
+
+### 1. `WalkRoutePreview.tsx`
+
+Props:
+```ts
+interface WalkRoutePreviewProps {
+  points: WalkPoint[];
+  totalDistanceM: number;
+  elapsedSec: number;
+}
+```
+
+- `react-native-maps` の `<MapView>` + `<Polyline>`（`walk-store.points` を `{ latitude, longitude }` にマップ）
+- マップのインタラクション全停止: `scrollEnabled=false` / `zoomEnabled=false` / `pitchEnabled=false` / `rotateEnabled=false` / `toolbarEnabled=false`
+- `<Marker>` × 2: start は `points[0]` に `theme.success` の小さな円、end は `points.at(-1)` に `theme.error` の小さな円
+- `initialRegion` は start/end の平均から（`latDelta = longDelta = 0.01` で仮決め。ズーム崩れたら `use-walk-detail-view-model.ts` の midpoint 計算を流用）
+- カードは `borderRadius: radius.xl`、`overflow: 'hidden'`、高さ約 180pt
+- **メトリクスピル 3 つ** を `position: 'absolute'` で左下に重畳:
+  - 親: `{ position: 'absolute', bottom: spacing.sm, left: spacing.sm, flexDirection: 'row', gap: spacing.xs }`
+  - 各ピル: `backgroundColor: theme.surface`, `borderRadius: radius.full`, `paddingVertical: 4`, `paddingHorizontal: spacing.sm`, `elevation.low`
+  - 中身: `formatDistance(totalDistanceM)` / `formatTime(elapsedSec)` / `formatPaceString(elapsedSec, totalDistanceM)`
+- **`points.length < 2` の時**: Polyline / Marker はスキップ、ピルはそのまま描画
+- `accessibilityElementsHidden={true}` で読み上げから除外（メトリクスはヒーロー上でも触れる）
+
+### 2. `PerDogSummaryCard.tsx`
+
+Props:
+```ts
+interface PerDogSummaryCardProps {
+  dogs: Dog[];
+  events: WalkEvent[];
+  onViewEach?: () => void;
+}
+```
+
+- 外側: ヘッダ行（カード外）
+  - 左: `<Text>` に `t('walk.finished.perDog')` ("Per dog")
+  - 右: `<Pressable>` に `t('walk.finished.viewEach')` ("View each")、`color: theme.primary`
+- 内側カード (`GroupedCard`):
+  - 各犬の行:
+    - 左: アバター (`expo-image` w/h=32, `borderRadius: 16`, fallback to `@/assets/images/icon.png`)
+    - 中: `styles.name` に犬名
+    - 右中: `💧N · 💩N · 📷N` を small caption 色
+    - 右端: chevron `›` (Text で `›` 描画 or `react-native-vector-icons` が既に入っていればそれを使用)
+  - 行の高さは `~56pt`、行間 divider (`hairlineWidth`, `theme.border`)
+- 件数集計: ローカルに `function countFor(dogId: string, events: WalkEvent[]): { pee; poo; photo }` を置く
+- 呼び出し側から `dogs.length <= 1` の場合は**呼ばない**
+
+### 3. `WalkSummaryCard.tsx` 書き直し
+
+```ts
+export function WalkSummaryCard() {
+  const router = useRouter();
+  const { t } = useTranslation();
+  const theme = useColors();
+  const insets = useSafeAreaInsets();
+
+  const walkId = useWalkStore((s) => s.walkId);
+  const startedAt = useWalkStore((s) => s.startedAt);
+  const totalDistanceM = useWalkStore((s) => s.totalDistanceM);
+  const points = useWalkStore((s) => s.points);
+  const events = useWalkStore((s) => s.events);
+  const selectedDogIds = useWalkStore((s) => s.selectedDogIds);
+  const reset = useWalkStore((s) => s.reset);
+
+  const { data: me } = useMe();
+  const dogs = useMemo(
+    () => (me?.dogs ?? []).filter((d) => selectedDogIds.includes(d.id)),
+    [me?.dogs, selectedDogIds],
+  );
+
+  const elapsedSec = startedAt
+    ? Math.floor((Date.now() - startedAt.getTime()) / 1000)
+    : 0;
+  const elapsedMin = Math.max(1, Math.round(elapsedSec / 60));
+
+  const isSingle = dogs.length <= 1;
+  const title = isSingle
+    ? t('walk.finished.titleSingle', { name: dogs[0]?.name ?? '' })
+    : t('walk.finished.titleMulti');
+  const subtitle = isSingle
+    ? t('walk.finished.minSolo', { name: dogs[0]?.name ?? '', min: elapsedMin })
+    : t('walk.finished.minTogether', {
+        names: joinNames(dogs, t),
+        min: elapsedMin,
+      });
+  const savedNote = isSingle
+    ? t('walk.finished.savedToHistorySingle', { name: dogs[0]?.name ?? '' })
+    : t('walk.finished.savedToHistoryMulti', {
+        a: dogs[0]?.name ?? '',
+        b: dogs[1]?.name ?? '',
+      });
+
+  const handleSave = () => {
+    const id = walkId;
+    reset();
+    if (id) router.push(`/walks/${id}`);
+  };
+
+  return (
+    <ScrollView contentContainerStyle={[styles.container, { paddingBottom: insets.bottom + spacing.lg }]}>
+      {/* Hero */}
+      <Text style={[styles.caption, { color: theme.success }]}>
+        {t('walk.finished.walkComplete')}
+      </Text>
+      <Text style={[styles.title, { color: theme.onSurface }]}>{title}</Text>
+      <View style={styles.subtitleRow}>
+        <AvatarStack dogs={dogs} />
+        <Text style={[styles.subtitle, { color: theme.onSurfaceVariant }]}>
+          {subtitle}
+        </Text>
+      </View>
+
+      {/* Route */}
+      <WalkRoutePreview
+        points={points}
+        totalDistanceM={totalDistanceM}
+        elapsedSec={elapsedSec}
+      />
+
+      {/* Per-dog (multi only) */}
+      {!isSingle && (
+        <PerDogSummaryCard
+          dogs={dogs}
+          events={events}
+          onViewEach={() => walkId && router.push(`/walks/${walkId}`)}
+        />
+      )}
+
+      {/* Saved note */}
+      <Text style={[styles.savedNote, { color: theme.onSurfaceVariant }]}>
+        {savedNote}
+      </Text>
+
+      {/* Actions */}
+      <View style={styles.actions}>
+        <Button label={t('walk.finished.addNote')} variant="ghost" style={styles.addNote} />
+        <Button label={t('walk.finished.saveWalk')} variant="primary" onPress={handleSave} style={styles.save} />
+      </View>
+    </ScrollView>
+  );
+}
+```
+
+補足:
+- `joinNames(dogs, t)` は `'Coco and Momo'`（英）/ `'CocoとMomo'`（日）風の join。単頭は n/a。
+- `AvatarStack` はヒーロー直下の小さい重畳アバター（最大 2 匹表示、`WalkControls` の avatars ロジックをそのまま抜き出して reuse 可能）。
+- `ScrollView` で縦を許容。下部 `insets.bottom` を取る。
+
+### 4. `formatPace` の共通化
+
+既存 `WalkControls.tsx` L211-217 のローカル `formatPace` を `apps/mobile/lib/walk/format.ts` に移設し:
+
+```ts
+export function formatPace(elapsedSec: number, totalM: number): { value: string; unit: string } {
+  if (totalM < 100 || elapsedSec === 0) return { value: '—', unit: '/km' };
+  const secPerKm = (elapsedSec / totalM) * 1000;
+  const mm = Math.floor(secPerKm / 60);
+  const ss = Math.floor(secPerKm % 60);
+  return { value: `${mm}'${ss.toString().padStart(2, '0')}"`, unit: '/km' };
+}
+
+export function formatPaceString(elapsedSec: number, totalM: number): string {
+  const { value, unit } = formatPace(elapsedSec, totalM);
+  return `${value}${unit}`;
+}
+```
+
+`WalkControls.tsx` は `import { formatPace } from '@/lib/walk/format'` に置き換え、既存ローカル関数を削除。
+
+### 5. i18n 追加キー (`walk.finished.*`)
+
+en.json:
+```json
+"walk.finished.walkComplete": "WALK COMPLETE",
+"walk.finished.titleSingle": "Nice walk, {{name}}!",
+"walk.finished.titleMulti": "Nice walk, everyone.",
+"walk.finished.perDog": "Per dog",
+"walk.finished.viewEach": "View each",
+"walk.finished.minTogether": "{{names}} · {{min}} min together",
+"walk.finished.minSolo": "{{name}} · {{min}} min",
+"walk.finished.savedToHistoryMulti": "Saved to both {{a}}'s and {{b}}'s history",
+"walk.finished.savedToHistorySingle": "Saved to {{name}}'s history",
+"walk.finished.addNote": "Add note",
+"walk.finished.saveWalk": "Save walk",
+"walk.finished.joiner.and": "and"
+```
+
+ja.json は対訳。既存 `walk.finished.title / details / done / saving` は他箇所で参照されている可能性があるため**残す**（Grep で参照なしなら削除）。
+
+## Testing
+
+### 1. `WalkRoutePreview.test.tsx`
+- `react-native-maps` を `jest.mock`（`{ __esModule: true, default: 'MapView', Polyline: 'Polyline', Marker: 'Marker' }`）
+- `points.length >= 2` のとき Polyline / start Marker / end Marker が存在
+- 3 つのピルが `1.42 km` / `24:18` / `4'18"/km` を含むテキストで表示
+- `points.length < 2` のとき Polyline なしでもピルは表示
+
+### 2. `PerDogSummaryCard.test.tsx`
+- 2 匹渡すと 2 行表示、犬名が出る
+- `💧N · 💩N · 📷N` が表示（`eventsFor` ロジックの検証）
+- `View each` 押下で `onViewEach` が呼ばれる
+- イベント 0 件でも `💧0 · 💩0 · 📷0` が出る
+
+### 3. `WalkSummaryCard.test.tsx` 改訂
+- 多頭ケース: `titleMulti` / `PerDogSummaryCard` 表示 / `savedToHistoryMulti` ノート / `Save walk` → `reset()` + `router.push('/walks/<id>')`
+- 単頭ケース: `titleSingle` / `PerDogSummaryCard` 非表示 / `savedToHistorySingle` ノート
+- `use-me` のモックで `me.dogs` と `selectedDogIds` から `dogs` を合成
+- `walk-store` のモックで `points`, `events`, `startedAt`, `totalDistanceM`, `selectedDogIds` を制御
+
+## 検証
+
+### コマンド
+```bash
+# typecheck / lint / unit tests
+docker compose -f apps/compose.yml run --rm mobile npm run typecheck
+docker compose -f apps/compose.yml run --rm mobile npm run lint
+docker compose -f apps/compose.yml run --rm mobile npm test -- --watchAll=false
+```
+
+### iOS Simulator 目視 (`ios-sim-test`)
+1. 犬 1 匹で散歩開始 → 数点 GPS 収集 → End Walk → 終了画面
+   - 単頭レイアウト: Per dog なし / `titleSingle` / `savedToHistorySingle`
+2. 犬 2 匹以上で散歩開始 → 数点 GPS 収集 → End Walk → 終了画面
+   - 多頭レイアウト: Per dog カード / `titleMulti` / `savedToHistoryMulti`
+3. マップに Polyline と start/end Marker が描画、3 ピルが左下に重畳、地図操作で反応しない
+4. `Save walk` 押下で `/walks/<id>` に遷移、store が `ready` にリセットされることを確認
+5. `Add note` は押しても no-op（クラッシュしない）
+6. タブバーが終了画面で復帰している
+
+## 非スコープ
+
+- `View each` の専用「犬ごとの詳細」画面の新規作成（現状は `/walks/<id>` への遷移で代替）
+- `Add note` の実装（既存の未実装 ghost ボタンを維持）
+- API 変更（今回は UI のみ）
+- 時間帯で title 文言を変える（単頭/多頭の 2 分岐のみ）
+- Walk summary の永続化や楽観的更新（既存 `handleSave` のまま）

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -65,7 +65,8 @@
     "rust-analyzer-lsp@claude-plugins-official": true,
     "swift-lsp@claude-plugins-official": true,
     "agent-skills@addy-agent-skills": true,
-    "ecc@everything-claude-code": false
+    "ecc@everything-claude-code": false,
+    "sentry@claude-plugins-official": true
   },
   "extraKnownMarketplaces": {
     "claude-plugins-official": {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/apps/api/AGENTS.md
+++ b/apps/api/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/apps/mobile/AGENTS.md
+++ b/apps/mobile/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/apps/mobile/CLAUDE.md
+++ b/apps/mobile/CLAUDE.md
@@ -31,6 +31,7 @@
 - Use Expo Router file-based routing — no manual navigation config
 - Use secure storage for tokens — avoid AsyncStorage for sensitive data
 - Conventional Commits: feat:, fix:, refactor:, test:, docs:, chore:
+- UI 実装は **Expo 公式ライブラリを最優先で検討する**（`expo-router/unstable-native-tabs` の `NativeTabs`、`presentation: 'formSheet'`、`expo-glass-effect`、`@expo/ui`、`expo-blur` など）。カスタム実装・community 製パッケージはネイティブ API が足りないことを確認してから採用する。
 
 ## Available Commands
 /plan, /code-review, /tdd, /build-fix, /perf, /upgrade, /debug, /deploy,


### PR DESCRIPTION
## Summary
- add the current `.claude/plans/*` planning documents to the repository
- add `AGENTS.md` symlinks that point to the existing `CLAUDE.md` files
- update Claude-related settings and mobile guidance for agent and plugin usage

## Notes
- this PR intentionally includes only the committed staged changes
- local `.env.local` edits and `.claude/worktrees/` remain outside the PR

## Testing
- not run (docs and agent configuration changes only)