### PR TITLE
feat(mobile): redesign Walk tab ready UI (map + glass card)

### DIFF
--- a/apps/mobile/__tests__/app/tabs/walk.test.tsx
+++ b/apps/mobile/__tests__/app/tabs/walk.test.tsx
@@ -1,0 +1,115 @@
+import type { ReactNode } from 'react';
+import { render, screen } from '@testing-library/react-native';
+import WalkScreen from '../../../app/(tabs)/walk';
+import type { Dog } from '@/types/graphql';
+
+jest.mock('@/hooks/use-color-scheme', () => ({ useColorScheme: () => 'light' }));
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+  useLocalSearchParams: () => ({}),
+}));
+jest.mock('expo-image', () => ({ Image: 'Image' }));
+
+jest.mock('@/components/walk/WalkMap', () => ({ WalkMap: () => null }));
+jest.mock('@/components/walk/WalkMapShell', () => {
+  const { View } = jest.requireActual('react-native');
+  return {
+    WalkMapShell: ({
+      map,
+      top,
+      bottom,
+    }: {
+      map: ReactNode;
+      top: ReactNode;
+      bottom: ReactNode;
+    }) => (
+      <View>
+        {map}
+        {top}
+        {bottom}
+      </View>
+    ),
+  };
+});
+jest.mock('@/components/walk/WalkSummaryCard', () => ({ WalkSummaryCard: () => null }));
+
+type Phase = 'ready' | 'recording' | 'finished';
+let mockDogs: Dog[] = [];
+let mockPhase: Phase = 'ready';
+
+jest.mock('@/hooks/use-me', () => ({
+  useMe: () => ({ data: { dogs: mockDogs }, isLoading: false }),
+}));
+
+jest.mock('@/hooks/use-pack-progress', () => ({
+  usePackProgress: () => ({
+    todayKm: 0,
+    goalKm: 5,
+    progressPct: 0,
+    packStreakDays: 0,
+    perDog: {},
+    isLoading: false,
+  }),
+}));
+
+type StoreState = {
+  selectedDogIds: string[];
+  phase: Phase;
+  selectDog: (id: string) => void;
+  setSelectedDogs: (ids: string[]) => void;
+};
+
+jest.mock('@/stores/walk-store', () => ({
+  useWalkStore: (selector: (s: StoreState) => unknown) =>
+    selector({
+      selectedDogIds: [],
+      phase: mockPhase,
+      selectDog: jest.fn(),
+      setSelectedDogs: jest.fn(),
+    }),
+}));
+
+jest.mock('@/hooks/use-walk-screen-view-model', () => ({
+  useWalkScreenViewModel: () => ({
+    phase: mockPhase,
+    isStarting: false,
+    handleStart: jest.fn(),
+  }),
+}));
+
+const buildDog = (overrides: Partial<Dog>): Dog =>
+  ({
+    id: 'd1',
+    name: 'Coco',
+    breed: 'Toy Poodle',
+    gender: null,
+    birthDate: null,
+    photoUrl: null,
+    createdAt: '2026-01-01',
+    ...overrides,
+  }) as Dog;
+
+describe('Walk tab route', () => {
+  beforeEach(() => {
+    mockDogs = [];
+    mockPhase = 'ready';
+  });
+
+  it('shows the NoDogsBody CTA when there are zero dogs', () => {
+    mockDogs = [];
+    render(<WalkScreen />);
+    expect(screen.getByRole('button', { name: 'Add your first dog' })).toBeTruthy();
+  });
+
+  it('shows the START WALK button for a single dog', () => {
+    mockDogs = [buildDog({})];
+    render(<WalkScreen />);
+    expect(screen.getByRole('button', { name: 'START WALK' })).toBeTruthy();
+  });
+
+  it('shows the Walking with section header for 2+ dogs', () => {
+    mockDogs = [buildDog({}), buildDog({ id: 'd2', name: 'Momo' })];
+    render(<WalkScreen />);
+    expect(screen.getByText('Walking with')).toBeTruthy();
+  });
+});

