### PR TITLE
fix: dedupe walk points by recordedAt before BatchWriteItem

### DIFF
--- a/apps/api/src/services/walk_points_service.rs
+++ b/apps/api/src/services/walk_points_service.rs
@@ -3,7 +3,7 @@ use aws_sdk_dynamodb::{
     types::{AttributeValue, PutRequest, WriteRequest},
     Client as DynamoClient,
 };
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use uuid::Uuid;
 
 /// Maximum number of write requests per DynamoDB BatchWriteItem call.
@@ -65,6 +65,20 @@ fn parse_point_row(item: &HashMap<String, AttributeValue>) -> Option<WalkPoint> 
     })
 }
 
+/// 同じ `recorded_at` を持つ point を 1 件に縮約する（最初に出現したものを保持）。
+///
+/// DynamoDB `BatchWriteItem` は同一バッチ内に同じ primary key を持つ
+/// `WriteRequest` を許容しない（`ValidationException: "Provided list of item
+/// keys contains duplicates"`）。`(walk_id, recorded_at)` が PK/SK なので、
+/// `recorded_at` が一致する 2 件は同じキーとして衝突する。
+fn dedup_points_by_recorded_at(points: Vec<WalkPointInput>) -> Vec<WalkPointInput> {
+    let mut seen: HashSet<String> = HashSet::new();
+    points
+        .into_iter()
+        .filter(|p| seen.insert(p.recorded_at.clone()))
+        .collect()
+}
+
 // ─── Public API ──────────────────────────────────────────────────────────────
 
 #[derive(Clone, Debug)]
@@ -96,6 +110,11 @@ pub async fn add_walk_points(
     if points.is_empty() {
         return Ok(true);
     }
+
+    // 同一 batch 内で `(pk, sk)` が重複すると DynamoDB が
+    // `ValidationException: "Provided list of item keys contains duplicates"`
+    // を返してバッチごと拒否する。送信前に recorded_at で dedup する。
+    let points = dedup_points_by_recorded_at(points);
 
     let all_requests: Vec<WriteRequest> = points
         .iter()
@@ -239,5 +258,53 @@ mod tests {
         item.insert(LAT_ATTR.to_string(), AttributeValue::N("35.0".to_string()));
         // lng and recorded_at are missing
         assert!(parse_point_row(&item).is_none());
+    }
+
+    fn make_point(recorded_at: &str, lat: f64) -> WalkPointInput {
+        WalkPointInput {
+            lat,
+            lng: 139.0,
+            recorded_at: recorded_at.to_string(),
+        }
+    }
+
+    #[test]
+    fn dedup_points_by_recorded_at_keeps_first_occurrence_of_duplicate() {
+        // DynamoDB BatchWriteItem の `(pk, sk)` 重複は ValidationException を引き起こす。
+        // 同じ recorded_at の point が 2 つ以上含まれていたら、先に来たものを保持する。
+        let points = vec![
+            make_point("2026-04-26T02:45:35.951Z", 35.6),
+            make_point("2026-04-26T02:45:35.951Z", 35.7),
+            make_point("2026-04-26T02:45:40.000Z", 35.8),
+        ];
+
+        let deduped = dedup_points_by_recorded_at(points);
+
+        assert_eq!(deduped.len(), 2);
+        assert!((deduped[0].lat - 35.6).abs() < 1e-9);
+        assert_eq!(deduped[0].recorded_at, "2026-04-26T02:45:35.951Z");
+        assert_eq!(deduped[1].recorded_at, "2026-04-26T02:45:40.000Z");
+    }
+
+    #[test]
+    fn dedup_points_by_recorded_at_preserves_order_when_no_duplicates() {
+        let points = vec![
+            make_point("2026-04-26T02:45:35.000Z", 1.0),
+            make_point("2026-04-26T02:45:36.000Z", 2.0),
+            make_point("2026-04-26T02:45:37.000Z", 3.0),
+        ];
+
+        let deduped = dedup_points_by_recorded_at(points);
+
+        assert_eq!(deduped.len(), 3);
+        assert_eq!(deduped[0].recorded_at, "2026-04-26T02:45:35.000Z");
+        assert_eq!(deduped[1].recorded_at, "2026-04-26T02:45:36.000Z");
+        assert_eq!(deduped[2].recorded_at, "2026-04-26T02:45:37.000Z");
+    }
+
+    #[test]
+    fn dedup_points_by_recorded_at_returns_empty_for_empty_input() {
+        let deduped = dedup_points_by_recorded_at(Vec::new());
+        assert!(deduped.is_empty());
     }
 }

