### PR TITLE
refactor(api): tighten error handling across error/auth/graphql layers

### DIFF
--- a/apps/api/src/auth/jwt.rs
+++ b/apps/api/src/auth/jwt.rs
@@ -19,20 +19,26 @@ pub struct CognitoJwtVerifier;
 #[async_trait]
 impl JwtVerifier for CognitoJwtVerifier {
     async fn verify(&self, token: &str) -> Result<Claims, AppError> {
-        let sub = verify_cognito_jwt(token)
-            .await
-            .map_err(AppError::Unauthorized)?;
+        let sub = verify_cognito_jwt(token).await?;
         Ok(Claims { sub })
     }
 }
 
-async fn verify_cognito_jwt(token: &str) -> Result<String, String> {
+async fn verify_cognito_jwt(token: &str) -> Result<String, AppError> {
+    use crate::error::format_error_chain;
     use jsonwebtoken::{decode, decode_header, Algorithm, DecodingKey, Validation};
 
-    let header = decode_header(token).map_err(|e| e.to_string())?;
-    let kid = header.kid.ok_or("missing kid")?;
+    // Malformed tokens are caller mistakes → Unauthorized.
+    let header = decode_header(token)
+        .map_err(|err| AppError::Unauthorized(format!("Invalid token header: {err}")))?;
+    let kid = header
+        .kid
+        .ok_or_else(|| AppError::Unauthorized("Token missing kid".to_string()))?;
 
-    let user_pool_id = std::env::var("COGNITO_USER_POOL_ID").map_err(|e| e.to_string())?;
+    // Missing config is a server-side problem → Internal so the client gets 500
+    // and retries instead of looping on token refresh.
+    let user_pool_id = std::env::var("COGNITO_USER_POOL_ID")
+        .map_err(|_| AppError::Internal("COGNITO_USER_POOL_ID env var not set".to_string()))?;
     let region = std::env::var("AWS_REGION").unwrap_or_else(|_| "ap-northeast-1".to_string());
 
     // COGNITO_ENDPOINT_URL が設定されている場合は cognito-local を使う
@@ -47,19 +53,30 @@ async fn verify_cognito_jwt(token: &str) -> Result<String, String> {
 
     let jwks: serde_json::Value = reqwest::get(&jwks_url)
         .await
-        .map_err(|e| e.to_string())?
+        .map_err(|err| {
+            AppError::Internal(format!("JWKS fetch failed: {}", format_error_chain(&err)))
+        })?
         .json()
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(|err| {
+            AppError::Internal(format!("JWKS parse failed: {}", format_error_chain(&err)))
+        })?;
 
+    // Token signed by an unknown kid is a token-side issue → Unauthorized.
     let key = jwks["keys"]
         .as_array()
         .and_then(|keys| keys.iter().find(|k| k["kid"] == kid))
-        .ok_or("key not found")?;
+        .ok_or_else(|| AppError::Unauthorized("Token signed by unknown kid".to_string()))?;
 
-    let n = key["n"].as_str().ok_or("missing n")?;
-    let e = key["e"].as_str().ok_or("missing e")?;
-    let decoding_key = DecodingKey::from_rsa_components(n, e).map_err(|e| e.to_string())?;
+    // Malformed JWKS payload from Cognito is a server/upstream issue → Internal.
+    let n = key["n"]
+        .as_str()
+        .ok_or_else(|| AppError::Internal("JWKS key missing 'n' component".to_string()))?;
+    let exp = key["e"]
+        .as_str()
+        .ok_or_else(|| AppError::Internal("JWKS key missing 'e' component".to_string()))?;
+    let decoding_key = DecodingKey::from_rsa_components(n, exp)
+        .map_err(|err| AppError::Internal(format!("JWKS RSA key decode failed: {err}")))?;
 
     let mut validation = Validation::new(Algorithm::RS256);
     // Skip issuer validation for local development
@@ -76,8 +93,9 @@ async fn verify_cognito_jwt(token: &str) -> Result<String, String> {
         sub: String,
     }
 
-    let token_data =
-        decode::<CognitoClaims>(token, &decoding_key, &validation).map_err(|e| e.to_string())?;
+    // Signature/expiry validation failure is a token-side issue → Unauthorized.
+    let token_data = decode::<CognitoClaims>(token, &decoding_key, &validation)
+        .map_err(|err| AppError::Unauthorized(format!("Token validation failed: {err}")))?;
 
     Ok(token_data.claims.sub)
 }

--- a/apps/api/src/auth/service.rs
+++ b/apps/api/src/auth/service.rs
@@ -164,7 +164,7 @@ pub async fn sign_out(client: &Client, access_token: &str) -> Result<(), AppErro
 
     match result {
         Ok(_) => Ok(()),
-        Err(ref e) => {
+        Err(e) => {
             let code = e.code();
             // cognito-local does not implement GlobalSignOut; treat as success in dev.
             if code
@@ -173,7 +173,7 @@ pub async fn sign_out(client: &Client, access_token: &str) -> Result<(), AppErro
             {
                 return Ok(());
             }
-            Err(map_cognito_error(&result.unwrap_err()))
+            Err(map_cognito_error(&e))
         }
     }
 }

--- a/apps/api/src/error.rs
+++ b/apps/api/src/error.rs
@@ -36,6 +36,8 @@ pub enum AppError {
     NotFound(String),
     #[error("Unauthorized: {0}")]
     Unauthorized(String),
+    #[error("Forbidden: {0}")]
+    Forbidden(String),
     #[error("Bad request: {0}")]
     BadRequest(String),
     #[error("Internal error: {0}")]
@@ -49,7 +51,7 @@ impl AppError {
     pub fn into_graphql_error(self) -> async_graphql::Error {
         use async_graphql::ErrorExtensions;
         // Report unexpected failures to Sentry. Expected user-facing errors
-        // (NotFound, Unauthorized, BadRequest, ValidationErrors) are skipped.
+        // (NotFound, Unauthorized, Forbidden, BadRequest, ValidationErrors) are skipped.
         if matches!(&self, AppError::Internal(_) | AppError::Database(_)) {
             sentry::capture_error(&self);
         }
@@ -62,6 +64,9 @@ impl AppError {
             }),
             AppError::Unauthorized(msg) => async_graphql::Error::new(msg).extend_with(|_, ext| {
                 ext.set("code", "UNAUTHENTICATED");
+            }),
+            AppError::Forbidden(msg) => async_graphql::Error::new(msg).extend_with(|_, ext| {
+                ext.set("code", "FORBIDDEN");
             }),
             AppError::ValidationErrors(errors) => {
                 let json =
@@ -184,5 +189,16 @@ mod tests {
         let code_val = ext.get("code").expect("code must be in extensions");
         // async_graphql::Value::String can be compared as string
         assert_eq!(code_val, &async_graphql::Value::from("BAD_USER_INPUT"));
+    }
+
+    #[test]
+    fn forbidden_sets_forbidden_code_and_preserves_message() {
+        let gql_err =
+            AppError::Forbidden("Not a member of either dog".to_string()).into_graphql_error();
+
+        let ext = gql_err.extensions.expect("extensions must be set");
+        let code_val = ext.get("code").expect("code must be in extensions");
+        assert_eq!(code_val, &async_graphql::Value::from("FORBIDDEN"));
+        assert_eq!(gql_err.message, "Not a member of either dog");
     }
 }

--- a/apps/api/src/graphql/custom_queries.rs
+++ b/apps/api/src/graphql/custom_queries.rs
@@ -143,7 +143,9 @@ pub fn encounter_output_type() -> Object {
                     .load_one(e.dog_id_1)
                     .await
                     .map_err(async_graphql::Error::new)?
-                    .ok_or_else(|| async_graphql::Error::new("Dog not found"))?;
+                    .ok_or_else(|| {
+                        AppError::NotFound("Dog not found".to_string()).into_graphql_error()
+                    })?;
                 Ok(Some(FieldValue::owned_any(DogOutput::from(dog))))
             })
         }))
