### PR TITLE
refactor(api): apply modularity-review fixes (H1-H3, M1-M3, L1-L2)

### DIFF
--- a/apps/api/src/graphql/custom_queries.rs
+++ b/apps/api/src/graphql/custom_queries.rs
@@ -206,32 +206,22 @@ pub fn encounter_output_type() -> Object {
         ))
         .field(Field::new("dog1", TypeRef::named_nn("DogOutput"), |ctx| {
             FieldFuture::new(async move {
-                use crate::entities::dogs::Entity as DogEntity;
-                use sea_orm::EntityTrait;
-
                 let e = ctx.parent_value.try_downcast_ref::<EncounterOutput>()?;
-                let dog_id = e.dog_id_1;
                 let state = ctx.data::<Arc<crate::AppState>>()?;
-                let dog = DogEntity::find_by_id(dog_id)
-                    .one(&state.db)
+                let dog = dog_service::get_dog_by_id(&state.db, e.dog_id_1)
                     .await
-                    .map_err(|e| AppError::Database(e).into_graphql_error())?
+                    .map_err(AppError::into_graphql_error)?
                     .ok_or_else(|| async_graphql::Error::new("Dog not found"))?;
                 Ok(Some(FieldValue::owned_any(DogOutput::from(dog))))
             })
         }))
         .field(Field::new("dog2", TypeRef::named_nn("DogOutput"), |ctx| {
             FieldFuture::new(async move {
-                use crate::entities::dogs::Entity as DogEntity;
-                use sea_orm::EntityTrait;
-
                 let e = ctx.parent_value.try_downcast_ref::<EncounterOutput>()?;
-                let dog_id = e.dog_id_2;
                 let state = ctx.data::<Arc<crate::AppState>>()?;
-                let dog = DogEntity::find_by_id(dog_id)
-                    .one(&state.db)
+                let dog = dog_service::get_dog_by_id(&state.db, e.dog_id_2)
                     .await
-                    .map_err(|e| AppError::Database(e).into_graphql_error())?
+                    .map_err(AppError::into_graphql_error)?
                     .ok_or_else(|| async_graphql::Error::new("Dog not found"))?;
                 Ok(Some(FieldValue::owned_any(DogOutput::from(dog))))
             })
@@ -295,9 +285,6 @@ pub fn friendship_output_type() -> Object {
             TypeRef::named_nn("DogOutput"),
             |ctx| {
                 FieldFuture::new(async move {
-                    use crate::entities::dogs::Entity as DogEntity;
-                    use sea_orm::EntityTrait;
-
                     let f = ctx.parent_value.try_downcast_ref::<FriendshipOutput>()?;
                     // If requesting dog is dog_id_1, the friend is dog_id_2 and vice versa
                     let friend_id = if f.requesting_dog_id == f.dog_id_1 {
@@ -306,10 +293,9 @@ pub fn friendship_output_type() -> Object {
                         f.dog_id_1
                     };
                     let state = ctx.data::<Arc<crate::AppState>>()?;
-                    let dog = DogEntity::find_by_id(friend_id)
-                        .one(&state.db)
+                    let dog = dog_service::get_dog_by_id(&state.db, friend_id)
                         .await
-                        .map_err(|e| AppError::Database(e).into_graphql_error())?
+                        .map_err(AppError::into_graphql_error)?
                         .ok_or_else(|| async_graphql::Error::new("Dog not found"))?;
                     Ok(Some(FieldValue::owned_any(DogOutput::from(dog))))
                 })

--- a/apps/api/src/graphql/custom_queries.rs
+++ b/apps/api/src/graphql/custom_queries.rs
@@ -2,8 +2,8 @@ use super::auth_helpers;
 use super::mutations::{DogOutput, UserOutput, WalkOutput};
 use crate::error::AppError;
 use crate::services::{
-    dog_member_service, dog_service, encounter_service, friendship_service, walk_points_service,
-    walk_service,
+    dog_member_service, dog_pair::DogPair, dog_service, encounter_service, friendship_service,
+    walk_points_service, walk_service,
 };
 use crate::AppState;
 use async_graphql::dynamic::{Field, FieldFuture, FieldValue, InputValue, Object, TypeRef};
@@ -563,7 +563,10 @@ fn friendship_field(state: Arc<AppState>) -> Field {
                     );
                 }
 
-                let friendship = friendship_service::get_friendship(&state.db, dog_id_1, dog_id_2)
+                let Some(pair) = DogPair::new(dog_id_1, dog_id_2) else {
+                    return Ok(None);
+                };
+                let friendship = friendship_service::get_friendship(&state.db, pair)
                     .await
                     .map_err(AppError::into_graphql_error)?;
 

--- a/apps/api/src/graphql/mod.rs
+++ b/apps/api/src/graphql/mod.rs
@@ -102,3 +102,57 @@ pub fn build_schema(state: Arc<AppState>) -> AppSchema {
         .finish()
         .expect("Failed to build GraphQL schema")
 }
+
+#[cfg(test)]
+mod tests {
+    //! Enum-parity guards.
+    //!
+    //! The GraphQL enums declared above are hand-rolled shadows of domain
+    //! enums that live elsewhere. Keeping the two in sync by hand is
+    //! error-prone; these tests fail as soon as a new domain variant ships
+    //! without its GraphQL counterpart.
+    //!
+    //! Convention: GraphQL variants are `SCREAMING_SNAKE_CASE`; the domain
+    //! enum's `Display` / `FromStr` uses lowercase (`walk_status`,
+    //! `walk_event_type`) or title-case (`period`). Parity is tested via
+    //! case-insensitive round-trip through the domain `FromStr`.
+    use std::str::FromStr;
+
+    fn assert_graphql_enum_matches<T, F>(graphql_variants: &[&str], parse: F)
+    where
+        F: Fn(&str) -> Result<T, String>,
+    {
+        for g in graphql_variants {
+            parse(g).unwrap_or_else(|e| {
+                panic!(
+                    "GraphQL enum variant `{}` does not map back to a domain variant: {}",
+                    g, e
+                )
+            });
+        }
+    }
+
+    #[test]
+    fn walk_status_graphql_enum_round_trips_through_domain() {
+        use crate::entities::walks::WalkStatus;
+        assert_graphql_enum_matches(&["ACTIVE", "FINISHED"], |g| {
+            WalkStatus::from_str(&g.to_ascii_lowercase())
+        });
+    }
+
+    #[test]
+    fn walk_event_type_graphql_enum_round_trips_through_domain() {
+        use crate::services::walk_event_service::WalkEventType;
+        assert_graphql_enum_matches(&["PEE", "POO", "PHOTO"], |g| {
+            WalkEventType::from_str(&g.to_ascii_lowercase())
+                .map_err(|e| format!("{:?}", e))
+        });
+    }
+
+    #[test]
+    fn period_graphql_enum_round_trips_through_domain() {
+        use crate::services::walk_service::Period;
+        // Period::from_str is case-insensitive so the raw uppercase name works.
+        assert_graphql_enum_matches(&["WEEK", "MONTH", "YEAR", "ALL"], Period::from_str);
+    }
+}

--- a/apps/api/src/graphql/mod.rs
+++ b/apps/api/src/graphql/mod.rs
@@ -75,7 +75,6 @@ pub fn build_schema(state: Arc<AppState>) -> AppSchema {
         .register(mutations::dog_output_type())
         .register(mutations::walk_output_type())
         .register(mutations::walker_output_type())
-        .register(mutations::walk_point_output_type())
         .register(mutations::user_output_type())
         .register(mutations::walk_event_output_type())
         .register(mutations::presigned_url_type())

--- a/apps/api/src/graphql/mutations/auth.rs
+++ b/apps/api/src/graphql/mutations/auth.rs
@@ -95,35 +95,19 @@ pub fn user_output_type() -> Object {
             TypeRef::named_nn_list_nn("DogOutput"),
             |ctx| {
                 FieldFuture::new(async move {
-                    use crate::entities::dog_members::{self, Entity as DogMemberEntity};
-                    use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
-
                     let u = ctx.parent_value.try_downcast_ref::<UserOutput>()?;
-                    let user_id = u.id;
                     let state = ctx.data::<Arc<crate::AppState>>()?;
-                    let dogs =
-                        crate::services::dog_service::get_dogs_by_user_id(&state.db, user_id)
-                            .await
-                            .map_err(crate::error::AppError::into_graphql_error)?;
-
-                    // Fetch memberships to get role for each dog
-                    let dog_ids: Vec<Uuid> = dogs.iter().map(|d| d.id).collect();
-                    let memberships = DogMemberEntity::find()
-                        .filter(dog_members::Column::UserId.eq(user_id))
-                        .filter(dog_members::Column::DogId.is_in(dog_ids))
-                        .all(&state.db)
+                    let dogs_with_roles =
+                        crate::services::dog_member_service::get_dogs_with_roles_for_user(
+                            &state.db, u.id,
+                        )
                         .await
-                        .map_err(|e| AppError::Database(e).into_graphql_error())?;
-
-                    let values: Vec<FieldValue> = dogs
+                        .map_err(AppError::into_graphql_error)?;
+                    let values: Vec<FieldValue> = dogs_with_roles
                         .into_iter()
-                        .map(|d| {
-                            let role = memberships
-                                .iter()
-                                .find(|m| m.dog_id == d.id)
-                                .map(|m| m.role.clone());
+                        .map(|(d, role)| {
                             let mut output = super::dog::DogOutput::from(d);
-                            output.role = role;
+                            output.role = Some(role);
                             FieldValue::owned_any(output)
                         })
                         .collect();

--- a/apps/api/src/graphql/mutations/walk.rs
+++ b/apps/api/src/graphql/mutations/walk.rs
@@ -1,6 +1,8 @@
 use crate::error::{AppError, FieldError};
 use crate::graphql::auth_helpers;
-use crate::services::{dog_member_service, walk_event_service, walk_points_service, walk_service};
+use crate::services::{
+    dog_member_service, user_service, walk_event_service, walk_points_service, walk_service,
+};
 use crate::AppState;
 use async_graphql::dynamic::{
     Field, FieldFuture, FieldValue, InputObject, InputValue, Object, TypeRef,
@@ -121,18 +123,11 @@ pub fn walk_output_type() -> Object {
             TypeRef::named("WalkerOutput"),
             |ctx| {
                 FieldFuture::new(async move {
-                    use crate::entities::users::Entity as UserEntity;
-                    use sea_orm::EntityTrait;
-
                     let w = ctx.parent_value.try_downcast_ref::<WalkOutput>()?;
-                    let user_id = w.user_id;
                     let state = ctx.data::<Arc<crate::AppState>>()?;
-
-                    let user = UserEntity::find_by_id(user_id)
-                        .one(&state.db)
+                    let user = user_service::get_user_by_id(&state.db, w.user_id)
                         .await
-                        .map_err(|e| AppError::Database(e).into_graphql_error())?;
-
+                        .map_err(AppError::into_graphql_error)?;
                     Ok(user.map(|u| FieldValue::owned_any(WalkerOutput::from(u))))
                 })
             },
@@ -142,29 +137,11 @@ pub fn walk_output_type() -> Object {
             TypeRef::named_nn_list_nn("DogOutput"),
             |ctx| {
                 FieldFuture::new(async move {
-                    use crate::entities::{
-                        dogs::{self, Entity as DogEntity},
-                        walk_dogs::{self, Entity as WalkDogEntity},
-                    };
-                    use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
-
                     let w = ctx.parent_value.try_downcast_ref::<WalkOutput>()?;
-                    let walk_id = w.id;
                     let state = ctx.data::<Arc<crate::AppState>>()?;
-
-                    let walk_dog_rows = WalkDogEntity::find()
-                        .filter(walk_dogs::Column::WalkId.eq(walk_id))
-                        .all(&state.db)
+                    let dogs = walk_service::get_dogs_for_walk(&state.db, w.id)
                         .await
-                        .map_err(|e| AppError::Database(e).into_graphql_error())?;
-                    let dog_ids: Vec<Uuid> = walk_dog_rows.iter().map(|wd| wd.dog_id).collect();
-
-                    let dogs = DogEntity::find()
-                        .filter(dogs::Column::Id.is_in(dog_ids))
-                        .all(&state.db)
-                        .await
-                        .map_err(|e| AppError::Database(e).into_graphql_error())?;
-
+                        .map_err(AppError::into_graphql_error)?;
                     let values: Vec<FieldValue> = dogs
                         .into_iter()
                         .map(|d| FieldValue::owned_any(super::dog::DogOutput::from(d)))

--- a/apps/api/src/graphql/mutations/walk.rs
+++ b/apps/api/src/graphql/mutations/walk.rs
@@ -310,9 +310,6 @@ pub fn add_walk_points_field(state: Arc<AppState>) -> Field {
         move |ctx| {
             let state = state.clone();
             FieldFuture::new(async move {
-                use crate::entities::{walks, walks::Entity as WalkEntity};
-                use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
-
                 let walk_id_str = ctx.args.try_get("walkId")?.string()?;
 
                 let mut field_errors: Vec<FieldError> = Vec::new();
@@ -329,13 +326,10 @@ pub fn add_walk_points_field(state: Arc<AppState>) -> Field {
                 let walk_id = walk_id_opt.unwrap();
 
                 let user = auth_helpers::resolve_user(&ctx, &state).await?;
-                // Only the walk owner can add points (walks.user_id check)
-                WalkEntity::find_by_id(walk_id)
-                    .filter(walks::Column::UserId.eq(user.id))
-                    .one(&state.db)
+                // Only the walk owner can add points.
+                walk_service::require_walk_owner(&state.db, walk_id, user.id)
                     .await
-                    .map_err(|e| AppError::Database(e).into_graphql_error())?
-                    .ok_or_else(|| async_graphql::Error::new("Walk not found"))?;
+                    .map_err(AppError::into_graphql_error)?;
 
                 let points_raw = ctx.args.try_get("points")?.list()?;
                 let points: Vec<walk_points_service::WalkPointInput> = points_raw

--- a/apps/api/src/graphql/mutations/walk.rs
+++ b/apps/api/src/graphql/mutations/walk.rs
@@ -175,7 +175,7 @@ pub fn walk_output_type() -> Object {
         ))
         .field(Field::new(
             "points",
-            TypeRef::named_nn_list_nn("WalkPointOutput"),
+            TypeRef::named_nn_list_nn("WalkPoint"),
             |ctx| {
                 FieldFuture::new(async move {
                     let w = ctx.parent_value.try_downcast_ref::<WalkOutput>()?;
@@ -220,46 +220,6 @@ pub fn walk_output_type() -> Object {
                         .map(|e| FieldValue::owned_any(super::walk_event::WalkEventOutput::from(e)))
                         .collect();
                     Ok(Some(FieldValue::list(values)))
-                })
-            },
-        ))
-}
-
-pub fn walk_point_output_type() -> Object {
-    Object::new("WalkPointOutput")
-        .field(Field::new(
-            "lat",
-            TypeRef::named_nn(TypeRef::FLOAT),
-            |ctx| {
-                FieldFuture::new(async move {
-                    let p = ctx
-                        .parent_value
-                        .try_downcast_ref::<crate::graphql::custom_queries::WalkPointOutput>()?;
-                    Ok(Some(FieldValue::value(p.lat)))
-                })
-            },
-        ))
-        .field(Field::new(
-            "lng",
-            TypeRef::named_nn(TypeRef::FLOAT),
-            |ctx| {
-                FieldFuture::new(async move {
-                    let p = ctx
-                        .parent_value
-                        .try_downcast_ref::<crate::graphql::custom_queries::WalkPointOutput>()?;
-                    Ok(Some(FieldValue::value(p.lng)))
-                })
-            },
-        ))
-        .field(Field::new(
-            "recordedAt",
-            TypeRef::named_nn(TypeRef::STRING),
-            |ctx| {
-                FieldFuture::new(async move {
-                    let p = ctx
-                        .parent_value
-                        .try_downcast_ref::<crate::graphql::custom_queries::WalkPointOutput>()?;
-                    Ok(Some(FieldValue::value(p.recorded_at.clone())))
                 })
             },
         ))

--- a/apps/api/src/services/dog_member_service.rs
+++ b/apps/api/src/services/dog_member_service.rs
@@ -50,6 +50,40 @@ pub async fn get_dogs_by_member(
         .map_err(AppError::Database)
 }
 
+/// Return the user's dogs together with the membership role for each dog.
+/// Result is `(dog, role)` pairs, where `role` is either `"owner"` or `"member"`.
+pub async fn get_dogs_with_roles_for_user(
+    db: &sea_orm::DatabaseConnection,
+    user_id: Uuid,
+) -> Result<Vec<(DogModel, String)>, AppError> {
+    let memberships = DogMemberEntity::find()
+        .filter(dog_members::Column::UserId.eq(user_id))
+        .all(db)
+        .await?;
+
+    if memberships.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let dog_ids: Vec<Uuid> = memberships.iter().map(|m| m.dog_id).collect();
+    let dogs_list = DogEntity::find()
+        .filter(crate::entities::dogs::Column::Id.is_in(dog_ids))
+        .all(db)
+        .await?;
+
+    let results = dogs_list
+        .into_iter()
+        .filter_map(|d| {
+            memberships
+                .iter()
+                .find(|m| m.dog_id == d.id)
+                .map(|m| (d, m.role.clone()))
+        })
+        .collect();
+
+    Ok(results)
+}
+
 pub async fn get_members_by_dog(
     db: &sea_orm::DatabaseConnection,
     dog_id: Uuid,

--- a/apps/api/src/services/dog_member_service.rs
+++ b/apps/api/src/services/dog_member_service.rs
@@ -51,7 +51,15 @@ pub async fn get_dogs_by_member(
 }
 
 /// Return the user's dogs together with the membership role for each dog.
-/// Result is `(dog, role)` pairs, where `role` is either `"owner"` or `"member"`.
+/// Result is `(dog, role)` pairs, where `role` is either `"owner"` or
+/// `"member"`.
+///
+/// A dog without a matching `dog_members` row for this user is silently
+/// skipped from the result. Under normal operation this cannot happen —
+/// every dog_member row references an existing dog — but if the two
+/// tables drift, the dog is omitted rather than being surfaced with a
+/// missing role. The FK constraint on `dog_members.dog_id` makes this a
+/// defensive guard rather than a practical concern.
 pub async fn get_dogs_with_roles_for_user(
     db: &sea_orm::DatabaseConnection,
     user_id: Uuid,

--- a/apps/api/src/services/dog_pair.rs
+++ b/apps/api/src/services/dog_pair.rs
@@ -1,0 +1,80 @@
+//! Canonical pair of dog IDs.
+//!
+//! Several tables (`encounters`, `friendships`) store relationships between two
+//! dogs with an invariant `dog_id_1 < dog_id_2` so that the same social bond is
+//! represented once regardless of which direction a request comes from. Before
+//! this module, that ordering was expressed by:
+//! - a private helper `normalize_dog_pair` inside `encounter_service`, and
+//! - an inline `if a < b { ... } else { ... }` swap inside
+//!   `friendship_service::get_friendship`.
+//!
+//! Callers had to remember this rule when inserting rows directly. `DogPair`
+//! moves the rule into the type system — you cannot construct an
+//! out-of-order pair, and `None` on equal IDs makes the degenerate case
+//! impossible to forget.
+
+use uuid::Uuid;
+
+/// A pair of distinct dog IDs, sorted so that `first() < second()`.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct DogPair {
+    first: Uuid,
+    second: Uuid,
+}
+
+impl DogPair {
+    /// Construct a canonically-sorted pair. Returns `None` when the two IDs
+    /// are equal (same dog — no pair to form).
+    pub fn new(a: Uuid, b: Uuid) -> Option<Self> {
+        match a.cmp(&b) {
+            std::cmp::Ordering::Less => Some(Self {
+                first: a,
+                second: b,
+            }),
+            std::cmp::Ordering::Greater => Some(Self {
+                first: b,
+                second: a,
+            }),
+            std::cmp::Ordering::Equal => None,
+        }
+    }
+
+    /// The smaller of the two IDs (stored in the `dog_id_1` column).
+    pub fn first(&self) -> Uuid {
+        self.first
+    }
+
+    /// The larger of the two IDs (stored in the `dog_id_2` column).
+    pub fn second(&self) -> Uuid {
+        self.second
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_orders_ascending_when_first_less_than_second() {
+        let a = Uuid::parse_str("00000000-0000-0000-0000-000000000001").unwrap();
+        let b = Uuid::parse_str("00000000-0000-0000-0000-000000000002").unwrap();
+        let pair = DogPair::new(a, b).unwrap();
+        assert_eq!(pair.first(), a);
+        assert_eq!(pair.second(), b);
+    }
+
+    #[test]
+    fn new_swaps_when_first_greater_than_second() {
+        let a = Uuid::parse_str("00000000-0000-0000-0000-000000000002").unwrap();
+        let b = Uuid::parse_str("00000000-0000-0000-0000-000000000001").unwrap();
+        let pair = DogPair::new(a, b).unwrap();
+        assert_eq!(pair.first(), b);
+        assert_eq!(pair.second(), a);
+    }
+
+    #[test]
+    fn new_returns_none_for_same_dog() {
+        let id = Uuid::parse_str("00000000-0000-0000-0000-000000000001").unwrap();
+        assert!(DogPair::new(id, id).is_none());
+    }
+}

--- a/apps/api/src/services/dog_service.rs
+++ b/apps/api/src/services/dog_service.rs
@@ -71,13 +71,6 @@ pub async fn update_dog(
     Ok(updated)
 }
 
-pub async fn get_dogs_by_user_id(
-    db: &sea_orm::DatabaseConnection,
-    user_id: Uuid,
-) -> Result<Vec<DogModel>, AppError> {
-    dog_member_service::get_dogs_by_member(db, user_id).await
-}
-
 pub async fn get_dog_by_id(
     db: &sea_orm::DatabaseConnection,
     dog_id: Uuid,

--- a/apps/api/src/services/encounter_service.rs
+++ b/apps/api/src/services/encounter_service.rs
@@ -7,14 +7,16 @@ use uuid::Uuid;
 
 use super::friendship_service;
 use crate::entities::{
+    dog_members::{self, Entity as DogMemberEntity},
     encounters::{
         self, ActiveModel as EncounterActiveModel, Entity as EncounterEntity,
         Model as EncounterModel,
     },
+    users::{self, Entity as UserEntity},
     walk_dogs::{self, Entity as WalkDogEntity},
+    walks::Entity as WalkEntity,
 };
 use crate::error::AppError;
-use crate::services::walk_event_service;
 
 /// Normalize a dog pair so that `dog_id_1 < dog_id_2` (UUID lexicographic order).
 /// Returns `None` if both IDs are equal (same dog — skip).
@@ -26,6 +28,95 @@ fn normalize_dog_pair(a: Uuid, b: Uuid) -> Option<(Uuid, Uuid)> {
     } else {
         None
     }
+}
+
+/// Verify that encounter detection is allowed for the acting user's walk.
+///
+/// Checks:
+/// 1. The walk exists.
+/// 2. The walk belongs to `user_id` (ownership check).
+/// 3. The user has `encounter_detection_enabled = true`.
+async fn verify_encounter_detection(
+    db: &sea_orm::DatabaseConnection,
+    walk_id: Uuid,
+    user_id: Uuid,
+) -> Result<(), AppError> {
+    let walk = WalkEntity::find_by_id(walk_id)
+        .one(db)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("Walk {} not found", walk_id)))?;
+
+    if walk.user_id != user_id {
+        return Err(AppError::Unauthorized(
+            "Walk does not belong to user".to_string(),
+        ));
+    }
+
+    let user = UserEntity::find_by_id(user_id)
+        .one(db)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("User {} not found", user_id)))?;
+
+    if !user.encounter_detection_enabled {
+        return Err(AppError::Unauthorized(
+            "Encounter detection is disabled for your account".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Verify that all users associated with the counterparty walk have
+/// encounter detection enabled.
+///
+/// Three fixed queries replace an N+M nested loop:
+/// 1. walk_dogs WHERE walk_id = their_walk_id → dog_ids
+/// 2. dog_members WHERE dog_id IN (dog_ids) → user_ids
+/// 3. users WHERE id IN (user_ids) AND encounter_detection_enabled = false
+///
+/// If any associated user has encounter detection disabled, returns
+/// `Unauthorized`.
+async fn verify_counterparty_encounter_detection(
+    db: &sea_orm::DatabaseConnection,
+    their_walk_id: Uuid,
+) -> Result<(), AppError> {
+    let dog_ids: Vec<Uuid> = WalkDogEntity::find()
+        .filter(walk_dogs::Column::WalkId.eq(their_walk_id))
+        .select_only()
+        .column(walk_dogs::Column::DogId)
+        .into_tuple()
+        .all(db)
+        .await?;
+
+    if dog_ids.is_empty() {
+        return Ok(());
+    }
+
+    let user_ids: Vec<Uuid> = DogMemberEntity::find()
+        .filter(dog_members::Column::DogId.is_in(dog_ids))
+        .select_only()
+        .column(dog_members::Column::UserId)
+        .into_tuple()
+        .all(db)
+        .await?;
+
+    if user_ids.is_empty() {
+        return Ok(());
+    }
+
+    let opted_out = UserEntity::find()
+        .filter(users::Column::Id.is_in(user_ids))
+        .filter(users::Column::EncounterDetectionEnabled.eq(false))
+        .one(db)
+        .await?;
+
+    if opted_out.is_some() {
+        return Err(AppError::Unauthorized(
+            "Encounter detection is disabled for the other user".to_string(),
+        ));
+    }
+
+    Ok(())
 }
 
 /// Record encounters between all dog pairs from two walks.
@@ -41,10 +132,10 @@ pub async fn record_encounter(
     acting_user_id: Uuid,
 ) -> Result<Vec<EncounterModel>, AppError> {
     // Verify acting user ownership + encounter detection enabled
-    walk_event_service::verify_encounter_detection(db, my_walk_id, acting_user_id).await?;
+    verify_encounter_detection(db, my_walk_id, acting_user_id).await?;
 
     // Verify all counterparty users have encounter detection enabled (fixed 2-3 queries)
-    walk_event_service::verify_counterparty_encounter_detection(db, their_walk_id).await?;
+    verify_counterparty_encounter_detection(db, their_walk_id).await?;
 
     // Fetch all dog IDs in each walk
     let my_dog_ids: Vec<Uuid> = WalkDogEntity::find()
@@ -147,7 +238,7 @@ pub async fn update_encounter_duration(
     acting_user_id: Uuid,
 ) -> Result<bool, AppError> {
     // Verify acting user ownership + encounter detection enabled
-    walk_event_service::verify_encounter_detection(db, my_walk_id, acting_user_id).await?;
+    verify_encounter_detection(db, my_walk_id, acting_user_id).await?;
     let their_dog_ids: Vec<Uuid> = WalkDogEntity::find()
         .filter(walk_dogs::Column::WalkId.eq(their_walk_id))
         .select_only()
@@ -281,25 +372,26 @@ mod tests {
         );
     }
 
-    /// Static guard: encounter_service must call verify_encounter_detection.
+    /// Static guard: encounter_service must own and call
+    /// verify_encounter_detection (no delegation to walk_event_service).
     #[test]
-    fn encounter_service_calls_verify_encounter_detection() {
+    fn encounter_service_defines_verify_encounter_detection() {
         let src = include_str!("encounter_service.rs");
         assert!(
-            src.contains("verify_encounter_detection"),
-            "encounter_service must call walk_event_service::verify_encounter_detection"
+            src.contains("async fn verify_encounter_detection"),
+            "encounter_service must define verify_encounter_detection internally"
         );
     }
 
-    /// Static guard: walk_event_service must expose verify_counterparty_encounter_detection.
-    /// References a separate file to avoid self-referential trap.
+    /// Static guard: encounter_service must own
+    /// verify_counterparty_encounter_detection (no delegation to
+    /// walk_event_service).
     #[test]
-    fn walk_event_service_exposes_verify_counterparty_encounter_detection() {
-        let src = include_str!("walk_event_service.rs");
+    fn encounter_service_defines_verify_counterparty_encounter_detection() {
+        let src = include_str!("encounter_service.rs");
         assert!(
-            src.contains("pub async fn verify_counterparty_encounter_detection"),
-            "walk_event_service must expose verify_counterparty_encounter_detection, \
-             but the function was not found"
+            src.contains("async fn verify_counterparty_encounter_detection"),
+            "encounter_service must define verify_counterparty_encounter_detection internally"
         );
     }
 

--- a/apps/api/src/services/encounter_service.rs
+++ b/apps/api/src/services/encounter_service.rs
@@ -17,18 +17,7 @@ use crate::entities::{
     walks::Entity as WalkEntity,
 };
 use crate::error::AppError;
-
-/// Normalize a dog pair so that `dog_id_1 < dog_id_2` (UUID lexicographic order).
-/// Returns `None` if both IDs are equal (same dog — skip).
-fn normalize_dog_pair(a: Uuid, b: Uuid) -> Option<(Uuid, Uuid)> {
-    if a < b {
-        Some((a, b))
-    } else if a > b {
-        Some((b, a))
-    } else {
-        None
-    }
-}
+use crate::services::dog_pair::DogPair;
 
 /// Verify that encounter detection is allowed for the acting user's walk.
 ///
@@ -167,8 +156,8 @@ pub async fn record_encounter(
 
     for my_dog in &my_dog_ids {
         for their_dog in &their_dog_ids {
-            // Normalize ordering: dog_id_1 < dog_id_2 (UUID lexicographic); skip same dog
-            let Some((dog_id_1, dog_id_2)) = normalize_dog_pair(*my_dog, *their_dog) else {
+            // DogPair enforces dog_id_1 < dog_id_2 and skips the same-dog case.
+            let Some(pair) = DogPair::new(*my_dog, *their_dog) else {
                 continue;
             };
 
@@ -179,8 +168,8 @@ pub async fn record_encounter(
                         .add(encounters::Column::WalkId.eq(my_walk_id))
                         .add(encounters::Column::WalkId.eq(their_walk_id)),
                 )
-                .filter(encounters::Column::DogId1.eq(dog_id_1))
-                .filter(encounters::Column::DogId2.eq(dog_id_2))
+                .filter(encounters::Column::DogId1.eq(pair.first()))
+                .filter(encounters::Column::DogId2.eq(pair.second()))
                 .one(&txn)
                 .await?;
 
@@ -196,8 +185,8 @@ pub async fn record_encounter(
                 let encounter = EncounterActiveModel {
                     id: Set(Uuid::new_v4()),
                     walk_id: Set(my_walk_id),
-                    dog_id_1: Set(dog_id_1),
-                    dog_id_2: Set(dog_id_2),
+                    dog_id_1: Set(pair.first()),
+                    dog_id_2: Set(pair.second()),
                     duration_sec: Set(duration_sec),
                     met_at: Set(met_at.into()),
                     created_at: Set(met_at.into()),
@@ -206,14 +195,7 @@ pub async fn record_encounter(
                 .await?;
 
                 // Upsert friendship (first encounter creates it)
-                friendship_service::upsert_friendship(
-                    &txn,
-                    dog_id_1,
-                    dog_id_2,
-                    duration_sec,
-                    met_at,
-                )
-                .await?;
+                friendship_service::upsert_friendship(&txn, pair, duration_sec, met_at).await?;
 
                 encounter
             };
@@ -257,14 +239,14 @@ pub async fn update_encounter_duration(
 
     for my_dog in &my_dog_ids {
         for their_dog in &their_dog_ids {
-            let Some((dog_id_1, dog_id_2)) = normalize_dog_pair(*my_dog, *their_dog) else {
+            let Some(pair) = DogPair::new(*my_dog, *their_dog) else {
                 continue;
             };
 
             let existing = EncounterEntity::find()
                 .filter(encounters::Column::WalkId.eq(my_walk_id))
-                .filter(encounters::Column::DogId1.eq(dog_id_1))
-                .filter(encounters::Column::DogId2.eq(dog_id_2))
+                .filter(encounters::Column::DogId1.eq(pair.first()))
+                .filter(encounters::Column::DogId2.eq(pair.second()))
                 .one(db)
                 .await?;
 
@@ -277,8 +259,7 @@ pub async fn update_encounter_duration(
 
                 // Update friendship total_interaction_sec with precise delta
                 let delta = new_duration - old_duration;
-                friendship_service::update_friendship_duration(db, dog_id_1, dog_id_2, delta)
-                    .await?;
+                friendship_service::update_friendship_duration(db, pair, delta).await?;
             }
         }
     }
@@ -315,29 +296,6 @@ pub async fn get_encounters_for_dog(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn normalize_dog_pair_returns_ordered_pair_when_a_less_than_b() {
-        let a = Uuid::parse_str("00000000-0000-0000-0000-000000000001").unwrap();
-        let b = Uuid::parse_str("00000000-0000-0000-0000-000000000002").unwrap();
-        let result = normalize_dog_pair(a, b);
-        assert_eq!(result, Some((a, b)));
-    }
-
-    #[test]
-    fn normalize_dog_pair_returns_swapped_pair_when_a_greater_than_b() {
-        let a = Uuid::parse_str("00000000-0000-0000-0000-000000000002").unwrap();
-        let b = Uuid::parse_str("00000000-0000-0000-0000-000000000001").unwrap();
-        let result = normalize_dog_pair(a, b);
-        assert_eq!(result, Some((b, a)));
-    }
-
-    #[test]
-    fn normalize_dog_pair_returns_none_when_same_dog() {
-        let id = Uuid::parse_str("00000000-0000-0000-0000-000000000001").unwrap();
-        let result = normalize_dog_pair(id, id);
-        assert_eq!(result, None);
-    }
 
     /// Static guard: record_encounter must accept acting_user_id parameter.
     #[test]

--- a/apps/api/src/services/friendship_service.rs
+++ b/apps/api/src/services/friendship_service.rs
@@ -9,19 +9,20 @@ use crate::entities::friendships::{
     Model as FriendshipModel,
 };
 use crate::error::AppError;
+use crate::services::dog_pair::DogPair;
 
-/// Insert or update a friendship between two dogs.
-/// dog_id_1 MUST be < dog_id_2 (normalized by caller).
+/// Insert or update a friendship between two dogs. The canonical
+/// `dog_id_1 < dog_id_2` ordering is enforced by the `DogPair` type, so
+/// callers can no longer pass an out-of-order tuple.
 pub async fn upsert_friendship<C: sea_orm::ConnectionTrait>(
     db: &C,
-    dog_id_1: Uuid,
-    dog_id_2: Uuid,
+    pair: DogPair,
     duration_sec: i32,
     met_at: DateTime<Utc>,
 ) -> Result<FriendshipModel, AppError> {
     let existing = FriendshipEntity::find()
-        .filter(friendships::Column::DogId1.eq(dog_id_1))
-        .filter(friendships::Column::DogId2.eq(dog_id_2))
+        .filter(friendships::Column::DogId1.eq(pair.first()))
+        .filter(friendships::Column::DogId2.eq(pair.second()))
         .one(db)
         .await?;
 
@@ -34,8 +35,8 @@ pub async fn upsert_friendship<C: sea_orm::ConnectionTrait>(
     } else {
         FriendshipActiveModel {
             id: Set(Uuid::new_v4()),
-            dog_id_1: Set(dog_id_1),
-            dog_id_2: Set(dog_id_2),
+            dog_id_1: Set(pair.first()),
+            dog_id_2: Set(pair.second()),
             encounter_count: Set(1),
             total_interaction_sec: Set(duration_sec),
             first_met_at: Set(met_at.into()),
@@ -52,8 +53,7 @@ pub async fn upsert_friendship<C: sea_orm::ConnectionTrait>(
 /// Update the total_interaction_sec of an existing friendship by a precise delta.
 pub async fn update_friendship_duration(
     db: &sea_orm::DatabaseConnection,
-    dog_id_1: Uuid,
-    dog_id_2: Uuid,
+    pair: DogPair,
     delta_sec: i32,
 ) -> Result<bool, AppError> {
     if delta_sec == 0 {
@@ -61,8 +61,8 @@ pub async fn update_friendship_duration(
     }
 
     let existing = FriendshipEntity::find()
-        .filter(friendships::Column::DogId1.eq(dog_id_1))
-        .filter(friendships::Column::DogId2.eq(dog_id_2))
+        .filter(friendships::Column::DogId1.eq(pair.first()))
+        .filter(friendships::Column::DogId2.eq(pair.second()))
         .one(db)
         .await?;
 
@@ -94,21 +94,14 @@ pub async fn get_friends_for_dog(
     Ok(friends)
 }
 
-/// Get a specific friendship between two dogs.
+/// Get the friendship record for a specific pair of dogs.
 pub async fn get_friendship(
     db: &sea_orm::DatabaseConnection,
-    dog_id_a: Uuid,
-    dog_id_b: Uuid,
+    pair: DogPair,
 ) -> Result<Option<FriendshipModel>, AppError> {
-    let (dog_id_1, dog_id_2) = if dog_id_a < dog_id_b {
-        (dog_id_a, dog_id_b)
-    } else {
-        (dog_id_b, dog_id_a)
-    };
-
     let friendship = FriendshipEntity::find()
-        .filter(friendships::Column::DogId1.eq(dog_id_1))
-        .filter(friendships::Column::DogId2.eq(dog_id_2))
+        .filter(friendships::Column::DogId1.eq(pair.first()))
+        .filter(friendships::Column::DogId2.eq(pair.second()))
         .one(db)
         .await?;
 

--- a/apps/api/src/services/mod.rs
+++ b/apps/api/src/services/mod.rs
@@ -1,5 +1,6 @@
 pub mod dog_invitation_service;
 pub mod dog_member_service;
+pub mod dog_pair;
 pub mod dog_service;
 pub mod encounter_service;
 pub mod friendship_service;

--- a/apps/api/src/services/user_service.rs
+++ b/apps/api/src/services/user_service.rs
@@ -42,6 +42,16 @@ pub async fn get_or_create_user(
     upsert_user(db, cognito_sub, None).await
 }
 
+pub async fn get_user_by_id(
+    db: &sea_orm::DatabaseConnection,
+    user_id: Uuid,
+) -> Result<Option<UserModel>, AppError> {
+    UserEntity::find_by_id(user_id)
+        .one(db)
+        .await
+        .map_err(AppError::Database)
+}
+
 pub async fn create_user_with_profile(
     db: &sea_orm::DatabaseConnection,
     cognito_sub: &str,

--- a/apps/api/src/services/walk_event_service.rs
+++ b/apps/api/src/services/walk_event_service.rs
@@ -1,6 +1,6 @@
 use chrono::Utc;
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, QuerySelect, Set,
+    ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, Set,
 };
 use std::fmt;
 use std::str::FromStr;

--- a/apps/api/src/services/walk_event_service.rs
+++ b/apps/api/src/services/walk_event_service.rs
@@ -7,8 +7,6 @@ use std::str::FromStr;
 use uuid::Uuid;
 
 use crate::entities::{
-    dog_members::{self, Entity as DogMemberEntity},
-    users::{self, Entity as UserEntity},
     walk_dogs::{self, Entity as WalkDogEntity},
     walk_events::{
         ActiveModel as WalkEventActiveModel, Column as WalkEventColumn, Entity as WalkEventEntity,
@@ -61,100 +59,6 @@ pub struct RecordEventInput {
     pub lng: Option<f64>,
     /// S3 key for photo events; required when event_type == "photo".
     pub photo_key: Option<String>,
-}
-
-/// Verify that encounter detection is allowed for the acting user's walk.
-///
-/// Checks:
-/// 1. The walk exists.
-/// 2. The walk belongs to `user_id` (ownership check).
-/// 3. The user has `encounter_detection_enabled = true`.
-pub async fn verify_encounter_detection(
-    db: &sea_orm::DatabaseConnection,
-    walk_id: Uuid,
-    user_id: Uuid,
-) -> Result<(), AppError> {
-    // 1. Fetch walk
-    let walk = WalkEntity::find_by_id(walk_id)
-        .one(db)
-        .await?
-        .ok_or_else(|| AppError::NotFound(format!("Walk {} not found", walk_id)))?;
-
-    // 2. Ownership check
-    if walk.user_id != user_id {
-        return Err(AppError::Unauthorized(
-            "Walk does not belong to user".to_string(),
-        ));
-    }
-
-    // 3. Encounter detection enabled check
-    let user = UserEntity::find_by_id(user_id)
-        .one(db)
-        .await?
-        .ok_or_else(|| AppError::NotFound(format!("User {} not found", user_id)))?;
-
-    if !user.encounter_detection_enabled {
-        return Err(AppError::Unauthorized(
-            "Encounter detection is disabled for your account".to_string(),
-        ));
-    }
-
-    Ok(())
-}
-
-/// Verify that all users associated with the counterparty walk have encounter detection enabled.
-///
-/// This replaces the N+M nested loop in the resolver with 2 fixed queries:
-/// 1. Walk_dogs WHERE walk_id = their_walk_id → dog_ids (all at once via IN)
-/// 2. Dog_members WHERE dog_id IN (dog_ids) → user_ids, then users WHERE id IN (user_ids)
-///    + filter encounter_detection_enabled = false
-///
-/// If any associated user has encounter detection disabled, returns `Unauthorized`.
-pub async fn verify_counterparty_encounter_detection(
-    db: &sea_orm::DatabaseConnection,
-    their_walk_id: Uuid,
-) -> Result<(), AppError> {
-    // Query 1: get all dog_ids in the counterparty walk
-    let dog_ids: Vec<Uuid> = WalkDogEntity::find()
-        .filter(walk_dogs::Column::WalkId.eq(their_walk_id))
-        .select_only()
-        .column(walk_dogs::Column::DogId)
-        .into_tuple()
-        .all(db)
-        .await?;
-
-    if dog_ids.is_empty() {
-        // No dogs in the counterparty walk — nothing to check
-        return Ok(());
-    }
-
-    // Query 2: get user_ids of all members of those dogs
-    let user_ids: Vec<Uuid> = DogMemberEntity::find()
-        .filter(dog_members::Column::DogId.is_in(dog_ids))
-        .select_only()
-        .column(dog_members::Column::UserId)
-        .into_tuple()
-        .all(db)
-        .await?;
-
-    if user_ids.is_empty() {
-        return Ok(());
-    }
-
-    // Query 3 (still fixed): check if any of those users has encounter detection disabled
-    let opted_out = UserEntity::find()
-        .filter(users::Column::Id.is_in(user_ids))
-        .filter(users::Column::EncounterDetectionEnabled.eq(false))
-        .one(db)
-        .await?;
-
-    if opted_out.is_some() {
-        return Err(AppError::Unauthorized(
-            "Encounter detection is disabled for the other user".to_string(),
-        ));
-    }
-
-    Ok(())
 }
 
 /// Verify that the given user is authorized to record events for the walk.

--- a/apps/api/src/services/walk_points_service.rs
+++ b/apps/api/src/services/walk_points_service.rs
@@ -126,10 +126,11 @@ pub async fn get_walk_points(
     table_name: &str,
     walk_id: Uuid,
 ) -> Result<Vec<WalkPoint>, AppError> {
+    // Static expression literal. Must stay in sync with `PK_ATTR`.
     let result = client
         .query()
         .table_name(table_name)
-        .key_condition_expression(format!("{} = :pk", PK_ATTR))
+        .key_condition_expression("pk = :pk")
         .expression_attribute_values(":pk", AttributeValue::S(walk_partition_key(walk_id)))
         .send()
         .await

--- a/apps/api/src/services/walk_points_service.rs
+++ b/apps/api/src/services/walk_points_service.rs
@@ -3,11 +3,69 @@ use aws_sdk_dynamodb::{
     types::{AttributeValue, PutRequest, WriteRequest},
     Client as DynamoClient,
 };
+use std::collections::HashMap;
 use uuid::Uuid;
 
 /// Maximum number of write requests per DynamoDB BatchWriteItem call.
 /// See: https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchWriteItem.html
 const DYNAMODB_BATCH_WRITE_LIMIT: usize = 25;
+
+// ─── DynamoDB schema authority ───────────────────────────────────────────────
+// Every bit of knowledge about how walk points are stored in DynamoDB lives
+// here. Callers should not need to know the attribute names, key prefixes, or
+// types. If the schema changes, this block is the only place that changes.
+
+const PK_ATTR: &str = "pk";
+const SK_ATTR: &str = "sk";
+const LAT_ATTR: &str = "lat";
+const LNG_ATTR: &str = "lng";
+const RECORDED_AT_ATTR: &str = "recorded_at";
+
+/// Partition key for all points belonging to a walk.
+fn walk_partition_key(walk_id: Uuid) -> String {
+    format!("WALK#{}", walk_id)
+}
+
+/// Sort key for an individual point within a walk's partition.
+fn walk_point_sort_key(recorded_at: &str) -> String {
+    format!("PT#{}", recorded_at)
+}
+
+/// Build the DynamoDB item representation of a single walk point.
+fn build_point_item(walk_id: Uuid, point: &WalkPointInput) -> HashMap<String, AttributeValue> {
+    HashMap::from([
+        (
+            PK_ATTR.to_string(),
+            AttributeValue::S(walk_partition_key(walk_id)),
+        ),
+        (
+            SK_ATTR.to_string(),
+            AttributeValue::S(walk_point_sort_key(&point.recorded_at)),
+        ),
+        (LAT_ATTR.to_string(), AttributeValue::N(point.lat.to_string())),
+        (LNG_ATTR.to_string(), AttributeValue::N(point.lng.to_string())),
+        (
+            RECORDED_AT_ATTR.to_string(),
+            AttributeValue::S(point.recorded_at.clone()),
+        ),
+    ])
+}
+
+/// Parse a DynamoDB item back into a `WalkPoint`. Returns `None` if any
+/// required attribute is missing or the wrong type — the caller should
+/// treat missing rows as silently dropped (legacy data tolerance).
+fn parse_point_row(item: &HashMap<String, AttributeValue>) -> Option<WalkPoint> {
+    let lat = item.get(LAT_ATTR)?.as_n().ok()?.parse().ok()?;
+    let lng = item.get(LNG_ATTR)?.as_n().ok()?.parse().ok()?;
+    let recorded_at = item.get(RECORDED_AT_ATTR)?.as_s().ok()?.clone();
+    Some(WalkPoint {
+        lat,
+        lng,
+        recorded_at,
+    })
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
 
 #[derive(Clone, Debug)]
 pub struct WalkPoint {
@@ -39,23 +97,10 @@ pub async fn add_walk_points(
         return Ok(true);
     }
 
-    let pk = format!("WALK#{}", walk_id);
     let all_requests: Vec<WriteRequest> = points
         .iter()
         .map(|point| {
-            let item = std::collections::HashMap::from([
-                ("pk".to_string(), AttributeValue::S(pk.clone())),
-                (
-                    "sk".to_string(),
-                    AttributeValue::S(format!("PT#{}", point.recorded_at)),
-                ),
-                ("lat".to_string(), AttributeValue::N(point.lat.to_string())),
-                ("lng".to_string(), AttributeValue::N(point.lng.to_string())),
-                (
-                    "recorded_at".to_string(),
-                    AttributeValue::S(point.recorded_at.clone()),
-                ),
-            ]);
+            let item = build_point_item(walk_id, point);
             WriteRequest::builder()
                 .put_request(PutRequest::builder().set_item(Some(item)).build().unwrap())
                 .build()
@@ -81,30 +126,16 @@ pub async fn get_walk_points(
     table_name: &str,
     walk_id: Uuid,
 ) -> Result<Vec<WalkPoint>, AppError> {
-    let pk = format!("WALK#{}", walk_id);
     let result = client
         .query()
         .table_name(table_name)
-        .key_condition_expression("pk = :pk")
-        .expression_attribute_values(":pk", AttributeValue::S(pk))
+        .key_condition_expression(format!("{} = :pk", PK_ATTR))
+        .expression_attribute_values(":pk", AttributeValue::S(walk_partition_key(walk_id)))
         .send()
         .await
         .map_err(|e| AppError::Internal(e.to_string()))?;
 
-    let mut points: Vec<WalkPoint> = result
-        .items()
-        .iter()
-        .filter_map(|item| {
-            let lat = item.get("lat")?.as_n().ok()?.parse().ok()?;
-            let lng = item.get("lng")?.as_n().ok()?.parse().ok()?;
-            let recorded_at = item.get("recorded_at")?.as_s().ok()?.clone();
-            Some(WalkPoint {
-                lat,
-                lng,
-                recorded_at,
-            })
-        })
-        .collect();
+    let mut points: Vec<WalkPoint> = result.items().iter().filter_map(parse_point_row).collect();
 
     // recorded_at でソート
     points.sort_by(|a, b| a.recorded_at.cmp(&b.recorded_at));
@@ -118,5 +149,71 @@ mod tests {
     #[test]
     fn dynamodb_batch_write_limit_is_25() {
         assert_eq!(DYNAMODB_BATCH_WRITE_LIMIT, 25);
+    }
+
+    #[test]
+    fn walk_partition_key_has_stable_format() {
+        // Existing rows in the `walk_points` table use this exact prefix;
+        // changing it is a breaking migration.
+        let walk_id = Uuid::parse_str("11111111-2222-3333-4444-555555555555").unwrap();
+        assert_eq!(
+            walk_partition_key(walk_id),
+            "WALK#11111111-2222-3333-4444-555555555555"
+        );
+    }
+
+    #[test]
+    fn walk_point_sort_key_has_stable_format() {
+        assert_eq!(
+            walk_point_sort_key("2026-04-24T10:00:00Z"),
+            "PT#2026-04-24T10:00:00Z"
+        );
+    }
+
+    #[test]
+    fn build_point_item_produces_all_required_attributes() {
+        let walk_id = Uuid::parse_str("11111111-2222-3333-4444-555555555555").unwrap();
+        let input = WalkPointInput {
+            lat: 35.6812,
+            lng: 139.7671,
+            recorded_at: "2026-04-24T10:00:00Z".to_string(),
+        };
+        let item = build_point_item(walk_id, &input);
+
+        assert_eq!(
+            item.get(PK_ATTR).and_then(|v| v.as_s().ok()),
+            Some(&walk_partition_key(walk_id))
+        );
+        assert_eq!(
+            item.get(SK_ATTR).and_then(|v| v.as_s().ok()),
+            Some(&walk_point_sort_key("2026-04-24T10:00:00Z"))
+        );
+        assert!(item.contains_key(LAT_ATTR));
+        assert!(item.contains_key(LNG_ATTR));
+        assert!(item.contains_key(RECORDED_AT_ATTR));
+    }
+
+    #[test]
+    fn parse_point_row_roundtrips_build_point_item() {
+        let walk_id = Uuid::parse_str("11111111-2222-3333-4444-555555555555").unwrap();
+        let input = WalkPointInput {
+            lat: 35.6812,
+            lng: 139.7671,
+            recorded_at: "2026-04-24T10:00:00Z".to_string(),
+        };
+        let item = build_point_item(walk_id, &input);
+        let parsed = parse_point_row(&item).expect("built item must parse");
+
+        assert!((parsed.lat - 35.6812).abs() < 1e-9);
+        assert!((parsed.lng - 139.7671).abs() < 1e-9);
+        assert_eq!(parsed.recorded_at, "2026-04-24T10:00:00Z");
+    }
+
+    #[test]
+    fn parse_point_row_returns_none_when_attribute_missing() {
+        let mut item = HashMap::new();
+        item.insert(LAT_ATTR.to_string(), AttributeValue::N("35.0".to_string()));
+        // lng and recorded_at are missing
+        assert!(parse_point_row(&item).is_none());
     }
 }

--- a/apps/api/src/services/walk_service.rs
+++ b/apps/api/src/services/walk_service.rs
@@ -42,12 +42,15 @@ impl fmt::Display for Period {
 impl FromStr for Period {
     type Err = String;
 
+    /// Case-insensitive. Accepts both the domain casing ("Week") and the
+    /// GraphQL enum casing ("WEEK") so that resolver input and internal
+    /// round-trips can share this parser.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "Week" => Ok(Period::Week),
-            "Month" => Ok(Period::Month),
-            "Year" => Ok(Period::Year),
-            "All" => Ok(Period::All),
+        match s.to_ascii_uppercase().as_str() {
+            "WEEK" => Ok(Period::Week),
+            "MONTH" => Ok(Period::Month),
+            "YEAR" => Ok(Period::Year),
+            "ALL" => Ok(Period::All),
             other => Err(format!("Invalid Period: '{}'", other)),
         }
     }
@@ -314,6 +317,16 @@ mod tests {
     fn period_from_str_invalid_returns_error() {
         let result: Result<Period, _> = "invalid".parse();
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn period_from_str_accepts_graphql_uppercase() {
+        // GraphQL sends these names via the Period enum type; the parser
+        // must accept them so dogWalkStats respects the period argument.
+        assert_eq!("WEEK".parse::<Period>().unwrap(), Period::Week);
+        assert_eq!("MONTH".parse::<Period>().unwrap(), Period::Month);
+        assert_eq!("YEAR".parse::<Period>().unwrap(), Period::Year);
+        assert_eq!("ALL".parse::<Period>().unwrap(), Period::All);
     }
 
     #[test]

--- a/apps/api/src/services/walk_service.rs
+++ b/apps/api/src/services/walk_service.rs
@@ -442,4 +442,47 @@ mod tests {
         assert_eq!(stats.total_distance_m, 0);
         assert_eq!(stats.total_duration_sec, 0);
     }
+
+    #[tokio::test]
+    async fn require_walk_owner_returns_walk_when_user_is_owner() {
+        let walk_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+        let walk = make_finished_walk(walk_id, user_id, None, None);
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![walk.clone()]])
+            .into_connection();
+
+        let result = require_walk_owner(&db, walk_id, user_id).await.unwrap();
+        assert_eq!(result.id, walk_id);
+        assert_eq!(result.user_id, user_id);
+    }
+
+    #[tokio::test]
+    async fn require_walk_owner_returns_not_found_when_user_is_not_owner() {
+        // Walk exists but belongs to a different user. The SQL filter
+        // (UserId.eq(user_id)) returns no rows, so MockDatabase returns
+        // an empty Vec. The function collapses both "walk missing" and
+        // "walk owned by another user" into NotFound, matching the
+        // auth_helpers convention that prevents walk-ID enumeration.
+        let walk_id = Uuid::new_v4();
+        let requesting_user_id = Uuid::new_v4();
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([Vec::<crate::entities::walks::Model>::new()])
+            .into_connection();
+
+        let result = require_walk_owner(&db, walk_id, requesting_user_id).await;
+        assert!(matches!(result, Err(crate::error::AppError::NotFound(_))));
+    }
+
+    #[tokio::test]
+    async fn require_walk_owner_returns_not_found_when_walk_does_not_exist() {
+        let walk_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([Vec::<crate::entities::walks::Model>::new()])
+            .into_connection();
+
+        let result = require_walk_owner(&db, walk_id, user_id).await;
+        assert!(matches!(result, Err(crate::error::AppError::NotFound(_))));
+    }
 }

--- a/apps/api/src/services/walk_service.rs
+++ b/apps/api/src/services/walk_service.rs
@@ -1,4 +1,5 @@
 use crate::entities::{
+    dogs::{self, Entity as DogEntity, Model as DogModel},
     walk_dogs::{self, ActiveModel as WalkDogActiveModel, Entity as WalkDogEntity},
     walks::{self, ActiveModel, Entity as WalkEntity, Model as WalkModel, WalkStatus},
 };
@@ -239,6 +240,30 @@ pub async fn get_walks_for_user(
 
     let walks = query.all(db).await?;
     Ok(walks)
+}
+
+/// Get the dogs associated with a walk (via `walk_dogs`).
+pub async fn get_dogs_for_walk(
+    db: &sea_orm::DatabaseConnection,
+    walk_id: Uuid,
+) -> Result<Vec<DogModel>, AppError> {
+    let dog_ids: Vec<Uuid> = WalkDogEntity::find()
+        .filter(walk_dogs::Column::WalkId.eq(walk_id))
+        .select_only()
+        .column(walk_dogs::Column::DogId)
+        .into_tuple()
+        .all(db)
+        .await?;
+
+    if dog_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    DogEntity::find()
+        .filter(dogs::Column::Id.is_in(dog_ids))
+        .all(db)
+        .await
+        .map_err(AppError::Database)
 }
 
 #[cfg(test)]

--- a/apps/api/src/services/walk_service.rs
+++ b/apps/api/src/services/walk_service.rs
@@ -242,6 +242,22 @@ pub async fn get_walks_for_user(
     Ok(walks)
 }
 
+/// Verify that the given user owns the walk. Returns the walk on success
+/// or `AppError::NotFound` when the walk does not exist or belongs to
+/// another user. Used by walk mutations that must only be performed by the
+/// walk's creator (e.g. recording GPS points, finishing the walk).
+pub async fn require_walk_owner(
+    db: &sea_orm::DatabaseConnection,
+    walk_id: Uuid,
+    user_id: Uuid,
+) -> Result<WalkModel, AppError> {
+    WalkEntity::find_by_id(walk_id)
+        .filter(walks::Column::UserId.eq(user_id))
+        .one(db)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("Walk {} not found", walk_id)))
+}
+
 /// Get the dogs associated with a walk (via `walk_dogs`).
 pub async fn get_dogs_for_walk(
     db: &sea_orm::DatabaseConnection,

--- a/apps/api/tests/test_walk.rs
+++ b/apps/api/tests/test_walk.rs
@@ -139,6 +139,150 @@ async fn test_my_walks_query() {
 }
 
 #[tokio::test]
+async fn test_add_walk_points_rejects_non_owner() {
+    // USER_A starts a walk; USER_B attempts to add GPS points to it.
+    // require_walk_owner should reject and collapse the authz failure
+    // into a NOT_FOUND error (walk-ID enumeration defense — see
+    // graphql/auth_helpers.rs::resolve_user_and_walk).
+    let client = support::test_client().await;
+
+    let a_dog_body = support::graphql_as(
+        &client,
+        &support::USER_A,
+        r#"mutation { createDog(input: { name: "UserADog" }) { id } }"#,
+    )
+    .await;
+    let a_dog_id = a_dog_body["data"]["createDog"]["id"].as_str().unwrap();
+
+    let a_walk_body = support::graphql_as(
+        &client,
+        &support::USER_A,
+        &format!(
+            r#"mutation {{ startWalk(dogIds: ["{}"]) {{ id }} }}"#,
+            a_dog_id
+        ),
+    )
+    .await;
+    let a_walk_id = a_walk_body["data"]["startWalk"]["id"].as_str().unwrap();
+
+    let b_res = support::graphql_as(
+        &client,
+        &support::USER_B,
+        &format!(
+            r#"mutation {{ addWalkPoints(walkId: "{}", points: [{{ lat: 35.0, lng: 139.0, recordedAt: "2026-04-24T10:00:00Z" }}]) }}"#,
+            a_walk_id
+        ),
+    )
+    .await;
+
+    assert!(
+        b_res["errors"].is_array() && !b_res["errors"].as_array().unwrap().is_empty(),
+        "USER_B must not be allowed to add points to USER_A's walk; got: {:?}",
+        b_res
+    );
+    let code = b_res["errors"][0]["extensions"]["code"].as_str();
+    assert_eq!(
+        code,
+        Some("NOT_FOUND"),
+        "Expected NOT_FOUND code (walk-ID enumeration defense); got: {:?}",
+        b_res["errors"][0]
+    );
+}
+
+#[tokio::test]
+async fn test_dog_walk_stats_respects_week_period() {
+    // End-to-end verification of the M3 fix: Period::from_str was
+    // case-sensitive and the GraphQL enum sends "WEEK" (uppercase),
+    // which silently fell back to Period::All. After the fix,
+    // dogWalkStats(period: "WEEK") should actually exclude walks
+    // older than 7 days.
+    use sea_orm::{ActiveModelTrait, EntityTrait, Set};
+
+    let client = support::test_client().await;
+
+    let dog_body = support::graphql_as(
+        &client,
+        &support::USER_A,
+        r#"mutation { createDog(input: { name: "PeriodDog" }) { id } }"#,
+    )
+    .await;
+    let dog_id_str = dog_body["data"]["createDog"]["id"].as_str().unwrap();
+
+    let walk_body = support::graphql_as(
+        &client,
+        &support::USER_A,
+        &format!(
+            r#"mutation {{ startWalk(dogIds: ["{}"]) {{ id }} }}"#,
+            dog_id_str
+        ),
+    )
+    .await;
+    let walk_id_str = walk_body["data"]["startWalk"]["id"].as_str().unwrap();
+    let walk_id = uuid::Uuid::parse_str(walk_id_str).unwrap();
+
+    let _ = support::graphql_as(
+        &client,
+        &support::USER_A,
+        &format!(
+            r#"mutation {{ finishWalk(walkId: "{}", distanceM: 500) {{ id }} }}"#,
+            walk_id_str
+        ),
+    )
+    .await;
+
+    // Backdate the walk by 14 days so it falls outside the WEEK window
+    // (7 days) but inside the ALL window (unbounded).
+    let config = walking_dog_api::config::Config::from_env();
+    let db = walking_dog_api::db::connect(&config.database_url)
+        .await
+        .expect("Failed to connect to DB");
+    let two_weeks_ago = chrono::Utc::now() - chrono::Duration::days(14);
+    let walk = walking_dog_api::entities::walks::Entity::find_by_id(walk_id)
+        .one(&db)
+        .await
+        .expect("DB query failed")
+        .expect("walk must exist after finishWalk");
+    let mut active: walking_dog_api::entities::walks::ActiveModel = walk.into();
+    active.started_at = Set(two_weeks_ago.into());
+    active
+        .update(&db)
+        .await
+        .expect("Failed to backdate walk.started_at");
+
+    // WEEK must EXCLUDE the 2-week-old walk (pre-M3 this returned 1 via All-fallback)
+    let week_body = support::graphql_as(
+        &client,
+        &support::USER_A,
+        &format!(
+            r#"{{ dogWalkStats(dogId: "{}", period: "WEEK") {{ totalWalks }} }}"#,
+            dog_id_str
+        ),
+    )
+    .await;
+    assert_eq!(
+        week_body["data"]["dogWalkStats"]["totalWalks"], 0,
+        "WEEK must exclude walks older than 7 days; got: {:?}",
+        week_body
+    );
+
+    // ALL must include the walk
+    let all_body = support::graphql_as(
+        &client,
+        &support::USER_A,
+        &format!(
+            r#"{{ dogWalkStats(dogId: "{}", period: "ALL") {{ totalWalks }} }}"#,
+            dog_id_str
+        ),
+    )
+    .await;
+    assert_eq!(
+        all_body["data"]["dogWalkStats"]["totalWalks"], 1,
+        "ALL must include the walk regardless of age; got: {:?}",
+        all_body
+    );
+}
+
+#[tokio::test]
 async fn test_add_walk_points() {
     let client = support::test_client().await;
     let dog_id = create_test_dog(&client).await;


### PR DESCRIPTION
## Summary

Apply the 8 issues from the `apps/api/` modularity review (`.claude/plans/functional-frolicking-pebble.md`) using the Balanced Coupling model. Plus 1 review-fixup commit and 1 integration-test commit.

10 commits, +726/-357 lines across 15 files. Behavior-preserving except for one intentional bug fix (Period parsing).

### Issue → commit map (priority order)

| # | Commit | Why it matters |
|---|---|---|
| **H3** | `9c53a62` | Collapse duplicate `WalkPointOutput` GraphQL type into `WalkPoint`. Mobile uses field-selection queries so the rename is non-breaking. |
| **H1** | `f0072aa` | Route `WalkOutput.{walker,dogs}`, `UserOutput.dogs`, `EncounterOutput.{dog1,dog2}`, `FriendshipOutput.friend` through service-layer methods (`walk_service::get_dogs_for_walk`, `user_service::get_user_by_id`, `dog_member_service::get_dogs_with_roles_for_user`). Removes inline entity queries from resolvers — the biggest single win for the volatile walk-data area. |
| **H2** | `489b643` | Centralise the DynamoDB walk-points key schema (`WALK#{id}` / `PT#{recorded_at}`, attribute names) into `walk_points_service` with named constants and key/item builders. Schema unchanged. |
| **L1** | `98424f2` | Extract `walk_service::require_walk_owner`. Replaces an inline ownership filter in `add_walk_points_field`. |
| **M3** | `d75cee9` | Add GraphQL ⇌ domain enum parity tests for `WalkStatus`, `WalkEventType`, `Period`. **Also fixes a pre-existing bug**: `Period::from_str` was case-sensitive so the GraphQL `WEEK`/`MONTH`/`YEAR` enum values silently fell back to `Period::All` — `dogWalkStats` was returning all-time stats regardless of period argument. Now case-insensitive. |
| **M1** | `905c0b0` | Move `verify_encounter_detection` and `verify_counterparty_encounter_detection` from `walk_event_service` into `encounter_service` (where they belong by domain). |
| **M2** | `e80009d` | Introduce `services::dog_pair::DogPair` newtype encoding the `dog_id_1 < dog_id_2` invariant. `friendship_service::{upsert_friendship, update_friendship_duration, get_friendship}` now take `DogPair`; `encounter_service` constructs pairs via `DogPair::new`. |
| **L2** | `ceb29bc` | Drop the now-unused `dog_service::get_dogs_by_user_id` pass-through. |
| review | `82982f1` | Address code-review findings: revert `key_condition_expression` from `format!` to a static literal, add 3 MockDatabase tests for `require_walk_owner`, document silent-drop semantics of `get_dogs_with_roles_for_user`. |
| tests | `753353c` | Two integration tests: `test_add_walk_points_rejects_non_owner` (USER_B → USER_A's walk → NOT_FOUND), and `test_dog_walk_stats_respects_week_period` (backdates a walk by 14 days, asserts WEEK=0 / ALL=1 — locks in the M3 fix). |

### Notable behavior change

- **`dogWalkStats` period argument now actually filters.** Pre-fix, every `WEEK`/`MONTH`/`YEAR` request silently returned ALL-time stats. Post-fix, it returns the correct windowed stats. Mobile clients that were unknowingly seeing all-time data will now see windowed data. This is the intended fix and not a regression.

### Things that did NOT change

- DynamoDB schema (key format, attribute names, attribute types — locked in by new pinning tests)
- GraphQL field selections used by the mobile (`points { lat lng recordedAt }` is type-name agnostic)
- Authorization semantics (`require_walk_owner` keeps the existing walk-ID-enumeration defense — collapses missing-walk and not-owner into the same `NOT_FOUND` error code, matching `auth_helpers::resolve_user_and_walk`)
- Public service-method behavior (only signatures changed, return values are equivalent)

## Test plan

- [x] `docker compose -f apps/compose.yml run --rm api cargo test --features test-utils -j 1 -- --test-threads=1` — all 75 unit + every integration suite green
- [x] `cargo check --features test-utils` clean (no warnings)
- [x] New unit tests added for: `DogPair::new`, walk-points key/item builders, `require_walk_owner` (3 branches), `Period::from_str` uppercase, GraphQL ⇌ domain enum parity (3 enums)
- [x] New integration tests for `addWalkPoints` non-owner rejection and `dogWalkStats(period: WEEK)` windowing
- [ ] Reviewer: confirm mobile client does not depend on the old `WalkPointOutput` GraphQL type name (grep returned 0 hits in `apps/mobile`)
- [ ] Reviewer: smoke-check `dogWalkStats` in the mobile UI to confirm the period selector now produces visibly different totals (the previous all-time fallback may have been masking expectations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)