### PR TITLE
refactor(api): normalize graphql loading and service boundaries

### DIFF
--- a/apps/api/src/auth/mod.rs
+++ b/apps/api/src/auth/mod.rs
@@ -1,4 +1,5 @@
 pub mod jwt;
+pub mod observability;
 pub mod service;
 
 use axum::{
@@ -16,6 +17,37 @@ pub struct AuthUser {
     pub cognito_sub: String,
 }
 
+fn bearer_token(request: &Request) -> Option<String> {
+    request
+        .headers()
+        .get("Authorization")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+        .map(str::to_string)
+}
+
+async fn authenticate_token(
+    verifier: &Arc<dyn JwtVerifier>,
+    token: Option<String>,
+) -> Result<Option<AuthUser>, StatusCode> {
+    let Some(token) = token else {
+        return Ok(None);
+    };
+
+    let claims = verifier
+        .verify(&token)
+        .await
+        .map_err(|_| StatusCode::UNAUTHORIZED)?;
+    Ok(Some(AuthUser {
+        cognito_sub: claims.sub,
+    }))
+}
+
+fn attach_auth_user(request: &mut Request, auth_user: AuthUser) {
+    observability::on_authentication_success(&auth_user.cognito_sub);
+    request.extensions_mut().insert(auth_user);
+}
+
 /// JWT検証ミドルウェア
 /// Authorization ヘッダーがない場合は AuthUser を挿入せずに続行する（オプショナル認証）
 pub async fn auth_middleware(
@@ -23,30 +55,9 @@ pub async fn auth_middleware(
     mut request: Request,
     next: Next,
 ) -> Result<Response, StatusCode> {
-    let auth_header = request
-        .headers()
-        .get("Authorization")
-        .and_then(|v| v.to_str().ok())
-        .and_then(|v| v.strip_prefix("Bearer "));
-
-    let token = match auth_header {
-        Some(t) => t.to_string(),
-        None => return Ok(next.run(request).await),
-    };
-
-    let cognito_sub = match verifier.verify(&token).await {
-        Ok(claims) => claims.sub,
-        Err(_) => return Err(StatusCode::UNAUTHORIZED),
-    };
-
-    sentry::configure_scope(|scope| {
-        scope.set_user(Some(sentry::User {
-            id: Some(cognito_sub.clone()),
-            ..Default::default()
-        }));
-    });
-
-    request.extensions_mut().insert(AuthUser { cognito_sub });
+    if let Some(auth_user) = authenticate_token(&verifier, bearer_token(&request)).await? {
+        attach_auth_user(&mut request, auth_user);
+    }
     Ok(next.run(request).await)
 }
 
@@ -58,4 +69,25 @@ pub fn require_auth(
     ctx.data::<Option<String>>()?
         .clone()
         .ok_or_else(|| async_graphql::Error::new("Unauthorized"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+
+    #[test]
+    fn bearer_token_returns_none_without_header() {
+        let request = Request::new(Body::empty());
+        assert!(bearer_token(&request).is_none());
+    }
+
+    #[test]
+    fn bearer_token_extracts_bearer_value() {
+        let mut request = Request::new(Body::empty());
+        request
+            .headers_mut()
+            .insert("Authorization", "Bearer token-123".parse().unwrap());
+        assert_eq!(bearer_token(&request).as_deref(), Some("token-123"));
+    }
 }

--- a/apps/api/src/auth/observability.rs
+++ b/apps/api/src/auth/observability.rs
@@ -1,0 +1,8 @@
+pub fn on_authentication_success(cognito_sub: &str) {
+    sentry::configure_scope(|scope| {
+        scope.set_user(Some(sentry::User {
+            id: Some(cognito_sub.to_string()),
+            ..Default::default()
+        }));
+    });
+}

--- a/apps/api/src/auth/service.rs
+++ b/apps/api/src/auth/service.rs
@@ -2,6 +2,7 @@ use aws_sdk_cognitoidentityprovider::types::AttributeType;
 use aws_sdk_cognitoidentityprovider::Client;
 use aws_smithy_types::error::metadata::ProvideErrorMetadata;
 
+use crate::error::external::map_cognito_sdk_error;
 use crate::error::AppError;
 use crate::services::user_service;
 
@@ -15,25 +16,11 @@ pub struct SignInResult {
     pub refresh_token: String,
 }
 
-/// Pure function: maps a Cognito error code string to an AppError.
-/// Extracted for unit testability without needing to construct SdkError.
-pub(crate) fn map_error_code(code: Option<&str>) -> AppError {
-    match code {
-        Some("UsernameExistsException") => AppError::BadRequest("USER_EXISTS".to_string()),
-        Some("NotAuthorizedException") => AppError::Unauthorized("INVALID_CREDENTIALS".to_string()),
-        Some("CodeMismatchException") => AppError::BadRequest("INVALID_CODE".to_string()),
-        Some("ExpiredCodeException") => AppError::BadRequest("EXPIRED_CODE".to_string()),
-        Some("InvalidPasswordException") => AppError::BadRequest("INVALID_PASSWORD".to_string()),
-        _ => AppError::Internal("AUTH_ERROR".to_string()),
-    }
-}
-
-/// Maps a Cognito SdkError to an AppError using ProvideErrorMetadata::code().
 fn map_cognito_error<E, R>(err: &aws_smithy_runtime_api::client::result::SdkError<E, R>) -> AppError
 where
     E: ProvideErrorMetadata,
 {
-    map_error_code(err.code())
+    map_cognito_sdk_error(err)
 }
 
 pub async fn sign_up(
@@ -193,48 +180,48 @@ pub async fn sign_out(client: &Client, access_token: &str) -> Result<(), AppErro
 
 #[cfg(test)]
 mod tests {
-    use super::map_error_code;
+    use crate::error::external::map_cognito_error_code;
     use crate::error::AppError;
 
     #[test]
     fn map_error_code_username_exists() {
-        let result = map_error_code(Some("UsernameExistsException"));
+        let result = map_cognito_error_code(Some("UsernameExistsException"));
         assert!(matches!(result, AppError::BadRequest(msg) if msg == "USER_EXISTS"));
     }
 
     #[test]
     fn map_error_code_not_authorized() {
-        let result = map_error_code(Some("NotAuthorizedException"));
+        let result = map_cognito_error_code(Some("NotAuthorizedException"));
         assert!(matches!(result, AppError::Unauthorized(msg) if msg == "INVALID_CREDENTIALS"));
     }
 
     #[test]
     fn map_error_code_code_mismatch() {
-        let result = map_error_code(Some("CodeMismatchException"));
+        let result = map_cognito_error_code(Some("CodeMismatchException"));
         assert!(matches!(result, AppError::BadRequest(msg) if msg == "INVALID_CODE"));
     }
 
     #[test]
     fn map_error_code_expired_code() {
-        let result = map_error_code(Some("ExpiredCodeException"));
+        let result = map_cognito_error_code(Some("ExpiredCodeException"));
         assert!(matches!(result, AppError::BadRequest(msg) if msg == "EXPIRED_CODE"));
     }
 
     #[test]
     fn map_error_code_invalid_password() {
-        let result = map_error_code(Some("InvalidPasswordException"));
+        let result = map_cognito_error_code(Some("InvalidPasswordException"));
         assert!(matches!(result, AppError::BadRequest(msg) if msg == "INVALID_PASSWORD"));
     }
 
     #[test]
     fn map_error_code_unknown() {
-        let result = map_error_code(None);
+        let result = map_cognito_error_code(None);
         assert!(matches!(result, AppError::Internal(msg) if msg == "AUTH_ERROR"));
     }
 
     #[test]
     fn map_error_code_unrecognized() {
-        let result = map_error_code(Some("SomeUnknownException"));
+        let result = map_cognito_error_code(Some("SomeUnknownException"));
         assert!(matches!(result, AppError::Internal(msg) if msg == "AUTH_ERROR"));
     }
 

--- a/apps/api/src/error.rs
+++ b/apps/api/src/error.rs
@@ -1,3 +1,5 @@
+pub mod external;
+
 // apps/api/src/error.rs
 use thiserror::Error;
 

--- a/apps/api/src/error/external.rs
+++ b/apps/api/src/error/external.rs
@@ -1,0 +1,77 @@
+use crate::error::{format_error_chain, AppError};
+use aws_smithy_types::error::metadata::ProvideErrorMetadata;
+use uuid::Uuid;
+
+pub fn dynamodb_batch_write_error<E: std::error::Error>(
+    err: &E,
+    table_name: &str,
+    walk_id: Uuid,
+    batch_size: usize,
+) -> AppError {
+    tracing::error!(
+        error = ?err,
+        table = table_name,
+        walk_id = %walk_id,
+        batch_size,
+        "DynamoDB BatchWriteItem failed"
+    );
+    AppError::Internal(format!(
+        "DynamoDB BatchWriteItem: {}",
+        format_error_chain(err)
+    ))
+}
+
+pub fn dynamodb_query_error<E: std::error::Error>(
+    err: &E,
+    table_name: &str,
+    walk_id: Uuid,
+) -> AppError {
+    tracing::error!(
+        error = ?err,
+        table = table_name,
+        walk_id = %walk_id,
+        "DynamoDB Query failed"
+    );
+    AppError::Internal(format!("DynamoDB Query: {}", format_error_chain(err)))
+}
+
+pub fn map_cognito_error_code(code: Option<&str>) -> AppError {
+    match code {
+        Some("UsernameExistsException") => AppError::BadRequest("USER_EXISTS".to_string()),
+        Some("NotAuthorizedException") => AppError::Unauthorized("INVALID_CREDENTIALS".to_string()),
+        Some("CodeMismatchException") => AppError::BadRequest("INVALID_CODE".to_string()),
+        Some("ExpiredCodeException") => AppError::BadRequest("EXPIRED_CODE".to_string()),
+        Some("InvalidPasswordException") => AppError::BadRequest("INVALID_PASSWORD".to_string()),
+        _ => AppError::Internal("AUTH_ERROR".to_string()),
+    }
+}
+
+pub fn map_cognito_sdk_error<E, R>(
+    err: &aws_smithy_runtime_api::client::result::SdkError<E, R>,
+) -> AppError
+where
+    E: ProvideErrorMetadata,
+{
+    map_cognito_error_code(err.code())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cognito_error_code_maps_username_exists() {
+        assert!(matches!(
+            map_cognito_error_code(Some("UsernameExistsException")),
+            AppError::BadRequest(msg) if msg == "USER_EXISTS"
+        ));
+    }
+
+    #[test]
+    fn cognito_error_code_maps_unknown_to_internal() {
+        assert!(matches!(
+            map_cognito_error_code(Some("SomethingElse")),
+            AppError::Internal(msg) if msg == "AUTH_ERROR"
+        ));
+    }
+}

--- a/apps/api/src/graphql/auth_helpers.rs
+++ b/apps/api/src/graphql/auth_helpers.rs
@@ -60,41 +60,33 @@ pub async fn resolve_user_and_walk(
     Ok(user)
 }
 
+/// Resolve the authenticated user and verify membership in any dog from the
+/// provided candidate set.
+pub async fn resolve_user_and_any_dog(
+    ctx: &ResolverContext<'_>,
+    state: &AppState,
+    dog_ids: &[Uuid],
+) -> async_graphql::Result<UserModel> {
+    let user = resolve_user(ctx, state).await?;
+    dog_member_service::require_any_dog_member(&state.db, dog_ids, user.id)
+        .await
+        .map_err(AppError::into_graphql_error)?;
+    Ok(user)
+}
+
 #[cfg(test)]
 mod tests {
+    use crate::error::AppError;
 
-    /// Static guard: resolve_user must call require_auth exactly once.
     #[test]
-    fn resolve_user_calls_require_auth() {
-        let src = include_str!("auth_helpers.rs");
-        assert!(
-            src.contains("crate::auth::require_auth(ctx)"),
-            "resolve_user must call crate::auth::require_auth"
-        );
-    }
-
-    /// Static guard: resolve_user_and_dog must delegate to resolve_user (not inline require_auth).
-    #[test]
-    fn resolve_user_and_dog_delegates_to_resolve_user() {
-        let src = include_str!("auth_helpers.rs");
-        // resolve_user_and_dog should not call get_or_create_user directly (it goes via resolve_user)
-        assert!(
-            !src[src.find("fn resolve_user_and_dog").unwrap()..]
-                .split("fn resolve_user_and_walk")
-                .next()
-                .unwrap_or("")
-                .contains("get_or_create_user"),
-            "resolve_user_and_dog must not call get_or_create_user directly"
-        );
-    }
-
-    /// Static guard: resolve_user_and_walk must delegate to resolve_user.
-    #[test]
-    fn resolve_user_and_walk_delegates_to_resolve_user() {
-        let src = include_str!("auth_helpers.rs");
-        assert!(
-            src.contains("resolve_user(ctx, state).await"),
-            "resolve_user_and_walk must call resolve_user internally"
-        );
+    fn resolve_user_and_walk_maps_unauthorized_to_not_found() {
+        let error = AppError::Unauthorized("hidden".to_string());
+        let mapped = match error {
+            AppError::Unauthorized(_) | AppError::NotFound(_) => {
+                AppError::NotFound("Walk not found".to_string())
+            }
+            other => other,
+        };
+        assert!(matches!(mapped, AppError::NotFound(message) if message == "Walk not found"));
     }
 }

--- a/apps/api/src/graphql/custom_queries.rs
+++ b/apps/api/src/graphql/custom_queries.rs
@@ -1,9 +1,11 @@
 use super::auth_helpers;
-use super::mutations::{DogOutput, UserOutput, WalkOutput};
+use super::dynamic_helpers::{float_field, int_field, parse_uuid, string_field, uuid_field};
+use super::loaders::DogLoader;
+use super::mutations::{auth::UserOutput, dog::DogOutput, walk::WalkOutput};
 use crate::error::AppError;
 use crate::services::{
-    dog_member_service, dog_pair::DogPair, dog_service, encounter_service, friendship_service,
-    walk_points_service, walk_service,
+    dog_pair::DogPair, dog_service, encounter_service, friendship_service, walk_points_service,
+    walk_service,
 };
 use crate::AppState;
 use async_graphql::dynamic::{Field, FieldFuture, FieldValue, InputValue, Object, TypeRef};
@@ -106,111 +108,41 @@ impl FriendshipOutput {
 
 pub fn walk_point_type() -> Object {
     Object::new("WalkPoint")
-        .field(Field::new(
-            "lat",
-            TypeRef::named_nn(TypeRef::FLOAT),
-            |ctx| {
-                FieldFuture::new(async move {
-                    let p = ctx.parent_value.try_downcast_ref::<WalkPointOutput>()?;
-                    Ok(Some(FieldValue::value(p.lat)))
-                })
-            },
-        ))
-        .field(Field::new(
-            "lng",
-            TypeRef::named_nn(TypeRef::FLOAT),
-            |ctx| {
-                FieldFuture::new(async move {
-                    let p = ctx.parent_value.try_downcast_ref::<WalkPointOutput>()?;
-                    Ok(Some(FieldValue::value(p.lng)))
-                })
-            },
-        ))
-        .field(Field::new(
-            "recordedAt",
-            TypeRef::named_nn(TypeRef::STRING),
-            |ctx| {
-                FieldFuture::new(async move {
-                    let p = ctx.parent_value.try_downcast_ref::<WalkPointOutput>()?;
-                    Ok(Some(FieldValue::value(p.recorded_at.clone())))
-                })
-            },
-        ))
+        .field(float_field("lat", |p: &WalkPointOutput| p.lat))
+        .field(float_field("lng", |p: &WalkPointOutput| p.lng))
+        .field(string_field("recordedAt", |p: &WalkPointOutput| {
+            p.recorded_at.clone()
+        }))
 }
 
 pub fn walk_stats_type() -> Object {
     Object::new("WalkStats")
-        .field(Field::new(
-            "totalWalks",
-            TypeRef::named_nn(TypeRef::INT),
-            |ctx| {
-                FieldFuture::new(async move {
-                    let s = ctx.parent_value.try_downcast_ref::<WalkStatsOutput>()?;
-                    Ok(Some(FieldValue::value(s.total_walks)))
-                })
-            },
-        ))
-        .field(Field::new(
-            "totalDistanceM",
-            TypeRef::named_nn(TypeRef::INT),
-            |ctx| {
-                FieldFuture::new(async move {
-                    let s = ctx.parent_value.try_downcast_ref::<WalkStatsOutput>()?;
-                    Ok(Some(FieldValue::value(s.total_distance_m)))
-                })
-            },
-        ))
-        .field(Field::new(
-            "totalDurationSec",
-            TypeRef::named_nn(TypeRef::INT),
-            |ctx| {
-                FieldFuture::new(async move {
-                    let s = ctx.parent_value.try_downcast_ref::<WalkStatsOutput>()?;
-                    Ok(Some(FieldValue::value(s.total_duration_sec)))
-                })
-            },
-        ))
+        .field(int_field("totalWalks", |s: &WalkStatsOutput| s.total_walks))
+        .field(int_field("totalDistanceM", |s: &WalkStatsOutput| {
+            s.total_distance_m
+        }))
+        .field(int_field("totalDurationSec", |s: &WalkStatsOutput| {
+            s.total_duration_sec
+        }))
 }
 
 pub fn encounter_output_type() -> Object {
     Object::new("EncounterOutput")
-        .field(Field::new(
-            "id",
-            TypeRef::named_nn(TypeRef::STRING),
-            |ctx| {
-                FieldFuture::new(async move {
-                    let e = ctx.parent_value.try_downcast_ref::<EncounterOutput>()?;
-                    Ok(Some(FieldValue::value(e.id.to_string())))
-                })
-            },
-        ))
-        .field(Field::new(
-            "durationSec",
-            TypeRef::named_nn(TypeRef::INT),
-            |ctx| {
-                FieldFuture::new(async move {
-                    let e = ctx.parent_value.try_downcast_ref::<EncounterOutput>()?;
-                    Ok(Some(FieldValue::value(e.duration_sec)))
-                })
-            },
-        ))
-        .field(Field::new(
-            "metAt",
-            TypeRef::named_nn(TypeRef::STRING),
-            |ctx| {
-                FieldFuture::new(async move {
-                    let e = ctx.parent_value.try_downcast_ref::<EncounterOutput>()?;
-                    Ok(Some(FieldValue::value(e.met_at.clone())))
-                })
-            },
-        ))
+        .field(uuid_field("id", |e: &EncounterOutput| e.id))
+        .field(int_field("durationSec", |e: &EncounterOutput| {
+            e.duration_sec
+        }))
+        .field(string_field("metAt", |e: &EncounterOutput| {
+            e.met_at.clone()
+        }))
         .field(Field::new("dog1", TypeRef::named_nn("DogOutput"), |ctx| {
             FieldFuture::new(async move {
                 let e = ctx.parent_value.try_downcast_ref::<EncounterOutput>()?;
-                let state = ctx.data::<Arc<crate::AppState>>()?;
-                let dog = dog_service::get_dog_by_id(&state.db, e.dog_id_1)
+                let dog = ctx
+                    .data::<Arc<DogLoader>>()?
+                    .load_one(e.dog_id_1)
                     .await
-                    .map_err(AppError::into_graphql_error)?
+                    .map_err(async_graphql::Error::new)?
                     .ok_or_else(|| async_graphql::Error::new("Dog not found"))?;
                 Ok(Some(FieldValue::owned_any(DogOutput::from(dog))))
             })
@@ -218,10 +150,11 @@ pub fn encounter_output_type() -> Object {
         .field(Field::new("dog2", TypeRef::named_nn("DogOutput"), |ctx| {
             FieldFuture::new(async move {
                 let e = ctx.parent_value.try_downcast_ref::<EncounterOutput>()?;
-                let state = ctx.data::<Arc<crate::AppState>>()?;
-                let dog = dog_service::get_dog_by_id(&state.db, e.dog_id_2)
+                let dog = ctx
+                    .data::<Arc<DogLoader>>()?
+                    .load_one(e.dog_id_2)
                     .await
-                    .map_err(AppError::into_graphql_error)?
+                    .map_err(async_graphql::Error::new)?
                     .ok_or_else(|| async_graphql::Error::new("Dog not found"))?;
                 Ok(Some(FieldValue::owned_any(DogOutput::from(dog))))
             })
@@ -230,56 +163,19 @@ pub fn encounter_output_type() -> Object {
 
 pub fn friendship_output_type() -> Object {
     Object::new("FriendshipOutput")
-        .field(Field::new(
-            "id",
-            TypeRef::named_nn(TypeRef::STRING),
-            |ctx| {
-                FieldFuture::new(async move {
-                    let f = ctx.parent_value.try_downcast_ref::<FriendshipOutput>()?;
-                    Ok(Some(FieldValue::value(f.id.to_string())))
-                })
-            },
-        ))
-        .field(Field::new(
-            "encounterCount",
-            TypeRef::named_nn(TypeRef::INT),
-            |ctx| {
-                FieldFuture::new(async move {
-                    let f = ctx.parent_value.try_downcast_ref::<FriendshipOutput>()?;
-                    Ok(Some(FieldValue::value(f.encounter_count)))
-                })
-            },
-        ))
-        .field(Field::new(
-            "totalInteractionSec",
-            TypeRef::named_nn(TypeRef::INT),
-            |ctx| {
-                FieldFuture::new(async move {
-                    let f = ctx.parent_value.try_downcast_ref::<FriendshipOutput>()?;
-                    Ok(Some(FieldValue::value(f.total_interaction_sec)))
-                })
-            },
-        ))
-        .field(Field::new(
-            "firstMetAt",
-            TypeRef::named_nn(TypeRef::STRING),
-            |ctx| {
-                FieldFuture::new(async move {
-                    let f = ctx.parent_value.try_downcast_ref::<FriendshipOutput>()?;
-                    Ok(Some(FieldValue::value(f.first_met_at.clone())))
-                })
-            },
-        ))
-        .field(Field::new(
-            "lastMetAt",
-            TypeRef::named_nn(TypeRef::STRING),
-            |ctx| {
-                FieldFuture::new(async move {
-                    let f = ctx.parent_value.try_downcast_ref::<FriendshipOutput>()?;
-                    Ok(Some(FieldValue::value(f.last_met_at.clone())))
-                })
-            },
-        ))
+        .field(uuid_field("id", |f: &FriendshipOutput| f.id))
+        .field(int_field("encounterCount", |f: &FriendshipOutput| {
+            f.encounter_count
+        }))
+        .field(int_field("totalInteractionSec", |f: &FriendshipOutput| {
+            f.total_interaction_sec
+        }))
+        .field(string_field("firstMetAt", |f: &FriendshipOutput| {
+            f.first_met_at.clone()
+        }))
+        .field(string_field("lastMetAt", |f: &FriendshipOutput| {
+            f.last_met_at.clone()
+        }))
         .field(Field::new(
             "friend",
             TypeRef::named_nn("DogOutput"),
@@ -292,10 +188,11 @@ pub fn friendship_output_type() -> Object {
                     } else {
                         f.dog_id_1
                     };
-                    let state = ctx.data::<Arc<crate::AppState>>()?;
-                    let dog = dog_service::get_dog_by_id(&state.db, friend_id)
+                    let dog = ctx
+                        .data::<Arc<DogLoader>>()?
+                        .load_one(friend_id)
                         .await
-                        .map_err(AppError::into_graphql_error)?
+                        .map_err(async_graphql::Error::new)?
                         .ok_or_else(|| async_graphql::Error::new("Dog not found"))?;
                     Ok(Some(FieldValue::owned_any(DogOutput::from(dog))))
                 })
@@ -327,8 +224,7 @@ fn walk_by_id_field(state: Arc<AppState>) -> Field {
             use sea_orm::EntityTrait;
 
             let walk_id_str = ctx.args.try_get("id")?.string()?;
-            let walk_id = Uuid::parse_str(walk_id_str)
-                .map_err(|_| async_graphql::Error::new("Invalid walk ID"))?;
+            let walk_id = parse_uuid(walk_id_str, "Invalid walk ID")?;
 
             auth_helpers::resolve_user_and_walk(&ctx, &state, walk_id).await?;
 
@@ -348,8 +244,7 @@ fn dog_field(state: Arc<AppState>) -> Field {
         let state = state.clone();
         FieldFuture::new(async move {
             let dog_id_str = ctx.args.try_get("id")?.string()?;
-            let dog_id = Uuid::parse_str(dog_id_str)
-                .map_err(|_| async_graphql::Error::new("Invalid dog ID"))?;
+            let dog_id = parse_uuid(dog_id_str, "Invalid dog ID")?;
 
             auth_helpers::resolve_user_and_dog(&ctx, &state, dog_id).await?;
 
@@ -357,7 +252,7 @@ fn dog_field(state: Arc<AppState>) -> Field {
                 .await
                 .map_err(AppError::into_graphql_error)?;
 
-            Ok(dog.map(|d| FieldValue::owned_any(super::mutations::DogOutput::from(d))))
+            Ok(dog.map(|d| FieldValue::owned_any(DogOutput::from(d))))
         })
     })
     .argument(InputValue::new("id", TypeRef::named_nn(TypeRef::ID)))
@@ -411,8 +306,7 @@ fn dog_walk_stats_field(state: Arc<AppState>) -> Field {
         let state = state.clone();
         FieldFuture::new(async move {
             let dog_id_str = ctx.args.try_get("dogId")?.string()?;
-            let dog_id = Uuid::parse_str(dog_id_str)
-                .map_err(|_| async_graphql::Error::new("Invalid dog ID"))?;
+            let dog_id = parse_uuid(dog_id_str, "Invalid dog ID")?;
 
             auth_helpers::resolve_user_and_dog(&ctx, &state, dog_id).await?;
 
@@ -438,8 +332,7 @@ fn walk_points_field(state: Arc<AppState>) -> Field {
             let state = state.clone();
             FieldFuture::new(async move {
                 let walk_id_str = ctx.args.try_get("walkId")?.string()?;
-                let walk_id = Uuid::parse_str(walk_id_str)
-                    .map_err(|_| async_graphql::Error::new("Invalid walk ID"))?;
+                let walk_id = parse_uuid(walk_id_str, "Invalid walk ID")?;
 
                 auth_helpers::resolve_user_and_walk(&ctx, &state, walk_id).await?;
 
@@ -470,8 +363,7 @@ fn dog_friends_field(state: Arc<AppState>) -> Field {
             let state = state.clone();
             FieldFuture::new(async move {
                 let dog_id_str = ctx.args.try_get("dogId")?.string()?;
-                let dog_id = Uuid::parse_str(dog_id_str)
-                    .map_err(|_| async_graphql::Error::new("Invalid dog ID"))?;
+                let dog_id = parse_uuid(dog_id_str, "Invalid dog ID")?;
 
                 auth_helpers::resolve_user_and_dog(&ctx, &state, dog_id).await?;
 
@@ -498,8 +390,7 @@ fn dog_encounters_field(state: Arc<AppState>) -> Field {
             let state = state.clone();
             FieldFuture::new(async move {
                 let dog_id_str = ctx.args.try_get("dogId")?.string()?;
-                let dog_id = Uuid::parse_str(dog_id_str)
-                    .map_err(|_| async_graphql::Error::new("Invalid dog ID"))?;
+                let dog_id = parse_uuid(dog_id_str, "Invalid dog ID")?;
                 let limit = ctx
                     .args
                     .get("limit")
@@ -540,28 +431,10 @@ fn friendship_field(state: Arc<AppState>) -> Field {
             FieldFuture::new(async move {
                 let dog_id_1_str = ctx.args.try_get("dogId1")?.string()?;
                 let dog_id_2_str = ctx.args.try_get("dogId2")?.string()?;
-                let dog_id_1 = Uuid::parse_str(dog_id_1_str)
-                    .map_err(|_| async_graphql::Error::new("Invalid dogId1"))?;
-                let dog_id_2 = Uuid::parse_str(dog_id_2_str)
-                    .map_err(|_| async_graphql::Error::new("Invalid dogId2"))?;
+                let dog_id_1 = parse_uuid(dog_id_1_str, "Invalid dogId1")?;
+                let dog_id_2 = parse_uuid(dog_id_2_str, "Invalid dogId2")?;
 
-                let user = auth_helpers::resolve_user(&ctx, &state).await?;
-
-                // User must be a member of at least one of the two dogs
-                let is_member_of_1 =
-                    dog_member_service::require_dog_member(&state.db, dog_id_1, user.id)
-                        .await
-                        .is_ok();
-                let is_member_of_2 =
-                    dog_member_service::require_dog_member(&state.db, dog_id_2, user.id)
-                        .await
-                        .is_ok();
-                if !is_member_of_1 && !is_member_of_2 {
-                    return Err(
-                        AppError::Unauthorized("Not a member of either dog".to_string())
-                            .into_graphql_error(),
-                    );
-                }
+                auth_helpers::resolve_user_and_any_dog(&ctx, &state, &[dog_id_1, dog_id_2]).await?;
 
                 let Some(pair) = DogPair::new(dog_id_1, dog_id_2) else {
                     return Ok(None);

--- a/apps/api/src/graphql/dynamic_helpers.rs
+++ b/apps/api/src/graphql/dynamic_helpers.rs
@@ -1,0 +1,167 @@
+use crate::error::FieldError;
+use async_graphql::dynamic::{Field, FieldFuture, FieldValue, TypeRef};
+use uuid::Uuid;
+
+pub fn string_field<T, F>(name: &'static str, accessor: F) -> Field
+where
+    T: Send + Sync + 'static,
+    F: Fn(&T) -> String + Send + Sync + Copy + 'static,
+{
+    Field::new(name, TypeRef::named_nn(TypeRef::STRING), move |ctx| {
+        FieldFuture::new(async move {
+            let value = ctx.parent_value.try_downcast_ref::<T>()?;
+            Ok(Some(FieldValue::value(accessor(value))))
+        })
+    })
+}
+
+pub fn optional_string_field<T, F>(name: &'static str, accessor: F) -> Field
+where
+    T: Send + Sync + 'static,
+    F: Fn(&T) -> Option<String> + Send + Sync + Copy + 'static,
+{
+    Field::new(name, TypeRef::named(TypeRef::STRING), move |ctx| {
+        FieldFuture::new(async move {
+            let value = ctx.parent_value.try_downcast_ref::<T>()?;
+            Ok(accessor(value).map(FieldValue::value))
+        })
+    })
+}
+
+pub fn uuid_field<T, F>(name: &'static str, accessor: F) -> Field
+where
+    T: Send + Sync + 'static,
+    F: Fn(&T) -> Uuid + Send + Sync + Copy + 'static,
+{
+    string_field(name, move |value: &T| accessor(value).to_string())
+}
+
+pub fn int_field<T, F>(name: &'static str, accessor: F) -> Field
+where
+    T: Send + Sync + 'static,
+    F: Fn(&T) -> i32 + Send + Sync + Copy + 'static,
+{
+    Field::new(name, TypeRef::named_nn(TypeRef::INT), move |ctx| {
+        FieldFuture::new(async move {
+            let value = ctx.parent_value.try_downcast_ref::<T>()?;
+            Ok(Some(FieldValue::value(accessor(value))))
+        })
+    })
+}
+
+pub fn optional_int_field<T, F>(name: &'static str, accessor: F) -> Field
+where
+    T: Send + Sync + 'static,
+    F: Fn(&T) -> Option<i32> + Send + Sync + Copy + 'static,
+{
+    Field::new(name, TypeRef::named(TypeRef::INT), move |ctx| {
+        FieldFuture::new(async move {
+            let value = ctx.parent_value.try_downcast_ref::<T>()?;
+            Ok(accessor(value).map(FieldValue::value))
+        })
+    })
+}
+
+pub fn float_field<T, F>(name: &'static str, accessor: F) -> Field
+where
+    T: Send + Sync + 'static,
+    F: Fn(&T) -> f64 + Send + Sync + Copy + 'static,
+{
+    Field::new(name, TypeRef::named_nn(TypeRef::FLOAT), move |ctx| {
+        FieldFuture::new(async move {
+            let value = ctx.parent_value.try_downcast_ref::<T>()?;
+            Ok(Some(FieldValue::value(accessor(value))))
+        })
+    })
+}
+
+pub fn optional_float_field<T, F>(name: &'static str, accessor: F) -> Field
+where
+    T: Send + Sync + 'static,
+    F: Fn(&T) -> Option<f64> + Send + Sync + Copy + 'static,
+{
+    Field::new(name, TypeRef::named(TypeRef::FLOAT), move |ctx| {
+        FieldFuture::new(async move {
+            let value = ctx.parent_value.try_downcast_ref::<T>()?;
+            Ok(accessor(value).map(FieldValue::value))
+        })
+    })
+}
+
+pub fn bool_field<T, F>(name: &'static str, accessor: F) -> Field
+where
+    T: Send + Sync + 'static,
+    F: Fn(&T) -> bool + Send + Sync + Copy + 'static,
+{
+    Field::new(name, TypeRef::named_nn(TypeRef::BOOLEAN), move |ctx| {
+        FieldFuture::new(async move {
+            let value = ctx.parent_value.try_downcast_ref::<T>()?;
+            Ok(Some(FieldValue::value(accessor(value))))
+        })
+    })
+}
+
+pub fn parse_uuid(value: &str, invalid_message: &'static str) -> async_graphql::Result<Uuid> {
+    Uuid::parse_str(value).map_err(|_| async_graphql::Error::new(invalid_message))
+}
+
+pub fn parse_uuid_with_field_error(
+    value: &str,
+    field: &'static str,
+    errors: &mut Vec<FieldError>,
+) -> Option<Uuid> {
+    Uuid::parse_str(value).ok().or_else(|| {
+        errors.push(FieldError {
+            field: field.to_string(),
+            message: "Invalid UUID format".to_string(),
+        });
+        None
+    })
+}
+
+pub fn format_photo_cdn_url(photo_cdn_url: &str, key: &str) -> String {
+    if key.starts_with("http") {
+        key.to_string()
+    } else {
+        format!("{}/{}", photo_cdn_url, key)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_uuid_accepts_valid_uuid() {
+        let value = "11111111-2222-3333-4444-555555555555";
+        assert_eq!(
+            parse_uuid(value, "invalid").unwrap(),
+            Uuid::parse_str(value).unwrap()
+        );
+    }
+
+    #[test]
+    fn parse_uuid_with_field_error_collects_validation_error() {
+        let mut errors = Vec::new();
+        let parsed = parse_uuid_with_field_error("not-a-uuid", "walkId", &mut errors);
+        assert!(parsed.is_none());
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].field, "walkId");
+    }
+
+    #[test]
+    fn format_photo_cdn_url_preserves_absolute_url() {
+        assert_eq!(
+            format_photo_cdn_url("https://cdn.example.com", "https://example.com/file.jpg"),
+            "https://example.com/file.jpg"
+        );
+    }
+
+    #[test]
+    fn format_photo_cdn_url_prefixes_relative_key() {
+        assert_eq!(
+            format_photo_cdn_url("https://cdn.example.com", "dogs/file.jpg"),
+            "https://cdn.example.com/dogs/file.jpg"
+        );
+    }
+}

--- a/apps/api/src/graphql/enums.rs
+++ b/apps/api/src/graphql/enums.rs
@@ -1,0 +1,63 @@
+use async_graphql::dynamic::{Enum, EnumItem};
+
+pub fn walk_status_enum() -> Enum {
+    Enum::new("WalkStatus")
+        .item(EnumItem::new("ACTIVE"))
+        .item(EnumItem::new("FINISHED"))
+}
+
+pub fn walk_event_type_enum() -> Enum {
+    Enum::new("WalkEventType")
+        .item(EnumItem::new("PEE"))
+        .item(EnumItem::new("POO"))
+        .item(EnumItem::new("PHOTO"))
+}
+
+pub fn period_enum() -> Enum {
+    Enum::new("Period")
+        .item(EnumItem::new("WEEK"))
+        .item(EnumItem::new("MONTH"))
+        .item(EnumItem::new("YEAR"))
+        .item(EnumItem::new("ALL"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    fn assert_graphql_enum_matches<T, F>(graphql_variants: &[&str], parse: F)
+    where
+        F: Fn(&str) -> Result<T, String>,
+    {
+        for g in graphql_variants {
+            parse(g).unwrap_or_else(|e| {
+                panic!(
+                    "GraphQL enum variant `{}` does not map back to a domain variant: {}",
+                    g, e
+                )
+            });
+        }
+    }
+
+    #[test]
+    fn walk_status_graphql_enum_round_trips_through_domain() {
+        use crate::entities::walks::WalkStatus;
+        assert_graphql_enum_matches(&["ACTIVE", "FINISHED"], |g| {
+            WalkStatus::from_str(&g.to_ascii_lowercase())
+        });
+    }
+
+    #[test]
+    fn walk_event_type_graphql_enum_round_trips_through_domain() {
+        use crate::services::walk_event_service::WalkEventType;
+        assert_graphql_enum_matches(&["PEE", "POO", "PHOTO"], |g| {
+            WalkEventType::from_str(&g.to_ascii_lowercase()).map_err(|e| format!("{:?}", e))
+        });
+    }
+
+    #[test]
+    fn period_graphql_enum_round_trips_through_domain() {
+        use crate::services::walk_service::Period;
+        assert_graphql_enum_matches(&["WEEK", "MONTH", "YEAR", "ALL"], Period::from_str);
+    }
+}

--- a/apps/api/src/graphql/input/birth_date.rs
+++ b/apps/api/src/graphql/input/birth_date.rs
@@ -1,6 +1,6 @@
 use async_graphql::dynamic::ValueAccessor;
 
-use crate::graphql::mutations::BirthDate;
+use crate::graphql::mutations::dog::BirthDate;
 
 /// Parse the optional `BirthDateInput` object from GraphQL input into a JSON value
 /// suitable for storage in the `birth_date` column.

--- a/apps/api/src/graphql/loaders.rs
+++ b/apps/api/src/graphql/loaders.rs
@@ -1,0 +1,176 @@
+use crate::entities::{dogs::Model as DogModel, users::Model as UserModel};
+use crate::graphql::mutations::dog_member::DogMemberOutput;
+use crate::services::{dog_member_service, dog_service, user_service, walk_service};
+use async_graphql::dataloader::Loader;
+use sea_orm::DatabaseConnection;
+use std::collections::HashMap;
+use std::sync::Arc;
+use uuid::Uuid;
+
+#[derive(Clone)]
+pub struct UserByIdLoader {
+    db: DatabaseConnection,
+}
+
+impl UserByIdLoader {
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self { db }
+    }
+}
+
+impl Loader<Uuid> for UserByIdLoader {
+    type Value = UserModel;
+    type Error = String;
+
+    fn load(
+        &self,
+        keys: &[Uuid],
+    ) -> impl std::future::Future<Output = Result<HashMap<Uuid, Self::Value>, Self::Error>> + Send
+    {
+        let db = self.db.clone();
+        let keys = keys.to_vec();
+        async move {
+            user_service::get_users_by_ids(&db, &keys)
+                .await
+                .map(|users| users.into_iter().map(|user| (user.id, user)).collect())
+                .map_err(|err| err.to_string())
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct DogByIdLoader {
+    db: DatabaseConnection,
+}
+
+impl DogByIdLoader {
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self { db }
+    }
+}
+
+impl Loader<Uuid> for DogByIdLoader {
+    type Value = DogModel;
+    type Error = String;
+
+    fn load(
+        &self,
+        keys: &[Uuid],
+    ) -> impl std::future::Future<Output = Result<HashMap<Uuid, Self::Value>, Self::Error>> + Send
+    {
+        let db = self.db.clone();
+        let keys = keys.to_vec();
+        async move {
+            dog_service::get_dogs_by_ids(&db, &keys)
+                .await
+                .map(|dogs| dogs.into_iter().map(|dog| (dog.id, dog)).collect())
+                .map_err(|err| err.to_string())
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct DogMembersByDogIdLoader {
+    db: DatabaseConnection,
+}
+
+impl DogMembersByDogIdLoader {
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self { db }
+    }
+}
+
+impl Loader<Uuid> for DogMembersByDogIdLoader {
+    type Value = Vec<DogMemberOutput>;
+    type Error = String;
+
+    fn load(
+        &self,
+        keys: &[Uuid],
+    ) -> impl std::future::Future<Output = Result<HashMap<Uuid, Self::Value>, Self::Error>> + Send
+    {
+        let db = self.db.clone();
+        let keys = keys.to_vec();
+        async move {
+            dog_member_service::get_members_by_dog_ids(&db, &keys)
+                .await
+                .map(|members| {
+                    members
+                        .into_iter()
+                        .map(|(dog_id, rows)| {
+                            (
+                                dog_id,
+                                rows.into_iter()
+                                    .map(DogMemberOutput::from)
+                                    .collect::<Vec<_>>(),
+                            )
+                        })
+                        .collect()
+                })
+                .map_err(|err| err.to_string())
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct DogsByWalkIdLoader {
+    db: DatabaseConnection,
+}
+
+impl DogsByWalkIdLoader {
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self { db }
+    }
+}
+
+impl Loader<Uuid> for DogsByWalkIdLoader {
+    type Value = Vec<DogModel>;
+    type Error = String;
+
+    fn load(
+        &self,
+        keys: &[Uuid],
+    ) -> impl std::future::Future<Output = Result<HashMap<Uuid, Self::Value>, Self::Error>> + Send
+    {
+        let db = self.db.clone();
+        let keys = keys.to_vec();
+        async move {
+            walk_service::get_dogs_for_walk_ids(&db, &keys)
+                .await
+                .map_err(|err| err.to_string())
+        }
+    }
+}
+
+pub type UserLoader = async_graphql::dataloader::DataLoader<UserByIdLoader>;
+pub type DogLoader = async_graphql::dataloader::DataLoader<DogByIdLoader>;
+pub type DogMembersLoader = async_graphql::dataloader::DataLoader<DogMembersByDogIdLoader>;
+pub type WalkDogsLoader = async_graphql::dataloader::DataLoader<DogsByWalkIdLoader>;
+
+pub fn build_user_loader(db: &DatabaseConnection) -> Arc<UserLoader> {
+    Arc::new(async_graphql::dataloader::DataLoader::new(
+        UserByIdLoader::new(db.clone()),
+        tokio::spawn,
+    ))
+}
+
+pub fn build_dog_loader(db: &DatabaseConnection) -> Arc<DogLoader> {
+    Arc::new(async_graphql::dataloader::DataLoader::new(
+        DogByIdLoader::new(db.clone()),
+        tokio::spawn,
+    ))
+}
+
+pub fn build_dog_members_loader(db: &DatabaseConnection) -> Arc<DogMembersLoader> {
+    Arc::new(async_graphql::dataloader::DataLoader::new(
+        DogMembersByDogIdLoader::new(db.clone()),
+        tokio::spawn,
+    ))
+}
+
+pub fn build_walk_dogs_loader(db: &DatabaseConnection) -> Arc<WalkDogsLoader> {
+    Arc::new(async_graphql::dataloader::DataLoader::new(
+        DogsByWalkIdLoader::new(db.clone()),
+        tokio::spawn,
+    ))
+}

--- a/apps/api/src/graphql/mod.rs
+++ b/apps/api/src/graphql/mod.rs
@@ -1,36 +1,26 @@
 use crate::AppState;
-use async_graphql::dynamic::{Enum, EnumItem};
 use seaography::BuilderContext;
 use std::sync::Arc;
 
 pub mod auth_helpers;
 pub mod custom_queries;
+pub mod dynamic_helpers;
+pub mod enums;
 pub mod input;
+pub mod loaders;
 pub mod mutations;
-
-/// GraphQL enum type for walk lifecycle status.
-fn walk_status_enum() -> Enum {
-    Enum::new("WalkStatus")
-        .item(EnumItem::new("ACTIVE"))
-        .item(EnumItem::new("FINISHED"))
-}
-
-/// GraphQL enum type for walk event types.
-fn walk_event_type_enum() -> Enum {
-    Enum::new("WalkEventType")
-        .item(EnumItem::new("PEE"))
-        .item(EnumItem::new("POO"))
-        .item(EnumItem::new("PHOTO"))
-}
-
-/// GraphQL enum type for walk statistics period.
-fn period_enum() -> Enum {
-    Enum::new("Period")
-        .item(EnumItem::new("WEEK"))
-        .item(EnumItem::new("MONTH"))
-        .item(EnumItem::new("YEAR"))
-        .item(EnumItem::new("ALL"))
-}
+use self::mutations::{
+    auth::{
+        confirm_sign_up_input_type, refresh_token_input_type, sign_in_input_type,
+        sign_in_output_type, sign_up_input_type, sign_up_output_type, update_profile_input_type,
+        user_output_type,
+    },
+    dog::{birth_date_type, create_dog_input_type, dog_output_type, update_dog_input_type},
+    dog_member::{dog_invitation_output_type, dog_member_output_type},
+    photo::presigned_url_type,
+    walk::{walk_output_type, walk_point_input_type, walker_output_type},
+    walk_event::{record_walk_event_input_type, walk_event_output_type},
+};
 
 /// Dynamic schema produced by Seaography.
 pub type AppSchema = async_graphql::dynamic::Schema;
@@ -45,7 +35,8 @@ static CONTEXT: std::sync::OnceLock<BuilderContext> = std::sync::OnceLock::new()
 ///   `updateProfile`, `deleteDog`, `generateDogPhotoUploadUrl`.
 pub fn build_schema(state: Arc<AppState>) -> AppSchema {
     let context = CONTEXT.get_or_init(BuilderContext::default);
-    let mut builder = seaography::Builder::new(context, state.db.clone());
+    let db = state.db.clone();
+    let mut builder = seaography::Builder::new(context, db.clone());
     builder = crate::entities::register_entity_modules(builder);
 
     // Add custom query fields to the root query object.
@@ -62,37 +53,37 @@ pub fn build_schema(state: Arc<AppState>) -> AppSchema {
     builder.schema = builder
         .schema
         // Enum types
-        .register(walk_status_enum())
-        .register(walk_event_type_enum())
-        .register(period_enum())
+        .register(enums::walk_status_enum())
+        .register(enums::walk_event_type_enum())
+        .register(enums::period_enum())
         // Query output types
         .register(custom_queries::walk_point_type())
         .register(custom_queries::walk_stats_type())
         .register(custom_queries::encounter_output_type())
         .register(custom_queries::friendship_output_type())
         // Mutation output types
-        .register(mutations::birth_date_type())
-        .register(mutations::dog_output_type())
-        .register(mutations::walk_output_type())
-        .register(mutations::walker_output_type())
-        .register(mutations::user_output_type())
-        .register(mutations::walk_event_output_type())
-        .register(mutations::presigned_url_type())
-        .register(mutations::dog_invitation_output_type())
-        .register(mutations::dog_member_output_type())
-        .register(mutations::sign_up_output_type())
-        .register(mutations::sign_in_output_type())
+        .register(birth_date_type())
+        .register(dog_output_type())
+        .register(walk_output_type())
+        .register(walker_output_type())
+        .register(user_output_type())
+        .register(walk_event_output_type())
+        .register(presigned_url_type())
+        .register(dog_invitation_output_type())
+        .register(dog_member_output_type())
+        .register(sign_up_output_type())
+        .register(sign_in_output_type())
         // Mutation input types
-        .register(mutations::birth_date_input_type())
-        .register(mutations::create_dog_input_type())
-        .register(mutations::update_dog_input_type())
-        .register(mutations::walk_point_input_type())
-        .register(mutations::update_profile_input_type())
-        .register(mutations::sign_up_input_type())
-        .register(mutations::confirm_sign_up_input_type())
-        .register(mutations::sign_in_input_type())
-        .register(mutations::refresh_token_input_type())
-        .register(mutations::record_walk_event_input_type());
+        .register(mutations::dog::birth_date_input_type())
+        .register(create_dog_input_type())
+        .register(update_dog_input_type())
+        .register(walk_point_input_type())
+        .register(update_profile_input_type())
+        .register(sign_up_input_type())
+        .register(confirm_sign_up_input_type())
+        .register(sign_in_input_type())
+        .register(refresh_token_input_type())
+        .register(record_walk_event_input_type());
 
     // schema_builder() registers builder.query and builder.mutation as root
     // Query/Mutation types, then returns the completed SchemaBuilder.
@@ -101,58 +92,4 @@ pub fn build_schema(state: Arc<AppState>) -> AppSchema {
         .data(state)
         .finish()
         .expect("Failed to build GraphQL schema")
-}
-
-#[cfg(test)]
-mod tests {
-    //! Enum-parity guards.
-    //!
-    //! The GraphQL enums declared above are hand-rolled shadows of domain
-    //! enums that live elsewhere. Keeping the two in sync by hand is
-    //! error-prone; these tests fail as soon as a new domain variant ships
-    //! without its GraphQL counterpart.
-    //!
-    //! Convention: GraphQL variants are `SCREAMING_SNAKE_CASE`; the domain
-    //! enum's `Display` / `FromStr` uses lowercase (`walk_status`,
-    //! `walk_event_type`) or title-case (`period`). Parity is tested via
-    //! case-insensitive round-trip through the domain `FromStr`.
-    use std::str::FromStr;
-
-    fn assert_graphql_enum_matches<T, F>(graphql_variants: &[&str], parse: F)
-    where
-        F: Fn(&str) -> Result<T, String>,
-    {
-        for g in graphql_variants {
-            parse(g).unwrap_or_else(|e| {
-                panic!(
-                    "GraphQL enum variant `{}` does not map back to a domain variant: {}",
-                    g, e
-                )
-            });
-        }
-    }
-
-    #[test]
-    fn walk_status_graphql_enum_round_trips_through_domain() {
-        use crate::entities::walks::WalkStatus;
-        assert_graphql_enum_matches(&["ACTIVE", "FINISHED"], |g| {
-            WalkStatus::from_str(&g.to_ascii_lowercase())
-        });
-    }
-
-    #[test]
-    fn walk_event_type_graphql_enum_round_trips_through_domain() {
-        use crate::services::walk_event_service::WalkEventType;
-        assert_graphql_enum_matches(&["PEE", "POO", "PHOTO"], |g| {
-            WalkEventType::from_str(&g.to_ascii_lowercase())
-                .map_err(|e| format!("{:?}", e))
-        });
-    }
-
-    #[test]
-    fn period_graphql_enum_round_trips_through_domain() {
-        use crate::services::walk_service::Period;
-        // Period::from_str is case-insensitive so the raw uppercase name works.
-        assert_graphql_enum_matches(&["WEEK", "MONTH", "YEAR", "ALL"], Period::from_str);
-    }
 }

--- a/apps/api/src/graphql/mutations/dog.rs
+++ b/apps/api/src/graphql/mutations/dog.rs
@@ -1,6 +1,10 @@
 use crate::error::AppError;
 use crate::graphql::auth_helpers;
+use crate::graphql::dynamic_helpers::{
+    optional_int_field, optional_string_field, parse_uuid, string_field, uuid_field,
+};
 use crate::graphql::input::birth_date::parse_birth_date_input;
+use crate::graphql::loaders::DogMembersLoader;
 use crate::services::{dog_member_service, dog_service};
 use crate::AppState;
 use async_graphql::dynamic::{
@@ -47,24 +51,9 @@ impl BirthDate {
 
 pub fn birth_date_type() -> Object {
     Object::new("BirthDate")
-        .field(Field::new("year", TypeRef::named(TypeRef::INT), |ctx| {
-            FieldFuture::new(async move {
-                let bd = ctx.parent_value.try_downcast_ref::<BirthDate>()?;
-                Ok(bd.year.map(FieldValue::value))
-            })
-        }))
-        .field(Field::new("month", TypeRef::named(TypeRef::INT), |ctx| {
-            FieldFuture::new(async move {
-                let bd = ctx.parent_value.try_downcast_ref::<BirthDate>()?;
-                Ok(bd.month.map(FieldValue::value))
-            })
-        }))
-        .field(Field::new("day", TypeRef::named(TypeRef::INT), |ctx| {
-            FieldFuture::new(async move {
-                let bd = ctx.parent_value.try_downcast_ref::<BirthDate>()?;
-                Ok(bd.day.map(FieldValue::value))
-            })
-        }))
+        .field(optional_int_field("year", |bd: &BirthDate| bd.year))
+        .field(optional_int_field("month", |bd: &BirthDate| bd.month))
+        .field(optional_int_field("day", |bd: &BirthDate| bd.day))
 }
 
 pub fn birth_date_input_type() -> InputObject {
@@ -107,46 +96,14 @@ impl From<crate::entities::dogs::Model> for DogOutput {
 
 pub fn dog_output_type() -> Object {
     Object::new("DogOutput")
-        .field(Field::new(
-            "id",
-            TypeRef::named_nn(TypeRef::STRING),
-            |ctx| {
-                FieldFuture::new(async move {
-                    let d = ctx.parent_value.try_downcast_ref::<DogOutput>()?;
-                    Ok(Some(FieldValue::value(d.id.to_string())))
-                })
-            },
-        ))
-        .field(Field::new(
-            "name",
-            TypeRef::named_nn(TypeRef::STRING),
-            |ctx| {
-                FieldFuture::new(async move {
-                    let d = ctx.parent_value.try_downcast_ref::<DogOutput>()?;
-                    Ok(Some(FieldValue::value(d.name.clone())))
-                })
-            },
-        ))
-        .field(Field::new(
-            "breed",
-            TypeRef::named(TypeRef::STRING),
-            |ctx| {
-                FieldFuture::new(async move {
-                    let d = ctx.parent_value.try_downcast_ref::<DogOutput>()?;
-                    Ok(d.breed.clone().map(FieldValue::value))
-                })
-            },
-        ))
-        .field(Field::new(
-            "gender",
-            TypeRef::named(TypeRef::STRING),
-            |ctx| {
-                FieldFuture::new(async move {
-                    let d = ctx.parent_value.try_downcast_ref::<DogOutput>()?;
-                    Ok(d.gender.clone().map(FieldValue::value))
-                })
-            },
-        ))
+        .field(uuid_field("id", |d: &DogOutput| d.id))
+        .field(string_field("name", |d: &DogOutput| d.name.clone()))
+        .field(optional_string_field("breed", |d: &DogOutput| {
+            d.breed.clone()
+        }))
+        .field(optional_string_field("gender", |d: &DogOutput| {
+            d.gender.clone()
+        }))
         .field(Field::new(
             "birthDate",
             TypeRef::named("BirthDate"),
@@ -165,31 +122,19 @@ pub fn dog_output_type() -> Object {
                     let d = ctx.parent_value.try_downcast_ref::<DogOutput>()?;
                     let state = ctx.data::<Arc<crate::AppState>>()?;
                     Ok(d.photo_url.clone().map(|key| {
-                        let url = if key.starts_with("http") {
-                            key
-                        } else {
-                            format!("{}/{}", state.config.photo_cdn_url, key)
-                        };
-                        FieldValue::value(url)
+                        FieldValue::value(crate::graphql::dynamic_helpers::format_photo_cdn_url(
+                            &state.config.photo_cdn_url,
+                            &key,
+                        ))
                     }))
                 })
             },
         ))
-        .field(Field::new(
-            "createdAt",
-            TypeRef::named_nn(TypeRef::STRING),
-            |ctx| {
-                FieldFuture::new(async move {
-                    let d = ctx.parent_value.try_downcast_ref::<DogOutput>()?;
-                    Ok(Some(FieldValue::value(d.created_at.clone())))
-                })
-            },
-        ))
-        .field(Field::new("role", TypeRef::named(TypeRef::STRING), |ctx| {
-            FieldFuture::new(async move {
-                let d = ctx.parent_value.try_downcast_ref::<DogOutput>()?;
-                Ok(d.role.clone().map(FieldValue::value))
-            })
+        .field(string_field("createdAt", |d: &DogOutput| {
+            d.created_at.clone()
+        }))
+        .field(optional_string_field("role", |d: &DogOutput| {
+            d.role.clone()
         }))
         .field(
             Field::new("walkStats", TypeRef::named("WalkStats"), |ctx| {
@@ -222,16 +167,13 @@ pub fn dog_output_type() -> Object {
                     let d = ctx.parent_value.try_downcast_ref::<DogOutput>()?;
                     let dog_id = d.id;
                     let state = ctx.data::<Arc<crate::AppState>>()?;
-                    let walk =
-                        crate::services::walk_service::get_latest_finished_walk_for_dog(
-                            &state.db, dog_id,
-                        )
-                        .await
-                        .map_err(AppError::into_graphql_error)?;
+                    let walk = crate::services::walk_service::get_latest_finished_walk_for_dog(
+                        &state.db, dog_id,
+                    )
+                    .await
+                    .map_err(AppError::into_graphql_error)?;
                     Ok(walk.map(|w| {
-                        FieldValue::owned_any(
-                            crate::graphql::mutations::WalkOutput::from(w),
-                        )
+                        FieldValue::owned_any(crate::graphql::mutations::walk::WalkOutput::from(w))
                     }))
                 })
             },
@@ -243,18 +185,14 @@ pub fn dog_output_type() -> Object {
                 FieldFuture::new(async move {
                     let d = ctx.parent_value.try_downcast_ref::<DogOutput>()?;
                     let dog_id = d.id;
-                    let state = ctx.data::<Arc<crate::AppState>>()?;
-                    let members = dog_member_service::get_members_by_dog(&state.db, dog_id)
+                    let members = ctx
+                        .data::<Arc<DogMembersLoader>>()?
+                        .load_one(dog_id)
                         .await
-                        .map_err(AppError::into_graphql_error)?;
-                    let values: Vec<FieldValue> = members
-                        .into_iter()
-                        .map(|(member, user)| {
-                            FieldValue::owned_any(super::dog_member::DogMemberOutput::from((
-                                member, user,
-                            )))
-                        })
-                        .collect();
+                        .map_err(async_graphql::Error::new)?
+                        .unwrap_or_default();
+                    let values: Vec<FieldValue> =
+                        members.into_iter().map(FieldValue::owned_any).collect();
                     Ok(Some(FieldValue::list(values)))
                 })
             },
@@ -318,8 +256,7 @@ pub fn update_dog_field(state: Arc<AppState>) -> Field {
         let state = state.clone();
         FieldFuture::new(async move {
             let id_str = ctx.args.try_get("id")?.string()?;
-            let dog_id =
-                Uuid::parse_str(id_str).map_err(|_| async_graphql::Error::new("Invalid dog ID"))?;
+            let dog_id = parse_uuid(id_str, "Invalid dog ID")?;
             let input = ctx.args.try_get("input")?.object()?;
             let name = input
                 .get("name")
@@ -363,8 +300,7 @@ pub fn delete_dog_field(state: Arc<AppState>) -> Field {
             let state = state.clone();
             FieldFuture::new(async move {
                 let dog_id_str = ctx.args.try_get("id")?.string()?;
-                let dog_id = Uuid::parse_str(dog_id_str)
-                    .map_err(|_| async_graphql::Error::new("Invalid dog ID"))?;
+                let dog_id = parse_uuid(dog_id_str, "Invalid dog ID")?;
 
                 let user = auth_helpers::resolve_user(&ctx, &state).await?;
                 dog_member_service::require_dog_owner(&state.db, dog_id, user.id)

--- a/apps/api/src/graphql/mutations/dog_member.rs
+++ b/apps/api/src/graphql/mutations/dog_member.rs
@@ -1,5 +1,6 @@
 use crate::error::AppError;
 use crate::graphql::auth_helpers;
+use crate::graphql::dynamic_helpers::{parse_uuid, string_field, uuid_field};
 use crate::services::{dog_invitation_service, dog_member_service, dog_service};
 use crate::AppState;
 use async_graphql::dynamic::{Field, FieldFuture, FieldValue, InputValue, Object, TypeRef};
@@ -64,80 +65,21 @@ impl
 
 pub fn dog_invitation_output_type() -> Object {
     Object::new("DogInvitationOutput")
-        .field(Field::new(
-            "id",
-            TypeRef::named_nn(TypeRef::STRING),
-            |ctx| {
-                FieldFuture::new(async move {
-                    let inv = ctx.parent_value.try_downcast_ref::<DogInvitationOutput>()?;
-                    Ok(Some(FieldValue::value(inv.id.to_string())))
-                })
-            },
-        ))
-        .field(Field::new(
-            "dogId",
-            TypeRef::named_nn(TypeRef::STRING),
-            |ctx| {
-                FieldFuture::new(async move {
-                    let inv = ctx.parent_value.try_downcast_ref::<DogInvitationOutput>()?;
-                    Ok(Some(FieldValue::value(inv.dog_id.to_string())))
-                })
-            },
-        ))
-        .field(Field::new(
-            "token",
-            TypeRef::named_nn(TypeRef::STRING),
-            |ctx| {
-                FieldFuture::new(async move {
-                    let inv = ctx.parent_value.try_downcast_ref::<DogInvitationOutput>()?;
-                    Ok(Some(FieldValue::value(inv.token.clone())))
-                })
-            },
-        ))
-        .field(Field::new(
-            "expiresAt",
-            TypeRef::named_nn(TypeRef::STRING),
-            |ctx| {
-                FieldFuture::new(async move {
-                    let inv = ctx.parent_value.try_downcast_ref::<DogInvitationOutput>()?;
-                    Ok(Some(FieldValue::value(inv.expires_at.clone())))
-                })
-            },
-        ))
+        .field(uuid_field("id", |inv: &DogInvitationOutput| inv.id))
+        .field(uuid_field("dogId", |inv: &DogInvitationOutput| inv.dog_id))
+        .field(string_field("token", |inv: &DogInvitationOutput| {
+            inv.token.clone()
+        }))
+        .field(string_field("expiresAt", |inv: &DogInvitationOutput| {
+            inv.expires_at.clone()
+        }))
 }
 
 pub fn dog_member_output_type() -> Object {
     Object::new("DogMemberOutput")
-        .field(Field::new(
-            "id",
-            TypeRef::named_nn(TypeRef::STRING),
-            |ctx| {
-                FieldFuture::new(async move {
-                    let m = ctx.parent_value.try_downcast_ref::<DogMemberOutput>()?;
-                    Ok(Some(FieldValue::value(m.id.to_string())))
-                })
-            },
-        ))
-        .field(Field::new(
-            "userId",
-            TypeRef::named_nn(TypeRef::STRING),
-            |ctx| {
-                FieldFuture::new(async move {
-                    let m = ctx.parent_value.try_downcast_ref::<DogMemberOutput>()?;
-                    Ok(Some(FieldValue::value(m.user_id.to_string())))
-                })
-            },
-        ))
-        .field(Field::new(
-            "role",
-            TypeRef::named_nn(TypeRef::STRING),
-            |ctx| {
-                FieldFuture::new(async move {
-                    let m = ctx.parent_value.try_downcast_ref::<DogMemberOutput>()?;
-                    Ok(Some(FieldValue::value(m.role.clone())))
-                })
-            },
-        ))
+        .field(uuid_field("id", |m: &DogMemberOutput| m.id))
+        .field(uuid_field("userId", |m: &DogMemberOutput| m.user_id))
+        .field(string_field("role", |m: &DogMemberOutput| m.role.clone()))
         .field(Field::new("user", TypeRef::named("WalkerOutput"), |ctx| {
             FieldFuture::new(async move {
                 let m = ctx.parent_value.try_downcast_ref::<DogMemberOutput>()?;
@@ -148,16 +90,9 @@ pub fn dog_member_output_type() -> Object {
                 })))
             })
         }))
-        .field(Field::new(
-            "createdAt",
-            TypeRef::named_nn(TypeRef::STRING),
-            |ctx| {
-                FieldFuture::new(async move {
-                    let m = ctx.parent_value.try_downcast_ref::<DogMemberOutput>()?;
-                    Ok(Some(FieldValue::value(m.created_at.clone())))
-                })
-            },
-        ))
+        .field(string_field("createdAt", |m: &DogMemberOutput| {
+            m.created_at.clone()
+        }))
 }
 
 pub fn generate_dog_invitation_field(state: Arc<AppState>) -> Field {
@@ -168,8 +103,7 @@ pub fn generate_dog_invitation_field(state: Arc<AppState>) -> Field {
             let state = state.clone();
             FieldFuture::new(async move {
                 let dog_id_str = ctx.args.try_get("dogId")?.string()?;
-                let dog_id = Uuid::parse_str(dog_id_str)
-                    .map_err(|_| async_graphql::Error::new("Invalid dog ID"))?;
+                let dog_id = parse_uuid(dog_id_str, "Invalid dog ID")?;
 
                 let user = auth_helpers::resolve_user(&ctx, &state).await?;
                 dog_member_service::require_dog_owner(&state.db, dog_id, user.id)
@@ -227,11 +161,9 @@ pub fn remove_dog_member_field(state: Arc<AppState>) -> Field {
             let state = state.clone();
             FieldFuture::new(async move {
                 let dog_id_str = ctx.args.try_get("dogId")?.string()?;
-                let dog_id = Uuid::parse_str(dog_id_str)
-                    .map_err(|_| async_graphql::Error::new("Invalid dog ID"))?;
+                let dog_id = parse_uuid(dog_id_str, "Invalid dog ID")?;
                 let target_user_id_str = ctx.args.try_get("userId")?.string()?;
-                let target_user_id = Uuid::parse_str(target_user_id_str)
-                    .map_err(|_| async_graphql::Error::new("Invalid user ID"))?;
+                let target_user_id = parse_uuid(target_user_id_str, "Invalid user ID")?;
 
                 let user = auth_helpers::resolve_user(&ctx, &state).await?;
 
@@ -267,8 +199,7 @@ pub fn leave_dog_field(state: Arc<AppState>) -> Field {
             let state = state.clone();
             FieldFuture::new(async move {
                 let dog_id_str = ctx.args.try_get("dogId")?.string()?;
-                let dog_id = Uuid::parse_str(dog_id_str)
-                    .map_err(|_| async_graphql::Error::new("Invalid dog ID"))?;
+                let dog_id = parse_uuid(dog_id_str, "Invalid dog ID")?;
 
                 let (user, membership) =
                     auth_helpers::resolve_user_and_dog(&ctx, &state, dog_id).await?;

--- a/apps/api/src/graphql/mutations/encounter.rs
+++ b/apps/api/src/graphql/mutations/encounter.rs
@@ -1,11 +1,11 @@
 use crate::error::{AppError, FieldError};
 use crate::graphql::auth_helpers;
 use crate::graphql::custom_queries::EncounterOutput;
+use crate::graphql::dynamic_helpers::{parse_uuid, parse_uuid_with_field_error};
 use crate::services::encounter_service;
 use crate::AppState;
 use async_graphql::dynamic::{Field, FieldFuture, FieldValue, InputValue, TypeRef};
 use std::sync::Arc;
-use uuid::Uuid;
 
 pub fn record_encounter_field(state: Arc<AppState>) -> Field {
     Field::new(
@@ -20,20 +20,13 @@ pub fn record_encounter_field(state: Arc<AppState>) -> Field {
 
                 let mut field_errors: Vec<FieldError> = Vec::new();
 
-                let my_walk_id = Uuid::parse_str(my_walk_id_str).ok().or_else(|| {
-                    field_errors.push(FieldError {
-                        field: "myWalkId".to_string(),
-                        message: "Invalid UUID format".to_string(),
-                    });
-                    None
-                });
-                let their_walk_id = Uuid::parse_str(their_walk_id_str).ok().or_else(|| {
-                    field_errors.push(FieldError {
-                        field: "theirWalkId".to_string(),
-                        message: "Invalid UUID format".to_string(),
-                    });
-                    None
-                });
+                let my_walk_id =
+                    parse_uuid_with_field_error(my_walk_id_str, "myWalkId", &mut field_errors);
+                let their_walk_id = parse_uuid_with_field_error(
+                    their_walk_id_str,
+                    "theirWalkId",
+                    &mut field_errors,
+                );
 
                 if !field_errors.is_empty() {
                     return Err(AppError::ValidationErrors(field_errors).into_graphql_error());
@@ -84,10 +77,8 @@ pub fn update_encounter_duration_field(state: Arc<AppState>) -> Field {
                 let my_walk_id_str = ctx.args.try_get("myWalkId")?.string()?;
                 let their_walk_id_str = ctx.args.try_get("theirWalkId")?.string()?;
                 let duration_sec = ctx.args.try_get("durationSec")?.i64()? as i32;
-                let my_walk_id = Uuid::parse_str(my_walk_id_str)
-                    .map_err(|_| async_graphql::Error::new("Invalid myWalkId"))?;
-                let their_walk_id = Uuid::parse_str(their_walk_id_str)
-                    .map_err(|_| async_graphql::Error::new("Invalid theirWalkId"))?;
+                let my_walk_id = parse_uuid(my_walk_id_str, "Invalid myWalkId")?;
+                let their_walk_id = parse_uuid(their_walk_id_str, "Invalid theirWalkId")?;
 
                 // Auth
                 let user = auth_helpers::resolve_user(&ctx, &state).await?;

--- a/apps/api/src/graphql/mutations/mod.rs
+++ b/apps/api/src/graphql/mutations/mod.rs
@@ -6,15 +6,6 @@ pub mod photo;
 pub mod walk;
 pub mod walk_event;
 
-// Re-export everything so `graphql/mod.rs` can use `mutations::` prefix unchanged.
-pub use auth::*;
-pub use dog::*;
-pub use dog_member::*;
-pub use encounter::*;
-pub use photo::*;
-pub use walk::*;
-pub use walk_event::*;
-
 use crate::AppState;
 use async_graphql::dynamic::Field;
 use std::sync::Arc;

--- a/apps/api/src/graphql/mutations/photo.rs
+++ b/apps/api/src/graphql/mutations/photo.rs
@@ -1,5 +1,6 @@
 use crate::error::AppError;
 use crate::graphql::auth_helpers;
+use crate::graphql::dynamic_helpers::{parse_uuid, string_field};
 use crate::services::s3_service;
 use crate::AppState;
 use async_graphql::dynamic::{Field, FieldFuture, FieldValue, InputValue, Object, TypeRef};
@@ -15,36 +16,11 @@ pub struct PresignedUrlOutput {
 
 pub fn presigned_url_type() -> Object {
     Object::new("PresignedUrlOutput")
-        .field(Field::new(
-            "url",
-            TypeRef::named_nn(TypeRef::STRING),
-            |ctx| {
-                FieldFuture::new(async move {
-                    let p = ctx.parent_value.try_downcast_ref::<PresignedUrlOutput>()?;
-                    Ok(Some(FieldValue::value(p.url.clone())))
-                })
-            },
-        ))
-        .field(Field::new(
-            "key",
-            TypeRef::named_nn(TypeRef::STRING),
-            |ctx| {
-                FieldFuture::new(async move {
-                    let p = ctx.parent_value.try_downcast_ref::<PresignedUrlOutput>()?;
-                    Ok(Some(FieldValue::value(p.key.clone())))
-                })
-            },
-        ))
-        .field(Field::new(
-            "expiresAt",
-            TypeRef::named_nn(TypeRef::STRING),
-            |ctx| {
-                FieldFuture::new(async move {
-                    let p = ctx.parent_value.try_downcast_ref::<PresignedUrlOutput>()?;
-                    Ok(Some(FieldValue::value(p.expires_at.clone())))
-                })
-            },
-        ))
+        .field(string_field("url", |p: &PresignedUrlOutput| p.url.clone()))
+        .field(string_field("key", |p: &PresignedUrlOutput| p.key.clone()))
+        .field(string_field("expiresAt", |p: &PresignedUrlOutput| {
+            p.expires_at.clone()
+        }))
 }
 
 pub fn generate_dog_photo_upload_url_field(state: Arc<AppState>) -> Field {
@@ -55,8 +31,7 @@ pub fn generate_dog_photo_upload_url_field(state: Arc<AppState>) -> Field {
             let state = state.clone();
             FieldFuture::new(async move {
                 let dog_id_str = ctx.args.try_get("dogId")?.string()?;
-                let dog_id = uuid::Uuid::parse_str(dog_id_str)
-                    .map_err(|_| async_graphql::Error::new("Invalid dog ID"))?;
+                let dog_id = parse_uuid(dog_id_str, "Invalid dog ID")?;
                 let content_type = ctx.args.try_get("contentType")?.string()?.to_string();
 
                 auth_helpers::resolve_user_and_dog(&ctx, &state, dog_id).await?;
@@ -93,8 +68,7 @@ pub fn generate_walk_event_photo_upload_url_field(state: Arc<AppState>) -> Field
             let state = state.clone();
             FieldFuture::new(async move {
                 let walk_id_str = ctx.args.try_get("walkId")?.string()?;
-                let walk_id = uuid::Uuid::parse_str(walk_id_str)
-                    .map_err(|_| async_graphql::Error::new("Invalid walk ID"))?;
+                let walk_id = parse_uuid(walk_id_str, "Invalid walk ID")?;
                 let content_type = ctx.args.try_get("contentType")?.string()?.to_string();
 
                 auth_helpers::resolve_user_and_walk(&ctx, &state, walk_id).await?;

--- a/apps/api/src/graphql/mutations/walk.rs
+++ b/apps/api/src/graphql/mutations/walk.rs
@@ -1,8 +1,13 @@
 use crate::error::{AppError, FieldError};
 use crate::graphql::auth_helpers;
+use crate::graphql::dynamic_helpers::{
+    optional_int_field, optional_string_field, parse_uuid, parse_uuid_with_field_error,
+    string_field, uuid_field,
+};
+use crate::graphql::loaders::{UserLoader, WalkDogsLoader};
 use crate::services::{
-    dog_member_service, user_service, walk_event_service, walk_points_queue_service,
-    walk_points_service, walk_service,
+    dog_member_service, walk_event_service, walk_points_queue_service, walk_points_service,
+    walk_service,
 };
 use crate::AppState;
 use async_graphql::dynamic::{
@@ -59,76 +64,31 @@ impl From<crate::entities::users::Model> for WalkerOutput {
 
 pub fn walk_output_type() -> Object {
     Object::new("WalkOutput")
-        .field(Field::new(
-            "id",
-            TypeRef::named_nn(TypeRef::STRING),
-            |ctx| {
-                FieldFuture::new(async move {
-                    let w = ctx.parent_value.try_downcast_ref::<WalkOutput>()?;
-                    Ok(Some(FieldValue::value(w.id.to_string())))
-                })
-            },
-        ))
-        .field(Field::new(
-            "status",
-            TypeRef::named_nn(TypeRef::STRING),
-            |ctx| {
-                FieldFuture::new(async move {
-                    let w = ctx.parent_value.try_downcast_ref::<WalkOutput>()?;
-                    Ok(Some(FieldValue::value(w.status.clone())))
-                })
-            },
-        ))
-        .field(Field::new(
-            "distanceM",
-            TypeRef::named(TypeRef::INT),
-            |ctx| {
-                FieldFuture::new(async move {
-                    let w = ctx.parent_value.try_downcast_ref::<WalkOutput>()?;
-                    Ok(w.distance_m.map(FieldValue::value))
-                })
-            },
-        ))
-        .field(Field::new(
-            "durationSec",
-            TypeRef::named(TypeRef::INT),
-            |ctx| {
-                FieldFuture::new(async move {
-                    let w = ctx.parent_value.try_downcast_ref::<WalkOutput>()?;
-                    Ok(w.duration_sec.map(FieldValue::value))
-                })
-            },
-        ))
-        .field(Field::new(
-            "startedAt",
-            TypeRef::named_nn(TypeRef::STRING),
-            |ctx| {
-                FieldFuture::new(async move {
-                    let w = ctx.parent_value.try_downcast_ref::<WalkOutput>()?;
-                    Ok(Some(FieldValue::value(w.started_at.clone())))
-                })
-            },
-        ))
-        .field(Field::new(
-            "endedAt",
-            TypeRef::named(TypeRef::STRING),
-            |ctx| {
-                FieldFuture::new(async move {
-                    let w = ctx.parent_value.try_downcast_ref::<WalkOutput>()?;
-                    Ok(w.ended_at.clone().map(FieldValue::value))
-                })
-            },
-        ))
+        .field(uuid_field("id", |w: &WalkOutput| w.id))
+        .field(string_field("status", |w: &WalkOutput| w.status.clone()))
+        .field(optional_int_field("distanceM", |w: &WalkOutput| {
+            w.distance_m
+        }))
+        .field(optional_int_field("durationSec", |w: &WalkOutput| {
+            w.duration_sec
+        }))
+        .field(string_field("startedAt", |w: &WalkOutput| {
+            w.started_at.clone()
+        }))
+        .field(optional_string_field("endedAt", |w: &WalkOutput| {
+            w.ended_at.clone()
+        }))
         .field(Field::new(
             "walker",
             TypeRef::named("WalkerOutput"),
             |ctx| {
                 FieldFuture::new(async move {
                     let w = ctx.parent_value.try_downcast_ref::<WalkOutput>()?;
-                    let state = ctx.data::<Arc<crate::AppState>>()?;
-                    let user = user_service::get_user_by_id(&state.db, w.user_id)
+                    let user = ctx
+                        .data::<Arc<UserLoader>>()?
+                        .load_one(w.user_id)
                         .await
-                        .map_err(AppError::into_graphql_error)?;
+                        .map_err(async_graphql::Error::new)?;
                     Ok(user.map(|u| FieldValue::owned_any(WalkerOutput::from(u))))
                 })
             },
@@ -139,10 +99,12 @@ pub fn walk_output_type() -> Object {
             |ctx| {
                 FieldFuture::new(async move {
                     let w = ctx.parent_value.try_downcast_ref::<WalkOutput>()?;
-                    let state = ctx.data::<Arc<crate::AppState>>()?;
-                    let dogs = walk_service::get_dogs_for_walk(&state.db, w.id)
+                    let dogs = ctx
+                        .data::<Arc<WalkDogsLoader>>()?
+                        .load_one(w.id)
                         .await
-                        .map_err(AppError::into_graphql_error)?;
+                        .map_err(async_graphql::Error::new)?
+                        .unwrap_or_default();
                     let values: Vec<FieldValue> = dogs
                         .into_iter()
                         .map(|d| FieldValue::owned_any(super::dog::DogOutput::from(d)))
@@ -205,36 +167,13 @@ pub fn walk_output_type() -> Object {
 
 pub fn walker_output_type() -> Object {
     Object::new("WalkerOutput")
-        .field(Field::new(
-            "id",
-            TypeRef::named_nn(TypeRef::STRING),
-            |ctx| {
-                FieldFuture::new(async move {
-                    let w = ctx.parent_value.try_downcast_ref::<WalkerOutput>()?;
-                    Ok(Some(FieldValue::value(w.id.to_string())))
-                })
-            },
-        ))
-        .field(Field::new(
-            "displayName",
-            TypeRef::named(TypeRef::STRING),
-            |ctx| {
-                FieldFuture::new(async move {
-                    let w = ctx.parent_value.try_downcast_ref::<WalkerOutput>()?;
-                    Ok(w.display_name.clone().map(FieldValue::value))
-                })
-            },
-        ))
-        .field(Field::new(
-            "avatarUrl",
-            TypeRef::named(TypeRef::STRING),
-            |ctx| {
-                FieldFuture::new(async move {
-                    let w = ctx.parent_value.try_downcast_ref::<WalkerOutput>()?;
-                    Ok(w.avatar_url.clone().map(FieldValue::value))
-                })
-            },
-        ))
+        .field(uuid_field("id", |w: &WalkerOutput| w.id))
+        .field(optional_string_field("displayName", |w: &WalkerOutput| {
+            w.display_name.clone()
+        }))
+        .field(optional_string_field("avatarUrl", |w: &WalkerOutput| {
+            w.avatar_url.clone()
+        }))
 }
 
 pub fn walk_point_input_type() -> InputObject {
@@ -257,7 +196,7 @@ pub fn start_walk_field(state: Arc<AppState>) -> Field {
                 .iter()
                 .map(|v| {
                     let s = v.string()?;
-                    Uuid::parse_str(s).map_err(|_| async_graphql::Error::new("Invalid dog ID"))
+                    parse_uuid(s, "Invalid dog ID")
                 })
                 .collect::<Result<Vec<Uuid>, _>>()?;
 
@@ -285,8 +224,7 @@ pub fn finish_walk_field(state: Arc<AppState>) -> Field {
         let state = state.clone();
         FieldFuture::new(async move {
             let walk_id_str = ctx.args.try_get("walkId")?.string()?;
-            let walk_id = Uuid::parse_str(walk_id_str)
-                .map_err(|_| async_graphql::Error::new("Invalid walk ID"))?;
+            let walk_id = parse_uuid(walk_id_str, "Invalid walk ID")?;
             let distance_m = ctx
                 .args
                 .get("distanceM")
@@ -314,13 +252,8 @@ pub fn add_walk_points_field(state: Arc<AppState>) -> Field {
                 let walk_id_str = ctx.args.try_get("walkId")?.string()?;
 
                 let mut field_errors: Vec<FieldError> = Vec::new();
-                let walk_id_opt = Uuid::parse_str(walk_id_str).ok().or_else(|| {
-                    field_errors.push(FieldError {
-                        field: "walkId".to_string(),
-                        message: "Invalid UUID format".to_string(),
-                    });
-                    None
-                });
+                let walk_id_opt =
+                    parse_uuid_with_field_error(walk_id_str, "walkId", &mut field_errors);
                 if !field_errors.is_empty() {
                     return Err(AppError::ValidationErrors(field_errors).into_graphql_error());
                 }
@@ -357,10 +290,7 @@ pub fn add_walk_points_field(state: Arc<AppState>) -> Field {
                     })?;
 
                 let result = walk_points_queue_service::enqueue_walk_points(
-                    &state.sqs,
-                    queue_url,
-                    walk_id,
-                    points,
+                    &state.sqs, queue_url, walk_id, points,
                 )
                 .await
                 .map_err(AppError::into_graphql_error)?;

--- a/apps/api/src/graphql/mutations/walk_event.rs
+++ b/apps/api/src/graphql/mutations/walk_event.rs
@@ -1,5 +1,9 @@
 use crate::error::AppError;
 use crate::graphql::auth_helpers;
+use crate::graphql::dynamic_helpers::{
+    format_photo_cdn_url, optional_float_field, optional_string_field, parse_uuid, string_field,
+    uuid_field,
+};
 use crate::services::walk_event_service;
 use crate::AppState;
 use async_graphql::dynamic::{
@@ -40,68 +44,19 @@ impl From<crate::entities::walk_events::Model> for WalkEventOutput {
 
 pub fn walk_event_output_type() -> Object {
     Object::new("WalkEventOutput")
-        .field(Field::new(
-            "id",
-            TypeRef::named_nn(TypeRef::STRING),
-            |ctx| {
-                FieldFuture::new(async move {
-                    let e = ctx.parent_value.try_downcast_ref::<WalkEventOutput>()?;
-                    Ok(Some(FieldValue::value(e.id.to_string())))
-                })
-            },
-        ))
-        .field(Field::new(
-            "walkId",
-            TypeRef::named_nn(TypeRef::STRING),
-            |ctx| {
-                FieldFuture::new(async move {
-                    let e = ctx.parent_value.try_downcast_ref::<WalkEventOutput>()?;
-                    Ok(Some(FieldValue::value(e.walk_id.to_string())))
-                })
-            },
-        ))
-        .field(Field::new(
-            "dogId",
-            TypeRef::named(TypeRef::STRING),
-            |ctx| {
-                FieldFuture::new(async move {
-                    let e = ctx.parent_value.try_downcast_ref::<WalkEventOutput>()?;
-                    Ok(e.dog_id.map(|id| FieldValue::value(id.to_string())))
-                })
-            },
-        ))
-        .field(Field::new(
-            "eventType",
-            TypeRef::named_nn(TypeRef::STRING),
-            |ctx| {
-                FieldFuture::new(async move {
-                    let e = ctx.parent_value.try_downcast_ref::<WalkEventOutput>()?;
-                    Ok(Some(FieldValue::value(e.event_type.clone())))
-                })
-            },
-        ))
-        .field(Field::new(
-            "occurredAt",
-            TypeRef::named_nn(TypeRef::STRING),
-            |ctx| {
-                FieldFuture::new(async move {
-                    let e = ctx.parent_value.try_downcast_ref::<WalkEventOutput>()?;
-                    Ok(Some(FieldValue::value(e.occurred_at.clone())))
-                })
-            },
-        ))
-        .field(Field::new("lat", TypeRef::named(TypeRef::FLOAT), |ctx| {
-            FieldFuture::new(async move {
-                let e = ctx.parent_value.try_downcast_ref::<WalkEventOutput>()?;
-                Ok(e.lat.map(FieldValue::value))
-            })
+        .field(uuid_field("id", |e: &WalkEventOutput| e.id))
+        .field(uuid_field("walkId", |e: &WalkEventOutput| e.walk_id))
+        .field(optional_string_field("dogId", |e: &WalkEventOutput| {
+            e.dog_id.map(|id| id.to_string())
         }))
-        .field(Field::new("lng", TypeRef::named(TypeRef::FLOAT), |ctx| {
-            FieldFuture::new(async move {
-                let e = ctx.parent_value.try_downcast_ref::<WalkEventOutput>()?;
-                Ok(e.lng.map(FieldValue::value))
-            })
+        .field(string_field("eventType", |e: &WalkEventOutput| {
+            e.event_type.clone()
         }))
+        .field(string_field("occurredAt", |e: &WalkEventOutput| {
+            e.occurred_at.clone()
+        }))
+        .field(optional_float_field("lat", |e: &WalkEventOutput| e.lat))
+        .field(optional_float_field("lng", |e: &WalkEventOutput| e.lng))
         .field(Field::new(
             "photoUrl",
             TypeRef::named(TypeRef::STRING),
@@ -110,12 +65,7 @@ pub fn walk_event_output_type() -> Object {
                     let e = ctx.parent_value.try_downcast_ref::<WalkEventOutput>()?;
                     let state = ctx.data::<Arc<crate::AppState>>()?;
                     Ok(e.photo_url.clone().map(|key| {
-                        let url = if key.starts_with("http") {
-                            key
-                        } else {
-                            format!("{}/{}", state.config.photo_cdn_url, key)
-                        };
-                        FieldValue::value(url)
+                        FieldValue::value(format_photo_cdn_url(&state.config.photo_cdn_url, &key))
                     }))
                 })
             },
@@ -149,15 +99,13 @@ pub fn record_walk_event_field(state: Arc<AppState>) -> Field {
                 let input = ctx.args.try_get("input")?.object()?;
 
                 let walk_id_str = input.try_get("walkId")?.string()?;
-                let walk_id = Uuid::parse_str(walk_id_str)
-                    .map_err(|_| async_graphql::Error::new("Invalid walkId"))?;
+                let walk_id = parse_uuid(walk_id_str, "Invalid walkId")?;
 
                 let dog_id = input
                     .get("dogId")
                     .and_then(|v| v.string().ok())
-                    .map(Uuid::parse_str)
-                    .transpose()
-                    .map_err(|_| async_graphql::Error::new("Invalid dogId"))?;
+                    .map(|value| parse_uuid(value, "Invalid dogId"))
+                    .transpose()?;
 
                 let event_type = input.try_get("eventType")?.string()?.to_string();
                 let occurred_at_str = input.try_get("occurredAt")?.string()?;

--- a/apps/api/src/lib.rs
+++ b/apps/api/src/lib.rs
@@ -39,6 +39,12 @@ pub struct AppState {
     pub verifier: Arc<dyn JwtVerifier>,
 }
 
+#[derive(Clone)]
+pub struct GraphqlState {
+    pub schema: AppSchema,
+    pub app_state: Arc<AppState>,
+}
+
 pub fn build_app(
     db: DatabaseConnection,
     dynamo: DynamoClient,
@@ -57,7 +63,11 @@ pub fn build_app(
         config,
         verifier: verifier.clone(),
     });
-    let schema = graphql::build_schema(state);
+    let schema = graphql::build_schema(state.clone());
+    let graphql_state = GraphqlState {
+        schema,
+        app_state: state.clone(),
+    };
 
     // Sentry middleware: NewSentryLayer creates a fresh Hub per request so user
     // context, breadcrumbs and transactions do not leak between concurrent requests.
@@ -110,15 +120,25 @@ pub fn build_app(
         .layer(PropagateRequestIdLayer::new(x_request_id.clone()))
         .layer(trace_layer)
         .layer(SetRequestIdLayer::new(x_request_id, MakeRequestUuid))
-        .with_state(schema)
+        .with_state(graphql_state)
 }
 
 async fn graphql_handler(
-    axum::extract::State(schema): axum::extract::State<AppSchema>,
+    axum::extract::State(state): axum::extract::State<GraphqlState>,
     auth_user: Option<axum::Extension<auth::AuthUser>>,
     req: GraphQLRequest,
 ) -> GraphQLResponse {
     let cognito_sub: Option<String> = auth_user.map(|u| u.cognito_sub.clone());
-    let request = req.into_inner().data(cognito_sub);
-    schema.execute(request).await.into()
+    let request = req
+        .into_inner()
+        .data(cognito_sub)
+        .data(graphql::loaders::build_user_loader(&state.app_state.db))
+        .data(graphql::loaders::build_dog_loader(&state.app_state.db))
+        .data(graphql::loaders::build_dog_members_loader(
+            &state.app_state.db,
+        ))
+        .data(graphql::loaders::build_walk_dogs_loader(
+            &state.app_state.db,
+        ));
+    state.schema.execute(request).await.into()
 }

--- a/apps/api/src/services/dog_member_service.rs
+++ b/apps/api/src/services/dog_member_service.rs
@@ -2,6 +2,7 @@ use sea_orm::{
     ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, JoinType, PaginatorTrait,
     QueryFilter, QuerySelect, RelationTrait, Set,
 };
+use std::collections::HashMap;
 use uuid::Uuid;
 
 use crate::entities::{
@@ -38,8 +39,8 @@ pub async fn require_dog_owner<C: ConnectionTrait>(
         .ok_or_else(|| AppError::NotFound(format!("Dog {} not found or not owner", dog_id)))
 }
 
-pub async fn get_dogs_by_member(
-    db: &sea_orm::DatabaseConnection,
+pub async fn get_dogs_by_member<C: ConnectionTrait>(
+    db: &C,
     user_id: Uuid,
 ) -> Result<Vec<DogModel>, AppError> {
     DogEntity::find()
@@ -60,62 +61,76 @@ pub async fn get_dogs_by_member(
 /// tables drift, the dog is omitted rather than being surfaced with a
 /// missing role. The FK constraint on `dog_members.dog_id` makes this a
 /// defensive guard rather than a practical concern.
-pub async fn get_dogs_with_roles_for_user(
-    db: &sea_orm::DatabaseConnection,
+pub async fn get_dogs_with_roles_for_user<C: ConnectionTrait>(
+    db: &C,
     user_id: Uuid,
 ) -> Result<Vec<(DogModel, String)>, AppError> {
-    let memberships = DogMemberEntity::find()
+    let rows = DogMemberEntity::find()
         .filter(dog_members::Column::UserId.eq(user_id))
+        .find_also_related(DogEntity)
         .all(db)
         .await?;
 
-    if memberships.is_empty() {
-        return Ok(Vec::new());
-    }
-
-    let dog_ids: Vec<Uuid> = memberships.iter().map(|m| m.dog_id).collect();
-    let dogs_list = DogEntity::find()
-        .filter(crate::entities::dogs::Column::Id.is_in(dog_ids))
-        .all(db)
-        .await?;
-
-    let results = dogs_list
+    Ok(rows
         .into_iter()
-        .filter_map(|d| {
-            memberships
-                .iter()
-                .find(|m| m.dog_id == d.id)
-                .map(|m| (d, m.role.clone()))
-        })
-        .collect();
-
-    Ok(results)
+        .filter_map(|(membership, dog)| dog.map(|dog| (dog, membership.role)))
+        .collect())
 }
 
-pub async fn get_members_by_dog(
-    db: &sea_orm::DatabaseConnection,
+pub async fn get_members_by_dog<C: ConnectionTrait>(
+    db: &C,
     dog_id: Uuid,
 ) -> Result<Vec<(DogMemberModel, UserModel)>, AppError> {
     let members = DogMemberEntity::find()
         .filter(dog_members::Column::DogId.eq(dog_id))
+        .find_also_related(UserEntity)
         .all(db)
         .await?;
 
-    let user_ids: Vec<Uuid> = members.iter().map(|m| m.user_id).collect();
-    let users = UserEntity::find()
-        .filter(crate::entities::users::Column::Id.is_in(user_ids))
-        .all(db)
-        .await?;
-
-    let results = members
+    Ok(members
         .into_iter()
-        .filter_map(|m| {
-            let user = users.iter().find(|u| u.id == m.user_id)?.clone();
-            Some((m, user))
-        })
-        .collect();
+        .filter_map(|(member, user)| user.map(|user| (member, user)))
+        .collect())
+}
 
-    Ok(results)
+pub async fn get_members_by_dog_ids<C: ConnectionTrait>(
+    db: &C,
+    dog_ids: &[Uuid],
+) -> Result<HashMap<Uuid, Vec<(DogMemberModel, UserModel)>>, AppError> {
+    if dog_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let rows = DogMemberEntity::find()
+        .filter(dog_members::Column::DogId.is_in(dog_ids.iter().copied()))
+        .find_also_related(UserEntity)
+        .all(db)
+        .await?;
+
+    let mut grouped = HashMap::new();
+    for (member, user) in rows {
+        if let Some(user) = user {
+            grouped
+                .entry(member.dog_id)
+                .or_insert_with(Vec::new)
+                .push((member, user));
+        }
+    }
+
+    Ok(grouped)
+}
+
+pub async fn require_any_dog_member<C: ConnectionTrait>(
+    db: &C,
+    dog_ids: &[Uuid],
+    user_id: Uuid,
+) -> Result<DogMemberModel, AppError> {
+    DogMemberEntity::find()
+        .filter(dog_members::Column::DogId.is_in(dog_ids.iter().copied()))
+        .filter(dog_members::Column::UserId.eq(user_id))
+        .one(db)
+        .await?
+        .ok_or_else(|| AppError::Unauthorized("Not a member of either dog".to_string()))
 }
 
 pub async fn remove_member(

--- a/apps/api/src/services/dog_service.rs
+++ b/apps/api/src/services/dog_service.rs
@@ -1,12 +1,13 @@
 use crate::entities::{
-    dogs::{ActiveModel, Entity as DogEntity, Model as DogModel},
+    dogs::{self, ActiveModel, Entity as DogEntity, Model as DogModel},
     walk_dogs::{self, Entity as WalkDogEntity},
     walks::Entity as WalkEntity,
 };
 use crate::error::AppError;
 use crate::services::dog_member_service;
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, EntityTrait, PaginatorTrait, QueryFilter, Set, TransactionTrait,
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, PaginatorTrait, QueryFilter, Set,
+    TransactionTrait,
 };
 use uuid::Uuid;
 
@@ -71,12 +72,27 @@ pub async fn update_dog(
     Ok(updated)
 }
 
-pub async fn get_dog_by_id(
-    db: &sea_orm::DatabaseConnection,
+pub async fn get_dog_by_id<C: ConnectionTrait>(
+    db: &C,
     dog_id: Uuid,
 ) -> Result<Option<DogModel>, AppError> {
     DogEntity::find_by_id(dog_id)
         .one(db)
+        .await
+        .map_err(AppError::Database)
+}
+
+pub async fn get_dogs_by_ids<C: ConnectionTrait>(
+    db: &C,
+    dog_ids: &[Uuid],
+) -> Result<Vec<DogModel>, AppError> {
+    if dog_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    DogEntity::find()
+        .filter(dogs::Column::Id.is_in(dog_ids.iter().copied()))
+        .all(db)
         .await
         .map_err(AppError::Database)
 }

--- a/apps/api/src/services/encounter_service.rs
+++ b/apps/api/src/services/encounter_service.rs
@@ -1,112 +1,14 @@
 use chrono::Utc;
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, Condition, EntityTrait, QueryFilter, QueryOrder, QuerySelect,
-    Set, TransactionTrait,
+    ColumnTrait, Condition, EntityTrait, QueryFilter, QueryOrder, QuerySelect, TransactionTrait,
 };
 use uuid::Uuid;
 
-use super::friendship_service;
-use crate::entities::{
-    dog_members::{self, Entity as DogMemberEntity},
-    encounters::{
-        self, ActiveModel as EncounterActiveModel, Entity as EncounterEntity,
-        Model as EncounterModel,
-    },
-    users::{self, Entity as UserEntity},
-    walk_dogs::{self, Entity as WalkDogEntity},
-    walks::Entity as WalkEntity,
-};
+use crate::entities::encounters::{self, Entity as EncounterEntity, Model as EncounterModel};
 use crate::error::AppError;
-use crate::services::dog_pair::DogPair;
-
-/// Verify that encounter detection is allowed for the acting user's walk.
-///
-/// Checks:
-/// 1. The walk exists.
-/// 2. The walk belongs to `user_id` (ownership check).
-/// 3. The user has `encounter_detection_enabled = true`.
-async fn verify_encounter_detection(
-    db: &sea_orm::DatabaseConnection,
-    walk_id: Uuid,
-    user_id: Uuid,
-) -> Result<(), AppError> {
-    let walk = WalkEntity::find_by_id(walk_id)
-        .one(db)
-        .await?
-        .ok_or_else(|| AppError::NotFound(format!("Walk {} not found", walk_id)))?;
-
-    if walk.user_id != user_id {
-        return Err(AppError::Unauthorized(
-            "Walk does not belong to user".to_string(),
-        ));
-    }
-
-    let user = UserEntity::find_by_id(user_id)
-        .one(db)
-        .await?
-        .ok_or_else(|| AppError::NotFound(format!("User {} not found", user_id)))?;
-
-    if !user.encounter_detection_enabled {
-        return Err(AppError::Unauthorized(
-            "Encounter detection is disabled for your account".to_string(),
-        ));
-    }
-
-    Ok(())
-}
-
-/// Verify that all users associated with the counterparty walk have
-/// encounter detection enabled.
-///
-/// Three fixed queries replace an N+M nested loop:
-/// 1. walk_dogs WHERE walk_id = their_walk_id → dog_ids
-/// 2. dog_members WHERE dog_id IN (dog_ids) → user_ids
-/// 3. users WHERE id IN (user_ids) AND encounter_detection_enabled = false
-///
-/// If any associated user has encounter detection disabled, returns
-/// `Unauthorized`.
-async fn verify_counterparty_encounter_detection(
-    db: &sea_orm::DatabaseConnection,
-    their_walk_id: Uuid,
-) -> Result<(), AppError> {
-    let dog_ids: Vec<Uuid> = WalkDogEntity::find()
-        .filter(walk_dogs::Column::WalkId.eq(their_walk_id))
-        .select_only()
-        .column(walk_dogs::Column::DogId)
-        .into_tuple()
-        .all(db)
-        .await?;
-
-    if dog_ids.is_empty() {
-        return Ok(());
-    }
-
-    let user_ids: Vec<Uuid> = DogMemberEntity::find()
-        .filter(dog_members::Column::DogId.is_in(dog_ids))
-        .select_only()
-        .column(dog_members::Column::UserId)
-        .into_tuple()
-        .all(db)
-        .await?;
-
-    if user_ids.is_empty() {
-        return Ok(());
-    }
-
-    let opted_out = UserEntity::find()
-        .filter(users::Column::Id.is_in(user_ids))
-        .filter(users::Column::EncounterDetectionEnabled.eq(false))
-        .one(db)
-        .await?;
-
-    if opted_out.is_some() {
-        return Err(AppError::Unauthorized(
-            "Encounter detection is disabled for the other user".to_string(),
-        ));
-    }
-
-    Ok(())
-}
+mod access_policy;
+mod pairs;
+mod persistence;
 
 /// Record encounters between all dog pairs from two walks.
 /// Creates or updates `encounters` and `friendships` rows.
@@ -121,88 +23,26 @@ pub async fn record_encounter(
     acting_user_id: Uuid,
 ) -> Result<Vec<EncounterModel>, AppError> {
     // Verify acting user ownership + encounter detection enabled
-    verify_encounter_detection(db, my_walk_id, acting_user_id).await?;
+    access_policy::verify_encounter_detection(db, my_walk_id, acting_user_id).await?;
 
     // Verify all counterparty users have encounter detection enabled (fixed 2-3 queries)
-    verify_counterparty_encounter_detection(db, their_walk_id).await?;
+    access_policy::verify_counterparty_encounter_detection(db, their_walk_id).await?;
 
-    // Fetch all dog IDs in each walk
-    let my_dog_ids: Vec<Uuid> = WalkDogEntity::find()
-        .filter(walk_dogs::Column::WalkId.eq(my_walk_id))
-        .select_only()
-        .column(walk_dogs::Column::DogId)
-        .into_tuple()
-        .all(db)
-        .await?;
-
-    let their_dog_ids: Vec<Uuid> = WalkDogEntity::find()
-        .filter(walk_dogs::Column::WalkId.eq(their_walk_id))
-        .select_only()
-        .column(walk_dogs::Column::DogId)
-        .into_tuple()
-        .all(db)
-        .await?;
-
-    if my_dog_ids.is_empty() || their_dog_ids.is_empty() {
-        return Err(AppError::BadRequest(
-            "One or both walks have no dogs".to_string(),
-        ));
-    }
+    let my_dog_ids = pairs::dog_ids_for_walk(db, my_walk_id).await?;
+    let their_dog_ids = pairs::dog_ids_for_walk(db, their_walk_id).await?;
+    let dog_pairs = pairs::expand_pairs(&my_dog_ids, &their_dog_ids)?;
 
     let met_at = Utc::now();
-    let mut result = Vec::new();
-
     let txn = db.begin().await?;
-
-    for my_dog in &my_dog_ids {
-        for their_dog in &their_dog_ids {
-            // DogPair enforces dog_id_1 < dog_id_2 and skips the same-dog case.
-            let Some(pair) = DogPair::new(*my_dog, *their_dog) else {
-                continue;
-            };
-
-            // Find existing encounter for this dog pair (from either walk direction)
-            let existing = EncounterEntity::find()
-                .filter(
-                    Condition::any()
-                        .add(encounters::Column::WalkId.eq(my_walk_id))
-                        .add(encounters::Column::WalkId.eq(their_walk_id)),
-                )
-                .filter(encounters::Column::DogId1.eq(pair.first()))
-                .filter(encounters::Column::DogId2.eq(pair.second()))
-                .one(&txn)
-                .await?;
-
-            let encounter = if let Some(existing) = existing {
-                // Update duration if longer
-                let new_duration = existing.duration_sec.max(duration_sec);
-                let mut active: encounters::ActiveModel = existing.into();
-                active.duration_sec = Set(new_duration);
-                active.met_at = Set(met_at.into());
-                active.update(&txn).await?
-            } else {
-                // Insert new encounter
-                let encounter = EncounterActiveModel {
-                    id: Set(Uuid::new_v4()),
-                    walk_id: Set(my_walk_id),
-                    dog_id_1: Set(pair.first()),
-                    dog_id_2: Set(pair.second()),
-                    duration_sec: Set(duration_sec),
-                    met_at: Set(met_at.into()),
-                    created_at: Set(met_at.into()),
-                }
-                .insert(&txn)
-                .await?;
-
-                // Upsert friendship (first encounter creates it)
-                friendship_service::upsert_friendship(&txn, pair, duration_sec, met_at).await?;
-
-                encounter
-            };
-
-            result.push(encounter);
-        }
-    }
+    let result = persistence::record_pairs(
+        &txn,
+        &dog_pairs,
+        my_walk_id,
+        their_walk_id,
+        duration_sec,
+        met_at,
+    )
+    .await?;
 
     txn.commit().await?;
     Ok(result)
@@ -220,51 +60,11 @@ pub async fn update_encounter_duration(
     acting_user_id: Uuid,
 ) -> Result<bool, AppError> {
     // Verify acting user ownership + encounter detection enabled
-    verify_encounter_detection(db, my_walk_id, acting_user_id).await?;
-    let their_dog_ids: Vec<Uuid> = WalkDogEntity::find()
-        .filter(walk_dogs::Column::WalkId.eq(their_walk_id))
-        .select_only()
-        .column(walk_dogs::Column::DogId)
-        .into_tuple()
-        .all(db)
-        .await?;
-
-    let my_dog_ids: Vec<Uuid> = WalkDogEntity::find()
-        .filter(walk_dogs::Column::WalkId.eq(my_walk_id))
-        .select_only()
-        .column(walk_dogs::Column::DogId)
-        .into_tuple()
-        .all(db)
-        .await?;
-
-    for my_dog in &my_dog_ids {
-        for their_dog in &their_dog_ids {
-            let Some(pair) = DogPair::new(*my_dog, *their_dog) else {
-                continue;
-            };
-
-            let existing = EncounterEntity::find()
-                .filter(encounters::Column::WalkId.eq(my_walk_id))
-                .filter(encounters::Column::DogId1.eq(pair.first()))
-                .filter(encounters::Column::DogId2.eq(pair.second()))
-                .one(db)
-                .await?;
-
-            if let Some(existing) = existing {
-                let old_duration = existing.duration_sec;
-                let new_duration = old_duration.max(duration_sec);
-                let mut active: encounters::ActiveModel = existing.into();
-                active.duration_sec = Set(new_duration);
-                active.update(db).await?;
-
-                // Update friendship total_interaction_sec with precise delta
-                let delta = new_duration - old_duration;
-                friendship_service::update_friendship_duration(db, pair, delta).await?;
-            }
-        }
-    }
-
-    Ok(true)
+    access_policy::verify_encounter_detection(db, my_walk_id, acting_user_id).await?;
+    let their_dog_ids = pairs::dog_ids_for_walk(db, their_walk_id).await?;
+    let my_dog_ids = pairs::dog_ids_for_walk(db, my_walk_id).await?;
+    let dog_pairs = pairs::expand_pairs(&my_dog_ids, &their_dog_ids)?;
+    persistence::update_pair_durations(db, &dog_pairs, my_walk_id, duration_sec).await
 }
 
 /// Get encounter history for a dog, ordered by met_at DESC.
@@ -296,64 +96,6 @@ pub async fn get_encounters_for_dog(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// Static guard: record_encounter must accept acting_user_id parameter.
-    #[test]
-    fn record_encounter_signature_has_acting_user_id() {
-        let src = include_str!("encounter_service.rs");
-        // The pub async fn record_encounter signature must include acting_user_id
-        let fn_start = src
-            .find("pub async fn record_encounter")
-            .expect("record_encounter must exist");
-        let fn_signature_end = src[fn_start..].find('{').unwrap_or(0);
-        let signature = &src[fn_start..fn_start + fn_signature_end];
-        assert!(
-            signature.contains("acting_user_id"),
-            "record_encounter signature must include acting_user_id: Uuid, got: {}",
-            signature
-        );
-    }
-
-    /// Static guard: update_encounter_duration must accept acting_user_id parameter.
-    #[test]
-    fn update_encounter_duration_signature_has_acting_user_id() {
-        let src = include_str!("encounter_service.rs");
-        let fn_start = src
-            .find("pub async fn update_encounter_duration")
-            .expect("update_encounter_duration must exist");
-        let fn_signature_end = src[fn_start..].find('{').unwrap_or(0);
-        let signature = &src[fn_start..fn_start + fn_signature_end];
-        assert!(
-            signature.contains("acting_user_id"),
-            "update_encounter_duration signature must include acting_user_id: Uuid, got: {}",
-            signature
-        );
-    }
-
-    /// Static guard: encounter_service must own and call
-    /// verify_encounter_detection (no delegation to walk_event_service).
-    #[test]
-    fn encounter_service_defines_verify_encounter_detection() {
-        let src = include_str!("encounter_service.rs");
-        assert!(
-            src.contains("async fn verify_encounter_detection"),
-            "encounter_service must define verify_encounter_detection internally"
-        );
-    }
-
-    /// Static guard: encounter_service must own
-    /// verify_counterparty_encounter_detection (no delegation to
-    /// walk_event_service).
-    #[test]
-    fn encounter_service_defines_verify_counterparty_encounter_detection() {
-        let src = include_str!("encounter_service.rs");
-        assert!(
-            src.contains("async fn verify_counterparty_encounter_detection"),
-            "encounter_service must define verify_counterparty_encounter_detection internally"
-        );
-    }
-
-    // ─── MockDatabase unit tests ─────────────────────────────────────────────
 
     use sea_orm::{DatabaseBackend, MockDatabase};
 

--- a/apps/api/src/services/encounter_service/access_policy.rs
+++ b/apps/api/src/services/encounter_service/access_policy.rs
@@ -1,0 +1,82 @@
+use crate::entities::{
+    dog_members::{self, Entity as DogMemberEntity},
+    users::{self, Entity as UserEntity},
+    walk_dogs::{self, Entity as WalkDogEntity},
+    walks::Entity as WalkEntity,
+};
+use crate::error::AppError;
+use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QuerySelect};
+use uuid::Uuid;
+
+pub async fn verify_encounter_detection<C: ConnectionTrait>(
+    db: &C,
+    walk_id: Uuid,
+    user_id: Uuid,
+) -> Result<(), AppError> {
+    let walk = WalkEntity::find_by_id(walk_id)
+        .one(db)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("Walk {} not found", walk_id)))?;
+
+    if walk.user_id != user_id {
+        return Err(AppError::Unauthorized(
+            "Walk does not belong to user".to_string(),
+        ));
+    }
+
+    let user = UserEntity::find_by_id(user_id)
+        .one(db)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("User {} not found", user_id)))?;
+
+    if !user.encounter_detection_enabled {
+        return Err(AppError::Unauthorized(
+            "Encounter detection is disabled for your account".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+pub async fn verify_counterparty_encounter_detection<C: ConnectionTrait>(
+    db: &C,
+    their_walk_id: Uuid,
+) -> Result<(), AppError> {
+    let dog_ids: Vec<Uuid> = WalkDogEntity::find()
+        .filter(walk_dogs::Column::WalkId.eq(their_walk_id))
+        .select_only()
+        .column(walk_dogs::Column::DogId)
+        .into_tuple()
+        .all(db)
+        .await?;
+
+    if dog_ids.is_empty() {
+        return Ok(());
+    }
+
+    let user_ids: Vec<Uuid> = DogMemberEntity::find()
+        .filter(dog_members::Column::DogId.is_in(dog_ids))
+        .select_only()
+        .column(dog_members::Column::UserId)
+        .into_tuple()
+        .all(db)
+        .await?;
+
+    if user_ids.is_empty() {
+        return Ok(());
+    }
+
+    let opted_out = UserEntity::find()
+        .filter(users::Column::Id.is_in(user_ids))
+        .filter(users::Column::EncounterDetectionEnabled.eq(false))
+        .one(db)
+        .await?;
+
+    if opted_out.is_some() {
+        return Err(AppError::Unauthorized(
+            "Encounter detection is disabled for the other user".to_string(),
+        ));
+    }
+
+    Ok(())
+}

--- a/apps/api/src/services/encounter_service/pairs.rs
+++ b/apps/api/src/services/encounter_service/pairs.rs
@@ -1,0 +1,54 @@
+use crate::entities::walk_dogs::{self, Entity as WalkDogEntity};
+use crate::error::AppError;
+use crate::services::dog_pair::DogPair;
+use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QuerySelect};
+use uuid::Uuid;
+
+pub async fn dog_ids_for_walk<C: ConnectionTrait>(
+    db: &C,
+    walk_id: Uuid,
+) -> Result<Vec<Uuid>, AppError> {
+    WalkDogEntity::find()
+        .filter(walk_dogs::Column::WalkId.eq(walk_id))
+        .select_only()
+        .column(walk_dogs::Column::DogId)
+        .into_tuple()
+        .all(db)
+        .await
+        .map_err(AppError::Database)
+}
+
+pub fn expand_pairs(my_dog_ids: &[Uuid], their_dog_ids: &[Uuid]) -> Result<Vec<DogPair>, AppError> {
+    if my_dog_ids.is_empty() || their_dog_ids.is_empty() {
+        return Err(AppError::BadRequest(
+            "One or both walks have no dogs".to_string(),
+        ));
+    }
+
+    Ok(my_dog_ids
+        .iter()
+        .flat_map(|my_dog| {
+            their_dog_ids
+                .iter()
+                .filter_map(|their_dog| DogPair::new(*my_dog, *their_dog))
+        })
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expand_pairs_rejects_missing_dogs() {
+        let error = expand_pairs(&[], &[Uuid::new_v4()]).unwrap_err();
+        assert!(matches!(error, AppError::BadRequest(_)));
+    }
+
+    #[test]
+    fn expand_pairs_skips_same_dog_pairs() {
+        let dog_id = Uuid::new_v4();
+        let pairs = expand_pairs(&[dog_id], &[dog_id]).unwrap();
+        assert!(pairs.is_empty());
+    }
+}

--- a/apps/api/src/services/encounter_service/persistence.rs
+++ b/apps/api/src/services/encounter_service/persistence.rs
@@ -1,0 +1,90 @@
+use crate::entities::encounters::{
+    self, ActiveModel as EncounterActiveModel, Entity as EncounterEntity, Model as EncounterModel,
+};
+use crate::error::AppError;
+use crate::services::{dog_pair::DogPair, friendship_service};
+use chrono::{DateTime, Utc};
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, Condition, ConnectionTrait, EntityTrait, QueryFilter, Set,
+};
+use uuid::Uuid;
+
+pub async fn record_pairs<C: ConnectionTrait>(
+    db: &C,
+    pairs: &[DogPair],
+    my_walk_id: Uuid,
+    their_walk_id: Uuid,
+    duration_sec: i32,
+    met_at: DateTime<Utc>,
+) -> Result<Vec<EncounterModel>, AppError> {
+    let mut result = Vec::new();
+
+    for pair in pairs {
+        let existing = EncounterEntity::find()
+            .filter(
+                Condition::any()
+                    .add(encounters::Column::WalkId.eq(my_walk_id))
+                    .add(encounters::Column::WalkId.eq(their_walk_id)),
+            )
+            .filter(encounters::Column::DogId1.eq(pair.first()))
+            .filter(encounters::Column::DogId2.eq(pair.second()))
+            .one(db)
+            .await?;
+
+        let encounter = if let Some(existing) = existing {
+            let new_duration = existing.duration_sec.max(duration_sec);
+            let mut active: encounters::ActiveModel = existing.into();
+            active.duration_sec = Set(new_duration);
+            active.met_at = Set(met_at.into());
+            active.update(db).await?
+        } else {
+            let encounter = EncounterActiveModel {
+                id: Set(Uuid::new_v4()),
+                walk_id: Set(my_walk_id),
+                dog_id_1: Set(pair.first()),
+                dog_id_2: Set(pair.second()),
+                duration_sec: Set(duration_sec),
+                met_at: Set(met_at.into()),
+                created_at: Set(met_at.into()),
+            }
+            .insert(db)
+            .await?;
+
+            friendship_service::upsert_friendship(db, *pair, duration_sec, met_at).await?;
+            encounter
+        };
+
+        result.push(encounter);
+    }
+
+    Ok(result)
+}
+
+pub async fn update_pair_durations<C: ConnectionTrait>(
+    db: &C,
+    pairs: &[DogPair],
+    my_walk_id: Uuid,
+    duration_sec: i32,
+) -> Result<bool, AppError> {
+    for pair in pairs {
+        let existing = EncounterEntity::find()
+            .filter(encounters::Column::WalkId.eq(my_walk_id))
+            .filter(encounters::Column::DogId1.eq(pair.first()))
+            .filter(encounters::Column::DogId2.eq(pair.second()))
+            .one(db)
+            .await?;
+
+        if let Some(existing) = existing {
+            let old_duration = existing.duration_sec;
+            let new_duration = old_duration.max(duration_sec);
+            let mut active: encounters::ActiveModel = existing.into();
+            active.duration_sec = Set(new_duration);
+            active.update(db).await?;
+
+            let delta = new_duration - old_duration;
+            friendship_service::update_friendship_duration(db, *pair, delta).await?;
+        }
+    }
+
+    Ok(true)
+}

--- a/apps/api/src/services/friendship_service.rs
+++ b/apps/api/src/services/friendship_service.rs
@@ -51,8 +51,8 @@ pub async fn upsert_friendship<C: sea_orm::ConnectionTrait>(
 }
 
 /// Update the total_interaction_sec of an existing friendship by a precise delta.
-pub async fn update_friendship_duration(
-    db: &sea_orm::DatabaseConnection,
+pub async fn update_friendship_duration<C: sea_orm::ConnectionTrait>(
+    db: &C,
     pair: DogPair,
     delta_sec: i32,
 ) -> Result<bool, AppError> {

--- a/apps/api/src/services/user_service.rs
+++ b/apps/api/src/services/user_service.rs
@@ -1,6 +1,8 @@
 use crate::entities::users::{self, ActiveModel, Entity as UserEntity, Model as UserModel};
 use crate::error::AppError;
-use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter, Set};
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, IntoActiveModel, QueryFilter, Set,
+};
 use uuid::Uuid;
 
 /// Internal helper: insert-or-fetch user by cognito_sub using SeaORM on_conflict.
@@ -42,12 +44,27 @@ pub async fn get_or_create_user(
     upsert_user(db, cognito_sub, None).await
 }
 
-pub async fn get_user_by_id(
-    db: &sea_orm::DatabaseConnection,
+pub async fn get_user_by_id<C: ConnectionTrait>(
+    db: &C,
     user_id: Uuid,
 ) -> Result<Option<UserModel>, AppError> {
     UserEntity::find_by_id(user_id)
         .one(db)
+        .await
+        .map_err(AppError::Database)
+}
+
+pub async fn get_users_by_ids<C: ConnectionTrait>(
+    db: &C,
+    user_ids: &[Uuid],
+) -> Result<Vec<UserModel>, AppError> {
+    if user_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    UserEntity::find()
+        .filter(users::Column::Id.is_in(user_ids.iter().copied()))
+        .all(db)
         .await
         .map_err(AppError::Database)
 }
@@ -85,51 +102,20 @@ pub async fn update_profile(
 
 #[cfg(test)]
 mod tests {
-    /// Verify that "duplicate key" string matching is no longer present in production code.
-    /// This test enforces the Phase 4 completion condition.
-    #[test]
-    fn no_duplicate_key_string_matching_in_production_code() {
-        let source = include_str!("user_service.rs");
-        // Split at cfg(test) to isolate production code
-        let production_code = source
-            .split("#[cfg(test)]")
-            .next()
-            .expect("file must contain #[cfg(test)]");
-        assert!(
-            !production_code.contains("duplicate key"),
-            "Production code must not contain 'duplicate key' string matching"
-        );
+    use super::*;
+    use sea_orm::{DatabaseBackend, MockDatabase};
+
+    #[tokio::test]
+    async fn get_users_by_ids_returns_empty_for_empty_input() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres).into_connection();
+        assert!(get_users_by_ids(&db, &[]).await.unwrap().is_empty());
     }
 
-    /// Verify that production code does not silently swallow Result with `let _ = ... .await`.
-    /// The `let _ = expr.await` pattern (ending with `.await;` not `.await?`) discards the
-    /// entire Result including genuine DB errors like connection lost or permission denied.
-    /// Using `.await?` propagates errors properly; discarding TryInsertResult after `?` is fine.
-    #[test]
-    fn no_silent_error_swallowing_in_upsert() {
-        let source = include_str!("user_service.rs");
-        let production_code = source
-            .split("#[cfg(test)]")
-            .next()
-            .expect("file must contain #[cfg(test)]");
-        // Detect `.await;` (Result silently discarded) after stripping whitespace.
-        // `.await?;` is acceptable because `?` already propagates the error.
-        let normalized = production_code.replace('\n', " ").replace("  ", " ");
-        assert!(
-            !normalized.contains(".await;"),
-            "Production code must not end an expression with '.await;' which silently swallows Result errors. Use '.await?' to propagate errors."
-        );
-    }
-
-    /// Verify that upsert_user is the single implementation path:
-    /// get_or_create_user and create_user_with_profile must delegate to upsert_user.
-    #[test]
-    fn get_or_create_user_uses_upsert_user() {
-        let source = include_str!("user_service.rs");
-        // After GREEN, get_or_create_user body should call upsert_user
-        assert!(
-            source.contains("upsert_user"),
-            "upsert_user helper must exist in user_service.rs"
-        );
+    #[tokio::test]
+    async fn get_user_by_id_returns_none_when_missing() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([Vec::<UserModel>::new()])
+            .into_connection();
+        assert!(get_user_by_id(&db, Uuid::new_v4()).await.unwrap().is_none());
     }
 }

--- a/apps/api/src/services/walk_event_service.rs
+++ b/apps/api/src/services/walk_event_service.rs
@@ -1,7 +1,5 @@
 use chrono::Utc;
-use sea_orm::{
-    ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, Set,
-};
+use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, Set};
 use std::fmt;
 use std::str::FromStr;
 use uuid::Uuid;

--- a/apps/api/src/services/walk_points_queue_service.rs
+++ b/apps/api/src/services/walk_points_queue_service.rs
@@ -18,10 +18,7 @@ pub struct DrainWalkPointsQueueResult {
     pub failed: usize,
 }
 
-pub fn build_message_body(
-    walk_id: Uuid,
-    points: Vec<WalkPointInput>,
-) -> Result<String, AppError> {
+pub fn build_message_body(walk_id: Uuid, points: Vec<WalkPointInput>) -> Result<String, AppError> {
     let points = walk_points_service::sanitize_points(points)?;
     serde_json::to_string(&WalkPointsQueueMessage { walk_id, points }).map_err(|error| {
         AppError::Internal(format!("Serialize walk points queue message: {error}"))
@@ -172,8 +169,9 @@ async fn process_received_message(
     table_name: &str,
 ) -> Result<(), AppError> {
     let body = body.ok_or_else(|| AppError::Internal("SQS message body is missing".to_string()))?;
-    let message: WalkPointsQueueMessage = serde_json::from_str(body)
-        .map_err(|error| AppError::Internal(format!("Deserialize walk points queue message: {error}")))?;
+    let message: WalkPointsQueueMessage = serde_json::from_str(body).map_err(|error| {
+        AppError::Internal(format!("Deserialize walk points queue message: {error}"))
+    })?;
 
     walk_points_service::add_walk_points(dynamo, table_name, message.walk_id, message.points)
         .await?;

--- a/apps/api/src/services/walk_points_service.rs
+++ b/apps/api/src/services/walk_points_service.rs
@@ -1,3 +1,4 @@
+use crate::error::external::{dynamodb_batch_write_error, dynamodb_query_error};
 use crate::error::AppError;
 use aws_sdk_dynamodb::{
     types::{AttributeValue, PutRequest, WriteRequest},
@@ -43,8 +44,14 @@ fn build_point_item(walk_id: Uuid, point: &WalkPointInput) -> HashMap<String, At
             SK_ATTR.to_string(),
             AttributeValue::S(walk_point_sort_key(&point.recorded_at)),
         ),
-        (LAT_ATTR.to_string(), AttributeValue::N(point.lat.to_string())),
-        (LNG_ATTR.to_string(), AttributeValue::N(point.lng.to_string())),
+        (
+            LAT_ATTR.to_string(),
+            AttributeValue::N(point.lat.to_string()),
+        ),
+        (
+            LNG_ATTR.to_string(),
+            AttributeValue::N(point.lng.to_string()),
+        ),
         (
             RECORDED_AT_ATTR.to_string(),
             AttributeValue::S(point.recorded_at.clone()),
@@ -129,19 +136,7 @@ pub async fn add_walk_points(
             .request_items(table_name, chunk.to_vec())
             .send()
             .await
-            .map_err(|e| {
-                tracing::error!(
-                    error = ?e,
-                    table = table_name,
-                    walk_id = %walk_id,
-                    batch_size = chunk.len(),
-                    "DynamoDB BatchWriteItem failed"
-                );
-                AppError::Internal(format!(
-                    "DynamoDB BatchWriteItem: {}",
-                    crate::error::format_error_chain(&e)
-                ))
-            })?;
+            .map_err(|e| dynamodb_batch_write_error(&e, table_name, walk_id, chunk.len()))?;
     }
 
     Ok(true)
@@ -161,18 +156,7 @@ pub async fn get_walk_points(
         .expression_attribute_values(":pk", AttributeValue::S(walk_partition_key(walk_id)))
         .send()
         .await
-        .map_err(|e| {
-            tracing::error!(
-                error = ?e,
-                table = table_name,
-                walk_id = %walk_id,
-                "DynamoDB Query failed"
-            );
-            AppError::Internal(format!(
-                "DynamoDB Query: {}",
-                crate::error::format_error_chain(&e)
-            ))
-        })?;
+        .map_err(|e| dynamodb_query_error(&e, table_name, walk_id))?;
 
     let mut points: Vec<WalkPoint> = result.items().iter().filter_map(parse_point_row).collect();
 

--- a/apps/api/src/services/walk_service.rs
+++ b/apps/api/src/services/walk_service.rs
@@ -1,14 +1,15 @@
 use crate::entities::{
-    dogs::{self, Entity as DogEntity, Model as DogModel},
+    dogs::{Entity as DogEntity, Model as DogModel},
     walk_dogs::{self, ActiveModel as WalkDogActiveModel, Entity as WalkDogEntity},
     walks::{self, ActiveModel, Entity as WalkEntity, Model as WalkModel, WalkStatus},
 };
 use crate::error::AppError;
 use chrono::Utc;
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, QuerySelect, Set,
-    TransactionTrait,
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QueryOrder,
+    QuerySelect, Set, TransactionTrait,
 };
+use std::collections::HashMap;
 use std::fmt;
 use std::str::FromStr;
 use uuid::Uuid;
@@ -262,27 +263,41 @@ pub async fn require_walk_owner(
 }
 
 /// Get the dogs associated with a walk (via `walk_dogs`).
-pub async fn get_dogs_for_walk(
-    db: &sea_orm::DatabaseConnection,
+pub async fn get_dogs_for_walk<C: ConnectionTrait>(
+    db: &C,
     walk_id: Uuid,
 ) -> Result<Vec<DogModel>, AppError> {
-    let dog_ids: Vec<Uuid> = WalkDogEntity::find()
-        .filter(walk_dogs::Column::WalkId.eq(walk_id))
-        .select_only()
-        .column(walk_dogs::Column::DogId)
-        .into_tuple()
+    Ok(get_dogs_for_walk_ids(db, &[walk_id])
+        .await?
+        .remove(&walk_id)
+        .unwrap_or_default())
+}
+
+pub async fn get_dogs_for_walk_ids<C: ConnectionTrait>(
+    db: &C,
+    walk_ids: &[Uuid],
+) -> Result<HashMap<Uuid, Vec<DogModel>>, AppError> {
+    if walk_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let walk_dogs = WalkDogEntity::find()
+        .filter(walk_dogs::Column::WalkId.is_in(walk_ids.iter().copied()))
+        .find_also_related(DogEntity)
         .all(db)
         .await?;
 
-    if dog_ids.is_empty() {
-        return Ok(Vec::new());
+    let mut grouped = HashMap::new();
+    for (walk_dog, dog) in walk_dogs {
+        if let Some(dog) = dog {
+            grouped
+                .entry(walk_dog.walk_id)
+                .or_insert_with(Vec::new)
+                .push(dog);
+        }
     }
 
-    DogEntity::find()
-        .filter(dogs::Column::Id.is_in(dog_ids))
-        .all(db)
-        .await
-        .map_err(AppError::Database)
+    Ok(grouped)
 }
 
 #[cfg(test)]

--- a/apps/api/tests/test_walk.rs
+++ b/apps/api/tests/test_walk.rs
@@ -317,7 +317,11 @@ async fn test_add_walk_points() {
     assert_eq!(body["data"]["addWalkPoints"], true, "got: {:?}", body);
 
     let messages = client.receive_walk_points_message_bodies().await;
-    assert_eq!(messages.len(), 1, "expected one queue message, got: {messages:?}");
+    assert_eq!(
+        messages.len(),
+        1,
+        "expected one queue message, got: {messages:?}"
+    );
 
     let message: walking_dog_api::services::walk_points_queue_service::WalkPointsQueueMessage =
         serde_json::from_str(&messages[0]).expect("walk points message must deserialize");

--- a/apps/api/tests/test_walk_points_worker.rs
+++ b/apps/api/tests/test_walk_points_worker.rs
@@ -26,7 +26,10 @@ async fn test_walk_points_worker_drains_queue_and_persists_deduped_points() {
     let start_body = support::graphql_as(
         &client,
         &support::USER_A,
-        &format!(r#"mutation {{ startWalk(dogIds: ["{}"]) {{ id }} }}"#, dog_id),
+        &format!(
+            r#"mutation {{ startWalk(dogIds: ["{}"]) {{ id }} }}"#,
+            dog_id
+        ),
     )
     .await;
     let walk_id = start_body["data"]["startWalk"]["id"].as_str().unwrap();
@@ -46,12 +49,19 @@ async fn test_walk_points_worker_drains_queue_and_persists_deduped_points() {
         ),
     )
     .await;
-    assert_eq!(enqueue_body["data"]["addWalkPoints"], true, "got: {:?}", enqueue_body);
+    assert_eq!(
+        enqueue_body["data"]["addWalkPoints"], true,
+        "got: {:?}",
+        enqueue_body
+    );
 
     let before_drain = support::graphql_as(
         &client,
         &support::USER_A,
-        &format!(r#"{{ walkPoints(walkId: "{}") {{ lat lng recordedAt }} }}"#, walk_id),
+        &format!(
+            r#"{{ walkPoints(walkId: "{}") {{ lat lng recordedAt }} }}"#,
+            walk_id
+        ),
     )
     .await;
     let before_points = before_drain["data"]["walkPoints"].as_array().unwrap();
@@ -63,16 +73,17 @@ async fn test_walk_points_worker_drains_queue_and_persists_deduped_points() {
 
     let sqs = client.sqs();
     let dynamo = client.dynamo();
-    let result = walking_dog_api::services::walk_points_queue_service::drain_walk_points_queue_once(
-        &sqs,
-        client.walk_points_queue_url(),
-        &dynamo,
-        client.walk_points_table_name(),
-        1,
-        10,
-    )
-    .await
-    .unwrap();
+    let result =
+        walking_dog_api::services::walk_points_queue_service::drain_walk_points_queue_once(
+            &sqs,
+            client.walk_points_queue_url(),
+            &dynamo,
+            client.walk_points_table_name(),
+            1,
+            10,
+        )
+        .await
+        .unwrap();
 
     assert_eq!(result.received, 1);
     assert_eq!(result.deleted, 1);
@@ -81,11 +92,19 @@ async fn test_walk_points_worker_drains_queue_and_persists_deduped_points() {
     let after_drain = support::graphql_as(
         &client,
         &support::USER_A,
-        &format!(r#"{{ walkPoints(walkId: "{}") {{ lat lng recordedAt }} }}"#, walk_id),
+        &format!(
+            r#"{{ walkPoints(walkId: "{}") {{ lat lng recordedAt }} }}"#,
+            walk_id
+        ),
     )
     .await;
     let points = after_drain["data"]["walkPoints"].as_array().unwrap();
-    assert_eq!(points.len(), 2, "expected deduped points, got: {:?}", after_drain);
+    assert_eq!(
+        points.len(),
+        2,
+        "expected deduped points, got: {:?}",
+        after_drain
+    );
     assert_eq!(points[0]["recordedAt"], "2026-03-21T10:00:00Z");
     assert_eq!(points[0]["lat"], serde_json::json!(35.6769));
     assert_eq!(points[0]["lng"], serde_json::json!(139.6509));

--- a/tasks/refactor/api-architecture/progress.md
+++ b/tasks/refactor/api-architecture/progress.md
@@ -1,0 +1,8 @@
+# Progress: api-architecture
+
+- Planning artifacts prepared — 2026-04-27
+- [x] Phase 1: GraphQL utility layer と境界整理 — 2026-04-27
+- [x] Phase 2: Nested field の batch loading 化 — 2026-04-27
+- [x] Phase 3: Read service と access helper の正規化 — 2026-04-27
+- [x] Phase 4: Encounter / auth orchestration の分割 — 2026-04-27
+- [x] Phase 5: Error adapter とテスト戦略の整理 — 2026-04-27


### PR DESCRIPTION
## Summary
- consolidate GraphQL dynamic schema helpers and enum registration into dedicated modules
- add request-scope DataLoaders so nested GraphQL fields batch dog, user, and membership reads instead of doing N+1 lookups
- normalize API service boundaries across dog member reads, encounter orchestration, auth middleware, and external error adapters
- replace source-shape guard tests with behavior-based coverage and update refactor progress tracking

## Testing
- docker compose -f apps/compose.yml run --rm api cargo test --lib
- docker compose -f apps/compose.yml run --rm api env CARGO_BUILD_JOBS=1 cargo test --features test-utils -- --test-threads=1
- docker compose -f apps/compose.yml exec -T api cargo fmt --check
- docker compose -f apps/compose.yml exec -T api cargo clippy -- -D warnings