@@ -155,7 +157,9 @@ pub fn encounter_output_type() -> Object {
                     .load_one(e.dog_id_2)
                     .await
                     .map_err(async_graphql::Error::new)?
-                    .ok_or_else(|| async_graphql::Error::new("Dog not found"))?;
+                    .ok_or_else(|| {
+                        AppError::NotFound("Dog not found".to_string()).into_graphql_error()
+                    })?;
                 Ok(Some(FieldValue::owned_any(DogOutput::from(dog))))
             })
         }))
@@ -193,7 +197,9 @@ pub fn friendship_output_type() -> Object {
                         .load_one(friend_id)
                         .await
                         .map_err(async_graphql::Error::new)?
-                        .ok_or_else(|| async_graphql::Error::new("Dog not found"))?;
+                        .ok_or_else(|| {
+                        AppError::NotFound("Dog not found".to_string()).into_graphql_error()
+                    })?;
                     Ok(Some(FieldValue::owned_any(DogOutput::from(dog))))
                 })
             },

--- a/apps/api/src/graphql/dynamic_helpers.rs
+++ b/apps/api/src/graphql/dynamic_helpers.rs
@@ -1,4 +1,4 @@
-use crate::error::FieldError;
+use crate::error::{AppError, FieldError};
 use async_graphql::dynamic::{Field, FieldFuture, FieldValue, TypeRef};
 use uuid::Uuid;
 
