### PR TITLE
refactor(mobile): event-actions facade hook + store-driven WalkMap (M1+L2)

### DIFF
--- a/apps/mobile/components/walk/WalkEventActions.tsx
+++ b/apps/mobile/components/walk/WalkEventActions.tsx
@@ -1,10 +1,10 @@
 import { useCallback } from 'react';
 import { Alert, StyleSheet, View } from 'react-native';
-import * as Haptics from 'expo-haptics';
 import * as ImagePicker from 'expo-image-picker';
 import { useTranslation } from 'react-i18next';
 import { useColors } from '@/hooks/use-colors';
 import { useCameraEventTrigger } from '@/hooks/use-camera-event-trigger';
+import { useCommitWalkEvent } from '@/hooks/use-commit-walk-event';
 import { useMutationWithAlert } from '@/hooks/use-mutation-with-alert';
 import { useWalkEventRecorder } from '@/hooks/use-walk-event-recorder';
 import { useWalkStore } from '@/stores/walk-store';
@@ -12,7 +12,7 @@ import { spacing } from '@/theme/tokens';
 import { EVENT_ORDER, UI_EVENT_EMOJIS, countEventsByType } from '@/lib/walk/events';
 import { DogEventActionRow } from './DogEventActionRow';
 import { EventPill } from './EventPill';