--- a/apps/mobile/app/(tabs)/walk.tsx
+++ b/apps/mobile/app/(tabs)/walk.tsx
@@ -9,9 +9,12 @@ export default function WalkScreen() {
   const theme = useColors();
   const vm = useWalkScreenViewModel();
 
+  if (vm.phase === 'ready') {
+    return <WalkReadyView onStart={vm.handleStart} isStarting={vm.isStarting} />;
+  }
+
   return (
     <SafeAreaView edges={['top']} style={[styles.container, { backgroundColor: theme.background }]}>
-      {vm.phase === 'ready' && <WalkReadyView onStart={vm.handleStart} isStarting={vm.isStarting} />}
       {vm.phase === 'finished' && <WalkSummaryCard />}
     </SafeAreaView>
   );

--- a/apps/mobile/app/walk-recording.tsx
+++ b/apps/mobile/app/walk-recording.tsx
@@ -1,13 +1,12 @@
 import { useEffect, useMemo, useRef } from 'react';
 import { StyleSheet, View } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { router, useLocalSearchParams } from 'expo-router';
 import { useColors } from '@/hooks/use-colors';
 import { useWalkStore } from '@/stores/walk-store';
 import { useMe } from '@/hooks/use-me';
 import { WalkMap } from '@/components/walk/WalkMap';
+import { WalkMapShell } from '@/components/walk/WalkMapShell';
 import { WalkTopChip } from '@/components/walk/WalkTopChip';
-import { spacing } from '@/theme/tokens';
 import type { Dog } from '@/types/graphql';
 
 export default function WalkRecordingScreen() {
@@ -17,7 +16,6 @@ export default function WalkRecordingScreen() {
   const params = useLocalSearchParams<{ action?: string }>();
 
   const { data: me } = useMe();
-  const insets = useSafeAreaInsets();
 
   const hasPushedRef = useRef(false);
   useEffect(() => {
@@ -37,20 +35,11 @@ export default function WalkRecordingScreen() {
 
   return (
     <View style={[styles.container, { backgroundColor: theme.background }]}>
-      <WalkMap />
-      <View style={[styles.topOverlay, { top: insets.top + spacing.xs }]}>
-        <WalkTopChip dogs={selectedDogs} />
-      </View>
+      <WalkMapShell map={<WalkMap mode="recording" />} top={<WalkTopChip dogs={selectedDogs} />} />
     </View>
   );
 }
 
 const styles = StyleSheet.create({
   container: { flex: 1 },
-  topOverlay: {
-    position: 'absolute',
-    left: 0,
-    right: 0,
-    alignItems: 'center',
-  },
 });

--- a/apps/mobile/components/walk/DogPickerCard.tsx
+++ b/apps/mobile/components/walk/DogPickerCard.tsx
@@ -25,54 +25,18 @@ export function DogPickerCard({
   variant = 'multi',
 }: DogPickerCardProps) {
   const theme = useColors();
-  const { t } = useTranslation();
   const now = useMemo(() => new Date(), []);
-  const showCheckbox = variant === 'multi';
+  const interactive = variant === 'multi';
 
   return (
     <GroupedCard>
       {dogs.map((dog, index) => {
         const isSelected = selectedIds.includes(dog.id);
         const isLast = index === dogs.length - 1;
-        const lastWalkText = formatLastWalk(dog.latestWalk?.endedAt, now, t);
-        const rowContent = (
-          <>
-            <Image
-              source={dog.photoUrl ?? require('@/assets/images/icon.png')}
-              style={styles.avatar}
-              contentFit="cover"
-            />
-            <View style={styles.textCol}>
-              <Text style={[styles.name, { color: theme.onSurface }]} numberOfLines={1}>
-                {dog.name}
-              </Text>
-              <Text
-                style={[styles.lastWalk, { color: theme.onSurfaceVariant }]}
-                numberOfLines={1}
-              >
-                {lastWalkText}
-              </Text>
-            </View>
-            {showCheckbox ? (
-              isSelected ? (
-                <View style={[styles.check, { backgroundColor: theme.interactive }]}>
-                  <Text style={styles.checkMark}>✓</Text>
-                </View>
-              ) : (
-                <View
-                  style={[
-                    styles.check,
-                    styles.checkEmpty,
-                    { borderColor: theme.textDisabled },
-                  ]}
-                />
-              )
-            ) : null}
-          </>
-        );
+
         return (
           <Fragment key={dog.id}>
-            {showCheckbox ? (
+            {interactive ? (
               <Pressable
                 accessibilityRole="checkbox"
                 accessibilityLabel={dog.name}
@@ -80,11 +44,17 @@ export function DogPickerCard({
                 onPress={() => onToggle(dog.id)}
                 style={styles.row}
               >
-                {rowContent}
+                <DogPickerRow dog={dog} isSelected={isSelected} now={now} showSelection />
               </Pressable>
             ) : (
               <View accessibilityLabel={dog.name} style={styles.row}>
-                {rowContent}
+                <DogPickerRow
+                  dog={dog}
+                  isSelected={isSelected}
+                  now={now}
+                  showSelection={false}
+                  showChevron
+                />
               </View>
             )}
             {!isLast ? (
@@ -99,6 +69,71 @@ export function DogPickerCard({
         );
       })}
     </GroupedCard>
+  );
+}
+
+interface DogPickerRowProps {
+  dog: Dog;
+  isSelected: boolean;
+  now: Date;
+  showSelection: boolean;
+  showChevron?: boolean;
+}
+
+function DogPickerRow({
+  dog,
+  isSelected,
+  now,
+  showSelection,
+  showChevron,
+}: DogPickerRowProps) {
+  const theme = useColors();
+  const { t } = useTranslation();
+  const lastWalkText = formatLastWalk(dog.latestWalk?.endedAt, now, t);
+
+  return (
+    <>
+      <Image
+        source={dog.photoUrl ?? require('@/assets/images/icon.png')}
+        style={styles.avatar}
+        contentFit="cover"
+      />
+      <View style={styles.textCol}>
+        <Text style={[styles.name, { color: theme.onSurface }]} numberOfLines={1}>
+          {dog.name}
+        </Text>
+        <Text style={[styles.lastWalk, { color: theme.onSurfaceVariant }]} numberOfLines={1}>
+          {lastWalkText}
+        </Text>
+      </View>
+
+      {showSelection ? <SelectionIndicator isSelected={isSelected} /> : null}
+      {!showSelection && showChevron ? (
+        <Text style={[styles.chevron, { color: theme.textDisabled }]}>›</Text>
+      ) : null}
+    </>
+  );
+}
+
+function SelectionIndicator({ isSelected }: { isSelected: boolean }) {
+  const theme = useColors();
+
+  if (!isSelected) {
+    return (
+      <View
+        style={[
+          styles.check,
+          styles.checkEmpty,
+          { borderColor: theme.textDisabled },
+        ]}
+      />
+    );
+  }
+
+  return (
+    <View style={[styles.check, { backgroundColor: theme.interactive }]}>
+      <Text style={styles.checkMark}>✓</Text>
+    </View>
   );
 }
 
@@ -148,5 +183,10 @@ const styles = StyleSheet.create({
   },
   separator: {
     height: StyleSheet.hairlineWidth,
+  },
+  chevron: {
+    fontSize: 22,
+    fontWeight: '300',
+    paddingLeft: spacing.xs,
   },
 });

--- a/apps/mobile/components/walk/NoDogsBody.test.tsx
+++ b/apps/mobile/components/walk/NoDogsBody.test.tsx
@@ -1,0 +1,28 @@
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { NoDogsBody } from './NoDogsBody';
+
+const mockPush = jest.fn();
+
+jest.mock('@/hooks/use-color-scheme', () => ({ useColorScheme: () => 'light' }));
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ push: (...args: unknown[]) => mockPush(...args) }),
+}));
+
+describe('NoDogsBody', () => {
+  beforeEach(() => {
+    mockPush.mockReset();
+  });
+
+  it('renders title, body and CTA button', () => {
+    render(<NoDogsBody />);
+    expect(screen.getByText('No dogs yet')).toBeTruthy();
+    expect(screen.getByText(/Add a dog to your pack/)).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Add your first dog' })).toBeTruthy();
+  });
+
+  it('navigates to /dogs/new when CTA is pressed', () => {
+    render(<NoDogsBody />);
+    fireEvent.press(screen.getByRole('button', { name: 'Add your first dog' }));
+    expect(mockPush).toHaveBeenCalledWith('/dogs/new');
+  });
+});

--- a/apps/mobile/components/walk/NoDogsBody.tsx
+++ b/apps/mobile/components/walk/NoDogsBody.tsx
@@ -1,0 +1,82 @@
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { useRouter } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { useColors } from '@/hooks/use-colors';
+import { radius, spacing, typography } from '@/theme/tokens';
+
+export function NoDogsBody() {
+  const { t } = useTranslation();
+  const theme = useColors();
+  const router = useRouter();
+
+  const ctaLabel = t('walk.ready.noDogsCta');
+  const handleAdd = () => router.push('/dogs/new');
+
+  return (
+    <View style={styles.container}>
+      <View style={[styles.illustration, { backgroundColor: theme.surfaceContainer }]}>
+        <Text style={styles.illustrationEmoji}>🐶</Text>
+      </View>
+      <Text style={[styles.title, { color: theme.onSurface }]}>
+        {t('walk.ready.noDogsTitle')}
+      </Text>
+      <Text style={[styles.body, { color: theme.onSurfaceVariant }]}>
+        {t('walk.ready.noDogs')}
+      </Text>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={ctaLabel}
+        onPress={handleAdd}
+        style={({ pressed }) => [
+          styles.cta,
+          { backgroundColor: theme.interactive, opacity: pressed ? 0.85 : 1 },
+        ]}
+      >
+        <Text style={[styles.ctaLabel, { color: theme.onInteractive }]}>＋ {ctaLabel}</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    paddingVertical: spacing.md,
+    gap: spacing.sm,
+  },
+  illustration: {
+    width: 96,
+    height: 96,
+    borderRadius: 48,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: spacing.sm,
+  },
+  illustrationEmoji: {
+    fontSize: 44,
+  },
+  title: {
+    ...typography.title2,
+    textAlign: 'center',
+  },
+  body: {
+    ...typography.subheadline,
+    textAlign: 'center',
+    maxWidth: 280,
+    lineHeight: 22,
+  },
+  cta: {
+    marginTop: spacing.md,
+    paddingHorizontal: spacing.lg,
+    height: 50,
+    borderRadius: radius.lg,
+    alignItems: 'center',
+    justifyContent: 'center',
+    minWidth: 220,
+  },
+  ctaLabel: {
+    ...typography.button,
+    fontSize: 17,
+    fontWeight: '600',
+  },
+});

--- a/apps/mobile/components/walk/WalkMap.tsx
+++ b/apps/mobile/components/walk/WalkMap.tsx
@@ -1,4 +1,4 @@
-import { StyleSheet, View, Text } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
 import MapView, { Polyline, Marker } from 'react-native-maps';
 import { useColors } from '@/hooks/use-colors';
 import { useWalkStore } from '@/stores/walk-store';
@@ -10,10 +10,15 @@ import { TOKYO_STATION_COORDINATE } from '@/lib/walk/constants';
  * from `walk-store` so the entire visible state comes from one source of
  * truth. Event markers update in lockstep with `WalkEventActions` writes.
  */
-export function WalkMap() {
+interface WalkMapProps {
+  mode?: 'preview' | 'recording';
+}
+
+export function WalkMap({ mode = 'recording' }: WalkMapProps) {
   const theme = useColors();
   const points = useWalkStore((s) => s.points);
   const events = useWalkStore((s) => s.events);
+  const isRecording = mode === 'recording';
 
   const coordinates = points.map((p) => ({ latitude: p.lat, longitude: p.lng }));
   const lastPoint = coordinates[coordinates.length - 1];
@@ -22,8 +27,8 @@ export function WalkMap() {
     <View style={styles.container}>
       <MapView
         style={styles.map}
-        showsUserLocation
-        followsUserLocation
+        showsUserLocation={isRecording}
+        followsUserLocation={isRecording}
         initialRegion={
           lastPoint
             ? {
@@ -40,26 +45,28 @@ export function WalkMap() {
               }
         }
       >
-        {coordinates.length >= 2 ? (
+        {isRecording && coordinates.length >= 2 ? (
           <Polyline
             coordinates={coordinates}
             strokeColor={theme.interactive}
             strokeWidth={4}
           />
         ) : null}
-        {lastPoint ? <Marker coordinate={lastPoint} /> : null}
-        {events
-          .filter((e) => e.lat != null && e.lng != null)
-          .map((e) => (
-            <Marker
-              key={e.id}
-              testID={`event-marker-${e.id}`}
-              coordinate={{ latitude: e.lat!, longitude: e.lng! }}
-              accessibilityLabel={`${MAP_EVENT_EMOJIS[e.eventType]} event at ${e.occurredAt}`}
-            >
-              <Text style={styles.eventMarker}>{MAP_EVENT_EMOJIS[e.eventType]}</Text>
-            </Marker>
-          ))}
+        {isRecording && lastPoint ? <Marker coordinate={lastPoint} /> : null}
+        {isRecording
+          ? events
+              .filter((e) => e.lat != null && e.lng != null)
+              .map((e) => (
+                <Marker
+                  key={e.id}
+                  testID={`event-marker-${e.id}`}
+                  coordinate={{ latitude: e.lat!, longitude: e.lng! }}
+                  accessibilityLabel={`${MAP_EVENT_EMOJIS[e.eventType]} event at ${e.occurredAt}`}
+                >
+                  <Text style={styles.eventMarker}>{MAP_EVENT_EMOJIS[e.eventType]}</Text>
+                </Marker>
+              ))
+          : null}
       </MapView>
     </View>
   );

--- a/apps/mobile/components/walk/WalkMapShell.tsx
+++ b/apps/mobile/components/walk/WalkMapShell.tsx
@@ -1,0 +1,57 @@
+import type { ReactNode } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { spacing } from '@/theme/tokens';
+
+interface WalkMapShellProps {
+  map: ReactNode;
+  top?: ReactNode;
+  bottom?: ReactNode;
+}
+
+export function WalkMapShell({ map, top, bottom }: WalkMapShellProps) {
+  const insets = useSafeAreaInsets();
+
+  return (
+    <View style={styles.container}>
+      {map}
+
+      {top ? (
+        <View style={[styles.topOverlay, { top: insets.top + spacing.xs }]}>{top}</View>
+      ) : null}
+
+      {bottom ? (
+        <View
+          style={[
+            styles.bottomOverlay,
+            {
+              paddingBottom: Math.max(insets.bottom, spacing.md),
+            },
+          ]}
+        >
+          {bottom}
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  topOverlay: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    alignItems: 'center',
+    paddingHorizontal: spacing.md,
+  },
+  bottomOverlay: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    paddingHorizontal: spacing.md,
+  },
+});

--- a/apps/mobile/components/walk/WalkReadyStatsRow.test.tsx
+++ b/apps/mobile/components/walk/WalkReadyStatsRow.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react-native';
+import { WalkReadyStatsRow } from './WalkReadyStatsRow';
+
+jest.mock('@/hooks/use-color-scheme', () => ({ useColorScheme: () => 'light' }));
+jest.mock('@/hooks/use-pack-progress', () => ({
+  usePackProgress: () => ({
+    todayKm: 3.52,
+    goalKm: 5,
+    progressPct: 70,
+    packStreakDays: 12,
+    perDog: {},
+    isLoading: false,
+  }),
+}));
+
+describe('WalkReadyStatsRow', () => {
+  it('renders Today / Streak / Goal labels and values', () => {
+    render(<WalkReadyStatsRow />);
+    expect(screen.getByText('Today')).toBeTruthy();
+    expect(screen.getByText('3.52 km')).toBeTruthy();
+    expect(screen.getByText('Streak')).toBeTruthy();
+    expect(screen.getByText(/12d/)).toBeTruthy();
+    expect(screen.getByText('Goal')).toBeTruthy();
+    expect(screen.getByText('70%')).toBeTruthy();
+  });
+});

--- a/apps/mobile/components/walk/WalkReadyStatsRow.tsx
+++ b/apps/mobile/components/walk/WalkReadyStatsRow.tsx
@@ -1,0 +1,76 @@
+import { StyleSheet, Text, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { useColors } from '@/hooks/use-colors';
+import { usePackProgress } from '@/hooks/use-pack-progress';
+import { radius, spacing, typography } from '@/theme/tokens';
+
+interface StatCell {
+  label: string;
+  value: string;
+  icon?: string;
+}
+
+export function WalkReadyStatsRow() {
+  const { t } = useTranslation();
+  const theme = useColors();
+  const pack = usePackProgress();
+
+  const cells: StatCell[] = [
+    {
+      label: t('walk.ready.stats.today'),
+      value: t('walk.ready.stats.kmShort', { value: pack.todayKm.toFixed(2) }),
+    },
+    {
+      label: t('walk.ready.stats.streak'),
+      value: t('walk.ready.stats.streakDays', { count: pack.packStreakDays }),
+      icon: '🔥',
+    },
+    {
+      label: t('walk.ready.stats.goal'),
+      value: t('walk.ready.stats.goalPercent', { value: pack.progressPct }),
+    },
+  ];
+
+  return (
+    <View style={[styles.row, { backgroundColor: theme.surfaceContainer }]}>
+      {cells.map((cell) => (
+        <View key={cell.label} style={styles.cell}>
+          <Text style={[styles.label, { color: theme.onSurfaceVariant }]}>{cell.label}</Text>
+          <Text style={[styles.value, { color: theme.onSurface }]} numberOfLines={1}>
+            {cell.icon ? <Text style={styles.icon}>{cell.icon} </Text> : null}
+            {cell.value}
+          </Text>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    borderRadius: radius.lg,
+    paddingVertical: spacing.step12,
+    paddingHorizontal: spacing.sm,
+  },
+  cell: {
+    flex: 1,
+    alignItems: 'center',
+    gap: 2,
+  },
+  label: {
+    ...typography.caption,
+    fontSize: 11,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    letterSpacing: 0.3,
+  },
+  value: {
+    ...typography.title2,
+    fontSize: 20,
+    lineHeight: 24,
+  },
+  icon: {
+    fontSize: 14,
+  },
+});

--- a/apps/mobile/components/walk/WalkReadyView.test.tsx
+++ b/apps/mobile/components/walk/WalkReadyView.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react-native';
+import type { ReactNode } from 'react';
 import { WalkReadyView } from './WalkReadyView';
 import type { Dog } from '@/types/graphql';
 
@@ -12,6 +13,34 @@ jest.mock('expo-router', () => ({
 
 jest.mock('expo-image', () => ({
   Image: 'Image',
+}));
+
+jest.mock('@/components/walk/WalkMap', () => ({
+  WalkMap: () => null,
+}));
+
+jest.mock('@/components/walk/WalkMapShell', () => {
+  const { View } = jest.requireActual('react-native');
+  return {
+    WalkMapShell: ({ map, top, bottom }: { map: ReactNode; top: ReactNode; bottom: ReactNode }) => (
+      <View>
+        {map}
+        {top}
+        {bottom}
+      </View>
+    ),
+  };
+});
+
+jest.mock('@/hooks/use-pack-progress', () => ({
+  usePackProgress: () => ({
+    todayKm: 0,
+    goalKm: 5,
+    progressPct: 0,
+    packStreakDays: 0,
+    perDog: {},
+    isLoading: false,
+  }),
 }));
 
 const FIXED_NOW = new Date('2026-04-19T12:00:00Z');
@@ -93,7 +122,7 @@ describe('WalkReadyView', () => {
     mockDogs = [coco, momo];
   });
 
-  it('renders the Walk largeTitle', () => {
+  it('renders the static "Walk" top chip label', () => {
     render(<WalkReadyView onStart={jest.fn()} isStarting={false} />);
     expect(screen.getByText('Walk')).toBeTruthy();
   });
@@ -104,17 +133,24 @@ describe('WalkReadyView', () => {
     expect(screen.getByText('Select all')).toBeTruthy();
   });
 
-  it('disables START when no dog is selected', () => {
+  it('renders the Today / Streak / Goal stats row when dogs exist', () => {
     render(<WalkReadyView onStart={jest.fn()} isStarting={false} />);
-    const btn = screen.getByRole('button', { name: 'START' });
+    expect(screen.getByText('Today')).toBeTruthy();
+    expect(screen.getByText('Streak')).toBeTruthy();
+    expect(screen.getByText('Goal')).toBeTruthy();
+  });
+
+  it('disables START WALK when no dog is selected', () => {
+    render(<WalkReadyView onStart={jest.fn()} isStarting={false} />);
+    const btn = screen.getByRole('button', { name: 'START WALK' });
     expect(btn.props.accessibilityState.disabled).toBe(true);
   });
 
-  it('enables START when at least one dog is selected and calls onStart', () => {
+  it('enables START WALK when at least one dog is selected and calls onStart', () => {
     mockStore = buildStore(['dog-1']);
     const onStart = jest.fn();
     render(<WalkReadyView onStart={onStart} isStarting={false} />);
-    const btn = screen.getByRole('button', { name: 'START' });
+    const btn = screen.getByRole('button', { name: 'START WALK' });
     expect(btn.props.accessibilityState.disabled).toBe(false);
     fireEvent.press(btn);
     expect(onStart).toHaveBeenCalledTimes(1);
@@ -134,25 +170,12 @@ describe('WalkReadyView', () => {
     expect(mockStore.setSelectedDogs).toHaveBeenCalledWith([]);
   });
 
-  it('renders the Precise hint copy', () => {
-    render(<WalkReadyView onStart={jest.fn()} isStarting={false} />);
-    expect(
-      screen.getByText(
-        "Tap to begin. We'll follow your route and log everything gently.",
-      ),
-    ).toBeTruthy();
-  });
-
-  it('does not render a Group walk summary anymore', () => {
-    mockStore = buildStore(['dog-1', 'dog-2']);
-    render(<WalkReadyView onStart={jest.fn()} isStarting={false} />);
-    expect(screen.queryByText('Group walk')).toBeNull();
-  });
-
-  it('shows the noDogs empty state when user has zero dogs', () => {
+  it('shows the noDogs empty state with CTA when user has zero dogs', () => {
     mockDogs = [];
     render(<WalkReadyView onStart={jest.fn()} isStarting={false} />);
-    expect(screen.getByText('Register a dog first')).toBeTruthy();
+    expect(screen.getByText('No dogs yet')).toBeTruthy();
+    expect(screen.getByText(/Add a dog to your pack/)).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Add your first dog' })).toBeTruthy();
   });
 
   describe('single-dog variant', () => {
@@ -166,14 +189,24 @@ describe('WalkReadyView', () => {
       expect(screen.queryByText('Select all')).toBeNull();
     });
 
-    it('hides the checkbox but still renders the dog', () => {
+    it('hides the Walking with section header (design 04b)', () => {
+      render(<WalkReadyView onStart={jest.fn()} isStarting={false} />);
+      expect(screen.queryByText('Walking with')).toBeNull();
+    });
+
+    it('hides the checkbox but renders the dog with last-walk text', () => {
       render(<WalkReadyView onStart={jest.fn()} isStarting={false} />);
       expect(screen.queryByRole('checkbox', { name: 'Coco' })).toBeNull();
       expect(screen.getByText('Coco')).toBeTruthy();
       expect(screen.getByText('Last walk 14 hours ago')).toBeTruthy();
     });
 
-    it('auto-selects the only dog so START is enabled', () => {
+    it('shows a trailing chevron on the single dog row', () => {
+      render(<WalkReadyView onStart={jest.fn()} isStarting={false} />);
+      expect(screen.getByText('›')).toBeTruthy();
+    });
+
+    it('auto-selects the only dog so START WALK is enabled', () => {
       render(<WalkReadyView onStart={jest.fn()} isStarting={false} />);
       expect(mockStore.setSelectedDogs).toHaveBeenCalledWith(['dog-1']);
     });

--- a/apps/mobile/components/walk/WalkReadyView.tsx
+++ b/apps/mobile/components/walk/WalkReadyView.tsx
@@ -1,14 +1,18 @@
 import { useCallback, useEffect, useMemo } from 'react';
-import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
-import { Button } from '@/components/ui/Button';
 import { GroupedCard } from '@/components/ui/GroupedCard';
-import { SectionHeader } from '@/components/ui/SectionHeader';
 import { DogPickerCard } from '@/components/walk/DogPickerCard';
+import { NoDogsBody } from '@/components/walk/NoDogsBody';
+import { WalkMap } from '@/components/walk/WalkMap';
+import { WalkMapShell } from '@/components/walk/WalkMapShell';
+import { WalkReadyStatsRow } from '@/components/walk/WalkReadyStatsRow';
+import { WalkStartButton } from '@/components/walk/WalkStartButton';
+import { WalkTopChip } from '@/components/walk/WalkTopChip';
 import { useColors } from '@/hooks/use-colors';
 import { useMe } from '@/hooks/use-me';
 import { useWalkStore } from '@/stores/walk-store';
-import { spacing, typography } from '@/theme/tokens';
+import { elevation, spacing, typography } from '@/theme/tokens';
 import type { Dog } from '@/types/graphql';
 
 interface WalkReadyViewProps {
@@ -49,102 +53,106 @@ export function WalkReadyView({ onStart, isStarting }: WalkReadyViewProps) {
   const selectAllLabel = allSelected
     ? t('walk.ready.deselectAll')
     : t('walk.ready.selectAll');
-  const showSelectAll = dogs.length >= 2;
+  const selectedDogs = dogs.filter((dog) => selectedDogIds.includes(dog.id));
 
   return (
-    <ScrollView
-      style={styles.container}
-      contentContainerStyle={styles.content}
-      showsVerticalScrollIndicator={false}
-    >
-      <Text style={[styles.largeTitle, { color: theme.onSurface }]}>
-        {t('walk.ready.largeTitle')}
-      </Text>
+    <View style={styles.container}>
+      <WalkMapShell
+        map={<WalkMap mode="preview" />}
+        top={<WalkTopChip dogs={selectedDogs} label={t('walk.ready.topLabelStatic')} />}
+        bottom={
+          <GroupedCard
+            style={[
+              styles.bottomCard,
+              { backgroundColor: theme.material, borderColor: theme.border },
+              elevation.mid,
+            ]}
+          >
+            <View style={[styles.grabber, { backgroundColor: theme.textDisabled }]} />
 
-      <View style={styles.walkingWith}>
-        <SectionHeader
-          label={t('walk.ready.walkingWith')}
-          trailing={
-            showSelectAll ? (
-              <Pressable
-                accessibilityRole="button"
-                accessibilityLabel={selectAllLabel}
-                onPress={handleSelectAll}
-                hitSlop={8}
-              >
-                <Text style={[styles.selectAll, { color: theme.interactive }]}>
-                  {selectAllLabel}
-                </Text>
-              </Pressable>
-            ) : null
-          }
-        />
-
-        {dogs.length === 0 ? (
-          <GroupedCard padding="lg">
-            <Text style={[styles.emptyText, { color: theme.onSurfaceVariant }]}>
-              {t('walk.ready.noDogs')}
-            </Text>
+            {dogs.length === 0 ? (
+              <NoDogsBody />
+            ) : isSingleDog ? (
+              <View style={styles.bodyColumn}>
+                <DogPickerCard
+                  dogs={[dogs[0]]}
+                  selectedIds={selectedDogIds}
+                  onToggle={() => undefined}
+                  variant="single"
+                />
+                <WalkReadyStatsRow />
+                <WalkStartButton onPress={onStart} disabled={!canStart} loading={isStarting} />
+              </View>
+            ) : (
+              <View style={styles.bodyColumn}>
+                <View style={styles.sectionHeader}>
+                  <Text style={[styles.sectionTitle, { color: theme.onSurfaceVariant }]}>
+                    {t('walk.ready.walkingWith')}
+                  </Text>
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityLabel={selectAllLabel}
+                    onPress={handleSelectAll}
+                    hitSlop={8}
+                  >
+                    <Text style={[styles.selectAll, { color: theme.interactive }]}>
+                      {selectAllLabel}
+                    </Text>
+                  </Pressable>
+                </View>
+                <DogPickerCard
+                  dogs={dogs}
+                  selectedIds={selectedDogIds}
+                  onToggle={selectDog}
+                  variant="multi"
+                />
+                <WalkReadyStatsRow />
+                <WalkStartButton onPress={onStart} disabled={!canStart} loading={isStarting} />
+              </View>
+            )}
           </GroupedCard>
-        ) : (
-          <DogPickerCard
-            dogs={dogs}
-            selectedIds={selectedDogIds}
-            onToggle={selectDog}
-            variant={isSingleDog ? 'single' : 'multi'}
-          />
-        )}
-      </View>
-
-      <View style={styles.ctaColumn}>
-        <Button
-          label={t('walk.ready.start')}
-          variant="success"
-          size="circle"
-          onPress={onStart}
-          disabled={!canStart}
-          loading={isStarting}
-        />
-        <Text style={[styles.hint, { color: theme.onSurfaceVariant }]}>
-          {t('walk.ready.hint')}
-        </Text>
-      </View>
-    </ScrollView>
+        }
+      />
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1 },
-  content: {
-    paddingBottom: spacing.xxl,
+  container: {
+    flex: 1,
   },
-  largeTitle: {
-    ...typography.largeTitle,
-    paddingHorizontal: spacing.lg,
+  bottomCard: {
+    borderWidth: StyleSheet.hairlineWidth,
+    paddingHorizontal: spacing.md,
     paddingTop: spacing.md,
-    paddingBottom: spacing.sm,
+    paddingBottom: spacing.lg,
   },
-  walkingWith: {
-    marginTop: spacing.md,
-    paddingHorizontal: spacing.sm,
+  grabber: {
+    width: 36,
+    height: 5,
+    borderRadius: 3,
+    alignSelf: 'center',
+    marginTop: -spacing.xs,
+    marginBottom: spacing.md,
+    opacity: 0.6,
+  },
+  bodyColumn: {
+    gap: spacing.md,
+  },
+  sectionHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  sectionTitle: {
+    ...typography.caption,
+    fontSize: 13,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
   },
   selectAll: {
     fontSize: 13,
     fontWeight: '500',
-  },
-  emptyText: {
-    ...typography.body,
-    textAlign: 'center',
-  },
-  ctaColumn: {
-    alignItems: 'center',
-    paddingTop: spacing.xl,
-    paddingHorizontal: spacing.lg,
-  },
-  hint: {
-    ...typography.footnote,
-    textAlign: 'center',
-    marginTop: spacing.lg,
-    maxWidth: 300,
   },
 });

--- a/apps/mobile/components/walk/WalkStartButton.test.tsx
+++ b/apps/mobile/components/walk/WalkStartButton.test.tsx
@@ -1,0 +1,32 @@
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { WalkStartButton } from './WalkStartButton';
+
+jest.mock('@/hooks/use-color-scheme', () => ({ useColorScheme: () => 'light' }));
+
+describe('WalkStartButton', () => {
+  it('renders the START WALK label', () => {
+    render(<WalkStartButton onPress={jest.fn()} />);
+    expect(screen.getByRole('button', { name: 'START WALK' })).toBeTruthy();
+  });
+
+  it('calls onPress when enabled and pressed', () => {
+    const onPress = jest.fn();
+    render(<WalkStartButton onPress={onPress} />);
+    fireEvent.press(screen.getByRole('button', { name: 'START WALK' }));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports disabled state via accessibility', () => {
+    render(<WalkStartButton onPress={jest.fn()} disabled />);
+    expect(
+      screen.getByRole('button', { name: 'START WALK' }).props.accessibilityState.disabled,
+    ).toBe(true);
+  });
+
+  it('does NOT call onPress while loading', () => {
+    const onPress = jest.fn();
+    render(<WalkStartButton onPress={onPress} loading />);
+    fireEvent.press(screen.getByRole('button', { name: 'START WALK' }));
+    expect(onPress).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/components/walk/WalkStartButton.tsx
+++ b/apps/mobile/components/walk/WalkStartButton.tsx
@@ -1,0 +1,68 @@
+import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { useColors } from '@/hooks/use-colors';
+import { elevation, typography } from '@/theme/tokens';
+
+interface WalkStartButtonProps {
+  onPress: () => void;
+  disabled?: boolean;
+  loading?: boolean;
+}
+
+export function WalkStartButton({ onPress, disabled, loading }: WalkStartButtonProps) {
+  const { t } = useTranslation();
+  const theme = useColors();
+  const isInteractive = !disabled && !loading;
+  const label = t('walk.ready.start');
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      accessibilityState={{ disabled: !isInteractive }}
+      disabled={!isInteractive}
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.button,
+        {
+          backgroundColor: theme.success,
+          opacity: disabled ? 0.5 : pressed ? 0.85 : 1,
+        },
+        elevation.accentStart,
+      ]}
+    >
+      {loading ? (
+        <ActivityIndicator color={theme.onInteractive} />
+      ) : (
+        <View style={styles.content}>
+          <Text style={[styles.icon, { color: theme.onInteractive }]}>▶</Text>
+          <Text style={[styles.label, { color: theme.onInteractive }]}>{label}</Text>
+        </View>
+      )}
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    width: '100%',
+    height: 56,
+    borderRadius: 28,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  content: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+  },
+  icon: {
+    fontSize: 16,
+  },
+  label: {
+    ...typography.button,
+    fontSize: 18,
+    fontWeight: '700',
+    letterSpacing: 1.5,
+  },
+});

--- a/apps/mobile/components/walk/WalkTopChip.tsx
+++ b/apps/mobile/components/walk/WalkTopChip.tsx
@@ -7,20 +7,23 @@ import type { Dog } from '@/types/graphql';
 
 interface WalkTopChipProps {
   dogs: Dog[];
+  label?: string;
 }
 
 const AVATAR = 22;
 
-export function WalkTopChip({ dogs }: WalkTopChipProps) {
+export function WalkTopChip({ dogs, label }: WalkTopChipProps) {
   const { t } = useTranslation();
   const theme = useColors();
 
-  if (dogs.length === 0) return null;
+  if (dogs.length === 0 && !label) return null;
 
   const isSingle = dogs.length === 1;
-  const label = isSingle
-    ? t('walk.recording.walkWith', { name: dogs[0].name })
-    : t('walk.recording.groupWalk');
+  const displayLabel =
+    label ??
+    (isSingle
+      ? t('walk.recording.walkWith', { name: dogs[0].name })
+      : t('walk.recording.groupWalk'));
 
   return (
     <View
@@ -30,7 +33,7 @@ export function WalkTopChip({ dogs }: WalkTopChipProps) {
         elevation.low,
       ]}
     >
-      {isSingle ? null : (
+      {isSingle || dogs.length === 0 ? null : (
         <View style={styles.avatars}>
           {dogs.slice(0, 2).map((dog, i) => (
             <Image
@@ -47,7 +50,7 @@ export function WalkTopChip({ dogs }: WalkTopChipProps) {
         </View>
       )}
       <Text style={[styles.label, { color: theme.onSurface }]} numberOfLines={1}>
-        {label}
+        {displayLabel}
       </Text>
     </View>
   );

--- a/apps/mobile/hooks/use-pack-progress.test.ts
+++ b/apps/mobile/hooks/use-pack-progress.test.ts
@@ -31,7 +31,29 @@ describe('aggregatePackProgress', () => {
 
   it('returns zeros when there are no walks', () => {
     const result = aggregatePackProgress([], 5, now);
-    expect(result).toEqual({ todayKm: 0, goalKm: 5, progressPct: 0, perDog: {} });
+    expect(result).toEqual({
+      todayKm: 0,
+      goalKm: 5,
+      progressPct: 0,
+      packStreakDays: 0,
+      perDog: {},
+    });
+  });
+
+  it('packStreakDays counts consecutive days where ANY dog walked', () => {
+    const walks: Walk[] = [
+      makeWalk('w1', ['coco'], new Date(2026, 3, 19, 8).toISOString(), 1000),
+      makeWalk('w2', ['momo'], new Date(2026, 3, 18, 8).toISOString(), 800),
+      makeWalk('w3', ['coco'], new Date(2026, 3, 16, 8).toISOString(), 500),
+    ];
+    expect(aggregatePackProgress(walks, 5, now).packStreakDays).toBe(2);
+  });
+
+  it('packStreakDays is zero if no recent pack walk', () => {
+    const walks: Walk[] = [
+      makeWalk('w1', ['coco'], new Date(2026, 3, 15, 8).toISOString(), 500),
+    ];
+    expect(aggregatePackProgress(walks, 5, now).packStreakDays).toBe(0);
   });
 
   it('sums today distance across all dogs for the pack card', () => {

--- a/apps/mobile/hooks/use-pack-progress.ts
+++ b/apps/mobile/hooks/use-pack-progress.ts
@@ -13,6 +13,7 @@ export interface PackProgress {
   todayKm: number;
   goalKm: number;
   progressPct: number;
+  packStreakDays: number;
   perDog: Record<string, DogProgress>;
   isLoading: boolean;
 }
@@ -61,6 +62,7 @@ export function aggregatePackProgress(
   const todayKey = localDayKey(now);
 
   let packTodayM = 0;
+  const packDays = new Set<string>();
   const dogDays = new Map<string, Set<string>>();
   const dogTodayM = new Map<string, number>();
   const dogTotalWalks = new Map<string, number>();
@@ -69,6 +71,7 @@ export function aggregatePackProgress(
     const dayKey = toLocalDayKey(walk.startedAt);
     const distanceM = walk.distanceM ?? 0;
     if (dayKey === todayKey) packTodayM += distanceM;
+    if (dayKey) packDays.add(dayKey);
 
     for (const dog of walk.dogs ?? []) {
       if (!dog?.id) continue;
@@ -98,8 +101,9 @@ export function aggregatePackProgress(
   const todayKm = packTodayM / 1000;
   const progressPct =
     goalKm > 0 ? Math.min(100, Math.round((todayKm / goalKm) * 100)) : 0;
+  const packStreakDays = computeStreak(packDays, now);
 
-  return { todayKm, goalKm, progressPct, perDog };
+  return { todayKm, goalKm, progressPct, packStreakDays, perDog };
 }
 
 export function usePackProgress(goalKm: number = DEFAULT_DAILY_GOAL_KM): PackProgress {

--- a/apps/mobile/lib/i18n/locales/en.json
+++ b/apps/mobile/lib/i18n/locales/en.json
@@ -143,13 +143,22 @@
   },
   "walk": {
     "ready": {
-      "largeTitle": "Walk",
+      "topLabelStatic": "Walk",
+      "noDogsTitle": "No dogs yet",
+      "noDogs": "Add a dog to your pack before starting a walk. It only takes a moment.",
+      "noDogsCta": "Add your first dog",
       "walkingWith": "Walking with",
       "selectAll": "Select all",
       "deselectAll": "Deselect all",
-      "hint": "Tap to begin. We'll follow your route and log everything gently.",
-      "start": "START",
-      "noDogs": "Register a dog first",
+      "start": "START WALK",
+      "stats": {
+        "today": "Today",
+        "streak": "Streak",
+        "goal": "Goal",
+        "kmShort": "{{value}} km",
+        "streakDays": "{{count}}d",
+        "goalPercent": "{{value}}%"
+      },
       "lastWalk": {
         "never": "Ready for the first walk",
         "justNow": "Last walk just now",

--- a/apps/mobile/lib/i18n/locales/ja.json
+++ b/apps/mobile/lib/i18n/locales/ja.json
@@ -143,13 +143,22 @@
   },
   "walk": {
     "ready": {
-      "largeTitle": "散歩",
-      "walkingWith": "一緒に散歩する犬",
+      "topLabelStatic": "散歩",
+      "noDogsTitle": "まだ犬がいません",
+      "noDogs": "散歩を始める前にパックに犬を追加しましょう。すぐに終わります。",
+      "noDogsCta": "はじめての犬を追加",
+      "walkingWith": "一緒に散歩",
       "selectAll": "すべて選択",
       "deselectAll": "すべて解除",
-      "hint": "タップして開始。ルートを追跡し、そっと記録します。",
-      "start": "START",
-      "noDogs": "先に犬を登録してください",
+      "start": "散歩を開始",
+      "stats": {
+        "today": "今日",
+        "streak": "連続",
+        "goal": "目標",
+        "kmShort": "{{value}} km",
+        "streakDays": "{{count}}日",
+        "goalPercent": "{{value}}%"
+      },
       "lastWalk": {
         "never": "はじめての散歩",
         "justNow": "今さっき散歩しました",


### PR DESCRIPTION
## Summary
- PR #148 → #149 で revert された Walk タブリデザインを `docs/claude-design/Precise Full App.html` の **04a / 04b / G1** デザインに合わせて再実装
- ready 状態 (0頭 / 1頭 / 複数頭) を地図ベース + フローティンググラスカード構造に統合
- ready / recording 共通シェル `WalkMapShell` + `WalkMap(mode='preview')` + `WalkTopChip` を活用

## Changes
**新規コンポーネント**
- `WalkReadyStatsRow` — Today / Streak / Goal の 3 カラム統計行 (`usePackProgress` を読む)
- `WalkStartButton` — 横長 pill + ▶ + `START WALK`、`disabled` / `loading` 対応
- `NoDogsBody` — 0頭時の illustration + title + body + `Add your first dog` CTA

**変更**
- `WalkReadyView` を design 04a / 04b / G1 準拠にリファクタ。`largeTitle` 削除、grabber 追加、`topLabel` を `Walk` 固定、stats と START ボタンを差し替え
- `DogPickerCard` single バリアントに右端 chevron `›` を表示
- `usePackProgress` に `packStreakDays` を追加（パック全体の連続散歩日数）
- `walk.ready.*` の i18n を design copy に合わせて刷新（旧 `largeTitle` / `topLabelEmpty` / `topLabelUnselected` / `hint` を削除、`stats.*` / `topLabelStatic` / `noDogsCta` 追加）
- `app/(tabs)/walk.tsx` で ready 時に `SafeAreaView` ラッパを外し、`WalkMapShell` の full-bleed レイアウトを優先

**スコープ外**
- `walk-recording.tsx` / `walk-recording-controls.tsx` の見た目変更
- `WalkSummaryCard` (finished phase) の変更
- grabber の drag-to-collapse 実機能（装飾のみ）

## Test plan
- [ ] `cd apps/mobile && npm test -- --testPathPattern "(walk|use-pack-progress|NoDogsBody|WalkReadyStatsRow|WalkStartButton)"` がすべて pass
- [ ] `cd apps/mobile && npx tsc --noEmit` で型エラーなし
- [ ] `cd apps/mobile && npm run lint` で lint エラーなし
- [ ] iOS Simulator で 0頭 / 1頭 / 2+頭 の各ケース目視確認 (`APP_ENV=local npx expo start --ios`)
- [ ] 1頭・複数頭で START を押下し recording 画面に遷移できること
- [ ] ダーク / ライト両モードでガラス効果が破綻しないこと
- [ ] Safe area (notch / Dynamic Island) で top pill / bottom card が被らないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)