@@ -102,7 +102,8 @@ where
 }
 
 pub fn parse_uuid(value: &str, invalid_message: &'static str) -> async_graphql::Result<Uuid> {
-    Uuid::parse_str(value).map_err(|_| async_graphql::Error::new(invalid_message))
+    Uuid::parse_str(value)
+        .map_err(|_| AppError::BadRequest(invalid_message.to_string()).into_graphql_error())
 }
 
 pub fn parse_uuid_with_field_error(

--- a/apps/api/src/graphql/loaders.rs
+++ b/apps/api/src/graphql/loaders.rs
@@ -33,7 +33,15 @@ impl Loader<Uuid> for UserByIdLoader {
             user_service::get_users_by_ids(&db, &keys)
                 .await
                 .map(|users| users.into_iter().map(|user| (user.id, user)).collect())
-                .map_err(|err| err.to_string())
+                .map_err(|err| {
+                    tracing::error!(
+                        error = ?err,
+                        loader = "UserByIdLoader",
+                        batch_size = keys.len(),
+                        "loader query failed"
+                    );
+                    err.to_string()
+                })
         }
     }
 }
@@ -64,7 +72,15 @@ impl Loader<Uuid> for DogByIdLoader {
             dog_service::get_dogs_by_ids(&db, &keys)
                 .await
                 .map(|dogs| dogs.into_iter().map(|dog| (dog.id, dog)).collect())
-                .map_err(|err| err.to_string())
+                .map_err(|err| {
+                    tracing::error!(
+                        error = ?err,
+                        loader = "DogByIdLoader",
+                        batch_size = keys.len(),
+                        "loader query failed"
+                    );
+                    err.to_string()
+                })
         }
     }
 }
@@ -107,7 +123,15 @@ impl Loader<Uuid> for DogMembersByDogIdLoader {
                         })
                         .collect()
                 })
-                .map_err(|err| err.to_string())
+                .map_err(|err| {
+                    tracing::error!(
+                        error = ?err,
+                        loader = "DogMembersByDogIdLoader",
+                        batch_size = keys.len(),
+                        "loader query failed"
+                    );
+                    err.to_string()
+                })
         }
     }
 }
@@ -137,7 +161,15 @@ impl Loader<Uuid> for DogsByWalkIdLoader {
         async move {
             walk_service::get_dogs_for_walk_ids(&db, &keys)
                 .await
-                .map_err(|err| err.to_string())
+                .map_err(|err| {
+                    tracing::error!(
+                        error = ?err,
+                        loader = "DogsByWalkIdLoader",
+                        batch_size = keys.len(),
+                        "loader query failed"
+                    );
+                    err.to_string()
+                })
         }
     }
 }