--- a/apps/api/tests/test_walk.rs
+++ b/apps/api/tests/test_walk.rs
@@ -316,3 +316,47 @@ async fn test_add_walk_points() {
     let body: serde_json::Value = res.json().await.unwrap();
     assert_eq!(body["data"]["addWalkPoints"], true, "got: {:?}", body);
 }
+
+// 同一バッチ内に同じ recorded_at を持つ point が複数含まれていても、
+// `BatchWriteItem` の `ValidationException: "Provided list of item keys
+// contains duplicates"` で失敗してはならない。Sentry WALKING-DOG-API-DEV-2/3/4
+// の回帰テスト。
+#[tokio::test]
+async fn test_add_walk_points_with_duplicate_recorded_at_succeeds() {
+    let client = support::test_client().await;
+    let dog_id = create_test_dog(&client).await;
+
+    let start_res = client
+        .post("/graphql")
+        .header("Authorization", "Bearer test-token")
+        .json(&serde_json::json!({
+            "query": format!(r#"mutation {{ startWalk(dogIds: ["{}"]) {{ id }} }}"#, dog_id)
+        }))
+        .send()
+        .await
+        .unwrap();
+    let start_body: serde_json::Value = start_res.json().await.unwrap();
+    let walk_id = start_body["data"]["startWalk"]["id"].as_str().unwrap();
+
+    let res = client
+        .post("/graphql")
+        .header("Authorization", "Bearer test-token")
+        .json(&serde_json::json!({
+            "query": format!(r#"mutation {{
+                addWalkPoints(walkId: "{}", points: [
+                    {{ lat: 35.6762, lng: 139.6503, recordedAt: "2026-04-26T02:45:35.951Z" }},
+                    {{ lat: 35.6763, lng: 139.6504, recordedAt: "2026-04-26T02:45:35.951Z" }},
+                    {{ lat: 35.6764, lng: 139.6505, recordedAt: "2026-04-26T02:45:40.000Z" }}
+                ])
+            }}"#, walk_id)
+        }))
+        .send()
+        .await
+        .unwrap();
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(
+        body["data"]["addWalkPoints"], true,
+        "duplicate recorded_at must be deduped server-side, got: {:?}",
+        body
+    );
+}

