### PR TITLE
feat(api): add HTTP request logging with request_id

### DIFF
--- a/apps/api/Cargo.lock
+++ b/apps/api/Cargo.lock
@@ -5566,6 +5566,8 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/apps/api/Cargo.toml
+++ b/apps/api/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 
 [dependencies]
 axum = { version = "0.8", features = ["macros"] }
-tower-http = { version = "0.6", features = ["cors"] }
+tower-http = { version = "0.6", features = ["cors", "trace", "request-id"] }
 tokio = { version = "1", features = ["full"] }
 async-graphql = { version = "~7.0.17", features = ["chrono", "uuid", "dataloader", "dynamic-schema"] }
 async-graphql-axum = "7"

--- a/apps/api/src/lib.rs
+++ b/apps/api/src/lib.rs
@@ -14,6 +14,7 @@ use async_graphql_axum::{GraphQLRequest, GraphQLResponse};
 use aws_sdk_dynamodb::Client as DynamoClient;
 use aws_sdk_s3::Client as S3Client;
 use aws_sdk_sqs::Client as SqsClient;
+use axum::http::header::HeaderName;
 use axum::{
     middleware,
     routing::{get, post},
@@ -23,6 +24,10 @@ use sea_orm::DatabaseConnection;
 use std::sync::Arc;
 use tower::ServiceBuilder;
 use tower_http::cors::CorsLayer;
+use tower_http::request_id::{MakeRequestUuid, PropagateRequestIdLayer, SetRequestIdLayer};
+use tower_http::trace::{DefaultOnFailure, DefaultOnRequest, DefaultOnResponse, TraceLayer};
+use tower_http::LatencyUnit;
+use tracing::Level;
 
 pub struct AppState {
     pub db: DatabaseConnection,
@@ -63,6 +68,32 @@ pub fn build_app(
         .layer(sentry_tower::NewSentryLayer::new_from_top())
         .layer(sentry_tower::SentryHttpLayer::new().enable_transaction());
 
+    let x_request_id = HeaderName::from_static("x-request-id");
+
+    let trace_layer = TraceLayer::new_for_http()
+        .make_span_with(|request: &axum::http::Request<_>| {
+            let request_id = request
+                .headers()
+                .get("x-request-id")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("-");
+            tracing::info_span!(
+                "http_request",
+                method = %request.method(),
+                path = %request.uri().path(),
+                request_id = %request_id,
+                status = tracing::field::Empty,
+                latency_ms = tracing::field::Empty,
+            )
+        })
+        .on_request(DefaultOnRequest::new().level(Level::INFO))
+        .on_response(
+            DefaultOnResponse::new()
+                .level(Level::INFO)
+                .latency_unit(LatencyUnit::Millis),
+        )
+        .on_failure(DefaultOnFailure::new().level(Level::ERROR));
+
     Router::new()
         .route("/graphql", post(graphql_handler))
         .layer(middleware::from_fn_with_state(
@@ -72,6 +103,13 @@ pub fn build_app(
         .layer(sentry_layer)
         .layer(CorsLayer::permissive())
         .route("/health", get(|| async { "ok" }))
+        // Layer order: the LAST `.layer()` is the outermost wrapper. So request
+        // flow is SetRequestIdLayer → trace_layer → PropagateRequestIdLayer →
+        // handler. SetRequestIdLayer must run first to populate x-request-id
+        // before trace_layer reads it for the span.
+        .layer(PropagateRequestIdLayer::new(x_request_id.clone()))
+        .layer(trace_layer)
+        .layer(SetRequestIdLayer::new(x_request_id, MakeRequestUuid))
         .with_state(schema)
 }
 


### PR DESCRIPTION
## Summary
- Add `tower-http` `TraceLayer` to emit INFO-level access logs for every HTTP request/response (method, path, latency, status).
- Add `SetRequestIdLayer` + `PropagateRequestIdLayer` so each request receives a UUID `x-request-id` echoed back to the client.
- The `request_id` is included in the tracing span, so existing `sqlx::query` logs are now auto-tagged per request for correlation.

## Why
Until now only `sqlx::query` logs surfaced at INFO; there was no way to see "an HTTP request was received" or correlate a chain of SQL queries back to a single request. Axum itself ships no access-log middleware — `tower_http::trace::TraceLayer` is the standard pattern.

## Test plan
- [x] `docker compose run --rm api cargo check` passes
- [x] `curl /health` and `curl -X POST /graphql` produce INFO logs with `method`/`path`/`request_id` and an `x-request-id` response header
- [x] sqlx query logs are nested inside the `http_request` span (verified in live container)
- [ ] CI tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)