--- a/apps/api/src/graphql/mutations/dog_member.rs
+++ b/apps/api/src/graphql/mutations/dog_member.rs
@@ -142,7 +142,9 @@ pub fn accept_dog_invitation_field(state: Arc<AppState>) -> Field {
                 let dog = dog_service::get_dog_by_id(&state.db, member.dog_id)
                     .await
                     .map_err(AppError::into_graphql_error)?
-                    .ok_or_else(|| async_graphql::Error::new("Dog not found"))?;
+                    .ok_or_else(|| {
+                        AppError::NotFound("Dog not found".to_string()).into_graphql_error()
+                    })?;
 
                 Ok(Some(FieldValue::owned_any(super::dog::DogOutput::from(
                     dog,
@@ -174,9 +176,10 @@ pub fn remove_dog_member_field(state: Arc<AppState>) -> Field {
 
                 // Cannot remove yourself (owner) via this mutation
                 if target_user_id == user.id {
-                    return Err(async_graphql::Error::new(
-                        "Cannot remove yourself. Use leaveDog instead.",
-                    ));
+                    return Err(AppError::BadRequest(
+                        "Cannot remove yourself. Use leaveDog instead.".to_string(),
+                    )
+                    .into_graphql_error());
                 }
 
                 let result = dog_member_service::remove_member(&state.db, dog_id, target_user_id)
@@ -206,9 +209,11 @@ pub fn leave_dog_field(state: Arc<AppState>) -> Field {
 
                 // Owners cannot leave their own dog
                 if membership.role == "owner" {
-                    return Err(async_graphql::Error::new(
-                        "Owners cannot leave their dog. Transfer ownership or delete the dog.",
-                    ));
+                    return Err(AppError::BadRequest(
+                        "Owners cannot leave their dog. Transfer ownership or delete the dog."
+                            .to_string(),
+                    )
+                    .into_graphql_error());
                 }
 
                 let result = dog_member_service::remove_member(&state.db, dog_id, user.id)

--- a/apps/api/src/graphql/mutations/encounter.rs
+++ b/apps/api/src/graphql/mutations/encounter.rs
@@ -76,7 +76,11 @@ pub fn update_encounter_duration_field(state: Arc<AppState>) -> Field {
                 // Input parse
                 let my_walk_id_str = ctx.args.try_get("myWalkId")?.string()?;
                 let their_walk_id_str = ctx.args.try_get("theirWalkId")?.string()?;
-                let duration_sec = ctx.args.try_get("durationSec")?.i64()? as i32;
+                let duration_sec = i32::try_from(ctx.args.try_get("durationSec")?.i64()?)
+                    .map_err(|_| {
+                        AppError::BadRequest("durationSec out of i32 range".to_string())
+                            .into_graphql_error()
+                    })?;
                 let my_walk_id = parse_uuid(my_walk_id_str, "Invalid myWalkId")?;
                 let their_walk_id = parse_uuid(their_walk_id_str, "Invalid theirWalkId")?;
 

--- a/apps/api/src/graphql/mutations/walk_event.rs
+++ b/apps/api/src/graphql/mutations/walk_event.rs
@@ -110,8 +110,9 @@ pub fn record_walk_event_field(state: Arc<AppState>) -> Field {
                 let event_type = input.try_get("eventType")?.string()?.to_string();
                 let occurred_at_str = input.try_get("occurredAt")?.string()?;
                 let occurred_at: chrono::DateTime<chrono::FixedOffset> =
-                    chrono::DateTime::parse_from_rfc3339(occurred_at_str).map_err(|_| {
-                        async_graphql::Error::new("Invalid occurredAt: must be RFC3339")
+                    chrono::DateTime::parse_from_rfc3339(occurred_at_str).map_err(|e| {
+                        AppError::BadRequest(format!("Invalid occurredAt (must be RFC3339): {e}"))
+                            .into_graphql_error()
                     })?;
 
                 let lat = input.get("lat").and_then(|v| v.f64().ok());

--- a/apps/api/src/main.rs
+++ b/apps/api/src/main.rs
@@ -100,6 +100,10 @@ async fn run(config: Config) {
     };
     let app = walking_dog_api::build_app(db, clients, config, verifier);
 
-    let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
-    axum::serve(listener, app).await.unwrap();
+    let listener = tokio::net::TcpListener::bind(addr)
+        .await
+        .unwrap_or_else(|e| panic!("failed to bind TCP listener on {addr}: {e}"));
+    axum::serve(listener, app)
+        .await
+        .expect("axum server terminated with an error");
 }

--- a/apps/api/src/services/dog_member_service.rs
+++ b/apps/api/src/services/dog_member_service.rs
@@ -130,7 +130,7 @@ pub async fn require_any_dog_member<C: ConnectionTrait>(
         .filter(dog_members::Column::UserId.eq(user_id))
         .one(db)
         .await?
-        .ok_or_else(|| AppError::Unauthorized("Not a member of either dog".to_string()))
+        .ok_or_else(|| AppError::Forbidden("Not a member of either dog".to_string()))
 }
 
 pub async fn remove_member(

--- a/apps/api/src/services/friendship_service.rs
+++ b/apps/api/src/services/friendship_service.rs
@@ -27,9 +27,11 @@ pub async fn upsert_friendship<C: sea_orm::ConnectionTrait>(
         .await?;
 
     let friendship = if let Some(existing) = existing {
+        let new_encounter_count = existing.encounter_count + 1;
+        let new_total_interaction_sec = existing.total_interaction_sec + duration_sec;
         let mut active: friendships::ActiveModel = existing.into();
-        active.encounter_count = Set(active.encounter_count.unwrap() + 1);
-        active.total_interaction_sec = Set(active.total_interaction_sec.unwrap() + duration_sec);
+        active.encounter_count = Set(new_encounter_count);
+        active.total_interaction_sec = Set(new_total_interaction_sec);
         active.last_met_at = Set(met_at.into());
         active.update(db).await?
     } else {

--- a/apps/api/src/services/walk_points_queue_service.rs
+++ b/apps/api/src/services/walk_points_queue_service.rs
@@ -127,7 +127,7 @@ pub async fn drain_walk_points_queue_once(
             Err(error) => {
                 failed += 1;
                 tracing::error!(
-                    error = %error,
+                    error = ?error,
                     message_id,
                     "Failed to process walk points queue message"
                 );

--- a/apps/api/src/services/walk_points_service.rs
+++ b/apps/api/src/services/walk_points_service.rs
@@ -123,11 +123,16 @@ pub async fn add_walk_points(
         .iter()
         .map(|point| {
             let item = build_point_item(walk_id, point);
-            WriteRequest::builder()
-                .put_request(PutRequest::builder().set_item(Some(item)).build().unwrap())
-                .build()
+            let put = PutRequest::builder().set_item(Some(item)).build().map_err(|e| {
+                AppError::Internal(format!(
+                    "PutRequest build failed for walk {}: {}",
+                    walk_id,
+                    crate::error::format_error_chain(&e)
+                ))
+            })?;
+            Ok(WriteRequest::builder().put_request(put).build())
         })
-        .collect();
+        .collect::<Result<Vec<_>, AppError>>()?;
 
     // DynamoDBは1バッチ最大 DYNAMODB_BATCH_WRITE_LIMIT 件のため分割送信
     for chunk in all_requests.chunks(DYNAMODB_BATCH_WRITE_LIMIT) {

--- a/apps/api/src/services/walk_service.rs
+++ b/apps/api/src/services/walk_service.rs
@@ -142,7 +142,9 @@ pub async fn get_walk_stats(
     dog_id: Uuid,
     period: &str,
 ) -> Result<WalkStats, AppError> {
-    let period: Period = period.parse().unwrap_or(Period::All);
+    let period: Period = period
+        .parse()
+        .map_err(|err| AppError::BadRequest(format!("Invalid period '{period}': {err}")))?;
     let since = period.since();
 
     let walk_ids: Vec<Uuid> = WalkDogEntity::find()


### PR DESCRIPTION
## Summary

`rust-review` スキルによる包括レビューで判明した **14 件** のエラー処理不整合を一括修正。

- **CRITICAL (2 件)**: 本番パニック源を除去（`walk_points_service` の `PutRequest::build().unwrap()`、`friendship_service` の `ActiveValue::unwrap()`）
- **HIGH (8 件)**: GraphQL Convention 3 違反（`async_graphql::Error::new` 直接生成）の解消、JWT エラー分類の修正、Loader の source chain 保持、`unwrap_or` でのサイレント不正入力受容など
- **MEDIUM (4 件)**: `AppError::Forbidden` variant 追加、整数オーバーフロー、起動失敗ログ、`tracing` の Display→Debug
- **新規テスト 1 件**: `forbidden_sets_forbidden_code_and_preserves_message`

## 設計の鍵

`parse_uuid` などの「Convention 3 違反」修正では、戻り値型 `async_graphql::Result<Uuid>` を維持しつつ内部で `AppError::*.into_graphql_error()` を呼ぶ設計を採用。9 つの caller を一切変更せずに `extensions.code` 付与と Sentry 報告ロジックを得られるようにした。

## JWT エラー分類

`verify_cognito_jwt` の各エラーを意味別に分類:
- **Unauthorized (401)**: トークン形式不正、未知 kid、署名検証失敗
- **Internal (500)**: `COGNITO_USER_POOL_ID` 未設定、JWKS fetch 失敗、JWKS payload 不正

これにより、本番で JWKS endpoint 障害時にクライアントが「401 → トークンリフレッシュループ」で Cognito を叩き続ける問題を回避できる。

## Test plan

- [x] `cargo check --features test-utils` — pass
- [x] `cargo clippy --features test-utils -- -D warnings` — clean
- [x] `cargo test --lib` — 85 passed / 0 failed
- [x] Mobile audit — `apps/mobile/src/` で `UNAUTHENTICATED`/`FORBIDDEN` 文字列はゼロヒット、`Forbidden` variant 追加は非ブレーキング
- [ ] dev デプロイ後、End Walk 長時間シナリオで動作確認

## 関連

- Sentry `WALKING-DOG-API-DEV-2/3/4` の duplicate keys バグは PR #155 で API 側修正済み（本 PR で直接の修正はないが、CRITICAL 1 件目はそのバッチ処理経路上に存在した別パニック源）
- Convention 1 (format_error_chain), Convention 3 (into_graphql_error) は CLAUDE.md / memory に記録済みの規約

🤖 Generated with [Claude Code](https://claude.com/claude-code)