### PR TITLE
fix(api): preserve AWS SDK error chain in AppError::Internal

### DIFF
--- a/apps/api/src/error.rs
+++ b/apps/api/src/error.rs
@@ -8,6 +8,24 @@ pub struct FieldError {
     pub message: String,
 }
 
+/// Format an error and its full source chain into a single string.
+///
+/// AWS SDK errors are the motivating case: `SdkError::ServiceError(...)`
+/// displays as just `"service error"`, which throws away the actual API
+/// error code such as `ProvisionedThroughputExceededException` or
+/// `InternalServerError`. Walking [`std::error::Error::source`] recovers
+/// that information so it can be surfaced to Sentry.
+pub fn format_error_chain<E: std::error::Error + ?Sized>(e: &E) -> String {
+    let mut chain = e.to_string();
+    let mut source = e.source();
+    while let Some(s) = source {
+        chain.push_str(": ");
+        chain.push_str(&s.to_string());
+        source = s.source();
+    }
+    chain
+}
+
 #[derive(Debug, Error)]
 pub enum AppError {
     #[error("Database error: {0}")]
@@ -100,6 +118,56 @@ mod tests {
         // Verify first field has correct structure
         assert_eq!(fields_arr[0]["field"], "myWalkId");
         assert_eq!(fields_arr[0]["message"], "Invalid UUID format");
+    }
+
+    #[test]
+    fn format_error_chain_walks_full_source_chain() {
+        // Mirrors the AWS SDK shape: outer "service error" wraps an inner
+        // structured error such as `ProvisionedThroughputExceededException`.
+        // Without source() walking, the outer Display would be all callers
+        // see, hiding the real error code.
+        #[derive(Debug)]
+        struct Inner;
+        impl std::fmt::Display for Inner {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "ProvisionedThroughputExceededException: rate limit")
+            }
+        }
+        impl std::error::Error for Inner {}
+
+        #[derive(Debug)]
+        struct Outer(Inner);
+        impl std::fmt::Display for Outer {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "service error")
+            }
+        }
+        impl std::error::Error for Outer {
+            fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+                Some(&self.0)
+            }
+        }
+
+        let err = Outer(Inner);
+        let formatted = format_error_chain(&err);
+        assert_eq!(
+            formatted,
+            "service error: ProvisionedThroughputExceededException: rate limit"
+        );
+    }
+
+    #[test]
+    fn format_error_chain_returns_display_when_no_source() {
+        #[derive(Debug)]
+        struct Lone;
+        impl std::fmt::Display for Lone {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "standalone")
+            }
+        }
+        impl std::error::Error for Lone {}
+
+        assert_eq!(format_error_chain(&Lone), "standalone");
     }
 
     #[test]