-import type { Dog, WalkEvent, WalkEventType } from '@/types/graphql';
+import type { Dog, WalkEventType } from '@/types/graphql';
 
 interface WalkEventActionsProps {
   dogs: Dog[];
@@ -24,10 +24,10 @@ export function WalkEventActions({ dogs }: WalkEventActionsProps) {
   const walkId = useWalkStore((s) => s.walkId);
   const points = useWalkStore((s) => s.points);
   const events = useWalkStore((s) => s.events);
-  const addEvent = useWalkStore((s) => s.addEvent);
   const cameraRequestedAt = useWalkStore((s) => s.cameraRequestedAt);
   const clearCameraRequest = useWalkStore((s) => s.clearCameraRequest);
   const runWithAlert = useMutationWithAlert();
+  const commitEvent = useCommitWalkEvent();
 
   const isSingleDog = dogs.length === 1;
   const singleDogId = isSingleDog ? dogs[0].id : undefined;
@@ -43,17 +43,6 @@ export function WalkEventActions({ dogs }: WalkEventActionsProps) {
     source: 'WalkEventActions',
   });
   const isDisabled = !walkId || isPending;
-
-  const commitEvent = useCallback(
-    async (run: () => Promise<WalkEvent | null>) => {
-      const event = await run();
-      if (!event) return;
-
-      addEvent(event);
-      void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-    },
-    [addEvent],
-  );
 
   const handlePeeOrPoo = useCallback(
     async (eventType: Extract<WalkEventType, 'pee' | 'poo'>, dogId?: string) => {

--- a/apps/mobile/components/walk/WalkMap.test.tsx
+++ b/apps/mobile/components/walk/WalkMap.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react-native';
 import { WalkMap } from './WalkMap';
-import type { WalkEvent } from '@/types/graphql';
+import type { WalkEvent, WalkPoint } from '@/types/graphql';
 
 jest.mock('@/hooks/use-color-scheme', () => ({
   useColorScheme: () => 'light',
@@ -33,8 +33,12 @@ jest.mock('react-native-maps', () => {
   };
 });
 
+let mockStorePoints: WalkPoint[] = [];
+let mockStoreEvents: WalkEvent[] = [];
+
 jest.mock('@/stores/walk-store', () => ({
-  useWalkStore: (selector: (s: object) => unknown) => selector({ points: [] }),
+  useWalkStore: (selector: (s: { points: WalkPoint[]; events: WalkEvent[] }) => unknown) =>
+    selector({ points: mockStorePoints, events: mockStoreEvents }),
 }));
 
 jest.mock('react-i18next', () => ({
@@ -63,24 +67,35 @@ const photoEventNoGps: WalkEvent = {
   photoUrl: 'https://cdn.example.com/walks/walk-123/photo.jpg',
 };
 
+beforeEach(() => {
+  mockStorePoints = [];
+  mockStoreEvents = [];
+});
+
 describe('WalkMap', () => {
-  it('renders without events prop', () => {
+  it('renders without any recorded events', () => {
     render(<WalkMap />);
     expect(screen.getByTestId('MapView')).toBeTruthy();
   });
 
-  it('renders event markers for events with lat/lng', () => {
-    render(<WalkMap events={[peeEvent]} />);
+  it('renders event markers for store events with lat/lng', () => {
+    mockStoreEvents = [peeEvent];
+    render(<WalkMap />);
     expect(screen.getByTestId('event-marker-event-1')).toBeTruthy();
   });
 
   it('does not render marker for events without lat/lng', () => {
-    render(<WalkMap events={[photoEventNoGps]} />);
+    mockStoreEvents = [photoEventNoGps];
+    render(<WalkMap />);
     expect(screen.queryByTestId('event-marker-event-2')).toBeNull();
   });
 
   it('renders markers for multiple events', () => {
-    render(<WalkMap events={[peeEvent, { ...peeEvent, id: 'event-3', lat: 35.682, lng: 139.768 }]} />);
+    mockStoreEvents = [
+      peeEvent,
+      { ...peeEvent, id: 'event-3', lat: 35.682, lng: 139.768 },
+    ];
+    render(<WalkMap />);
     expect(screen.getByTestId('event-marker-event-1')).toBeTruthy();
     expect(screen.getByTestId('event-marker-event-3')).toBeTruthy();
   });

--- a/apps/mobile/components/walk/WalkMap.tsx
+++ b/apps/mobile/components/walk/WalkMap.tsx
@@ -4,15 +4,16 @@ import { useColors } from '@/hooks/use-colors';
 import { useWalkStore } from '@/stores/walk-store';
 import { MAP_EVENT_EMOJIS } from '@/lib/walk/events';
 import { TOKYO_STATION_COORDINATE } from '@/lib/walk/constants';
-import type { WalkEvent } from '@/types/graphql';
 
-interface WalkMapProps {
-  events?: WalkEvent[];
-}
-
-export function WalkMap({ events = [] }: WalkMapProps) {
+/**
+ * Live recording map. Reads both the GPS trail (`points`) and recorded events
+ * from `walk-store` so the entire visible state comes from one source of
+ * truth. Event markers update in lockstep with `WalkEventActions` writes.
+ */
+export function WalkMap() {
   const theme = useColors();
   const points = useWalkStore((s) => s.points);
+  const events = useWalkStore((s) => s.events);
 
   const coordinates = points.map((p) => ({ latitude: p.lat, longitude: p.lng }));
   const lastPoint = coordinates[coordinates.length - 1];

--- a/apps/mobile/hooks/use-commit-walk-event.test.ts
+++ b/apps/mobile/hooks/use-commit-walk-event.test.ts
@@ -1,0 +1,78 @@
+import { act, renderHook } from '@testing-library/react-native';
+import * as Haptics from 'expo-haptics';
+import { useCommitWalkEvent } from './use-commit-walk-event';
+import * as walkStore from '@/stores/walk-store';
+import type { WalkEvent } from '@/types/graphql';
+
+jest.mock('expo-haptics', () => ({
+  impactAsync: jest.fn(),
+  ImpactFeedbackStyle: { Light: 'Light' },
+}));
+
+jest.mock('@/stores/walk-store', () => ({
+  useWalkStore: jest.fn(),
+}));
+
+const mockAddEvent = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (walkStore.useWalkStore as unknown as jest.Mock).mockImplementation(
+    (selector: (s: { addEvent: typeof mockAddEvent }) => unknown) =>
+      selector({ addEvent: mockAddEvent }),
+  );
+});
+
+const sampleEvent: WalkEvent = {
+  id: 'event-1',
+  walkId: 'walk-1',
+  dogId: 'dog-1',
+  eventType: 'pee',
+  occurredAt: '2026-04-25T08:00:00Z',
+  lat: 35.68,
+  lng: 139.76,
+  photoUrl: null,
+};
+
+describe('useCommitWalkEvent', () => {
+  it('appends the resolved event to the walk store and fires a light haptic', async () => {
+    const { result } = renderHook(() => useCommitWalkEvent());
+
+    let returned: WalkEvent | null = null;
+    await act(async () => {
+      returned = await result.current(async () => sampleEvent);
+    });
+
+    expect(mockAddEvent).toHaveBeenCalledWith(sampleEvent);
+    expect(Haptics.impactAsync).toHaveBeenCalledWith(Haptics.ImpactFeedbackStyle.Light);
+    expect(returned).toEqual(sampleEvent);
+  });
+
+  it('returns null and skips store + haptic when the producer resolves to null', async () => {
+    const { result } = renderHook(() => useCommitWalkEvent());
+
+    let returned: WalkEvent | null = sampleEvent;
+    await act(async () => {
+      returned = await result.current(async () => null);
+    });
+
+    expect(mockAddEvent).not.toHaveBeenCalled();
+    expect(Haptics.impactAsync).not.toHaveBeenCalled();
+    expect(returned).toBeNull();
+  });
+
+  it('propagates rejection without writing to the store or firing haptics', async () => {
+    const { result } = renderHook(() => useCommitWalkEvent());
+
+    await act(async () => {
+      await expect(
+        result.current(async () => {
+          throw new Error('boom');
+        }),
+      ).rejects.toThrow('boom');
+    });
+
+    expect(mockAddEvent).not.toHaveBeenCalled();
+    expect(Haptics.impactAsync).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/hooks/use-commit-walk-event.ts
+++ b/apps/mobile/hooks/use-commit-walk-event.ts
@@ -1,0 +1,29 @@
+import { useCallback } from 'react';
+import * as Haptics from 'expo-haptics';
+import { useWalkStore } from '@/stores/walk-store';
+import type { WalkEvent } from '@/types/graphql';
+
+/**
+ * Facade for the post-mutation step of recording a walk event: append the
+ * server-confirmed event to the walk-store cache and fire the user-feedback
+ * haptic. Wraps the previously inline `commitEvent` helper from
+ * `WalkEventActions.tsx` so consumers don't have to know about the store
+ * shape or the exact haptic style — they call `commit(() => recordEvent(...))`
+ * and get back the recorded event (or `null` if the mutation didn't return
+ * one).
+ */
+export function useCommitWalkEvent() {
+  const addEvent = useWalkStore((s) => s.addEvent);
+
+  return useCallback(
+    async (run: () => Promise<WalkEvent | null>): Promise<WalkEvent | null> => {
+      const event = await run();
+      if (!event) return null;
+
+      addEvent(event);
+      void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+      return event;
+    },
+    [addEvent],
+  );
+}


### PR DESCRIPTION
## Summary

Applies the **M1** and **L2** findings from \`.claude/plans/apps-mobile-bright-kahan.md\` (Balanced Coupling modularity review of \`apps/mobile/\`).

- **M1**: Extract the post-mutation step (\`addEvent\` + haptic) into a reusable \`useCommitWalkEvent()\` hook so \`WalkEventActions.tsx\` no longer reaches into store internals or imports expo-haptics directly.
- **L2**: \`WalkMap.tsx\` now reads both \`points\` and \`events\` from walk-store (drop the unused \`events\` prop) — single source of truth for the visible state.

## Why

\`WalkEventActions.tsx\` was the only walk-feature component that combined a store write and a haptic call inline; every other store interaction in the recording surface goes through a hook. M1 moves that pattern behind a small facade so it's reusable and testable in isolation.

\`WalkMap.tsx\` had **two** sources of knowledge: \`events\` came in as a prop, \`points\` came from walk-store. The only caller (\`app/walk-recording.tsx\`) never passed events, so event markers silently never appeared during recording. Reading both from the store fixes the inconsistency *and* a real UX gap.

## What changed

### New: \`hooks/use-commit-walk-event.ts\` (+37 lines, 3 tests)
\`\`\`ts
const commit = useCommitWalkEvent();
await commit(() => recordWalkEvent(...)); // store write + haptic in one place
\`\`\`

### \`components/walk/WalkEventActions.tsx\`
- Removed \`expo-haptics\` import
- Removed \`addEvent\` selector and inline \`commitEvent\` callback
- Added \`useCommitWalkEvent()\` call (1 line) and dropped the unused \`WalkEvent\` type import

### \`components/walk/WalkMap.tsx\`
- Dropped \`events?: WalkEvent[]\` prop
- Added \`useWalkStore((s) => s.events)\` selector
- All caller references already used \`<WalkMap />\` with no events prop, so no caller-side change required

### \`components/walk/WalkMap.test.tsx\`
- Rewrote store mock to support both \`points\` and \`events\` selectors
- Tests now drive event markers via \`mockStoreEvents = [...]\` instead of props

## Behavior change

Event markers (\`🚽\` / \`💩\` / \`📷\`) now appear on the **live recording map** as soon as they are recorded. Previously they only appeared on the post-walk detail view. This is a positive UX improvement aligned with the product vision (immediate data feedback during the walk).

## Test plan

- [x] \`docker run ... node_modules/.bin/jest --testPathPatterns 'use-commit-walk-event|WalkEventActions|WalkMap|use-walk-event-recorder'\` → **28 tests green / 4 suites pass**
- [x] Broader regression: \`'lib/walk|stores/walk-store|hooks/use-walk|components/walk'\` → **214 tests green / 29 suites pass**
- [ ] Manual iOS check: start walk → tap pee → confirm 🚽 marker on the live map at the user's current location
- [ ] Manual iOS check: tap poo → 💩 marker appears
- [ ] Manual iOS check: take photo → 📷 marker appears at GPS lat/lng
- [ ] Manual iOS check: post-walk detail view still shows the same markers

## Out of scope

- M2 (Walk event offline outbox / retry queue) — separate PR
- This PR completes the H1 / H2 / M1 / L1 / L2 sweep from the BC review of \`apps/mobile/\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)