### PR TITLE
refactor(mobile): move iOS Live Activity state into walk-store (H2)

### DIFF
--- a/apps/mobile/hooks/use-walk-session.test.ts
+++ b/apps/mobile/hooks/use-walk-session.test.ts
@@ -7,6 +7,7 @@ import {
 import * as walkMutations from './use-walk-mutations';
 import * as gpsTracker from '@/lib/walk/gps-tracker';
 import * as liveActivity from '@/lib/walk/live-activity';
+import type { LiveActivityState } from '@/stores/walk-store';
 import type { WalkPoint } from '@/types/graphql';
 
 jest.mock('./use-walk-mutations', () => ({
@@ -23,6 +24,7 @@ jest.mock('@/lib/walk/live-activity', () => ({
   startLiveActivity: jest.fn(),
   endLiveActivity: jest.fn(),
   updateLiveActivityDistance: jest.fn(),
+  UPDATE_DEBOUNCE_MS: 10_000,
 }));
 
 const mockStoreStartRecording = jest.fn();
@@ -34,6 +36,7 @@ let mockStoreStartedAt: Date | null = null;
 let mockStorePhase: 'ready' | 'recording' | 'finished' = 'ready';
 let mockStoreTrackingGeneration = 0;
 let mockStoreTrackingCleanup: (() => void) | null = null;
+let mockStoreLiveActivity: LiveActivityState | null = null;
 
 jest.mock('@/stores/walk-store', () => {
   const state = {
@@ -63,6 +66,17 @@ jest.mock('@/stores/walk-store', () => {
     },
     get trackingCleanup() {
       return mockStoreTrackingCleanup;
+    },
+    get liveActivity() {
+      return mockStoreLiveActivity;
+    },
+    setLiveActivity: (activity: LiveActivityState | null) => {
+      mockStoreLiveActivity = activity;
+    },
+    bumpLiveActivityUpdateAt: (at: number) => {
+      if (mockStoreLiveActivity) {
+        mockStoreLiveActivity = { ...mockStoreLiveActivity, lastUpdateAt: at };
+      }
     },
     activateTrackingSession: () => {
       mockStoreTrackingGeneration += 1;
@@ -120,6 +134,7 @@ beforeEach(() => {
   mockStorePhase = 'ready';
   mockStoreTrackingGeneration = 0;
   mockStoreTrackingCleanup = null;
+  mockStoreLiveActivity = null;
 
   (walkMutations.useStartWalk as jest.Mock).mockReturnValue({
     mutateAsync: mockStartWalkMutateAsync,
@@ -132,7 +147,7 @@ beforeEach(() => {
     mutateAsync: mockAddPointsMutateAsync,
   });
   (gpsTracker.startTracking as jest.Mock).mockResolvedValue(mockStopTracking);
-  (liveActivity.startLiveActivity as jest.Mock).mockResolvedValue(undefined);
+  (liveActivity.startLiveActivity as jest.Mock).mockResolvedValue('activity-1');
   (liveActivity.endLiveActivity as jest.Mock).mockResolvedValue(undefined);
   (liveActivity.updateLiveActivityDistance as jest.Mock).mockResolvedValue(undefined);
 });
@@ -183,8 +198,37 @@ describe('useWalkSession.start', () => {
     );
   });
 
-  it('startTracking callback adds point to store and updates live activity distance', async () => {
+  it('persists the started Live Activity id (and seeds lastUpdateAt to 0) into the walk store', async () => {
     mockStartWalkMutateAsync.mockResolvedValue({ id: 'walk-1' });
+    (liveActivity.startLiveActivity as jest.Mock).mockResolvedValue('activity-xyz');
+
+    const { result } = renderHook(() => useWalkSession());
+    await act(async () => {
+      await result.current.start({ selectedDogIds: ['dog-1'], liveActivityDogName: 'Rex' });
+    });
+
+    expect(mockStoreLiveActivity).toEqual({
+      activityId: 'activity-xyz',
+      startedAt: mockStoreStartedAt,
+      lastUpdateAt: 0,
+    });
+  });
+
+  it('does not seed liveActivity in store when startLiveActivity returns null (unsupported / failed)', async () => {
+    mockStartWalkMutateAsync.mockResolvedValue({ id: 'walk-1' });
+    (liveActivity.startLiveActivity as jest.Mock).mockResolvedValue(null);
+
+    const { result } = renderHook(() => useWalkSession());
+    await act(async () => {
+      await result.current.start({ selectedDogIds: ['dog-1'], liveActivityDogName: 'Rex' });
+    });
+
+    expect(mockStoreLiveActivity).toBeNull();
+  });
+
+  it('startTracking callback adds point to store and updates live activity distance with the stored activity id', async () => {
+    mockStartWalkMutateAsync.mockResolvedValue({ id: 'walk-1' });
+    (liveActivity.startLiveActivity as jest.Mock).mockResolvedValue('activity-1');
     let capturedOnPoint: ((point: WalkPoint) => void) | null = null;
     (gpsTracker.startTracking as jest.Mock).mockImplementation(
       async (cb: (p: WalkPoint) => void) => {
@@ -203,7 +247,55 @@ describe('useWalkSession.start', () => {
     capturedOnPoint!(point);
 
     expect(mockStoreAddPoint).toHaveBeenCalledWith(point);
-    expect(liveActivity.updateLiveActivityDistance).toHaveBeenCalledWith(42);
+    expect(liveActivity.updateLiveActivityDistance).toHaveBeenCalledWith('activity-1', 42);
+  });
+
+  it('debounces consecutive distance updates within UPDATE_DEBOUNCE_MS', async () => {
+    mockStartWalkMutateAsync.mockResolvedValue({ id: 'walk-1' });
+    (liveActivity.startLiveActivity as jest.Mock).mockResolvedValue('activity-1');
+    let capturedOnPoint: ((point: WalkPoint) => void) | null = null;
+    (gpsTracker.startTracking as jest.Mock).mockImplementation(
+      async (cb: (p: WalkPoint) => void) => {
+        capturedOnPoint = cb;
+        return mockStopTracking;
+      },
+    );
+
+    const { result } = renderHook(() => useWalkSession());
+    await act(async () => {
+      await result.current.start({ selectedDogIds: ['dog-1'], liveActivityDogName: 'Rex' });
+    });
+
+    const point: WalkPoint = { lat: 35.68, lng: 139.76, recordedAt: '2026-04-01T00:01:00Z' };
+    mockStoreTotalDistanceM = 10;
+    capturedOnPoint!(point);
+    mockStoreTotalDistanceM = 20;
+    capturedOnPoint!(point);
+
+    expect(liveActivity.updateLiveActivityDistance).toHaveBeenCalledTimes(1);
+    expect(liveActivity.updateLiveActivityDistance).toHaveBeenCalledWith('activity-1', 10);
+  });
+
+  it('skips Live Activity updates entirely when no activity was started', async () => {
+    mockStartWalkMutateAsync.mockResolvedValue({ id: 'walk-1' });
+    (liveActivity.startLiveActivity as jest.Mock).mockResolvedValue(null);
+    let capturedOnPoint: ((point: WalkPoint) => void) | null = null;
+    (gpsTracker.startTracking as jest.Mock).mockImplementation(
+      async (cb: (p: WalkPoint) => void) => {
+        capturedOnPoint = cb;
+        return mockStopTracking;
+      },
+    );
+
+    const { result } = renderHook(() => useWalkSession());
+    await act(async () => {
+      await result.current.start({ selectedDogIds: ['dog-1'], liveActivityDogName: 'Rex' });
+    });
+
+    mockStoreTotalDistanceM = 42;
+    capturedOnPoint!({ lat: 35.68, lng: 139.76, recordedAt: '2026-04-01T00:01:00Z' });
+
+    expect(liveActivity.updateLiveActivityDistance).not.toHaveBeenCalled();
   });
 
   it('exposes isStarting from startWalk mutation', () => {
@@ -301,8 +393,9 @@ describe('useWalkSession.stop', () => {
     expect(secondBatch).toHaveLength(50);
   });
 
-  it('calls finishWalk with rounded distance and ends live activity', async () => {
+  it('calls finishWalk with rounded distance, ends live activity by id, and clears it from store', async () => {
     mockStartWalkMutateAsync.mockResolvedValue({ id: 'walk-1' });
+    (liveActivity.startLiveActivity as jest.Mock).mockResolvedValue('activity-7');
     mockStoreTotalDistanceM = 1234.7;
 
     const { result } = renderHook(() => useWalkSession());
@@ -316,6 +409,23 @@ describe('useWalkSession.stop', () => {
     expect(mockFinishWalkMutateAsync).toHaveBeenCalledWith({ walkId: 'walk-1', distanceM: 1235 });
     expect(mockStoreFinish).toHaveBeenCalledTimes(1);
     expect(liveActivity.endLiveActivity).toHaveBeenCalledTimes(1);
+    expect(liveActivity.endLiveActivity).toHaveBeenCalledWith('activity-7');
+    expect(mockStoreLiveActivity).toBeNull();
+  });
+
+  it('does not call endLiveActivity when stop runs without an active live activity', async () => {
+    mockStartWalkMutateAsync.mockResolvedValue({ id: 'walk-1' });
+    (liveActivity.startLiveActivity as jest.Mock).mockResolvedValue(null);
+
+    const { result } = renderHook(() => useWalkSession());
+    await act(async () => {
+      await result.current.start({ selectedDogIds: ['dog-1'], liveActivityDogName: 'Rex' });
+    });
+    await act(async () => {
+      await result.current.stop('walk-1');
+    });
+
+    expect(liveActivity.endLiveActivity).not.toHaveBeenCalled();
   });
 
   it('does not call addWalkPoints when there are no points', async () => {

--- a/apps/mobile/hooks/use-walk-session.ts
+++ b/apps/mobile/hooks/use-walk-session.ts
@@ -3,6 +3,7 @@ import {
   endLiveActivity,
   startLiveActivity,
   updateLiveActivityDistance,
+  UPDATE_DEBOUNCE_MS,
 } from '@/lib/walk/live-activity';
 import {
   beginWalkTracking,
@@ -39,20 +40,37 @@ export function useWalkSession() {
       const walk = await startWalkMutation.mutateAsync(selectedDogIds);
       startRecording(walk.id);
 
-      await startLiveActivity({
+      const startedAt = useWalkStore.getState().startedAt ?? new Date();
+      const activityId = await startLiveActivity({
         walkId: walk.id,
         dogId: selectedDogIds[0],
         dogName: liveActivityDogName,
-        startedAt: useWalkStore.getState().startedAt ?? new Date(),
+        startedAt,
         distanceM: 0,
       });
+      if (activityId) {
+        useWalkStore.getState().setLiveActivity({
+          activityId,
+          startedAt,
+          // 0 so the first GPS-driven distance update fires immediately rather
+          // than being debounced for ~10 seconds.
+          lastUpdateAt: 0,
+        });
+      }
 
       await beginWalkTracking({
         onPoint: (point) => {
           useWalkStore.getState().addPoint(point);
         },
         onDistanceChange: (distanceM) => {
-          void updateLiveActivityDistance(distanceM);
+          const la = useWalkStore.getState().liveActivity;
+          if (!la) return;
+          const now = Date.now();
+          if (now - la.lastUpdateAt < UPDATE_DEBOUNCE_MS) return;
+          // Bump first so a slow native update doesn't let a second GPS tick
+          // through the gate while we're still in flight.
+          useWalkStore.getState().bumpLiveActivityUpdateAt(now);
+          void updateLiveActivityDistance(la.activityId, distanceM);
         },
       });
 
@@ -78,7 +96,12 @@ export function useWalkSession() {
         distanceM: Math.round(totalDistanceM),
       });
       finish();
-      void endLiveActivity();
+
+      const la = useWalkStore.getState().liveActivity;
+      if (la) {
+        useWalkStore.getState().setLiveActivity(null);
+        void endLiveActivity(la.activityId);
+      }
     },
     [addWalkPointsMutation, finishWalkMutation, finish],
   );

--- a/apps/mobile/lib/walk/live-activity.ts
+++ b/apps/mobile/lib/walk/live-activity.ts
@@ -20,10 +20,12 @@ const extras = (Constants.expoConfig?.extra ?? {}) as {
   appGroup?: string;
 };
 
-const UPDATE_DEBOUNCE_MS = 10_000;
-
-let currentActivityId: string | null = null;
-let lastUpdateAt = 0;
+/**
+ * Minimum elapsed time between consecutive `updateLiveActivityDistance` calls.
+ * Owners (e.g. the walk session hook) compare this against
+ * `walk-store.liveActivity.lastUpdateAt` to gate native updates.
+ */
+export const UPDATE_DEBOUNCE_MS = 10_000;
 
 export interface LiveActivityStartInput {
   walkId: string;
@@ -37,15 +39,20 @@ export function isLiveActivitySupported(): boolean {
   return mod?.isSupported() ?? false;
 }
 
-export async function startLiveActivity(input: LiveActivityStartInput): Promise<void> {
-  if (!mod || !mod.isSupported()) return;
+/**
+ * Starts an iOS Live Activity. Returns the activity id on success or null when
+ * Live Activities are unsupported, config is missing, or the native call
+ * throws. Callers are responsible for persisting the id (typically in the
+ * walk-store) and passing it to subsequent update / end calls.
+ */
+export async function startLiveActivity(input: LiveActivityStartInput): Promise<string | null> {
+  if (!mod || !mod.isSupported()) return null;
   if (!extras.appGroup || !extras.apiUrl) {
     console.warn('[live-activity] appGroup or apiUrl missing from expo config extras');
-    return;
+    return null;
   }
-  if (currentActivityId) return;
   try {
-    const id = await mod.startActivity({
+    return await mod.startActivity({
       walkId: input.walkId,
       dogId: input.dogId,
       dogName: input.dogName,
@@ -54,34 +61,33 @@ export async function startLiveActivity(input: LiveActivityStartInput): Promise<
       appGroup: extras.appGroup,
       apiUrl: extras.apiUrl,
     });
-    currentActivityId = id;
-    lastUpdateAt = Date.now();
   } catch (err) {
     console.error('[live-activity] start failed', err);
+    return null;
   }
 }
 
-export async function updateLiveActivityDistance(distanceM: number): Promise<void> {
-  if (!mod || !currentActivityId) return;
-  const now = Date.now();
-  if (now - lastUpdateAt < UPDATE_DEBOUNCE_MS) return;
-  lastUpdateAt = now;
+export async function updateLiveActivityDistance(
+  activityId: string,
+  distanceM: number,
+): Promise<void> {
+  if (!mod) return;
   try {
-    await mod.updateActivity(currentActivityId, { distanceM });
+    await mod.updateActivity(activityId, { distanceM });
   } catch (err) {
     console.error('[live-activity] update failed', err);
   }
 }
 
 export async function updateLiveActivityEvent(
+  activityId: string,
   distanceM: number,
   eventKind: string,
   eventAt: Date,
 ): Promise<void> {
-  if (!mod || !currentActivityId) return;
-  lastUpdateAt = Date.now();
+  if (!mod) return;
   try {
-    await mod.updateActivity(currentActivityId, {
+    await mod.updateActivity(activityId, {
       distanceM,
       lastEventKind: eventKind,
       lastEventAtMs: eventAt.getTime(),
@@ -91,14 +97,11 @@ export async function updateLiveActivityEvent(
   }
 }
 
-export async function endLiveActivity(): Promise<void> {
-  if (!mod || !currentActivityId) return;
-  const id = currentActivityId;
-  currentActivityId = null;
-  lastUpdateAt = 0;
+export async function endLiveActivity(activityId: string): Promise<void> {
+  if (!mod) return;
   if (!extras.appGroup) return;
   try {
-    await mod.endActivity(id, extras.appGroup);
+    await mod.endActivity(activityId, extras.appGroup);
   } catch (err) {
     console.error('[live-activity] end failed', err);
   }

--- a/apps/mobile/stores/walk-store.test.ts
+++ b/apps/mobile/stores/walk-store.test.ts
@@ -102,6 +102,66 @@ describe('walk-store', () => {
     expect(state.selectedDogIds).toEqual([]);
   });
 
+  describe('liveActivity state', () => {
+    it('initial liveActivity is null', () => {
+      expect(useWalkStore.getState().liveActivity).toBeNull();
+    });
+
+    it('setLiveActivity stores the activity record', () => {
+      const startedAt = new Date('2026-04-19T08:00:00Z');
+      useWalkStore.getState().setLiveActivity({
+        activityId: 'activity-1',
+        startedAt,
+        lastUpdateAt: 0,
+      });
+      expect(useWalkStore.getState().liveActivity).toEqual({
+        activityId: 'activity-1',
+        startedAt,
+        lastUpdateAt: 0,
+      });
+    });
+
+    it('setLiveActivity(null) clears the activity record', () => {
+      useWalkStore.getState().setLiveActivity({
+        activityId: 'activity-1',
+        startedAt: new Date(),
+        lastUpdateAt: 0,
+      });
+      useWalkStore.getState().setLiveActivity(null);
+      expect(useWalkStore.getState().liveActivity).toBeNull();
+    });
+
+    it('bumpLiveActivityUpdateAt updates lastUpdateAt while preserving identity fields', () => {
+      const startedAt = new Date('2026-04-19T08:00:00Z');
+      useWalkStore.getState().setLiveActivity({
+        activityId: 'activity-1',
+        startedAt,
+        lastUpdateAt: 0,
+      });
+      useWalkStore.getState().bumpLiveActivityUpdateAt(1234);
+      expect(useWalkStore.getState().liveActivity).toEqual({
+        activityId: 'activity-1',
+        startedAt,
+        lastUpdateAt: 1234,
+      });
+    });
+
+    it('bumpLiveActivityUpdateAt is a no-op when liveActivity is null', () => {
+      useWalkStore.getState().bumpLiveActivityUpdateAt(1234);
+      expect(useWalkStore.getState().liveActivity).toBeNull();
+    });
+
+    it('reset clears liveActivity', () => {
+      useWalkStore.getState().setLiveActivity({
+        activityId: 'activity-1',
+        startedAt: new Date(),
+        lastUpdateAt: 1234,
+      });
+      useWalkStore.getState().reset();
+      expect(useWalkStore.getState().liveActivity).toBeNull();
+    });
+  });
+
   describe('walk events', () => {
     const mockEvent: WalkEvent = {
       id: 'event-1',

--- a/apps/mobile/stores/walk-store.ts
+++ b/apps/mobile/stores/walk-store.ts
@@ -4,6 +4,13 @@ import type { WalkPoint, WalkEvent } from '@/types/graphql';
 
 type WalkPhase = 'ready' | 'recording' | 'finished';
 
+export interface LiveActivityState {
+  activityId: string;
+  startedAt: Date;
+  /** Epoch ms of the most recent successful native update. 0 means no update has happened yet. */
+  lastUpdateAt: number;
+}
+
 interface WalkState {
   phase: WalkPhase;
   walkId: string | null;
@@ -22,6 +29,13 @@ interface WalkState {
   cameraRequestedAt: number | null;
   /** Recording bottom sheet collapsed to the compact pill variant. */
   isMinimized: boolean;
+  /**
+   * iOS Live Activity bookkeeping. `null` while no activity is alive (Android,
+   * unsupported iOS, or after `endLiveActivity`). When set, `activityId` is
+   * the native handle returned by the iOS module and `lastUpdateAt` gates the
+   * native-update debounce in the session hook.
+   */
+  liveActivity: LiveActivityState | null;
   selectDog: (dogId: string) => void;
   setSelectedDogs: (dogIds: string[]) => void;
   startRecording: (walkId: string) => void;
@@ -35,6 +49,8 @@ interface WalkState {
   attachTrackingCleanup: (generation: number, cleanup: () => void) => boolean;
   stopTrackingSession: () => void;
   resetTrackingSession: () => void;
+  setLiveActivity: (activity: LiveActivityState | null) => void;
+  bumpLiveActivityUpdateAt: (at: number) => void;
   finish: () => void;
   reset: () => void;
 }
@@ -55,6 +71,7 @@ export const useWalkStore = create<WalkState>((set, get) => ({
   trackingCleanup: null,
   cameraRequestedAt: null,
   isMinimized: false,
+  liveActivity: null,
 
   selectDog: (dogId) =>
     set((state) => ({
@@ -120,6 +137,13 @@ export const useWalkStore = create<WalkState>((set, get) => ({
     clearTrackingCleanup(cleanup);
   },
 
+  setLiveActivity: (activity) => set({ liveActivity: activity }),
+
+  bumpLiveActivityUpdateAt: (at) =>
+    set((state) =>
+      state.liveActivity ? { liveActivity: { ...state.liveActivity, lastUpdateAt: at } } : {},
+    ),
+
   finish: () => set({ phase: 'finished', cameraRequestedAt: null, isMinimized: false }),
 
   reset: () => {
@@ -136,6 +160,7 @@ export const useWalkStore = create<WalkState>((set, get) => ({
       trackingCleanup: null,
       cameraRequestedAt: null,
       isMinimized: false,
+      liveActivity: null,
     });
     clearTrackingCleanup(cleanup);
   },


### PR DESCRIPTION
## Summary

Applies the **H2** finding from the Balanced Coupling modularity review in `.claude/plans/apps-mobile-bright-kahan.md`. The iOS Live Activity adapter previously held its own module-level mutable state (`currentActivityId`, `lastUpdateAt`) that was hidden from \`walk-store\`, breaking the "single source of truth" invariant.

This PR strips all module-level state from the adapter, lifts activity bookkeeping into \`walk-store\`, and makes the session hook the orchestrator of debounce + lifecycle.

## Why

Hidden mutable state in \`lib/walk/live-activity.ts\` had two concrete risks:
1. **Orphan activities** — on Hot Reload or process crash, the module variables reset but the iOS Live Activity remained alive with no JS reference to end it.
2. **Onboarding friction** — new contributors reading \`walk-store\` couldn't see Live Activity lifecycle, because it lived two files away.

Live Activity UI is volatile (iOS 26 Liquid Glass changes are ongoing), and this is a core subdomain — exactly where Balanced Coupling flags hidden state as urgent to address.

## What changed

### \`stores/walk-store.ts\`
- New \`LiveActivityState\` exported type (\`activityId\`, \`startedAt\`, \`lastUpdateAt\`)
- New \`liveActivity\` field, initialized to \`null\`, included in \`reset()\`
- New actions \`setLiveActivity\` and \`bumpLiveActivityUpdateAt\`

### \`lib/walk/live-activity.ts\`
- Removed module variables \`currentActivityId\` and \`lastUpdateAt\`
- \`startLiveActivity(input): Promise<string | null>\` — now returns the activity id (or null if unsupported / failed)
- \`updateLiveActivityDistance(activityId, distanceM)\`, \`updateLiveActivityEvent(activityId, ...)\`, \`endLiveActivity(activityId)\` — all take activity id explicitly
- Exports \`UPDATE_DEBOUNCE_MS\` so the session hook can enforce the gate

### \`hooks/use-walk-session.ts\`
- After \`startLiveActivity\` returns, persist the activity to \`walk-store.liveActivity\` (or skip if null)
- \`onDistanceChange\`: read activity from store, gate by \`UPDATE_DEBOUNCE_MS\`, **bump-then-fire** to prevent a slow native call from letting a second tick through
- On stop: clear store first, then call \`endLiveActivity(activityId)\`
- Seed \`lastUpdateAt: 0\` so the very first GPS tick fires immediately

## Behavior change

Previously, the adapter set \`lastUpdateAt = Date.now()\` at the end of \`startLiveActivity\`, which silently swallowed the first ~10s of distance updates after walk start. Now \`lastUpdateAt: 0\` lets the first tick through immediately — better UX, no test contract weakened.

## Out of scope

- M1 (facade hook for \`WalkEventActions\` store access) and L2 (\`WalkMap\` data-source consistency) remain for a follow-up
- Recovery on app relaunch (re-end orphan activities via the persisted \`activityId\`) — out of scope; H2 enables this design but does not implement it

## Test plan

- [x] \`docker run ... node_modules/.bin/jest --testPathPatterns 'lib/walk|stores/walk-store|hooks/use-walk'\` → **130 tests green / 15 suites pass**
  - \`stores/walk-store.test.ts\`: +6 cases (initial null, set/clear/bump, no-op when null, reset clears)
  - \`hooks/use-walk-session.test.ts\`: +4 cases (id-seed in store, null-skip, debounce honored, no-LA-stop)
  - Existing assertions updated to the new \`(activityId, distanceM)\` signatures
- [ ] Manual iOS device check: start walk → background app → return → confirm Live Activity shows correct distance updates
- [ ] Manual stress check: end walk → confirm Live Activity disappears from Lock Screen / Dynamic Island
- [ ] Manual recovery check: force-quit during recording → reopen → confirm no orphan Live Activity (acceptable to remain orphan in this PR; recovery is follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)