--- a/apps/api/src/services/s3_service.rs
+++ b/apps/api/src/services/s3_service.rs
@@ -44,11 +44,27 @@ pub async fn generate_walk_event_photo_upload_url(
         .key(&key)
         .content_type(content_type)
         .presigned(
-            PresigningConfig::expires_in(S3_PRESIGNED_URL_EXPIRY)
-                .map_err(|e| crate::error::AppError::Internal(e.to_string()))?,
+            PresigningConfig::expires_in(S3_PRESIGNED_URL_EXPIRY).map_err(|e| {
+                tracing::error!(error = ?e, "S3 PresigningConfig failed");
+                crate::error::AppError::Internal(format!(
+                    "S3 PresigningConfig: {}",
+                    crate::error::format_error_chain(&e)
+                ))
+            })?,
         )
         .await
-        .map_err(|e| crate::error::AppError::Internal(e.to_string()))?;
+        .map_err(|e| {
+            tracing::error!(
+                error = ?e,
+                bucket = bucket,
+                key = key.as_str(),
+                "S3 PutObject presign failed"
+            );
+            crate::error::AppError::Internal(format!(
+                "S3 PutObject presign: {}",
+                crate::error::format_error_chain(&e)
+            ))
+        })?;
 
     let expires_at =
         chrono::Utc::now() + chrono::Duration::seconds(S3_PRESIGNED_URL_EXPIRY.as_secs() as i64);
@@ -77,11 +93,27 @@ pub async fn generate_dog_photo_upload_url(
         .key(&key)
         .content_type(content_type)
         .presigned(
-            PresigningConfig::expires_in(S3_PRESIGNED_URL_EXPIRY)
-                .map_err(|e| crate::error::AppError::Internal(e.to_string()))?,
+            PresigningConfig::expires_in(S3_PRESIGNED_URL_EXPIRY).map_err(|e| {
+                tracing::error!(error = ?e, "S3 PresigningConfig failed");
+                crate::error::AppError::Internal(format!(
+                    "S3 PresigningConfig: {}",
+                    crate::error::format_error_chain(&e)
+                ))
+            })?,
         )
         .await
-        .map_err(|e| crate::error::AppError::Internal(e.to_string()))?;
+        .map_err(|e| {
+            tracing::error!(
+                error = ?e,
+                bucket = bucket,
+                key = key.as_str(),
+                "S3 PutObject presign failed"
+            );
+            crate::error::AppError::Internal(format!(
+                "S3 PutObject presign: {}",
+                crate::error::format_error_chain(&e)
+            ))
+        })?;
 
     let expires_at =
         chrono::Utc::now() + chrono::Duration::seconds(S3_PRESIGNED_URL_EXPIRY.as_secs() as i64);

--- a/apps/api/src/services/walk_points_service.rs
+++ b/apps/api/src/services/walk_points_service.rs
@@ -114,7 +114,19 @@ pub async fn add_walk_points(
             .request_items(table_name, chunk.to_vec())
             .send()
             .await
-            .map_err(|e| AppError::Internal(e.to_string()))?;
+            .map_err(|e| {
+                tracing::error!(
+                    error = ?e,
+                    table = table_name,
+                    walk_id = %walk_id,
+                    batch_size = chunk.len(),
+                    "DynamoDB BatchWriteItem failed"
+                );
+                AppError::Internal(format!(
+                    "DynamoDB BatchWriteItem: {}",
+                    crate::error::format_error_chain(&e)
+                ))
+            })?;
     }
 
     Ok(true)
@@ -134,7 +146,18 @@ pub async fn get_walk_points(
         .expression_attribute_values(":pk", AttributeValue::S(walk_partition_key(walk_id)))
         .send()
         .await
-        .map_err(|e| AppError::Internal(e.to_string()))?;
+        .map_err(|e| {
+            tracing::error!(
+                error = ?e,
+                table = table_name,
+                walk_id = %walk_id,
+                "DynamoDB Query failed"
+            );
+            AppError::Internal(format!(
+                "DynamoDB Query: {}",
+                crate::error::format_error_chain(&e)
+            ))
+        })?;
 
     let mut points: Vec<WalkPoint> = result.items().iter().filter_map(parse_point_row).collect();
 


### PR DESCRIPTION
## Summary
- DynamoDB \`BatchWriteItem\`/\`Query\` と S3 presign のエラー文字列化で AWS SDK の source chain を保持するよう変更（\`e.to_string()\` → \`format_error_chain\`）
- \`error.rs\` に \`format_error_chain\` ヘルパー（\`std::error::Error::source\` を再帰 walk）を新設、ユニットテスト2本付き
- 各呼び出し箇所で \`tracing::error!\` を構造化フィールド（walk_id, table, bucket, batch_size）付きで追加

[WALKING-DOG-API-DEV-1](https://matsuokashuhei.sentry.io/issues/WALKING-DOG-API-DEV-1) の調査用。長時間散歩 (53:23) で End Walk が "Failed to save walk" で失敗するが、現状 Sentry には \`Internal error: service error\` までしか出ず DynamoDB の真因（\`ProvisionedThroughputExceededException\` 等）が見えない。本 PR 後は実際の SDK エラー名が Sentry に出るようになる。

## Test plan
- [x] \`cargo check\` (Docker 経由)
- [x] \`cargo test --lib error::\` (4/4, 新規 2 本含む)
- [x] \`cargo test --lib services::walk_points_service\` (6/6)
- [x] \`cargo test --lib services::s3_service\` (8/8)
- [ ] Sakura VPS dev へデプロイ後、長時間散歩で再現し Sentry の新メッセージで真因を特定

🤖 Generated with [Claude Code](https://claude.com/claude-code)