### PR TITLE
chore: deduplicate Dependabot commit-message scope

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,6 @@ updates:
     commit-message:
       prefix: "chore(deps)"
       prefix-development: "chore(deps-dev)"
-      include: "scope"
     groups:
       aws-sdk:
         patterns:
@@ -51,7 +50,6 @@ updates:
     commit-message:
       prefix: "chore(deps)"
       prefix-development: "chore(deps-dev)"
-      include: "scope"
     ignore:
       - dependency-name: "expo"
         update-types: ["version-update:semver-major"]
@@ -92,7 +90,6 @@ updates:
       - "docker"
     commit-message:
       prefix: "chore(deps)"
-      include: "scope"
 
   # ----- GitHub Actions -----
   - package-ecosystem: "github-actions"
@@ -108,7 +105,6 @@ updates:
       - "ci"
     commit-message:
       prefix: "chore(deps)"
-      include: "scope"
     groups:
       actions:
         patterns:


### PR DESCRIPTION
## Summary
Fixes a bug introduced in #156 where Dependabot PR titles came out as `chore(deps)(deps): bump foo` (double scope).

Root cause: `prefix: "chore(deps)"` and `include: "scope"` were used together — `include: "scope"` auto-appends `(deps)`, so the explicit prefix duplicated it.

Fix: drop `include: "scope"` from all 4 update entries. Result going forward:
- production deps → `chore(deps): bump foo`
- dev deps → `chore(deps-dev): bump bar`

## Out of scope
- The 4 already-open Dependabot PRs (#158–#161) keep their existing titles. They can be merged as-is; this PR only affects PRs Dependabot creates *after* merge.
- Repository labels (`dependencies` / `rust` / `mobile` / `docker` / `ci`) were created via \`gh label create\` so future Dependabot PRs render them. Not part of this PR diff.

## Test plan
- [ ] Merge to main
- [ ] Wait for next Dependabot run (next Monday 09:00 JST or trigger via Insights → Dependency graph → Dependabot → "Check for updates")
- [ ] Verify new PR titles are `chore(deps): ...` (single scope)
- [ ] Verify new PRs receive `dependencies` + ecosystem label

🤖 Generated with [Claude Code](https://claude.com/claude-code)