--- a/apps/mobile/hooks/use-walk-session.test.ts
+++ b/apps/mobile/hooks/use-walk-session.test.ts
@@ -375,7 +375,9 @@ describe('useWalkSession.stop', () => {
     mockStorePoints = Array.from({ length: MAX_POINTS_PER_BATCH + 50 }, (_, i) => ({
       lat: 35.68,
       lng: 139.76,
-      recordedAt: `2026-04-01T00:0${i % 10}:00Z`,
+      // Unique recordedAt per point — flushWalkPoints now dedupes by
+      // recordedAt before batching, so any collision shrinks the batch count.
+      recordedAt: `2026-04-01T00:00:00.${String(i).padStart(3, '0')}Z`,
     }));
 
     const { result } = renderHook(() => useWalkSession());

--- a/apps/mobile/lib/walk/tracking-manager.test.ts
+++ b/apps/mobile/lib/walk/tracking-manager.test.ts
@@ -121,7 +121,9 @@ describe('flushWalkPoints', () => {
     const points: WalkPoint[] = Array.from({ length: MAX_POINTS_PER_BATCH + 50 }, (_, index) => ({
       lat: 35.68,
       lng: 139.76,
-      recordedAt: `2026-04-01T00:${String(index % 60).padStart(2, '0')}:00Z`,
+      // recordedAt must stay unique across the whole array; the flush step now
+      // dedupes by recordedAt so any collision shrinks the batch count.
+      recordedAt: `2026-04-01T00:00:00.${String(index).padStart(3, '0')}Z`,
     }));
 
     await flushWalkPoints({ walkId: 'walk-1', points, addWalkPoints });
@@ -132,5 +134,47 @@ describe('flushWalkPoints', () => {
     );
     expect(addWalkPoints.mock.calls[0][0].points).toHaveLength(MAX_POINTS_PER_BATCH);
     expect(addWalkPoints.mock.calls[1][0].points).toHaveLength(50);
+  });
+
+  // 同一 recordedAt の point が複数 store に蓄積された場合（GPS 二重 emit
+  // など）、API へのバッチ送信前に dedup する必要がある。さもなければ
+  // DynamoDB BatchWriteItem が ValidationException で失敗する。
+  // Sentry WALKING-DOG-API-DEV-2/3/4 の回帰テスト。
+  it('dedupes points sharing the same recordedAt before batching', async () => {
+    const addWalkPoints = jest.fn().mockResolvedValue(true);
+    const points: WalkPoint[] = [
+      { lat: 35.68, lng: 139.76, recordedAt: '2026-04-26T02:45:35.951Z' },
+      { lat: 35.69, lng: 139.77, recordedAt: '2026-04-26T02:45:35.951Z' },
+      { lat: 35.7, lng: 139.78, recordedAt: '2026-04-26T02:45:40.000Z' },
+    ];
+
+    await flushWalkPoints({ walkId: 'walk-1', points, addWalkPoints });
+
+    expect(addWalkPoints).toHaveBeenCalledTimes(1);
+    const sentPoints = addWalkPoints.mock.calls[0][0].points;
+    expect(sentPoints).toHaveLength(2);
+    expect(sentPoints.map((p: { recordedAt: string }) => p.recordedAt)).toEqual([
+      '2026-04-26T02:45:35.951Z',
+      '2026-04-26T02:45:40.000Z',
+    ]);
+  });
+
+  it('keeps order of distinct points unchanged when no duplicates exist', async () => {
+    const addWalkPoints = jest.fn().mockResolvedValue(true);
+    const points: WalkPoint[] = [
+      { lat: 1, lng: 1, recordedAt: '2026-04-26T02:45:35.000Z' },
+      { lat: 2, lng: 2, recordedAt: '2026-04-26T02:45:36.000Z' },
+      { lat: 3, lng: 3, recordedAt: '2026-04-26T02:45:37.000Z' },
+    ];
+
+    await flushWalkPoints({ walkId: 'walk-1', points, addWalkPoints });
+
+    expect(addWalkPoints).toHaveBeenCalledTimes(1);
+    const sentPoints = addWalkPoints.mock.calls[0][0].points;
+    expect(sentPoints.map((p: { recordedAt: string }) => p.recordedAt)).toEqual([
+      '2026-04-26T02:45:35.000Z',
+      '2026-04-26T02:45:36.000Z',
+      '2026-04-26T02:45:37.000Z',
+    ]);
   });
 });

--- a/apps/mobile/lib/walk/tracking-manager.ts
+++ b/apps/mobile/lib/walk/tracking-manager.ts
@@ -45,9 +45,28 @@ export function resetWalkTrackingState() {
   useWalkStore.getState().resetTrackingSession();
 }
 
+/**
+ * 同じ `recordedAt` を持つ point を 1 件に縮約する（最初に出現したものを保持）。
+ *
+ * DynamoDB `BatchWriteItem` は同一バッチ内に同じ primary key を持つ
+ * `WriteRequest` を許容しない。`(walk_id, recorded_at)` が PK/SK のため、
+ * `recordedAt` が一致する 2 件は同じキーとして衝突する。サーバー側にも
+ * 防御的 dedup があるが、ネットワーク負荷を減らすためクライアントでも縮約する。
+ */
+function dedupePointsByRecordedAt(points: WalkPoint[]): WalkPoint[] {
+  const seen = new Set<string>();
+  return points.filter((p) => {
+    if (seen.has(p.recordedAt)) return false;
+    seen.add(p.recordedAt);
+    return true;
+  });
+}
+
 export async function flushWalkPoints({ walkId, points, addWalkPoints }: FlushWalkPointsOptions) {
-  for (let index = 0; index < points.length; index += MAX_POINTS_PER_BATCH) {
-    const batch = points.slice(index, index + MAX_POINTS_PER_BATCH).map((point) => ({
+  const deduped = dedupePointsByRecordedAt(points);
+
+  for (let index = 0; index < deduped.length; index += MAX_POINTS_PER_BATCH) {
+    const batch = deduped.slice(index, index + MAX_POINTS_PER_BATCH).map((point) => ({
       lat: point.lat,
       lng: point.lng,
       recordedAt: point.recordedAt,

--- a/apps/mobile/stores/walk-store.test.ts
+++ b/apps/mobile/stores/walk-store.test.ts
@@ -85,6 +85,23 @@ describe('walk-store', () => {
     expect(state.totalDistanceM).toBeGreaterThan(0);
   });
 
+  // GPS subscription の二重発火等で同一 recordedAt の point が連続して来た
+  // 場合、後続を黙って捨てる。距離も加算しない。Sentry WALKING-DOG-API-DEV-2/3/4
+  // の発生源対策。
+  it('addPoint ignores a duplicate recordedAt of the previous point', () => {
+    useWalkStore.getState().startRecording('walk-123');
+    const p1: WalkPoint = { lat: 35.6812, lng: 139.7671, recordedAt: '2026-04-26T02:45:35.951Z' };
+    const dup: WalkPoint = { lat: 35.7, lng: 139.8, recordedAt: '2026-04-26T02:45:35.951Z' };
+    useWalkStore.getState().addPoint(p1);
+    const distanceAfterFirst = useWalkStore.getState().totalDistanceM;
+
+    useWalkStore.getState().addPoint(dup);
+
+    const state = useWalkStore.getState();
+    expect(state.points).toHaveLength(1);
+    expect(state.totalDistanceM).toBe(distanceAfterFirst);
+  });
+
   it('finish transitions to finished phase', () => {
     useWalkStore.getState().startRecording('walk-123');
     useWalkStore.getState().finish();

--- a/apps/mobile/stores/walk-store.ts
+++ b/apps/mobile/stores/walk-store.ts
@@ -88,6 +88,12 @@ export const useWalkStore = create<WalkState>((set, get) => ({
   addPoint: (point) =>
     set((state) => {
       const prev = state.points[state.points.length - 1];
+      // GPS subscription の二重発火等で同一 recordedAt の point が連続して
+      // 来た場合は捨てる。さもなければ DynamoDB BatchWriteItem の
+      // (walk_id, recorded_at) PK 重複で flush が ValidationException になる。
+      if (prev && prev.recordedAt === point.recordedAt) {
+        return state;
+      }
       const added = prev ? haversineDistance(prev, point) : 0;
       return {
         points: [...state.points, point],


### PR DESCRIPTION
## Summary

End Walk が長時間散歩で失敗していた問題を修正。真因は DynamoDB `BatchWriteItem` の `ValidationException: "Provided list of item keys contains duplicates"`（同一バッチ内 PK 重複）。3 層 dedup で防御する。

- **API（最終防衛）**: `walk_points_service::add_walk_points` が `BatchWriteItem` 送信前に `recorded_at` で dedup。
- **Mobile flush**: `flushWalkPoints` が batch 化前に `recordedAt` で dedup。ネットワーク負荷削減も兼ねる。
- **Mobile store**: `walk-store.addPoint` が直前 point と同一 `recordedAt` の場合スキップ。GPS subscription の二重発火（バックグラウンド復帰時等）が発生源。

PR #143 のログ追加で真因が判明（生 SDK エラーが Sentry に届いた）。仮説していた `ProvisionedThroughputExceededException` ではなく `ValidationException` だった。

## 真因の Sentry トレース

- 発生箇所: `apps/api/src/services/walk_points_service.rs:118`
- batch_size: 25, table: `walking-dog-dev-WalkPoints`
- 2026-04-26 02:12 / 02:45 UTC に再発確認

## Test plan

- [x] `cargo test --lib services::walk_points_service`（dedup helper unit test 3 件 + 既存 6 件、計 9/9）
- [x] `cargo test --features test-utils --test test_walk`（重複 recordedAt の回帰 integration test 含む 8/8）
- [x] `cargo test --features test-utils --lib`（80/80）
- [x] `cargo clippy --features test-utils --tests -- -D warnings`（warning 0）
- [x] Mobile `npx jest`（621/621、+ 既存テストデータの recordedAt をユニーク化して dedup と整合）
- [x] Mobile `npx tsc --noEmit`（clean）
- [x] Mobile `npx eslint`（変更ファイル clean）
- [ ] Sakura VPS dev デプロイ後、長時間散歩で End Walk 成功を確認

Fixes WALKING-DOG-API-DEV-2
Fixes WALKING-DOG-API-DEV-3
Fixes WALKING-DOG-API-DEV-4

🤖 Generated with [Claude Code](https://claude.com/claude-code)