### PR TITLE
Redesign the mobile walk tab flow

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -91,8 +91,8 @@ function RootLayout() {
               presentation: 'formSheet',
               sheetAllowedDetents: [0.15, 0.45],
               sheetInitialDetentIndex: 1,
-              sheetGrabberVisible: true,
-              sheetCornerRadius: 24,
+              sheetGrabberVisible: false,
+              sheetCornerRadius: 32,
               gestureEnabled: false,
               contentStyle: { backgroundColor: 'transparent' },
             }}

--- a/apps/mobile/app/walk-recording-controls.tsx
+++ b/apps/mobile/app/walk-recording-controls.tsx
@@ -9,6 +9,7 @@ import { useBleSession } from '@/hooks/use-ble-session';
 import { useEncounterSession } from '@/hooks/use-encounter-session';
 import { WalkControls } from '@/components/walk/WalkControls';
 import { WalkEventActions } from '@/components/walk/WalkEventActions';
+import { WalkMinimizedControls } from '@/components/walk/WalkMinimizedControls';
 import { spacing } from '@/theme/tokens';
 import type { Dog } from '@/types/graphql';
 
@@ -17,6 +18,7 @@ export default function WalkRecordingControlsScreen() {
   const walkId = useWalkStore((s) => s.walkId);
   const phase = useWalkStore((s) => s.phase);
   const selectedDogIds = useWalkStore((s) => s.selectedDogIds);
+  const isMinimized = useWalkStore((s) => s.isMinimized);
   const requestCamera = useWalkStore((s) => s.requestCamera);
   const params = useLocalSearchParams<{ action?: string }>();
 
@@ -26,7 +28,7 @@ export default function WalkRecordingControlsScreen() {
   const encounterSession = useEncounterSession();
   const navigation = useNavigation();
   const [isStopping, setIsStopping] = useState(false);
-  const lastDetentRef = useRef(0);
+  const lastDetentRef = useRef('');
 
   const selectedDogs = useMemo<Dog[]>(
     () => (me?.dogs ?? []).filter((d) => selectedDogIds.includes(d.id)),
@@ -44,27 +46,28 @@ export default function WalkRecordingControlsScreen() {
   const handleLayout = useCallback(
     (e: LayoutChangeEvent) => {
       const { height: screenH } = Dimensions.get('window');
-      // Grabber + padding beyond measured content area (~28pt for grabber & inset).
       const sheetHeight = e.nativeEvent.layout.height + 28;
-      const fraction = Math.min(0.9, Math.max(0.25, sheetHeight / screenH));
-      if (Math.abs(fraction - lastDetentRef.current) < 0.01) return;
-      lastDetentRef.current = fraction;
+      const fraction = Math.min(0.9, Math.max(isMinimized ? 0.15 : 0.25, sheetHeight / screenH));
+      const detents = isMinimized ? [0.15] : [0.15, fraction];
+      const detentKey = detents.join(',');
+      if (detentKey === lastDetentRef.current) return;
+      lastDetentRef.current = detentKey;
       navigation.setOptions({
-        sheetAllowedDetents: [0.15, fraction],
+        sheetAllowedDetents: detents,
       });
     },
-    [navigation],
+    [isMinimized, navigation],
   );
 
   const handleStop = useCallback(async () => {
     if (!walkId) return;
     setIsStopping(true);
-    bleSession.stop();
-    encounterSession.stop();
     try {
       await walkSession.stop(walkId);
+      bleSession.stop();
+      encounterSession.stop();
       router.dismissTo('/(tabs)/walk');
-    } catch (err) {
+    } catch {
       Alert.alert(t('common.error'), t('walk.error.finishFailed'));
     } finally {
       setIsStopping(false);
@@ -73,16 +76,21 @@ export default function WalkRecordingControlsScreen() {
 
   return (
     <View style={styles.container} onLayout={handleLayout}>
-      <WalkControls dogs={selectedDogs} onStop={handleStop} isStopping={isStopping}>
-        <WalkEventActions dogs={selectedDogs} />
-      </WalkControls>
+      {isMinimized ? (
+        <WalkMinimizedControls dogs={selectedDogs} />
+      ) : (
+        <WalkControls dogs={selectedDogs} onStop={handleStop} isStopping={isStopping}>
+          <WalkEventActions dogs={selectedDogs} />
+        </WalkControls>
+      )}
     </View>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
-    paddingHorizontal: spacing.lg,
-    paddingTop: spacing.xs,
+    paddingHorizontal: spacing.sm,
+    paddingTop: 0,
+    paddingBottom: spacing.sm,
   },
 });

--- a/apps/mobile/app/walk-recording.tsx
+++ b/apps/mobile/app/walk-recording.tsx
@@ -1,20 +1,25 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { router, useLocalSearchParams } from 'expo-router';
 import { useColors } from '@/hooks/use-colors';
 import { useWalkStore } from '@/stores/walk-store';
 import { useMe } from '@/hooks/use-me';
+import { WalkFloatingBar } from '@/components/walk/WalkFloatingBar';
 import { WalkMap } from '@/components/walk/WalkMap';
-import { WalkTopChip } from '@/components/walk/WalkTopChip';
 import { spacing } from '@/theme/tokens';
 import type { Dog } from '@/types/graphql';
+
+type LiveMapType = 'standard' | 'hybrid';
 
 export default function WalkRecordingScreen() {
   const theme = useColors();
   const phase = useWalkStore((s) => s.phase);
   const selectedDogIds = useWalkStore((s) => s.selectedDogIds);
+  const isMinimized = useWalkStore((s) => s.isMinimized);
+  const setMinimized = useWalkStore((s) => s.setMinimized);
   const params = useLocalSearchParams<{ action?: string }>();
+  const [mapType, setMapType] = useState<LiveMapType>('standard');
 
   const { data: me } = useMe();
   const insets = useSafeAreaInsets();
@@ -35,11 +40,25 @@ export default function WalkRecordingScreen() {
     [me?.dogs, selectedDogIds],
   );
 
+  const handleMinimize = useCallback(() => {
+    setMinimized(true);
+  }, [setMinimized]);
+
+  const handleToggleMapType = useCallback(() => {
+    setMapType((current) => (current === 'standard' ? 'hybrid' : 'standard'));
+  }, []);
+
   return (
     <View style={[styles.container, { backgroundColor: theme.background }]}>
-      <WalkMap />
+      <WalkMap mapType={mapType} />
       <View style={[styles.topOverlay, { top: insets.top + spacing.xs }]}>
-        <WalkTopChip dogs={selectedDogs} />
+        <WalkFloatingBar
+          dogs={selectedDogs}
+          isMinimized={isMinimized}
+          isHybridMap={mapType === 'hybrid'}
+          onMinimize={handleMinimize}
+          onToggleMapType={handleToggleMapType}
+        />
       </View>
     </View>
   );

--- a/apps/mobile/components/walk/DogPickerCard.test.tsx
+++ b/apps/mobile/components/walk/DogPickerCard.test.tsx
@@ -46,7 +46,7 @@ const momo: Dog = {
 };
 
 describe('DogPickerCard', () => {
-  it('renders each dog name and the last walk label', () => {
+  it('renders each dog name with breed and last walk subtitle', () => {
     render(
       <DogPickerCard
         dogs={[coco, momo]}
@@ -55,9 +55,9 @@ describe('DogPickerCard', () => {
       />,
     );
     expect(screen.getByText('Coco')).toBeTruthy();
-    expect(screen.getByText('Last walk 2 hours ago')).toBeTruthy();
+    expect(screen.getByText('Toy Poodle · Last walk 2 hours ago')).toBeTruthy();
     expect(screen.getByText('Momo')).toBeTruthy();
-    expect(screen.getByText('Last walk yesterday')).toBeTruthy();
+    expect(screen.getByText('Shiba Inu · Last walk yesterday')).toBeTruthy();
   });
 
   it('marks selected rows with accessibilityState.checked = true', () => {
@@ -87,8 +87,27 @@ describe('DogPickerCard', () => {
     expect(onToggle).toHaveBeenCalledWith('dog-2');
   });
 
-  it('renders never-walked copy when latestWalk is missing', () => {
+  it('renders breed-only subtitle when latestWalk is missing', () => {
     const mystery: Dog = { ...coco, id: 'dog-3', name: 'Mystery', latestWalk: null };
+    render(
+      <DogPickerCard
+        dogs={[mystery]}
+        selectedIds={[]}
+        onToggle={jest.fn()}
+      />,
+    );
+    expect(screen.getByText('Mystery')).toBeTruthy();
+    expect(screen.getByText('Toy Poodle')).toBeTruthy();
+  });
+
+  it('falls back to first-walk copy when breed and latestWalk are missing', () => {
+    const mystery: Dog = {
+      ...coco,
+      id: 'dog-3',
+      name: 'Mystery',
+      breed: null,
+      latestWalk: null,
+    };
     render(
       <DogPickerCard
         dogs={[mystery]}
@@ -111,6 +130,6 @@ describe('DogPickerCard', () => {
     );
     expect(screen.queryByRole('checkbox', { name: 'Coco' })).toBeNull();
     expect(screen.getByText('Coco')).toBeTruthy();
-    expect(screen.getByText('Last walk 2 hours ago')).toBeTruthy();
+    expect(screen.getByText('Toy Poodle · Last walk 2 hours ago')).toBeTruthy();
   });
 });

--- a/apps/mobile/components/walk/DogPickerCard.tsx
+++ b/apps/mobile/components/walk/DogPickerCard.tsx
@@ -1,6 +1,7 @@
 import { Fragment, useMemo } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { Image } from 'expo-image';
+import type { TFunction } from 'i18next';
 import { useTranslation } from 'react-i18next';
 import { GroupedCard } from '@/components/ui/GroupedCard';
 import { useColors } from '@/hooks/use-colors';
@@ -34,7 +35,7 @@ export function DogPickerCard({
       {dogs.map((dog, index) => {
         const isSelected = selectedIds.includes(dog.id);
         const isLast = index === dogs.length - 1;
-        const lastWalkText = formatLastWalk(dog.latestWalk?.endedAt, now, t);
+        const subtitle = buildSubtitle(dog, now, t);
         const rowContent = (
           <>
             <Image
@@ -50,7 +51,7 @@ export function DogPickerCard({
                 style={[styles.lastWalk, { color: theme.onSurfaceVariant }]}
                 numberOfLines={1}
               >
-                {lastWalkText}
+                {subtitle}
               </Text>
             </View>
             {showCheckbox ? (
@@ -100,6 +101,24 @@ export function DogPickerCard({
       })}
     </GroupedCard>
   );
+}
+
+function buildSubtitle(dog: Dog, now: Date, t: TFunction) {
+  const parts: string[] = [];
+
+  if (dog.breed) {
+    parts.push(dog.breed);
+  }
+
+  if (dog.latestWalk?.endedAt) {
+    parts.push(formatLastWalk(dog.latestWalk.endedAt, now, t));
+  }
+
+  if (parts.length > 0) {
+    return parts.join(' · ');
+  }
+
+  return t('walk.ready.lastWalk.never');
 }
 
 const styles = StyleSheet.create({

--- a/apps/mobile/components/walk/GroupWalkSummaryCard.test.tsx
+++ b/apps/mobile/components/walk/GroupWalkSummaryCard.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react-native';
+import { GroupWalkSummaryCard } from './GroupWalkSummaryCard';
+import type { Dog } from '@/types/graphql';
+
+jest.mock('@/hooks/use-color-scheme', () => ({
+  useColorScheme: () => 'light',
+}));
+
+jest.mock('expo-image', () => ({
+  Image: 'Image',
+}));
+
+const dogs: Dog[] = [
+  {
+    id: 'dog-1',
+    name: 'Coco',
+    breed: 'Toy Poodle',
+    gender: null,
+    birthDate: null,
+    photoUrl: null,
+    createdAt: '2026-01-01',
+  },
+  {
+    id: 'dog-2',
+    name: 'Momo',
+    breed: 'Shiba Inu',
+    gender: null,
+    birthDate: null,
+    photoUrl: null,
+    createdAt: '2026-01-02',
+  },
+  {
+    id: 'dog-3',
+    name: 'Sora',
+    breed: 'Beagle',
+    gender: null,
+    birthDate: null,
+    photoUrl: null,
+    createdAt: '2026-01-03',
+  },
+];
+
+describe('GroupWalkSummaryCard', () => {
+  it('does not render when fewer than two dogs are selected', () => {
+    render(<GroupWalkSummaryCard dogs={dogs.slice(0, 1)} />);
+    expect(screen.queryByText('Group walk')).toBeNull();
+  });
+
+  it('renders stacked avatars, count copy, and tag for two dogs', () => {
+    render(<GroupWalkSummaryCard dogs={dogs.slice(0, 2)} />);
+    expect(screen.getByText('2 dogs')).toBeTruthy();
+    expect(screen.getByText('walking together')).toBeTruthy();
+    expect(screen.getByText('Group walk')).toBeTruthy();
+    expect(screen.getAllByTestId(/group-walk-avatar-/)).toHaveLength(2);
+  });
+
+  it('renders three avatars when three dogs are selected', () => {
+    render(<GroupWalkSummaryCard dogs={dogs} />);
+    expect(screen.getByText('3 dogs')).toBeTruthy();
+    expect(screen.getAllByTestId(/group-walk-avatar-/)).toHaveLength(3);
+  });
+});

--- a/apps/mobile/components/walk/GroupWalkSummaryCard.tsx
+++ b/apps/mobile/components/walk/GroupWalkSummaryCard.tsx
@@ -1,0 +1,124 @@
+import { StyleSheet, Text, View } from 'react-native';
+import { Image } from 'expo-image';
+import { useTranslation } from 'react-i18next';
+import { GroupedCard } from '@/components/ui/GroupedCard';
+import { Tag } from '@/components/ui/Tag';
+import { useColors } from '@/hooks/use-colors';
+import { radius, spacing, typography } from '@/theme/tokens';
+import type { Dog } from '@/types/graphql';
+
+interface GroupWalkSummaryCardProps {
+  dogs: Dog[];
+}
+
+const MAX_VISIBLE_AVATARS = 3;
+
+export function GroupWalkSummaryCard({ dogs }: GroupWalkSummaryCardProps) {
+  const { t } = useTranslation();
+  const theme = useColors();
+
+  if (dogs.length < 2) return null;
+
+  const visibleDogs = dogs.slice(0, MAX_VISIBLE_AVATARS);
+  const remainingCount = dogs.length - visibleDogs.length;
+
+  return (
+    <GroupedCard padding="md">
+      <View style={styles.row}>
+        <View style={styles.left}>
+          <View style={styles.avatarStack}>
+            {visibleDogs.map((dog, index) => (
+              <Image
+                key={dog.id}
+                testID={`group-walk-avatar-${dog.id}`}
+                source={dog.photoUrl ?? require('@/assets/images/icon.png')}
+                style={[
+                  styles.avatar,
+                  index > 0 ? styles.avatarOverlap : null,
+                  {
+                    zIndex: visibleDogs.length - index,
+                    borderColor: theme.surface,
+                  },
+                ]}
+                contentFit="cover"
+              />
+            ))}
+            {remainingCount > 0 ? (
+              <View
+                style={[
+                  styles.countBadge,
+                  {
+                    borderColor: theme.surface,
+                    backgroundColor: theme.surfaceContainer,
+                  },
+                ]}
+              >
+                <Text style={[styles.countLabel, { color: theme.onSurface }]}>+{remainingCount}</Text>
+              </View>
+            ) : null}
+          </View>
+
+          <Text style={[styles.summary, { color: theme.onSurface }]}>
+            <Text style={styles.summaryStrong}>
+              {t('walk.ready.dogsWalkingBold', { count: dogs.length })}
+            </Text>
+            <Text>{t('walk.ready.dogsWalkingTail')}</Text>
+          </Text>
+        </View>
+
+        <Tag tone="success" label={t('walk.ready.groupWalk')} />
+      </View>
+    </GroupedCard>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: spacing.md,
+  },
+  left: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flex: 1,
+    minWidth: 0,
+  },
+  avatarStack: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginRight: spacing.md,
+    flexShrink: 0,
+  },
+  avatar: {
+    width: 36,
+    height: 36,
+    borderRadius: radius.full,
+    borderWidth: 2,
+  },
+  avatarOverlap: {
+    marginLeft: -10,
+  },
+  countBadge: {
+    minWidth: 28,
+    height: 28,
+    borderRadius: radius.full,
+    marginLeft: -10,
+    paddingHorizontal: spacing.xs,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 2,
+  },
+  countLabel: {
+    ...typography.caption,
+    fontWeight: '700',
+  },
+  summary: {
+    ...typography.subheadline,
+    flexShrink: 1,
+  },
+  summaryStrong: {
+    fontWeight: '700',
+  },
+});

--- a/apps/mobile/components/walk/WalkControls.test.tsx
+++ b/apps/mobile/components/walk/WalkControls.test.tsx
@@ -1,4 +1,5 @@
 import { act, fireEvent, render, screen } from '@testing-library/react-native';
+import { Text } from 'react-native';
 import { WalkControls } from './WalkControls';
 import type { Dog } from '@/types/graphql';
 
@@ -10,7 +11,14 @@ jest.mock('expo-image', () => ({ Image: 'Image' }));
 
 const mockWalkStoreState = {
   startedAt: null as Date | null,
+  pauseStartedAtMs: null as number | null,
   totalDistanceM: 0,
+  isPaused: false,
+  totalPausedMs: 0,
+  togglePaused: jest.fn(() => {
+    mockWalkStoreState.pauseStartedAtMs = mockWalkStoreState.isPaused ? null : Date.now();
+    mockWalkStoreState.isPaused = !mockWalkStoreState.isPaused;
+  }),
 };
 
 jest.mock('@/stores/walk-store', () => ({
@@ -50,7 +58,11 @@ describe('WalkControls', () => {
   beforeEach(() => {
     jest.useFakeTimers();
     mockWalkStoreState.startedAt = null;
+    mockWalkStoreState.pauseStartedAtMs = null;
     mockWalkStoreState.totalDistanceM = 0;
+    mockWalkStoreState.isPaused = false;
+    mockWalkStoreState.totalPausedMs = 0;
+    mockWalkStoreState.togglePaused.mockClear();
   });
 
   afterEach(() => {
@@ -67,6 +79,18 @@ describe('WalkControls', () => {
   it('renders a LIVE status tag', () => {
     render(<WalkControls dogs={[coco]} onStop={jest.fn()} isStopping={false} />);
     expect(screen.getByText('LIVE')).toBeTruthy();
+  });
+
+  it('renders the glass sheet grabber and child quick actions slot', () => {
+    render(
+      <WalkControls dogs={[coco]} onStop={jest.fn()} isStopping={false}>
+        <Text>Quick actions</Text>
+      </WalkControls>,
+    );
+
+    expect(screen.getByTestId('walk-controls-sheet')).toBeTruthy();
+    expect(screen.getByTestId('walk-controls-grabber')).toBeTruthy();
+    expect(screen.getByText('Quick actions')).toBeTruthy();
   });
 
   it('renders the destructive End Walk button', () => {
@@ -97,9 +121,10 @@ describe('WalkControls', () => {
   });
 
   it('Pause button toggles to Resume when pressed', () => {
-    render(<WalkControls dogs={[coco]} onStop={jest.fn()} isStopping={false} />);
+    const { rerender } = render(<WalkControls dogs={[coco]} onStop={jest.fn()} isStopping={false} />);
     const pause = screen.getByRole('button', { name: 'Pause' });
     fireEvent.press(pause);
+    rerender(<WalkControls dogs={[coco]} onStop={jest.fn()} isStopping={false} />);
     expect(screen.getByRole('button', { name: 'Resume' })).toBeTruthy();
   });
 

--- a/apps/mobile/components/walk/WalkControls.tsx
+++ b/apps/mobile/components/walk/WalkControls.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { type ReactNode } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
+import { useColors } from '@/hooks/use-colors';
 import { useWalkElapsed } from '@/hooks/use-walk-elapsed';
-import { spacing } from '@/theme/tokens';
+import { radius, spacing } from '@/theme/tokens';
 import { useSettingsStore } from '@/stores/settings-store';
 import { useWalkStore } from '@/stores/walk-store';
 import { formatDistanceParts, formatPace, formatTime } from '@/lib/walk/format';
@@ -21,32 +22,20 @@ interface WalkControlsProps {
 
 export function WalkControls({ dogs, onStop, isStopping, children }: WalkControlsProps) {
   const { t } = useTranslation();
+  const theme = useColors();
   const startedAt = useWalkStore((s) => s.startedAt);
-  const startedAtMs = startedAt?.getTime() ?? null;
+  const isPaused = useWalkStore((s) => s.isPaused);
+  const totalPausedMs = useWalkStore((s) => s.totalPausedMs);
+  const pauseStartedAtMs = useWalkStore((s) => s.pauseStartedAtMs);
+  const togglePaused = useWalkStore((s) => s.togglePaused);
   const totalDistanceM = useWalkStore((s) => s.totalDistanceM);
   const units = useSettingsStore((s) => s.units);
-
-  const [isPaused, setIsPaused] = useState(false);
-  const [totalPausedMs, setTotalPausedMs] = useState(0);
-  const pausedAtMsRef = useRef<number | null>(null);
-  const elapsedSec = useWalkElapsed({ startedAt, isPaused, totalPausedMs });
-
-  useEffect(() => {
-    pausedAtMsRef.current = null;
-    setIsPaused(false);
-    setTotalPausedMs(0);
-  }, [startedAtMs]);
-
-  const togglePause = () => {
-    if (isPaused && pausedAtMsRef.current !== null) {
-      setTotalPausedMs((ms) => ms + (Date.now() - pausedAtMsRef.current!));
-      pausedAtMsRef.current = null;
-      setIsPaused(false);
-    } else {
-      pausedAtMsRef.current = Date.now();
-      setIsPaused(true);
-    }
-  };
+  const elapsedSec = useWalkElapsed({
+    startedAt,
+    isPaused,
+    totalPausedMs,
+    pauseStartedAtMs,
+  });
 
   const { value: distanceValue, unit: distanceUnit } = formatDistanceParts(totalDistanceM, units);
   const pace = formatPace(elapsedSec, totalDistanceM, units);
@@ -67,7 +56,19 @@ export function WalkControls({ dogs, onStop, isStopping, children }: WalkControl
     : `${t('walk.recording.groupWalk')} · ${t('walk.recording.together')}`;
 
   return (
-    <View style={styles.sheet}>
+    <View
+      testID="walk-controls-sheet"
+      style={[
+        styles.sheet,
+        {
+          backgroundColor: theme.material,
+          borderColor: theme.border,
+        },
+      ]}
+    >
+      <View style={styles.grabberWrap}>
+        <View testID="walk-controls-grabber" style={[styles.grabber, { backgroundColor: theme.onSurfaceVariant }]} />
+      </View>
       <WalkIdentityHeader dogs={dogs} title={title} subtitle={subtitle} />
       <WalkMetricsRow metrics={metrics} />
 
@@ -76,7 +77,7 @@ export function WalkControls({ dogs, onStop, isStopping, children }: WalkControl
       <WalkControlsActions
         isPaused={isPaused}
         isStopping={isStopping}
-        onTogglePause={togglePause}
+        onTogglePause={togglePaused}
         onStop={onStop}
       />
     </View>
@@ -92,9 +93,24 @@ function contextualWalkLabel(startedAt: Date | null, t: (key: string) => string)
 
 const styles = StyleSheet.create({
   sheet: {
-    paddingTop: spacing.md,
+    borderRadius: 32,
+    borderWidth: StyleSheet.hairlineWidth,
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.sm,
+    paddingBottom: spacing.lg,
+    overflow: 'hidden',
+  },
+  grabberWrap: {
+    alignItems: 'center',
+    paddingBottom: spacing.md,
+  },
+  grabber: {
+    width: 36,
+    height: 5,
+    borderRadius: radius.full,
+    opacity: 0.45,
   },
   slot: {
-    marginBottom: spacing.md,
+    marginBottom: spacing.lg,
   },
 });

--- a/apps/mobile/components/walk/WalkFloatingBar.test.tsx
+++ b/apps/mobile/components/walk/WalkFloatingBar.test.tsx
@@ -1,0 +1,91 @@
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { WalkFloatingBar } from './WalkFloatingBar';
+import type { Dog } from '@/types/graphql';
+
+jest.mock('@/hooks/use-color-scheme', () => ({
+  useColorScheme: () => 'light',
+}));
+
+jest.mock('./WalkTopChip', () => ({
+  WalkTopChip: ({ dogs }: { dogs: Dog[] }) => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { Text } = require('react-native');
+    return <Text>{dogs.map((dog) => dog.name).join(' + ')}</Text>;
+  },
+}));
+
+const coco: Dog = {
+  id: 'dog-1',
+  name: 'Coco',
+  breed: null,
+  gender: null,
+  birthDate: null,
+  photoUrl: null,
+  createdAt: '2026-01-01',
+};
+
+const momo: Dog = {
+  id: 'dog-2',
+  name: 'Momo',
+  breed: null,
+  gender: null,
+  birthDate: null,
+  photoUrl: null,
+  createdAt: '2026-01-02',
+};
+
+describe('WalkFloatingBar', () => {
+  it('renders the center chip and both action buttons', () => {
+    render(
+      <WalkFloatingBar
+        dogs={[coco, momo]}
+        isMinimized={false}
+        isHybridMap={false}
+        onMinimize={jest.fn()}
+        onToggleMapType={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Coco + Momo')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Minimize' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Toggle map style' })).toBeTruthy();
+  });
+
+  it('fires both actions', () => {
+    const onMinimize = jest.fn();
+    const onToggleMapType = jest.fn();
+
+    render(
+      <WalkFloatingBar
+        dogs={[coco]}
+        isMinimized={false}
+        isHybridMap={true}
+        onMinimize={onMinimize}
+        onToggleMapType={onToggleMapType}
+      />,
+    );
+
+    fireEvent.press(screen.getByRole('button', { name: 'Minimize' }));
+    fireEvent.press(screen.getByRole('button', { name: 'Toggle map style' }));
+
+    expect(onMinimize).toHaveBeenCalledTimes(1);
+    expect(onToggleMapType).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('Map')).toBeTruthy();
+  });
+
+  it('disables the minimize button while already minimized', () => {
+    render(
+      <WalkFloatingBar
+        dogs={[coco]}
+        isMinimized={true}
+        isHybridMap={false}
+        onMinimize={jest.fn()}
+        onToggleMapType={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Minimize' }).props.accessibilityState.disabled).toBe(
+      true,
+    );
+  });
+});

--- a/apps/mobile/components/walk/WalkFloatingBar.tsx
+++ b/apps/mobile/components/walk/WalkFloatingBar.tsx
@@ -1,0 +1,117 @@
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { useColors } from '@/hooks/use-colors';
+import { elevation, spacing, typography } from '@/theme/tokens';
+import { WalkTopChip } from './WalkTopChip';
+import type { Dog } from '@/types/graphql';
+
+interface WalkFloatingBarProps {
+  dogs: Dog[];
+  isMinimized: boolean;
+  isHybridMap: boolean;
+  onMinimize: () => void;
+  onToggleMapType: () => void;
+}
+
+export function WalkFloatingBar({
+  dogs,
+  isMinimized,
+  isHybridMap,
+  onMinimize,
+  onToggleMapType,
+}: WalkFloatingBarProps) {
+  const { t } = useTranslation();
+  const theme = useColors();
+
+  if (dogs.length === 0) return null;
+
+  return (
+    <View style={styles.bar}>
+      <FloatingButton
+        label="X"
+        accessibilityLabel={t('walk.recording.minimize')}
+        onPress={onMinimize}
+        disabled={isMinimized}
+        theme={{ background: theme.material, border: theme.border, text: theme.onSurface }}
+      />
+
+      <View style={styles.center}>
+        <WalkTopChip dogs={dogs} />
+      </View>
+
+      <FloatingButton
+        label={isHybridMap ? t('walk.recording.mapLabel') : t('walk.recording.satelliteLabel')}
+        accessibilityLabel={t('walk.recording.toggleMapStyle')}
+        onPress={onToggleMapType}
+        theme={{ background: theme.material, border: theme.border, text: theme.onSurface }}
+      />
+    </View>
+  );
+}
+
+interface FloatingButtonProps {
+  label: string;
+  accessibilityLabel: string;
+  onPress: () => void;
+  disabled?: boolean;
+  theme: { background: string; border: string; text: string };
+}
+
+function FloatingButton({
+  label,
+  accessibilityLabel,
+  onPress,
+  disabled = false,
+  theme,
+}: FloatingButtonProps) {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      accessibilityState={{ disabled }}
+      disabled={disabled}
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.button,
+        {
+          backgroundColor: theme.background,
+          borderColor: theme.border,
+          opacity: pressed ? 0.8 : 1,
+        },
+        elevation.low,
+        disabled && styles.buttonDisabled,
+      ]}
+    >
+      <Text style={[styles.buttonLabel, { color: theme.text }]}>{label}</Text>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  bar: {
+    width: '100%',
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    paddingHorizontal: spacing.lg,
+  },
+  center: {
+    flex: 1,
+    alignItems: 'center',
+  },
+  button: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    borderWidth: StyleSheet.hairlineWidth,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  buttonLabel: {
+    ...typography.footnote,
+    fontWeight: '700',
+  },
+  buttonDisabled: {
+    opacity: 0.4,
+  },
+});

--- a/apps/mobile/components/walk/WalkMap.test.tsx
+++ b/apps/mobile/components/walk/WalkMap.test.tsx
@@ -23,7 +23,8 @@ jest.mock('react-native-maps', () => {
     accessibilityLabel?: string;
   }) => React.createElement(View, { testID, accessibilityLabel });
 
-  const MockPolyline = () => React.createElement(View, null);
+  const MockPolyline = ({ testID, ...props }: { testID?: string }) =>
+    React.createElement(View, { testID, ...props });
 
   return {
     __esModule: true,
@@ -98,5 +99,17 @@ describe('WalkMap', () => {
     render(<WalkMap />);
     expect(screen.getByTestId('event-marker-event-1')).toBeTruthy();
     expect(screen.getByTestId('event-marker-event-3')).toBeTruthy();
+  });
+
+  it('renders the dual route polylines with the updated active-walk styling', () => {
+    mockStorePoints = [
+      { lat: 35.68, lng: 139.76, recordedAt: '2026-04-12T10:00:00Z' },
+      { lat: 35.681, lng: 139.761, recordedAt: '2026-04-12T10:01:00Z' },
+    ];
+
+    render(<WalkMap />);
+
+    expect(screen.getByTestId('walk-route-highlight').props.strokeWidth).toBe(8);
+    expect(screen.getByTestId('walk-route-line').props.strokeWidth).toBe(5);
   });
 });

--- a/apps/mobile/components/walk/WalkMap.tsx
+++ b/apps/mobile/components/walk/WalkMap.tsx
@@ -5,23 +5,30 @@ import { useWalkStore } from '@/stores/walk-store';
 import { MAP_EVENT_EMOJIS } from '@/lib/walk/events';
 import { TOKYO_STATION_COORDINATE } from '@/lib/walk/constants';
 
+interface WalkMapProps {
+  mapType?: 'standard' | 'hybrid';
+}
+
 /**
  * Live recording map. Reads both the GPS trail (`points`) and recorded events
  * from `walk-store` so the entire visible state comes from one source of
  * truth. Event markers update in lockstep with `WalkEventActions` writes.
  */
-export function WalkMap() {
+export function WalkMap({ mapType = 'standard' }: WalkMapProps) {
   const theme = useColors();
   const points = useWalkStore((s) => s.points);
+  const routeBreakIndices = useWalkStore((s) => s.routeBreakIndices ?? []);
   const events = useWalkStore((s) => s.events);
 
   const coordinates = points.map((p) => ({ latitude: p.lat, longitude: p.lng }));
+  const routeSegments = buildRouteSegments(coordinates, routeBreakIndices);
   const lastPoint = coordinates[coordinates.length - 1];
 
   return (
     <View style={styles.container}>
       <MapView
         style={styles.map}
+        mapType={mapType}
         showsUserLocation
         followsUserLocation
         initialRegion={
@@ -40,13 +47,26 @@ export function WalkMap() {
               }
         }
       >
-        {coordinates.length >= 2 ? (
+        {routeSegments.flatMap((segment, index) => [
           <Polyline
-            coordinates={coordinates}
-            strokeColor={theme.interactive}
-            strokeWidth={4}
-          />
-        ) : null}
+            key={`highlight-${index}`}
+            testID={index === 0 ? 'walk-route-highlight' : undefined}
+            coordinates={segment}
+            strokeColor="rgba(255,255,255,0.3)"
+            strokeWidth={8}
+            lineCap="round"
+            lineJoin="round"
+          />,
+          <Polyline
+            key={`route-${index}`}
+            testID={index === 0 ? 'walk-route-line' : undefined}
+            coordinates={segment}
+            strokeColor={theme.success}
+            strokeWidth={5}
+            lineCap="round"
+            lineJoin="round"
+          />,
+        ])}
         {lastPoint ? <Marker coordinate={lastPoint} /> : null}
         {events
           .filter((e) => e.lat != null && e.lng != null)
@@ -63,6 +83,32 @@ export function WalkMap() {
       </MapView>
     </View>
   );
+}
+
+function buildRouteSegments(
+  coordinates: { latitude: number; longitude: number }[],
+  breakIndices: number[],
+) {
+  if (coordinates.length < 2) return [];
+
+  const sortedBreaks = [...breakIndices].sort((a, b) => a - b);
+  const segments: { latitude: number; longitude: number }[][] = [];
+  let start = 0;
+
+  for (const breakIndex of sortedBreaks) {
+    const segment = coordinates.slice(start, breakIndex);
+    if (segment.length >= 2) {
+      segments.push(segment);
+    }
+    start = breakIndex;
+  }
+
+  const lastSegment = coordinates.slice(start);
+  if (lastSegment.length >= 2) {
+    segments.push(lastSegment);
+  }
+
+  return segments;
 }
 
 const styles = StyleSheet.create({

--- a/apps/mobile/components/walk/WalkMinimizedControls.test.tsx
+++ b/apps/mobile/components/walk/WalkMinimizedControls.test.tsx
@@ -11,6 +11,9 @@ jest.mock('expo-image', () => ({ Image: 'Image' }));
 const mockSetMinimized = jest.fn();
 const mockWalkStoreState = {
   startedAt: null as Date | null,
+  isPaused: false,
+  totalPausedMs: 0,
+  pauseStartedAtMs: null as number | null,
   totalDistanceM: 1420,
   setMinimized: mockSetMinimized,
 };
@@ -40,6 +43,9 @@ describe('WalkMinimizedControls', () => {
     jest.useFakeTimers();
     mockSetMinimized.mockClear();
     mockWalkStoreState.startedAt = null;
+    mockWalkStoreState.isPaused = false;
+    mockWalkStoreState.totalPausedMs = 0;
+    mockWalkStoreState.pauseStartedAtMs = null;
     mockWalkStoreState.totalDistanceM = 1420;
   });
 

--- a/apps/mobile/components/walk/WalkMinimizedControls.tsx
+++ b/apps/mobile/components/walk/WalkMinimizedControls.tsx
@@ -20,10 +20,18 @@ export function WalkMinimizedControls({ dogs }: WalkMinimizedControlsProps) {
   const { t } = useTranslation();
   const theme = useColors();
   const startedAt = useWalkStore((s) => s.startedAt);
+  const isPaused = useWalkStore((s) => s.isPaused);
+  const totalPausedMs = useWalkStore((s) => s.totalPausedMs);
+  const pauseStartedAtMs = useWalkStore((s) => s.pauseStartedAtMs);
   const totalDistanceM = useWalkStore((s) => s.totalDistanceM);
   const setMinimized = useWalkStore((s) => s.setMinimized);
   const units = useSettingsStore((s) => s.units);
-  const elapsedSec = useWalkElapsed({ startedAt, isPaused: false, totalPausedMs: 0 });
+  const elapsedSec = useWalkElapsed({
+    startedAt,
+    isPaused,
+    totalPausedMs,
+    pauseStartedAtMs,
+  });
 
   const expand = () => setMinimized(false);
 

--- a/apps/mobile/components/walk/WalkReadyView.test.tsx
+++ b/apps/mobile/components/walk/WalkReadyView.test.tsx
@@ -98,9 +98,9 @@ describe('WalkReadyView', () => {
     expect(screen.getByText('Walk')).toBeTruthy();
   });
 
-  it('renders the Walking with section with Select all action when 2+ dogs', () => {
+  it("renders the Who's coming? section with Select all action when 2+ dogs", () => {
     render(<WalkReadyView onStart={jest.fn()} isStarting={false} />);
-    expect(screen.getByText('Walking with')).toBeTruthy();
+    expect(screen.getByText("Who's coming?")).toBeTruthy();
     expect(screen.getByText('Select all')).toBeTruthy();
   });
 
@@ -138,21 +138,28 @@ describe('WalkReadyView', () => {
     render(<WalkReadyView onStart={jest.fn()} isStarting={false} />);
     expect(
       screen.getByText(
-        "Tap to begin. We'll follow your route and log everything gently.",
+        "We'll log pees, poops and photos for each dog separately.",
       ),
     ).toBeTruthy();
   });
 
-  it('does not render a Group walk summary anymore', () => {
+  it('renders a Group walk summary when two dogs are selected', () => {
     mockStore = buildStore(['dog-1', 'dog-2']);
     render(<WalkReadyView onStart={jest.fn()} isStarting={false} />);
-    expect(screen.queryByText('Group walk')).toBeNull();
+    expect(screen.getByText('Group walk')).toBeTruthy();
+    expect(screen.getByText('2 dogs')).toBeTruthy();
+    expect(screen.getByText('walking together')).toBeTruthy();
   });
 
   it('shows the noDogs empty state when user has zero dogs', () => {
     mockDogs = [];
     render(<WalkReadyView onStart={jest.fn()} isStarting={false} />);
     expect(screen.getByText('Register a dog first')).toBeTruthy();
+  });
+
+  it('does not render recent walks content', () => {
+    render(<WalkReadyView onStart={jest.fn()} isStarting={false} />);
+    expect(screen.queryByText('Recent Walks')).toBeNull();
   });
 
   describe('single-dog variant', () => {
@@ -170,12 +177,21 @@ describe('WalkReadyView', () => {
       render(<WalkReadyView onStart={jest.fn()} isStarting={false} />);
       expect(screen.queryByRole('checkbox', { name: 'Coco' })).toBeNull();
       expect(screen.getByText('Coco')).toBeTruthy();
-      expect(screen.getByText('Last walk 14 hours ago')).toBeTruthy();
+      expect(screen.getByText('Toy Poodle · Last walk 14 hours ago')).toBeTruthy();
     });
 
     it('auto-selects the only dog so START is enabled', () => {
       render(<WalkReadyView onStart={jest.fn()} isStarting={false} />);
       expect(mockStore.setSelectedDogs).toHaveBeenCalledWith(['dog-1']);
+    });
+
+    it('replaces a stale selection with the current dog', () => {
+      mockStore = buildStore(['dog-999']);
+      render(<WalkReadyView onStart={jest.fn()} isStarting={false} />);
+      expect(mockStore.setSelectedDogs).toHaveBeenCalledWith(['dog-1']);
+      expect(screen.getByRole('button', { name: 'START' }).props.accessibilityState.disabled).toBe(
+        false,
+      );
     });
   });
 });

--- a/apps/mobile/components/walk/WalkReadyView.tsx
+++ b/apps/mobile/components/walk/WalkReadyView.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/Button';
 import { GroupedCard } from '@/components/ui/GroupedCard';
 import { SectionHeader } from '@/components/ui/SectionHeader';
 import { DogPickerCard } from '@/components/walk/DogPickerCard';
+import { GroupWalkSummaryCard } from '@/components/walk/GroupWalkSummaryCard';
 import { useColors } from '@/hooks/use-colors';
 import { useMe } from '@/hooks/use-me';
 import { useWalkStore } from '@/stores/walk-store';
@@ -21,21 +22,38 @@ export function WalkReadyView({ onStart, isStarting }: WalkReadyViewProps) {
   const theme = useColors();
   const { data: me } = useMe();
   const dogs = useMemo<Dog[]>(() => me?.dogs ?? [], [me?.dogs]);
+  const dogIds = useMemo(() => new Set(dogs.map((dog) => dog.id)), [dogs]);
   const selectedDogIds = useWalkStore((s) => s.selectedDogIds);
   const selectDog = useWalkStore((s) => s.selectDog);
   const setSelectedDogs = useWalkStore((s) => s.setSelectedDogs);
 
   const isSingleDog = dogs.length === 1;
+  const selectedDogIdsInPack = useMemo(
+    () => selectedDogIds.filter((dogId) => dogIds.has(dogId)),
+    [dogIds, selectedDogIds],
+  );
+  const effectiveSelectedDogIds = useMemo(() => {
+    if (isSingleDog && dogs[0]) {
+      return [dogs[0].id];
+    }
+    return selectedDogIdsInPack;
+  }, [dogs, isSingleDog, selectedDogIdsInPack]);
+  const selectedDogs = useMemo(
+    () => dogs.filter((dog) => effectiveSelectedDogIds.includes(dog.id)),
+    [dogs, effectiveSelectedDogIds],
+  );
 
   // With a single dog, there is no picker — keep the selection in sync so START works.
   useEffect(() => {
-    if (isSingleDog && selectedDogIds.length === 0) {
+    if (!isSingleDog || !dogs[0]) return;
+
+    if (selectedDogIds.length !== 1 || selectedDogIds[0] !== dogs[0].id) {
       setSelectedDogs([dogs[0].id]);
     }
-  }, [isSingleDog, dogs, selectedDogIds.length, setSelectedDogs]);
+  }, [dogs, isSingleDog, selectedDogIds, setSelectedDogs]);
 
   const allSelected =
-    dogs.length > 0 && dogs.every((d) => selectedDogIds.includes(d.id));
+    dogs.length > 0 && dogs.every((d) => effectiveSelectedDogIds.includes(d.id));
 
   const handleSelectAll = useCallback(() => {
     if (allSelected) {
@@ -45,7 +63,7 @@ export function WalkReadyView({ onStart, isStarting }: WalkReadyViewProps) {
     }
   }, [allSelected, dogs, setSelectedDogs]);
 
-  const canStart = selectedDogIds.length > 0 && !isStarting;
+  const canStart = effectiveSelectedDogIds.length > 0 && !isStarting;
   const selectAllLabel = allSelected
     ? t('walk.ready.deselectAll')
     : t('walk.ready.selectAll');
@@ -61,9 +79,9 @@ export function WalkReadyView({ onStart, isStarting }: WalkReadyViewProps) {
         {t('walk.ready.largeTitle')}
       </Text>
 
-      <View style={styles.walkingWith}>
+      <View style={styles.dogSection}>
         <SectionHeader
-          label={t('walk.ready.walkingWith')}
+          label={t('walk.ready.whosComing')}
           trailing={
             showSelectAll ? (
               <Pressable
@@ -89,11 +107,15 @@ export function WalkReadyView({ onStart, isStarting }: WalkReadyViewProps) {
         ) : (
           <DogPickerCard
             dogs={dogs}
-            selectedIds={selectedDogIds}
+            selectedIds={effectiveSelectedDogIds}
             onToggle={selectDog}
             variant={isSingleDog ? 'single' : 'multi'}
           />
         )}
+
+        <View style={styles.summaryCard}>
+          <GroupWalkSummaryCard dogs={selectedDogs} />
+        </View>
       </View>
 
       <View style={styles.ctaColumn}>
@@ -124,13 +146,16 @@ const styles = StyleSheet.create({
     paddingTop: spacing.md,
     paddingBottom: spacing.sm,
   },
-  walkingWith: {
+  dogSection: {
     marginTop: spacing.md,
     paddingHorizontal: spacing.sm,
   },
   selectAll: {
     fontSize: 13,
     fontWeight: '500',
+  },
+  summaryCard: {
+    marginTop: spacing.sm,
   },
   emptyText: {
     ...typography.body,

--- a/apps/mobile/components/walk/WalkRoutePreview.tsx
+++ b/apps/mobile/components/walk/WalkRoutePreview.tsx
@@ -12,6 +12,7 @@ import type { WalkPoint } from '@/types/graphql';
 
 interface WalkRoutePreviewProps {
   points: WalkPoint[];
+  routeBreakIndices?: number[];
   totalDistanceM: number;
   elapsedSec: number;
 }
@@ -21,12 +22,14 @@ const DOT_SIZE = 14;
 
 export function WalkRoutePreview({
   points,
+  routeBreakIndices = [],
   totalDistanceM,
   elapsedSec,
 }: WalkRoutePreviewProps) {
   const theme = useColors();
 
   const coordinates = points.map((p) => ({ latitude: p.lat, longitude: p.lng }));
+  const routeSegments = buildRouteSegments(coordinates, routeBreakIndices);
   const start = coordinates[0];
   const end = coordinates[coordinates.length - 1];
 
@@ -57,15 +60,16 @@ export function WalkRoutePreview({
         toolbarEnabled={false}
         pointerEvents="none"
       >
-        {coordinates.length >= 2 ? (
+        {routeSegments.map((segment, index) => (
           <Polyline
-            coordinates={coordinates}
+            key={index}
+            coordinates={segment}
             strokeColor={theme.success}
             strokeWidth={5}
             lineCap="round"
             lineJoin="round"
           />
-        ) : null}
+        ))}
         {start ? (
           <Marker
             testID="route-preview-start"
@@ -105,6 +109,32 @@ export function WalkRoutePreview({
       </View>
     </View>
   );
+}
+
+function buildRouteSegments(
+  coordinates: { latitude: number; longitude: number }[],
+  breakIndices: number[],
+) {
+  if (coordinates.length < 2) return [];
+
+  const sortedBreaks = [...breakIndices].sort((a, b) => a - b);
+  const segments: { latitude: number; longitude: number }[][] = [];
+  let start = 0;
+
+  for (const breakIndex of sortedBreaks) {
+    const segment = coordinates.slice(start, breakIndex);
+    if (segment.length >= 2) {
+      segments.push(segment);
+    }
+    start = breakIndex;
+  }
+
+  const lastSegment = coordinates.slice(start);
+  if (lastSegment.length >= 2) {
+    segments.push(lastSegment);
+  }
+
+  return segments;
 }
 
 interface PillProps {

--- a/apps/mobile/components/walk/WalkSummaryCard.test.tsx
+++ b/apps/mobile/components/walk/WalkSummaryCard.test.tsx
@@ -53,11 +53,15 @@ jest.mock('@/stores/walk-store', () => ({
     selector({
       walkId: 'walk-1',
       startedAt: new Date(Date.now() - 24 * 60 * 1000),
+      isPaused: false,
+      totalPausedMs: 0,
+      pauseStartedAtMs: null,
       totalDistanceM: 1420,
       points: [
         { lat: 35.6812, lng: 139.7671, recordedAt: '2026-04-19T10:00:00Z' },
         { lat: 35.682, lng: 139.768, recordedAt: '2026-04-19T10:05:00Z' },
       ],
+      routeBreakIndices: [],
       events: mockEvents,
       selectedDogIds: mockSelectedDogIds,
       reset: mockReset,

--- a/apps/mobile/components/walk/WalkSummaryCard.tsx
+++ b/apps/mobile/components/walk/WalkSummaryCard.tsx
@@ -23,8 +23,13 @@ export function WalkSummaryCard() {
 
   const walkId = useWalkStore((s) => s.walkId);
   const startedAt = useWalkStore((s) => s.startedAt);
+  const finishedAt = useWalkStore((s) => s.finishedAt);
+  const isPaused = useWalkStore((s) => s.isPaused);
+  const totalPausedMs = useWalkStore((s) => s.totalPausedMs);
+  const pauseStartedAtMs = useWalkStore((s) => s.pauseStartedAtMs);
   const totalDistanceM = useWalkStore((s) => s.totalDistanceM);
   const points = useWalkStore((s) => s.points);
+  const routeBreakIndices = useWalkStore((s) => s.routeBreakIndices);
   const events = useWalkStore((s) => s.events);
   const selectedDogIds = useWalkStore((s) => s.selectedDogIds);
   const reset = useWalkStore((s) => s.reset);
@@ -35,8 +40,16 @@ export function WalkSummaryCard() {
     [me?.dogs, selectedDogIds],
   );
 
+  const elapsedBaseMs = finishedAt?.getTime()
+    ?? (isPaused ? pauseStartedAtMs ?? Date.now() : Date.now());
+
   const elapsedSec = startedAt
-    ? Math.floor((Date.now() - startedAt.getTime()) / 1000)
+    ? Math.max(
+        0,
+        Math.floor(
+          (elapsedBaseMs - startedAt.getTime() - totalPausedMs) / 1000,
+        ),
+      )
     : 0;
   const elapsedMin = Math.max(1, Math.round(elapsedSec / 60));
 
@@ -103,6 +116,7 @@ export function WalkSummaryCard() {
 
         <WalkRoutePreview
           points={points}
+          routeBreakIndices={routeBreakIndices}
           totalDistanceM={totalDistanceM}
           elapsedSec={elapsedSec}
         />

--- a/apps/mobile/components/walk/WalkTopChip.tsx
+++ b/apps/mobile/components/walk/WalkTopChip.tsx
@@ -2,7 +2,7 @@ import { StyleSheet, Text, View } from 'react-native';
 import { Image } from 'expo-image';
 import { useTranslation } from 'react-i18next';
 import { useColors } from '@/hooks/use-colors';
-import { elevation, radius, spacing, typography } from '@/theme/tokens';
+import { elevation, spacing, typography } from '@/theme/tokens';
 import type { Dog } from '@/types/graphql';
 
 interface WalkTopChipProps {
@@ -20,13 +20,13 @@ export function WalkTopChip({ dogs }: WalkTopChipProps) {
   const isSingle = dogs.length === 1;
   const label = isSingle
     ? t('walk.recording.walkWith', { name: dogs[0].name })
-    : t('walk.recording.groupWalk');
+    : dogs.map((dog) => dog.name).join(' + ');
 
   return (
     <View
       style={[
         styles.chip,
-        { backgroundColor: theme.surface, borderColor: theme.border },
+        { backgroundColor: theme.material, borderColor: theme.border },
         elevation.low,
       ]}
     >
@@ -38,7 +38,7 @@ export function WalkTopChip({ dogs }: WalkTopChipProps) {
               source={dog.photoUrl ?? require('@/assets/images/icon.png')}
               style={[
                 styles.avatar,
-                { borderColor: theme.surface },
+                { borderColor: theme.material },
                 i > 0 && styles.avatarOverlap,
               ]}
               contentFit="cover"
@@ -60,10 +60,10 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     paddingVertical: spacing.xs + 2,
     paddingHorizontal: spacing.md,
-    borderRadius: radius.full,
+    borderRadius: 20,
     borderWidth: StyleSheet.hairlineWidth,
     gap: spacing.xs,
-    maxWidth: '80%',
+    maxWidth: '100%',
   },
   avatars: {
     flexDirection: 'row',

--- a/apps/mobile/hooks/use-walk-elapsed.ts
+++ b/apps/mobile/hooks/use-walk-elapsed.ts
@@ -4,12 +4,14 @@ interface UseWalkElapsedOptions {
   startedAt: Date | null;
   isPaused: boolean;
   totalPausedMs: number;
+  pauseStartedAtMs?: number | null;
 }
 
 export function useWalkElapsed({
   startedAt,
   isPaused,
   totalPausedMs,
+  pauseStartedAtMs,
 }: UseWalkElapsedOptions) {
   const [elapsedSec, setElapsedSec] = useState(0);
   const pausedAtRef = useRef<number | null>(null);
@@ -22,13 +24,15 @@ export function useWalkElapsed({
     }
 
     if (isPaused) {
-      pausedAtRef.current ??= Date.now();
+      pausedAtRef.current ??= pauseStartedAtMs ?? Date.now();
     } else {
       pausedAtRef.current = null;
     }
 
     const tick = () => {
-      const currentTimeMs = isPaused ? pausedAtRef.current ?? Date.now() : Date.now();
+      const currentTimeMs = isPaused
+        ? pauseStartedAtMs ?? pausedAtRef.current ?? Date.now()
+        : Date.now();
       const elapsedMs = currentTimeMs - startedAt.getTime() - totalPausedMs;
       setElapsedSec(Math.max(0, Math.floor(elapsedMs / 1000)));
     };
@@ -36,7 +40,7 @@ export function useWalkElapsed({
     tick();
     const intervalId = setInterval(tick, 1000);
     return () => clearInterval(intervalId);
-  }, [startedAt, isPaused, totalPausedMs]);
+  }, [startedAt, isPaused, totalPausedMs, pauseStartedAtMs]);
 
   return elapsedSec;
 }

--- a/apps/mobile/hooks/use-walk-session.test.ts
+++ b/apps/mobile/hooks/use-walk-session.test.ts
@@ -28,12 +28,17 @@ jest.mock('@/lib/walk/live-activity', () => ({
 }));
 
 const mockStoreStartRecording = jest.fn();
+const mockStoreAbortRecordingStart = jest.fn();
 const mockStoreAddPoint = jest.fn();
 const mockStoreFinish = jest.fn();
+const mockStoreResumePausedWalk = jest.fn();
+const mockStoreTogglePaused = jest.fn();
 let mockStorePoints: WalkPoint[] = [];
+let mockStoreUploadedPointCount = 0;
 let mockStoreTotalDistanceM = 0;
 let mockStoreStartedAt: Date | null = null;
 let mockStorePhase: 'ready' | 'recording' | 'finished' = 'ready';
+let mockStoreIsPaused = false;
 let mockStoreTrackingGeneration = 0;
 let mockStoreTrackingCleanup: (() => void) | null = null;
 let mockStoreLiveActivity: LiveActivityState | null = null;
@@ -45,21 +50,45 @@ jest.mock('@/stores/walk-store', () => {
     },
     startRecording: (...args: unknown[]) => {
       mockStorePhase = 'recording';
+      mockStoreIsPaused = false;
+      mockStoreUploadedPointCount = 0;
       return mockStoreStartRecording(...args);
     },
+    abortRecordingStart: () => {
+      mockStorePhase = 'ready';
+      mockStoreIsPaused = false;
+      mockStoreUploadedPointCount = 0;
+      mockStoreLiveActivity = null;
+      return mockStoreAbortRecordingStart();
+    },
     addPoint: (...args: unknown[]) => mockStoreAddPoint(...args),
-    finish: () => {
+    finish: (...args: unknown[]) => {
       mockStorePhase = 'finished';
-      return mockStoreFinish();
+      mockStoreIsPaused = false;
+      return mockStoreFinish(...args);
+    },
+    resumePausedWalk: () => mockStoreResumePausedWalk(),
+    togglePaused: () => {
+      mockStoreIsPaused = !mockStoreIsPaused;
+      return mockStoreTogglePaused();
+    },
+    markUploadedPointCount: (count: number) => {
+      mockStoreUploadedPointCount = Math.max(mockStoreUploadedPointCount, count);
     },
     get points() {
       return mockStorePoints;
+    },
+    get uploadedPointCount() {
+      return mockStoreUploadedPointCount;
     },
     get totalDistanceM() {
       return mockStoreTotalDistanceM;
     },
     get startedAt() {
       return mockStoreStartedAt;
+    },
+    get isPaused() {
+      return mockStoreIsPaused;
     },
     get trackingGeneration() {
       return mockStoreTrackingGeneration;
@@ -128,10 +157,15 @@ function requireCapturedOnPoint(
 beforeEach(() => {
   jest.clearAllMocks();
   resetWalkSessionTrackingState();
+  mockStoreAbortRecordingStart.mockClear();
+  mockStoreResumePausedWalk.mockClear();
+  mockStoreTogglePaused.mockClear();
   mockStorePoints = [];
+  mockStoreUploadedPointCount = 0;
   mockStoreTotalDistanceM = 0;
   mockStoreStartedAt = new Date('2026-04-01T00:00:00Z');
   mockStorePhase = 'ready';
+  mockStoreIsPaused = false;
   mockStoreTrackingGeneration = 0;
   mockStoreTrackingCleanup = null;
   mockStoreLiveActivity = null;
@@ -307,6 +341,22 @@ describe('useWalkSession.start', () => {
     const { result } = renderHook(() => useWalkSession());
     expect(result.current.isStarting).toBe(true);
   });
+
+  it('rolls back the recording state if tracking startup fails after the walk is created', async () => {
+    mockStartWalkMutateAsync.mockResolvedValue({ id: 'walk-1' });
+    (gpsTracker.startTracking as jest.Mock).mockRejectedValue(new Error('gps failed'));
+
+    const { result } = renderHook(() => useWalkSession());
+
+    await expect(
+      result.current.start({ selectedDogIds: ['dog-1'], liveActivityDogName: 'Rex' }),
+    ).rejects.toThrow('gps failed');
+
+    expect(mockStoreAbortRecordingStart).toHaveBeenCalledTimes(1);
+    expect(liveActivity.endLiveActivity).toHaveBeenCalledWith('activity-1');
+    expect(mockStorePhase).toBe('ready');
+    expect(mockStoreLiveActivity).toBeNull();
+  });
 });
 
 describe('useWalkSession.stop', () => {
@@ -322,6 +372,7 @@ describe('useWalkSession.stop', () => {
     });
 
     expect(mockStopTracking).toHaveBeenCalledTimes(1);
+    expect(mockStoreTogglePaused).toHaveBeenCalledTimes(1);
   });
 
   it('stops the active GPS subscription even when stop is called from another hook instance', async () => {
@@ -338,6 +389,7 @@ describe('useWalkSession.stop', () => {
     });
 
     expect(mockStopTracking).toHaveBeenCalledTimes(1);
+    expect(mockStoreTogglePaused).toHaveBeenCalledTimes(1);
   });
 
   it('ignores late GPS callbacks after stop begins', async () => {
@@ -397,6 +449,8 @@ describe('useWalkSession.stop', () => {
     mockStartWalkMutateAsync.mockResolvedValue({ id: 'walk-1' });
     (liveActivity.startLiveActivity as jest.Mock).mockResolvedValue('activity-7');
     mockStoreTotalDistanceM = 1234.7;
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-04-21T09:15:30.000Z'));
 
     const { result } = renderHook(() => useWalkSession());
     await act(async () => {
@@ -408,9 +462,13 @@ describe('useWalkSession.stop', () => {
 
     expect(mockFinishWalkMutateAsync).toHaveBeenCalledWith({ walkId: 'walk-1', distanceM: 1235 });
     expect(mockStoreFinish).toHaveBeenCalledTimes(1);
+    expect(mockStoreFinish).toHaveBeenCalledWith(new Date('2026-04-21T09:15:30.000Z'));
+  expect(mockStoreTogglePaused).toHaveBeenCalledTimes(1);
     expect(liveActivity.endLiveActivity).toHaveBeenCalledTimes(1);
     expect(liveActivity.endLiveActivity).toHaveBeenCalledWith('activity-7');
     expect(mockStoreLiveActivity).toBeNull();
+
+    jest.useRealTimers();
   });
 
   it('does not call endLiveActivity when stop runs without an active live activity', async () => {
@@ -426,6 +484,55 @@ describe('useWalkSession.stop', () => {
     });
 
     expect(liveActivity.endLiveActivity).not.toHaveBeenCalled();
+  });
+
+  it('keeps the walk locally recoverable if stop persistence fails', async () => {
+    mockStartWalkMutateAsync.mockResolvedValue({ id: 'walk-1' });
+    mockAddPointsMutateAsync.mockRejectedValue(new Error('flush failed'));
+    mockStorePoints = [{ lat: 35.68, lng: 139.76, recordedAt: '2026-04-01T00:01:00Z' }];
+
+    const { result } = renderHook(() => useWalkSession());
+    await act(async () => {
+      await result.current.start({ selectedDogIds: ['dog-1'], liveActivityDogName: 'Rex' });
+    });
+
+    await expect(result.current.stop('walk-1')).rejects.toThrow('flush failed');
+
+    expect(mockStorePhase).toBe('recording');
+    expect(mockStopTracking).not.toHaveBeenCalled();
+    expect(mockStoreFinish).not.toHaveBeenCalled();
+    expect(liveActivity.endLiveActivity).not.toHaveBeenCalled();
+    expect(mockStoreTogglePaused).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not re-upload points that already flushed before a retry', async () => {
+    mockStartWalkMutateAsync.mockResolvedValue({ id: 'walk-1' });
+    mockStorePoints = Array.from({ length: MAX_POINTS_PER_BATCH + 1 }, (_, index) => ({
+      lat: 35.68,
+      lng: 139.76,
+      recordedAt: `2026-04-01T00:${String(index).padStart(2, '0')}:00Z`,
+    }));
+    mockAddPointsMutateAsync
+      .mockResolvedValueOnce(true)
+      .mockRejectedValueOnce(new Error('second batch failed'))
+      .mockResolvedValueOnce(true);
+
+    const { result } = renderHook(() => useWalkSession());
+    await act(async () => {
+      await result.current.start({ selectedDogIds: ['dog-1'], liveActivityDogName: 'Rex' });
+    });
+
+    await expect(result.current.stop('walk-1')).rejects.toThrow('second batch failed');
+    expect(mockStoreUploadedPointCount).toBe(MAX_POINTS_PER_BATCH);
+
+    mockAddPointsMutateAsync.mockClear();
+
+    await act(async () => {
+      await result.current.stop('walk-1');
+    });
+
+    expect(mockAddPointsMutateAsync).toHaveBeenCalledTimes(1);
+    expect((mockAddPointsMutateAsync.mock.calls[0][0] as { points: WalkPoint[] }).points).toHaveLength(1);
   });
 
   it('does not call addWalkPoints when there are no points', async () => {

--- a/apps/mobile/hooks/use-walk-session.ts
+++ b/apps/mobile/hooks/use-walk-session.ts
@@ -31,6 +31,7 @@ export function useWalkSession() {
   const finishWalkMutation = useFinishWalk();
   const addWalkPointsMutation = useAddWalkPoints();
   const startRecording = useWalkStore((s) => s.startRecording);
+  const abortRecordingStart = useWalkStore((s) => s.abortRecordingStart);
   const finish = useWalkStore((s) => s.finish);
 
   const start = useCallback(
@@ -38,69 +39,94 @@ export function useWalkSession() {
       stopWalkTracking();
 
       const walk = await startWalkMutation.mutateAsync(selectedDogIds);
-      startRecording(walk.id);
+      try {
+        startRecording(walk.id);
 
-      const startedAt = useWalkStore.getState().startedAt ?? new Date();
-      const activityId = await startLiveActivity({
-        walkId: walk.id,
-        dogId: selectedDogIds[0],
-        dogName: liveActivityDogName,
-        startedAt,
-        distanceM: 0,
-      });
-      if (activityId) {
-        useWalkStore.getState().setLiveActivity({
-          activityId,
+        const startedAt = useWalkStore.getState().startedAt ?? new Date();
+        const activityId = await startLiveActivity({
+          walkId: walk.id,
+          dogId: selectedDogIds[0],
+          dogName: liveActivityDogName,
           startedAt,
-          // 0 so the first GPS-driven distance update fires immediately rather
-          // than being debounced for ~10 seconds.
-          lastUpdateAt: 0,
+          distanceM: 0,
         });
+        if (activityId) {
+          useWalkStore.getState().setLiveActivity({
+            activityId,
+            startedAt,
+            // 0 so the first GPS-driven distance update fires immediately rather
+            // than being debounced for ~10 seconds.
+            lastUpdateAt: 0,
+          });
+        }
+
+        await beginWalkTracking({
+          onPoint: (point) => {
+            useWalkStore.getState().addPoint(point);
+          },
+          onDistanceChange: (distanceM) => {
+            const la = useWalkStore.getState().liveActivity;
+            if (!la) return;
+            const now = Date.now();
+            if (now - la.lastUpdateAt < UPDATE_DEBOUNCE_MS) return;
+            // Bump first so a slow native update doesn't let a second GPS tick
+            // through the gate while we're still in flight.
+            useWalkStore.getState().bumpLiveActivityUpdateAt(now);
+            void updateLiveActivityDistance(la.activityId, distanceM);
+          },
+        });
+
+        return walk.id;
+      } catch (error) {
+        stopWalkTracking();
+        const liveActivity = useWalkStore.getState().liveActivity;
+        if (liveActivity) {
+          useWalkStore.getState().setLiveActivity(null);
+          void endLiveActivity(liveActivity.activityId);
+        }
+        abortRecordingStart();
+        throw error;
       }
-
-      await beginWalkTracking({
-        onPoint: (point) => {
-          useWalkStore.getState().addPoint(point);
-        },
-        onDistanceChange: (distanceM) => {
-          const la = useWalkStore.getState().liveActivity;
-          if (!la) return;
-          const now = Date.now();
-          if (now - la.lastUpdateAt < UPDATE_DEBOUNCE_MS) return;
-          // Bump first so a slow native update doesn't let a second GPS tick
-          // through the gate while we're still in flight.
-          useWalkStore.getState().bumpLiveActivityUpdateAt(now);
-          void updateLiveActivityDistance(la.activityId, distanceM);
-        },
-      });
-
-      return walk.id;
     },
-    [startWalkMutation, startRecording],
+    [abortRecordingStart, startRecording, startWalkMutation],
   );
 
   const stop = useCallback(
     async (walkId: string) => {
-      stopWalkTracking();
+      const endedAt = new Date();
+      const wasPaused = useWalkStore.getState().isPaused;
+      if (!wasPaused) {
+        useWalkStore.getState().togglePaused();
+      }
 
-      const currentPoints = useWalkStore.getState().points;
-      await flushWalkPoints({
-        walkId,
-        points: currentPoints,
-        addWalkPoints: addWalkPointsMutation.mutateAsync,
-      });
+      try {
+        const currentState = useWalkStore.getState();
+        await flushWalkPoints({
+          walkId,
+          points: currentState.points,
+          uploadedPointCount: currentState.uploadedPointCount,
+          addWalkPoints: addWalkPointsMutation.mutateAsync,
+          markUploadedPointCount: (count) => useWalkStore.getState().markUploadedPointCount(count),
+        });
 
-      const totalDistanceM = useWalkStore.getState().totalDistanceM;
-      await finishWalkMutation.mutateAsync({
-        walkId,
-        distanceM: Math.round(totalDistanceM),
-      });
-      finish();
+        const totalDistanceM = useWalkStore.getState().totalDistanceM;
+        await finishWalkMutation.mutateAsync({
+          walkId,
+          distanceM: Math.round(totalDistanceM),
+        });
+        stopWalkTracking();
+        finish(endedAt);
 
-      const la = useWalkStore.getState().liveActivity;
-      if (la) {
-        useWalkStore.getState().setLiveActivity(null);
-        void endLiveActivity(la.activityId);
+        const la = useWalkStore.getState().liveActivity;
+        if (la) {
+          useWalkStore.getState().setLiveActivity(null);
+          void endLiveActivity(la.activityId);
+        }
+      } catch (error) {
+        if (!wasPaused) {
+          useWalkStore.getState().togglePaused();
+        }
+        throw error;
       }
     },
     [addWalkPointsMutation, finishWalkMutation, finish],

--- a/apps/mobile/lib/i18n/locales/en.json
+++ b/apps/mobile/lib/i18n/locales/en.json
@@ -145,10 +145,14 @@
     "ready": {
       "largeTitle": "Walk",
       "walkingWith": "Walking with",
+      "whosComing": "Who's coming?",
       "selectAll": "Select all",
       "deselectAll": "Deselect all",
-      "hint": "Tap to begin. We'll follow your route and log everything gently.",
+      "hint": "We'll log pees, poops and photos for each dog separately.",
       "start": "START",
+      "dogsWalkingBold": "{{count}} dogs",
+      "dogsWalkingTail": " walking together",
+      "groupWalk": "Group walk",
       "noDogs": "Register a dog first",
       "lastWalk": {
         "never": "Ready for the first walk",
@@ -176,6 +180,9 @@
       "resume": "Resume",
       "endWalk": "End Walk",
       "minimize": "Minimize",
+      "mapLabel": "Map",
+      "satelliteLabel": "Sat",
+      "toggleMapStyle": "Toggle map style",
       "expand": "Expand",
       "expandHint": "Tap to expand for controls"
     },

--- a/apps/mobile/lib/i18n/locales/ja.json
+++ b/apps/mobile/lib/i18n/locales/ja.json
@@ -145,10 +145,14 @@
     "ready": {
       "largeTitle": "散歩",
       "walkingWith": "一緒に散歩する犬",
+      "whosComing": "今日の散歩メンバー",
       "selectAll": "すべて選択",
       "deselectAll": "すべて解除",
-      "hint": "タップして開始。ルートを追跡し、そっと記録します。",
+      "hint": "おしっこ・うんち・写真は犬ごとに記録されます。",
       "start": "START",
+      "dogsWalkingBold": "{{count}}頭",
+      "dogsWalkingTail": "でおでかけ",
+      "groupWalk": "グループ散歩",
       "noDogs": "先に犬を登録してください",
       "lastWalk": {
         "never": "はじめての散歩",
@@ -176,6 +180,9 @@
       "resume": "再開",
       "endWalk": "散歩を終了",
       "minimize": "縮小表示",
+      "mapLabel": "地図",
+      "satelliteLabel": "航空",
+      "toggleMapStyle": "地図表示を切り替え",
       "expand": "展開",
       "expandHint": "タップして操作を展開"
     },

--- a/apps/mobile/lib/walk/tracking-manager.test.ts
+++ b/apps/mobile/lib/walk/tracking-manager.test.ts
@@ -118,15 +118,24 @@ describe('beginWalkTracking', () => {
 describe('flushWalkPoints', () => {
   it('batches walk points with MAX_POINTS_PER_BATCH', async () => {
     const addWalkPoints = jest.fn().mockResolvedValue(true);
+    const markUploadedPointCount = jest.fn();
     const points: WalkPoint[] = Array.from({ length: MAX_POINTS_PER_BATCH + 50 }, (_, index) => ({
       lat: 35.68,
       lng: 139.76,
       recordedAt: `2026-04-01T00:${String(index % 60).padStart(2, '0')}:00Z`,
     }));
 
-    await flushWalkPoints({ walkId: 'walk-1', points, addWalkPoints });
+    await flushWalkPoints({
+      walkId: 'walk-1',
+      points,
+      uploadedPointCount: 0,
+      addWalkPoints,
+      markUploadedPointCount,
+    });
 
     expect(addWalkPoints).toHaveBeenCalledTimes(2);
+    expect(markUploadedPointCount).toHaveBeenNthCalledWith(1, MAX_POINTS_PER_BATCH);
+    expect(markUploadedPointCount).toHaveBeenNthCalledWith(2, MAX_POINTS_PER_BATCH + 50);
     expect(addWalkPoints.mock.calls[0][0]).toEqual(
       expect.objectContaining({ points: expect.arrayContaining(points.slice(0, MAX_POINTS_PER_BATCH)) }),
     );

--- a/apps/mobile/lib/walk/tracking-manager.ts
+++ b/apps/mobile/lib/walk/tracking-manager.ts
@@ -14,7 +14,9 @@ interface BeginWalkTrackingOptions {
 interface FlushWalkPointsOptions {
   walkId: string;
   points: WalkPoint[];
+  uploadedPointCount: number;
   addWalkPoints: (args: { walkId: string; points: WalkPointInput[] }) => Promise<unknown>;
+  markUploadedPointCount: (count: number) => void;
 }
 
 export async function beginWalkTracking({ onPoint, onDistanceChange }: BeginWalkTrackingOptions) {
@@ -24,6 +26,7 @@ export async function beginWalkTracking({ onPoint, onDistanceChange }: BeginWalk
     const state = useWalkStore.getState();
     if (state.trackingGeneration !== trackingGeneration) return;
     if (state.phase !== 'recording') return;
+    if (state.isPaused) return;
 
     onPoint(point);
     onDistanceChange?.(useWalkStore.getState().totalDistanceM);
@@ -45,8 +48,18 @@ export function resetWalkTrackingState() {
   useWalkStore.getState().resetTrackingSession();
 }
 
-export async function flushWalkPoints({ walkId, points, addWalkPoints }: FlushWalkPointsOptions) {
-  for (let index = 0; index < points.length; index += MAX_POINTS_PER_BATCH) {
+export async function flushWalkPoints({
+  walkId,
+  points,
+  uploadedPointCount,
+  addWalkPoints,
+  markUploadedPointCount,
+}: FlushWalkPointsOptions) {
+  for (
+    let index = Math.min(uploadedPointCount, points.length);
+    index < points.length;
+    index += MAX_POINTS_PER_BATCH
+  ) {
     const batch = points.slice(index, index + MAX_POINTS_PER_BATCH).map((point) => ({
       lat: point.lat,
       lng: point.lng,
@@ -54,5 +67,6 @@ export async function flushWalkPoints({ walkId, points, addWalkPoints }: FlushWa
     }));
 
     await addWalkPoints({ walkId, points: batch });
+    markUploadedPointCount(index + batch.length);
   }
 }

--- a/apps/mobile/stores/walk-store.test.ts
+++ b/apps/mobile/stores/walk-store.test.ts
@@ -56,6 +56,58 @@ describe('walk-store', () => {
     expect(useWalkStore.getState().isMinimized).toBe(false);
   });
 
+  it('togglePaused pauses and resumes a recording walk while accumulating paused time', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-04-20T10:00:00.000Z'));
+
+    useWalkStore.getState().startRecording('walk-123');
+    useWalkStore.getState().togglePaused();
+
+    expect(useWalkStore.getState().isPaused).toBe(true);
+    expect(useWalkStore.getState().pauseStartedAtMs).toBe(Date.now());
+
+    jest.advanceTimersByTime(5_000);
+    useWalkStore.getState().togglePaused();
+
+    expect(useWalkStore.getState().isPaused).toBe(false);
+    expect(useWalkStore.getState().pauseStartedAtMs).toBeNull();
+    expect(useWalkStore.getState().totalPausedMs).toBe(5_000);
+
+    jest.useRealTimers();
+  });
+
+  it('breaks the route and skips paused displacement on the first point after resume', () => {
+    const p1: WalkPoint = { lat: 35.6812, lng: 139.7671, recordedAt: '2026-03-23T10:00:00Z' };
+    const p2: WalkPoint = { lat: 35.6912, lng: 139.7771, recordedAt: '2026-03-23T10:10:00Z' };
+    const p3: WalkPoint = { lat: 35.6913, lng: 139.7772, recordedAt: '2026-03-23T10:10:05Z' };
+
+    useWalkStore.getState().startRecording('walk-123');
+    useWalkStore.getState().addPoint(p1);
+    useWalkStore.getState().togglePaused();
+    useWalkStore.getState().togglePaused();
+    useWalkStore.getState().addPoint(p2);
+
+    expect(useWalkStore.getState().routeBreakIndices).toEqual([1]);
+    expect(useWalkStore.getState().totalDistanceM).toBe(0);
+
+    useWalkStore.getState().addPoint(p3);
+
+    expect(useWalkStore.getState().totalDistanceM).toBeGreaterThan(0);
+  });
+
+  it('tracks uploaded points monotonically and resets them for a new walk', () => {
+    useWalkStore.getState().startRecording('walk-123');
+
+    useWalkStore.getState().markUploadedPointCount(5);
+    useWalkStore.getState().markUploadedPointCount(3);
+
+    expect(useWalkStore.getState().uploadedPointCount).toBe(5);
+
+    useWalkStore.getState().startRecording('walk-456');
+
+    expect(useWalkStore.getState().uploadedPointCount).toBe(0);
+  });
+
   it('selectDog toggles dog selection', () => {
     const { selectDog } = useWalkStore.getState();
     selectDog('dog-1');
@@ -89,6 +141,23 @@ describe('walk-store', () => {
     useWalkStore.getState().startRecording('walk-123');
     useWalkStore.getState().finish();
     expect(useWalkStore.getState().phase).toBe('finished');
+  });
+
+  it('finish uses the provided timestamp and closes any active paused span', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-04-20T10:00:00.000Z'));
+
+    useWalkStore.getState().startRecording('walk-123');
+    useWalkStore.getState().togglePaused();
+
+    const finishedAt = new Date('2026-04-20T10:00:05.000Z');
+    useWalkStore.getState().finish(finishedAt);
+
+    expect(useWalkStore.getState().finishedAt).toEqual(finishedAt);
+    expect(useWalkStore.getState().totalPausedMs).toBe(5_000);
+    expect(useWalkStore.getState().isPaused).toBe(false);
+
+    jest.useRealTimers();
   });
 
   it('reset returns to ready phase', () => {

--- a/apps/mobile/stores/walk-store.ts
+++ b/apps/mobile/stores/walk-store.ts
@@ -16,8 +16,15 @@ interface WalkState {
   walkId: string | null;
   selectedDogIds: string[];
   points: WalkPoint[];
+  routeBreakIndices: number[];
+  breakRouteOnNextPoint: boolean;
+  uploadedPointCount: number;
   totalDistanceM: number;
   startedAt: Date | null;
+  finishedAt: Date | null;
+  isPaused: boolean;
+  totalPausedMs: number;
+  pauseStartedAtMs: number | null;
   events: WalkEvent[];
   trackingGeneration: number;
   trackingCleanup: (() => void) | null;
@@ -39,19 +46,23 @@ interface WalkState {
   selectDog: (dogId: string) => void;
   setSelectedDogs: (dogIds: string[]) => void;
   startRecording: (walkId: string) => void;
+  abortRecordingStart: () => void;
   addPoint: (point: WalkPoint) => void;
   addEvent: (event: WalkEvent) => void;
   removeEvent: (eventId: string) => void;
   requestCamera: () => void;
   clearCameraRequest: () => void;
   setMinimized: (value: boolean) => void;
+  togglePaused: () => void;
+  resumePausedWalk: () => void;
+  markUploadedPointCount: (count: number) => void;
   activateTrackingSession: () => number;
   attachTrackingCleanup: (generation: number, cleanup: () => void) => boolean;
   stopTrackingSession: () => void;
   resetTrackingSession: () => void;
   setLiveActivity: (activity: LiveActivityState | null) => void;
   bumpLiveActivityUpdateAt: (at: number) => void;
-  finish: () => void;
+  finish: (finishedAt?: Date) => void;
   reset: () => void;
 }
 
@@ -64,8 +75,15 @@ export const useWalkStore = create<WalkState>((set, get) => ({
   walkId: null,
   selectedDogIds: [],
   points: [],
+  routeBreakIndices: [],
+  breakRouteOnNextPoint: false,
+  uploadedPointCount: 0,
   totalDistanceM: 0,
   startedAt: null,
+  finishedAt: null,
+  isPaused: false,
+  totalPausedMs: 0,
+  pauseStartedAtMs: null,
   events: [],
   trackingGeneration: 0,
   trackingCleanup: null,
@@ -83,10 +101,53 @@ export const useWalkStore = create<WalkState>((set, get) => ({
   setSelectedDogs: (dogIds) => set({ selectedDogIds: dogIds }),
 
   startRecording: (walkId) =>
-    set({ phase: 'recording', walkId, startedAt: new Date() }),
+    set({
+      phase: 'recording',
+      walkId,
+      startedAt: new Date(),
+      finishedAt: null,
+      routeBreakIndices: [],
+      breakRouteOnNextPoint: false,
+      uploadedPointCount: 0,
+      isPaused: false,
+      totalPausedMs: 0,
+      pauseStartedAtMs: null,
+    }),
+
+  abortRecordingStart: () =>
+    set((state) => ({
+      phase: 'ready',
+      walkId: null,
+      points: [],
+      routeBreakIndices: [],
+      breakRouteOnNextPoint: false,
+      uploadedPointCount: 0,
+      totalDistanceM: 0,
+      startedAt: null,
+      finishedAt: null,
+      isPaused: false,
+      totalPausedMs: 0,
+      pauseStartedAtMs: null,
+      events: [],
+      cameraRequestedAt: null,
+      isMinimized: false,
+      liveActivity: null,
+      selectedDogIds: state.selectedDogIds,
+    })),
 
   addPoint: (point) =>
     set((state) => {
+      if (state.breakRouteOnNextPoint) {
+        return {
+          points: [...state.points, point],
+          routeBreakIndices:
+            state.points.length > 0
+              ? [...state.routeBreakIndices, state.points.length]
+              : state.routeBreakIndices,
+          breakRouteOnNextPoint: false,
+        };
+      }
+
       const prev = state.points[state.points.length - 1];
       const added = prev ? haversineDistance(prev, point) : 0;
       return {
@@ -106,6 +167,52 @@ export const useWalkStore = create<WalkState>((set, get) => ({
   clearCameraRequest: () => set({ cameraRequestedAt: null }),
 
   setMinimized: (value) => set({ isMinimized: value }),
+
+  togglePaused: () =>
+    set((state) => {
+      if (state.phase !== 'recording' || !state.startedAt) {
+        return {};
+      }
+
+      if (state.isPaused) {
+        const resumedAt = Date.now();
+        return {
+          isPaused: false,
+          breakRouteOnNextPoint: state.points.length > 0,
+          totalPausedMs:
+            state.totalPausedMs +
+            (state.pauseStartedAtMs ? resumedAt - state.pauseStartedAtMs : 0),
+          pauseStartedAtMs: null,
+        };
+      }
+
+      return {
+        isPaused: true,
+        pauseStartedAtMs: Date.now(),
+      };
+    }),
+
+  resumePausedWalk: () =>
+    set((state) => {
+      if (!state.isPaused) {
+        return {};
+      }
+
+      const resumedAt = Date.now();
+      return {
+        isPaused: false,
+        breakRouteOnNextPoint: state.points.length > 0,
+        totalPausedMs:
+          state.totalPausedMs +
+          (state.pauseStartedAtMs ? resumedAt - state.pauseStartedAtMs : 0),
+        pauseStartedAtMs: null,
+      };
+    }),
+
+  markUploadedPointCount: (count) =>
+    set((state) => ({
+      uploadedPointCount: Math.max(state.uploadedPointCount, count),
+    })),
 
   activateTrackingSession: () => {
     const nextGeneration = get().trackingGeneration + 1;
@@ -144,7 +251,20 @@ export const useWalkStore = create<WalkState>((set, get) => ({
       state.liveActivity ? { liveActivity: { ...state.liveActivity, lastUpdateAt: at } } : {},
     ),
 
-  finish: () => set({ phase: 'finished', cameraRequestedAt: null, isMinimized: false }),
+  finish: (finishedAt = new Date()) =>
+    set((state) => ({
+      phase: 'finished',
+      cameraRequestedAt: null,
+      isMinimized: false,
+      finishedAt,
+      totalPausedMs:
+        state.totalPausedMs +
+        (state.isPaused && state.pauseStartedAtMs
+          ? Math.max(0, finishedAt.getTime() - state.pauseStartedAtMs)
+          : 0),
+      isPaused: false,
+      pauseStartedAtMs: null,
+    })),
 
   reset: () => {
     const cleanup = get().trackingCleanup;
@@ -153,8 +273,15 @@ export const useWalkStore = create<WalkState>((set, get) => ({
       walkId: null,
       selectedDogIds: [],
       points: [],
+      routeBreakIndices: [],
+      breakRouteOnNextPoint: false,
+      uploadedPointCount: 0,
       totalDistanceM: 0,
       startedAt: null,
+      finishedAt: null,
+      isPaused: false,
+      totalPausedMs: 0,
+      pauseStartedAtMs: null,
       events: [],
       trackingGeneration: 0,
       trackingCleanup: null,


### PR DESCRIPTION
## Summary
- redesign the walk ready state with a clearer dog picker, group-walk summary card, and updated localized copy
- refresh the active walk experience with the floating top bar, minimized controls flow, glass sheet controls, map style toggle, and route preview updates
- harden walk session behavior by making pause state store-backed, segmenting routes across pauses, freezing finished summaries at stop time, and making stop persistence retry-safe
- add coverage for the redesigned walk UI, walk session lifecycle, tracking manager, and walk store behavior

## Testing
- cd apps/mobile && npm test -- --watchAll=false
- cd apps/mobile && npm run typecheck
- cd apps/mobile && npm run lint

## Notes
- lint still reports pre-existing warnings in untouched UI test files under apps/mobile/components/ui
