### PR TITLE
chore: introduce Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -78,42 +78,9 @@ updates:
       dev-dependencies:
         dependency-type: "development"
 
-  # ----- E2E (Playwright) -----
-  - package-ecosystem: "npm"
-    directory: "/apps/e2e"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
-      timezone: "Asia/Tokyo"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "e2e"
-    commit-message:
-      prefix: "chore(deps)"
-      prefix-development: "chore(deps-dev)"
-      include: "scope"
-
   # ----- Docker (API image) -----
   - package-ecosystem: "docker"
     directory: "/apps/api"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
-      timezone: "Asia/Tokyo"
-    open-pull-requests-limit: 3
-    labels:
-      - "dependencies"
-      - "docker"
-    commit-message:
-      prefix: "chore(deps)"
-      include: "scope"
-
-  # ----- Docker (E2E image) -----
-  - package-ecosystem: "docker"
-    directory: "/apps/e2e"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,151 @@
+# Dependabot v2 configuration
+# Docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Schedule: every Monday 09:00 Asia/Tokyo so we can triage at start of the week.
+# Security updates are enabled separately at the repository level by GitHub.
+version: 2
+updates:
+  # ----- Rust API -----
+  - package-ecosystem: "cargo"
+    directory: "/apps/api"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "rust"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+      include: "scope"
+    groups:
+      aws-sdk:
+        patterns:
+          - "aws-sdk-*"
+          - "aws-config"
+          - "aws-smithy-*"
+      tracing:
+        patterns:
+          - "tracing"
+          - "tracing-*"
+      serde:
+        patterns:
+          - "serde"
+          - "serde_*"
+
+  # ----- Mobile (Expo / React Native) -----
+  - package-ecosystem: "npm"
+    directory: "/apps/mobile"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "mobile"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+      include: "scope"
+    ignore:
+      - dependency-name: "expo"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-native"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@aws-amplify/*"
+        update-types: ["version-update:semver-major"]
+    groups:
+      expo-stack:
+        patterns:
+          - "expo"
+          - "expo-*"
+      react-native-stack:
+        patterns:
+          - "react-native"
+          - "@react-native/*"
+          - "react-native-*"
+      aws-amplify:
+        patterns:
+          - "@aws-amplify/*"
+          - "aws-amplify"
+      dev-dependencies:
+        dependency-type: "development"
+
+  # ----- E2E (Playwright) -----
+  - package-ecosystem: "npm"
+    directory: "/apps/e2e"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "e2e"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+      include: "scope"
+
+  # ----- Docker (API image) -----
+  - package-ecosystem: "docker"
+    directory: "/apps/api"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+
+  # ----- Docker (E2E image) -----
+  - package-ecosystem: "docker"
+    directory: "/apps/e2e"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+
+  # ----- GitHub Actions -----
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    groups:
+      actions:
+        patterns:
+          - "actions/*"
+      aws-actions:
+        patterns:
+          - "aws-actions/*"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` to automate weekly dependency PRs across 6 update entries (cargo, npm × 2, docker × 2, github-actions).
- Groups related packages (AWS SDK, Expo SDK, React Native, Amplify, tracing, serde, actions/*) so one PR covers a whole stack instead of N separate PRs.
- Ignores semver-major bumps for `expo`, `react-native`, `react`, `@aws-amplify/*` to avoid noisy breaking-change PRs — these will be handled manually.
- Schedule: every Monday 09:00 Asia/Tokyo so dependency triage lands at the start of the week.
- Commits use `chore(deps)` / `chore(deps-dev)` prefix with conventional-commit scope, matching repo style.

## Out of scope (follow-up)
- Terraform (`/infra/aws`): wait until `.terraform.lock.hcl` is generated and committed for reproducibility.
- `apps/compose.yml` dev images (postgres / dynamodb-local / cognito-local): low risk, not auto-tracked.
- Adding CI for `apps/e2e` so its Dependabot PRs run a check.

## Test plan
- [ ] Merge to `main`.
- [ ] Visit Insights → Dependency graph → Dependabot and confirm all 6 entries report green (no parse / fetch errors).
- [ ] Within 24h, confirm `chore(deps)` PRs start arriving with the expected `dependencies` + ecosystem labels.
- [ ] Verify `test-api` and `test-mobile` checks run on PRs that touch `apps/api/Cargo.lock` and `apps/mobile/package-lock.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)