### PR TITLE
feat(ci): add code comments

### DIFF
--- a/apps/mobile/app/(auth)/_layout.tsx
+++ b/apps/mobile/app/(auth)/_layout.tsx
@@ -1,5 +1,6 @@
 import { Stack } from 'expo-router';
 
+// 認証画面群は独立した Stack として、アプリ本体のタブ UI を表示しません。
 export default function AuthLayout() {
   return (
     <Stack screenOptions={{ headerShown: false }} />

--- a/apps/mobile/app/(auth)/login.tsx
+++ b/apps/mobile/app/(auth)/login.tsx
@@ -6,6 +6,7 @@ import { LoginForm } from '@/components/auth/LoginForm';
 import { useColors } from '@/hooks/use-colors';
 import { spacing, typography } from '@/theme/tokens';
 
+// ログイン画面は認証フォームだけを担当し、成功後の遷移はルートの認証ガードに任せます。
 export default function LoginScreen() {
   const router = useRouter();
   const { t } = useTranslation();
@@ -25,7 +26,7 @@ export default function LoginScreen() {
         </View>
         <LoginForm
           onSuccess={() => {
-            // Navigation guard in _layout.tsx handles redirect to (tabs)
+            // 認証後の遷移は _layout.tsx の NavigationGuard が一元管理します。
           }}
         />
       </View>

--- a/apps/mobile/app/(auth)/register.tsx
+++ b/apps/mobile/app/(auth)/register.tsx
@@ -9,6 +9,7 @@ import { spacing, typography } from '@/theme/tokens';
 
 type Step = 'register' | 'confirm';
 
+// 登録画面はアカウント作成と確認コード入力の 2 ステップを同じ route 内で切り替えます。
 export default function RegisterScreen() {
   const router = useRouter();
   const theme = useColors();
@@ -17,6 +18,7 @@ export default function RegisterScreen() {
   const [step, setStep] = useState<Step>('register');
   const [pendingEmail, setPendingEmail] = useState('');
 
+  // サインアップ結果に応じて、確認済みならログインへ、未確認なら確認ステップへ進めます。
   function handleRegisterSuccess(email: string, userConfirmed: boolean) {
     if (userConfirmed) {
       router.replace('/(auth)/login');
@@ -35,6 +37,7 @@ export default function RegisterScreen() {
       contentContainerStyle={[styles.container, { backgroundColor: theme.background }]}
       keyboardShouldPersistTaps="handled"
     >
+      {/* 現在の登録ステップに合わせて、入力フォームと確認コードフォームを切り替えます。 */}
       {step === 'register' ? (
         <>
           <Pressable

--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 
 import { useColors } from '@/hooks/use-colors';
 
+// タブレイアウトは犬一覧・散歩・設定の主要導線を NativeTabs で提供します。
 export default function TabLayout() {
   const { t } = useTranslation();
   const theme = useColors();

--- a/apps/mobile/app/(tabs)/dogs.tsx
+++ b/apps/mobile/app/(tabs)/dogs.tsx
@@ -10,6 +10,7 @@ import { SectionHeader } from '@/components/ui/SectionHeader';
 import { useColors } from '@/hooks/use-colors';
 import { spacing, typography } from '@/theme/tokens';
 
+// 犬一覧タブは pack 全体の進捗と登録済み犬の一覧操作を view-model へ委譲します。
 export default function DogsScreen() {
   const { t } = useTranslation();
   const theme = useColors();
@@ -17,6 +18,7 @@ export default function DogsScreen() {
 
   if (vm.isLoading) return <LoadingScreen />;
 
+  // 一覧の先頭には画面タイトル、追加導線、pack の集計カードをまとめて表示します。
   const ListHeader = (
     <View style={styles.headerContainer}>
       <View style={styles.titleRow}>
@@ -70,6 +72,7 @@ export default function DogsScreen() {
         onRefresh={vm.handleRefresh}
         refreshing={vm.isLoading}
         ListEmptyComponent={
+          // 登録済みの犬がいない場合だけ、犬追加への導線を空状態として表示します。
           <EmptyState
             message={t('dogs.list.empty')}
             ctaLabel={t('dogs.list.addDog')}

--- a/apps/mobile/app/(tabs)/settings.tsx
+++ b/apps/mobile/app/(tabs)/settings.tsx
@@ -11,6 +11,7 @@ import { PreferencesSection } from '@/components/settings/PreferencesSection';
 import { LegalSection } from '@/components/settings/LegalSection';
 import { SignOutRow } from '@/components/settings/SignOutRow';
 
+// 設定タブはプロフィール、表示設定、法務リンク、サインアウト導線をまとめます。
 export default function SettingsScreen() {
   const { t } = useTranslation();
   const theme = useColors();
@@ -18,6 +19,7 @@ export default function SettingsScreen() {
 
   if (vm.status === 'loading') return <LoadingScreen />;
   if (vm.status === 'error') {
+    // 設定の取得に失敗した場合は、同じ view-model の再試行だけを許可します。
     return <ErrorScreen message={t('settings.loadError')} onRetry={vm.handleRetry} />;
   }
 

--- a/apps/mobile/app/(tabs)/walk.tsx
+++ b/apps/mobile/app/(tabs)/walk.tsx
@@ -5,11 +5,13 @@ import { useWalkScreenViewModel } from '@/hooks/use-walk-screen-view-model';
 import { WalkReadyView } from '@/components/walk/WalkReadyView';
 import { WalkSummaryCard } from '@/components/walk/WalkSummaryCard';
 
+// 散歩タブは現在の散歩フェーズに応じて、開始前または終了後サマリーを表示します。
 export default function WalkScreen() {
   const theme = useColors();
   const vm = useWalkScreenViewModel();
 
   if (vm.phase === 'ready') {
+    // 開始前はマップ付きの準備画面に開始操作を委譲します。
     return <WalkReadyView onStart={vm.handleStart} isStarting={vm.isStarting} />;
   }
 

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -17,6 +17,7 @@ import {
   deletePendingInviteToken,
 } from '@/lib/auth/pending-invite-token';
 
+// 認証状態と現在の route group を見て、ログイン画面とアプリ本体の行き先を制御します。
 function NavigationGuard() {
   const { isAuthenticated, isLoading } = useAuthStore();
   const segments = useSegments();
@@ -30,7 +31,7 @@ function NavigationGuard() {
     if (!isAuthenticated && !inAuthGroup) {
       router.replace('/(auth)/login');
     } else if (isAuthenticated && inAuthGroup) {
-      // Check for pending invite token from deep link before auth
+      // 未ログイン時に受け取った招待 deep link は、認証完了後に本来の招待画面へ戻します。
       getPendingInviteToken().then((token) => {
         if (token) {
           deletePendingInviteToken();
@@ -49,6 +50,7 @@ export const unstable_settings = {
   anchor: '(tabs)',
 };
 
+// ルートレイアウトは provider、テーマ、認証ガード、主要 Stack 構成をまとめます。
 function RootLayout() {
   const colorScheme = useColorScheme();
   const isLoading = useAuthStore((s) => s.isLoading);
@@ -58,6 +60,7 @@ function RootLayout() {
   const { t } = useTranslation();
 
   useEffect(() => {
+    // アプリ起動時に認証情報と設定を復元し、以降の画面が同じ前提で動けるようにします。
     initialize();
     initializeSettings();
   }, [initialize, initializeSettings]);
@@ -89,6 +92,7 @@ function RootLayout() {
             options={{
               headerShown: false,
               presentation: 'formSheet',
+              // 記録操作はマップ上に重ねるため、form sheet の高さだけをこの route で固定します。
               sheetAllowedDetents: [0.15, 0.45],
               sheetInitialDetentIndex: 1,
               sheetGrabberVisible: true,

--- a/apps/mobile/app/dogs/[id]/_layout.tsx
+++ b/apps/mobile/app/dogs/[id]/_layout.tsx
@@ -2,6 +2,7 @@ import { Stack } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useColors } from '@/hooks/use-colors';
 
+// 犬詳細配下の編集、メンバー、友達、遭遇履歴 route のヘッダー設定を集約します。
 export default function DogDetailLayout() {
   const { t } = useTranslation();
   const theme = useColors();

--- a/apps/mobile/app/dogs/[id]/edit.tsx
+++ b/apps/mobile/app/dogs/[id]/edit.tsx
@@ -8,10 +8,11 @@ import { useMutationWithAlert } from '@/hooks/use-mutation-with-alert';
 import { DogForm, type DogFormValues } from '@/components/dogs/DogForm';
 import { PhotoPicker } from '@/components/dogs/PhotoPicker';
 import { LoadingScreen } from '@/components/ui/LoadingScreen';
-import { uploadToPresignedUrl } from '@/lib/upload';
+import { normalizeImageContentType, uploadToPresignedUrl } from '@/lib/upload';
 import { useColors } from '@/hooks/use-colors';
 import { spacing } from '@/theme/tokens';
 
+// 犬編集画面はプロフィールフォームと写真アップロードを同じ route で扱います。
 export default function EditDogScreen() {
   const { t } = useTranslation();
   const { id } = useLocalSearchParams<{ id: string }>();
@@ -27,18 +28,27 @@ export default function EditDogScreen() {
 
   if (isLoading || !dog) return <LoadingScreen />;
 
+  // 写真は先に署名付き URL へアップロードし、成功した key だけを犬プロフィールへ保存します。
   async function handlePhotoChange(uri: string, contentType: string) {
+    const normalizedContentType = normalizeImageContentType(contentType);
     setPreviewUri(uri);
     setPhotoLoading(true);
-    await runWithAlert(async () => {
-      const { url, key } = await generateUploadUrl({ dogId: id, contentType });
-      await uploadToPresignedUrl(url, uri, contentType);
-      await updateDog({ id, input: { photoUrl: key } });
-    }, 'dogs.edit.photoUploadError');
-    setPreviewUri(null);
-    setPhotoLoading(false);
+    try {
+      await runWithAlert(async () => {
+        const { url, key } = await generateUploadUrl({
+          dogId: id,
+          contentType: normalizedContentType,
+        });
+        await uploadToPresignedUrl(url, uri, normalizedContentType);
+        await updateDog({ id, input: { photoUrl: key } });
+      }, 'dogs.edit.photoUploadError');
+    } finally {
+      setPreviewUri(null);
+      setPhotoLoading(false);
+    }
   }
 
+  // 基本情報の更新後は元の詳細画面へ戻り、変更結果は query の再取得に任せます。
   async function handleSubmit(values: DogFormValues) {
     await updateDog({
       id,

--- a/apps/mobile/app/dogs/[id]/encounters.tsx
+++ b/apps/mobile/app/dogs/[id]/encounters.tsx
@@ -9,6 +9,7 @@ import { useColors } from '@/hooks/use-colors';
 import { spacing, typography } from '@/theme/tokens';
 import type { Encounter } from '@/types/graphql';
 
+// 遭遇履歴画面は指定された犬 ID の encounter 一覧を取得して時系列カードで表示します。
 export default function DogEncountersScreen() {
   const { t } = useTranslation();
   const { id } = useLocalSearchParams<{ id: string }>();
@@ -30,6 +31,7 @@ export default function DogEncountersScreen() {
       </View>
 
       {!encounters || encounters.length === 0 ? (
+        // まだ散歩中の遭遇がない場合は、履歴リストの代わりに空状態を表示します。
         <EmptyState
           message={t('dogs.encounters.empty', 'No encounters yet. Start a walk to meet other dogs!')}
         />

--- a/apps/mobile/app/dogs/[id]/friends/[friendDogId].tsx
+++ b/apps/mobile/app/dogs/[id]/friends/[friendDogId].tsx
@@ -10,6 +10,7 @@ import { useColors } from '@/hooks/use-colors';
 import { formatDuration, formatShortDate } from '@/lib/walk/format';
 import { spacing, radius, typography } from '@/theme/tokens';
 
+// 友達犬詳細画面は自分の犬 ID と相手の犬 ID から関係サマリーを表示します。
 export default function FriendDogDetailScreen() {
   const { t, i18n } = useTranslation();
   const { id, friendDogId } = useLocalSearchParams<{ id: string; friendDogId: string }>();
@@ -42,6 +43,7 @@ export default function FriendDogDetailScreen() {
       </View>
 
       <View style={styles.statsGrid}>
+        {/* 関係の強さが分かるよう、遭遇回数と合計時間を先に並べます。 */}
         <OutlinedCard padding="md">
           <Text style={[styles.statLabel, { color: theme.onSurfaceVariant }]}>
             {t('dogs.friends.encounters', 'Encounters').toUpperCase()}
@@ -61,6 +63,7 @@ export default function FriendDogDetailScreen() {
       </View>
 
       <View style={styles.statsGrid}>
+        {/* 初回と直近の遭遇日を並べ、関係がいつ始まり更新されたかを見せます。 */}
         <OutlinedCard padding="md">
           <Text style={[styles.statLabel, { color: theme.onSurfaceVariant }]}>
             {t('dogs.friends.firstMet', 'First Met').toUpperCase()}

--- a/apps/mobile/app/dogs/[id]/friends/index.tsx
+++ b/apps/mobile/app/dogs/[id]/friends/index.tsx
@@ -9,6 +9,7 @@ import { useColors } from '@/hooks/use-colors';
 import { spacing, typography } from '@/theme/tokens';
 import type { Friendship } from '@/types/graphql';
 
+// 友達一覧画面は遭遇から生まれた犬同士の関係を一覧化し、個別詳細へつなげます。
 export default function DogFriendsScreen() {
   const { t } = useTranslation();
   const { id } = useLocalSearchParams<{ id: string }>();
@@ -31,6 +32,7 @@ export default function DogFriendsScreen() {
       </View>
 
       {!friends || friends.length === 0 ? (
+        // 友達がまだいない場合は、散歩開始を促す空状態だけを表示します。
         <EmptyState
           message={t('dogs.friends.empty', 'No friends yet. Start a walk to meet other dogs!')}
         />

--- a/apps/mobile/app/dogs/[id]/index.tsx
+++ b/apps/mobile/app/dogs/[id]/index.tsx
@@ -13,6 +13,7 @@ import { GroupedRow } from '@/components/ui/GroupedRow';
 import { useColors } from '@/hooks/use-colors';
 import { spacing, typography } from '@/theme/tokens';
 
+// 犬詳細画面はヒーロー表示、散歩統計、メンバー/友達導線、削除操作をまとめます。
 export default function DogDetailScreen() {
   const { t } = useTranslation();
   const theme = useColors();
@@ -47,6 +48,7 @@ export default function DogDetailScreen() {
         </View>
 
         <GroupedCard style={styles.group}>
+          {/* 共有中の犬だけメンバー管理導線を出し、友達一覧は常に確認できるようにします。 */}
           {vm.memberCount > 0 ? (
             <GroupedRow
               label={t('dogs.detail.members')}
@@ -63,6 +65,7 @@ export default function DogDetailScreen() {
         </GroupedCard>
 
         {vm.isOwner ? (
+          // 削除操作は owner のみに限定し、確認ダイアログを経由して実行します。
           <View style={styles.actions}>
             <Button
               label={t('dogs.detail.delete')}

--- a/apps/mobile/app/dogs/[id]/members.tsx
+++ b/apps/mobile/app/dogs/[id]/members.tsx
@@ -17,6 +17,7 @@ import { LoadingScreen } from '@/components/ui/LoadingScreen';
 import { useColors } from '@/hooks/use-colors';
 import { spacing } from '@/theme/tokens';
 
+// メンバー画面は招待、メンバー削除、自分の退出を権限に応じて切り替えます。
 export default function DogMembersScreen() {
   const { t } = useTranslation();
   const { id } = useLocalSearchParams<{ id: string }>();
@@ -44,6 +45,7 @@ export default function DogMembersScreen() {
     (m) => m.userId === currentUserId && m.role === 'owner',
   );
 
+  // 招待作成後はアプリの deep link を共有シートへ渡し、相手が参加できるようにします。
   async function handleInvite() {
     const invitation = await runWithAlert(
       () => generateInvitation.mutateAsync(id),
@@ -54,6 +56,7 @@ export default function DogMembersScreen() {
     }
   }
 
+  // メンバー削除は確認ダイアログで選ばれたユーザーだけを対象にします。
   async function handleRemove() {
     if (!confirmRemove) return;
     const ok = await runWithAlert(
@@ -63,6 +66,7 @@ export default function DogMembersScreen() {
     if (ok) setConfirmRemove(null);
   }
 
+  // owner 以外の退出は成功後に犬一覧へ戻し、参照できない犬詳細に残らないようにします。
   async function handleLeave() {
     const ok = await runWithAlert(
       () => leaveDog.mutateAsync(id),
@@ -83,6 +87,7 @@ export default function DogMembersScreen() {
       </View>
 
       <View style={styles.actions}>
+        {/* owner は招待、member は退出だけを表示して誤操作を防ぎます。 */}
         {isOwner ? (
           <Button
             label={t('dogs.members.invite')}

--- a/apps/mobile/app/dogs/_layout.tsx
+++ b/apps/mobile/app/dogs/_layout.tsx
@@ -1,6 +1,7 @@
 import { Stack } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 
+// 犬関連 route は新規登録と詳細配下の Stack をここで束ねます。
 export default function DogsLayout() {
   const { t } = useTranslation();
 

--- a/apps/mobile/app/dogs/new.tsx
+++ b/apps/mobile/app/dogs/new.tsx
@@ -6,12 +6,14 @@ import { DogForm, type DogFormValues } from '@/components/dogs/DogForm';
 import { useColors } from '@/hooks/use-colors';
 import { spacing } from '@/theme/tokens';
 
+// 新規犬登録画面はフォーム送信後、作成した犬の詳細へ遷移します。
 export default function NewDogScreen() {
   const { t } = useTranslation();
   const router = useRouter();
   const theme = useColors();
   const { mutateAsync: createDog } = useCreateDog();
 
+  // フォーム値を API 入力へ整え、作成完了後にモーダルを閉じて詳細画面へ進みます。
   async function handleSubmit(values: DogFormValues) {
     const dog = await createDog({
       name: values.name,

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -1,5 +1,6 @@
 import { Redirect } from 'expo-router';
 
+// ルート URL はアプリのメイン導線である散歩タブへ集約します。
 export default function Index() {
   return <Redirect href="/(tabs)/walk" />;
 }

--- a/apps/mobile/app/invite/[token].tsx
+++ b/apps/mobile/app/invite/[token].tsx
@@ -7,6 +7,7 @@ import { spacing, typography } from '@/theme/tokens';
 import { useAcceptInviteFlow } from '@/hooks/use-accept-invite-flow';
 import { Button } from '@/components/ui/Button';
 
+// 招待受け入れ画面は URL の token を検証し、参加処理の状態ごとに表示を切り替えます。
 export default function AcceptInviteScreen() {
   const { token } = useLocalSearchParams<{ token: string }>();
   const { t } = useTranslation();
@@ -16,6 +17,7 @@ export default function AcceptInviteScreen() {
   const bg = { backgroundColor: theme.background };
 
   if (flow.status === 'loading') {
+    // token 検証・受け入れ処理中は、追加操作を出さずに進行中だけを示します。
     return (
       <View style={[styles.container, bg]}>
         <ActivityIndicator size="large" />
@@ -25,6 +27,7 @@ export default function AcceptInviteScreen() {
   }
 
   if (flow.status === 'error') {
+    // 招待が無効または通信に失敗した場合は、前の画面へ戻る導線に限定します。
     return (
       <View style={[styles.container, bg]}>
         <Text style={[styles.errorText, { color: theme.error }]}>
@@ -36,6 +39,7 @@ export default function AcceptInviteScreen() {
   }
 
   if (flow.status === 'success') {
+    // 参加完了後は犬一覧へ戻し、参加した犬を pack の中で確認できるようにします。
     return (
       <View style={[styles.container, bg]}>
         <Text style={[styles.successText, { color: theme.onSurface }]}>

--- a/apps/mobile/app/invite/_layout.tsx
+++ b/apps/mobile/app/invite/_layout.tsx
@@ -1,5 +1,6 @@
 import { Stack } from 'expo-router';
 
+// 招待 route は deep link から直接開かれるため、ヘッダーなしの独立 Stack にします。
 export default function InviteLayout() {
   return (
     <Stack screenOptions={{ headerShown: false }} />

--- a/apps/mobile/app/walk-recording-controls.tsx
+++ b/apps/mobile/app/walk-recording-controls.tsx
@@ -12,6 +12,7 @@ import { WalkEventActions } from '@/components/walk/WalkEventActions';
 import { spacing } from '@/theme/tokens';
 import type { Dog } from '@/types/graphql';
 
+// 記録操作パネルは form sheet として表示され、イベント記録と停止操作を担当します。
 export default function WalkRecordingControlsScreen() {
   const { t } = useTranslation();
   const walkId = useWalkStore((s) => s.walkId);
@@ -28,12 +29,14 @@ export default function WalkRecordingControlsScreen() {
   const [isStopping, setIsStopping] = useState(false);
   const lastDetentRef = useRef(0);
 
+  // 操作対象の犬は store の選択 ID と me.dogs を突き合わせて復元します。
   const selectedDogs = useMemo<Dog[]>(
     () => (me?.dogs ?? []).filter((d) => selectedDogIds.includes(d.id)),
     [me?.dogs, selectedDogIds],
   );
 
   useEffect(() => {
+    // クイック操作からカメラ指定で開かれた場合だけ、準備完了後に撮影要求へ変換します。
     if (params.action !== 'camera') return;
     if (phase === 'recording' && walkId) {
       requestCamera();
@@ -44,7 +47,7 @@ export default function WalkRecordingControlsScreen() {
   const handleLayout = useCallback(
     (e: LayoutChangeEvent) => {
       const { height: screenH } = Dimensions.get('window');
-      // Grabber + padding beyond measured content area (~28pt for grabber & inset).
+      // 実測した操作パネルの高さに grabber と inset 分を足し、sheet の detent を更新します。
       const sheetHeight = e.nativeEvent.layout.height + 28;
       const fraction = Math.min(0.9, Math.max(0.25, sheetHeight / screenH));
       if (Math.abs(fraction - lastDetentRef.current) < 0.01) return;
@@ -56,6 +59,7 @@ export default function WalkRecordingControlsScreen() {
     [navigation],
   );
 
+  // 停止時は BLE と遭遇検知を先に止めてから散歩セッションを終了し、サマリーへ戻します。
   const handleStop = useCallback(async () => {
     if (!walkId) return;
     setIsStopping(true);

--- a/apps/mobile/app/walk-recording.tsx
+++ b/apps/mobile/app/walk-recording.tsx
@@ -9,6 +9,7 @@ import { WalkMapShell } from '@/components/walk/WalkMapShell';
 import { WalkTopChip } from '@/components/walk/WalkTopChip';
 import type { Dog } from '@/types/graphql';
 
+// 記録中画面は全画面マップを表示し、操作パネル route を重ねて開きます。
 export default function WalkRecordingScreen() {
   const theme = useColors();
   const phase = useWalkStore((s) => s.phase);
@@ -19,6 +20,7 @@ export default function WalkRecordingScreen() {
 
   const hasPushedRef = useRef(false);
   useEffect(() => {
+    // 記録フェーズに入った最初の 1 回だけ form sheet の操作パネルを表示します。
     if (phase !== 'recording') return;
     if (hasPushedRef.current) return;
     hasPushedRef.current = true;
@@ -28,6 +30,7 @@ export default function WalkRecordingScreen() {
     });
   }, [phase, params.action]);
 
+  // 選択済み犬 ID から表示用の犬情報を引き直し、上部チップの単一情報源にします。
   const selectedDogs = useMemo<Dog[]>(
     () => (me?.dogs ?? []).filter((d) => selectedDogIds.includes(d.id)),
     [me?.dogs, selectedDogIds],

--- a/apps/mobile/app/walks/[id].tsx
+++ b/apps/mobile/app/walks/[id].tsx
@@ -11,6 +11,7 @@ import { useWalkDetailViewModel } from '@/hooks/use-walk-detail-view-model';
 import { WalkEventTimeline } from '@/components/walk/WalkEventTimeline';
 import { MAP_EVENT_EMOJIS } from '@/lib/walk/events';
 
+// 散歩詳細画面は保存済み散歩のルート、メトリクス、担当者、イベント履歴を表示します。
 export default function WalkDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const { t } = useTranslation();
@@ -19,6 +20,7 @@ export default function WalkDetailScreen() {
   const vm = useWalkDetailViewModel(walk);
 
   if (isLoading || !walk || !vm) {
+    // 詳細データまたは表示用モデルが揃うまでは、地図を描画せずローディングに留めます。
     return (
       <View style={[styles.center, { backgroundColor: theme.background }]}>
         <ActivityIndicator />
@@ -27,6 +29,7 @@ export default function WalkDetailScreen() {
   }
 
   const separator = t('walk.detail.timeSeparator');
+  // スクリーンリーダー向けには開始・終了の文脈を含めた時刻ラベルを組み立てます。
   const timeLabel = vm.endTime
     ? `${t('walk.detail.startTime')} ${vm.startTime}${separator}${t('walk.detail.endTime')} ${vm.endTime}`
     : `${t('walk.detail.startTime')} ${vm.startTime}`;
@@ -47,6 +50,7 @@ export default function WalkDetailScreen() {
               longitudeDelta: 0.01,
             }}
           >
+            {/* GPS 点が 2 点以上ある場合だけルート線を描き、単一点の誤表示を避けます。 */}
             {vm.coordinates.length >= 2 ? (
               <Polyline
                 coordinates={vm.coordinates}
@@ -59,6 +63,7 @@ export default function WalkDetailScreen() {
             {vm.events
               .filter((e) => e.lat != null && e.lng != null)
               .map((e) => (
+                // 座標を持つイベントだけを、種別ごとの絵文字マーカーとして地図に重ねます。
                 <Marker
                   key={e.id}
                   coordinate={{ latitude: e.lat!, longitude: e.lng! }}
@@ -112,6 +117,7 @@ export default function WalkDetailScreen() {
         </GroupedCard>
 
         {vm.walker ? (
+          // 担当者情報がある散歩だけ、アバターまたはイニシャル付きで表示します。
           <View style={styles.walkerSection}>
             <Text style={[styles.walkerLabel, { color: theme.onSurfaceVariant }]}>
               {t('walk.detail.walker')}
@@ -146,6 +152,7 @@ export default function WalkDetailScreen() {
         ) : null}
 
         {vm.events.length > 0 ? (
+          // 記録イベントがある場合だけ、詳細タイムラインを追加します。
           <GroupedCard style={styles.timelineCard}>
             <WalkEventTimeline events={vm.events} />
           </GroupedCard>
@@ -155,6 +162,7 @@ export default function WalkDetailScreen() {
   );
 }
 
+// メトリクスセルは距離・時間・ペースで同じ見た目を共有します。
 function Metric({
   label,
   value,

--- a/apps/mobile/app/walks/_layout.tsx
+++ b/apps/mobile/app/walks/_layout.tsx
@@ -3,6 +3,7 @@ import { Pressable, Text, StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColors } from '@/hooks/use-colors';
 
+// 散歩詳細 Stack は独自の戻るボタンを使い、タブ内の履歴から自然に戻します。
 export default function WalksLayout() {
   const { t } = useTranslation();
   const router = useRouter();

--- a/apps/mobile/components/walk/DogEventActionRow.tsx
+++ b/apps/mobile/components/walk/DogEventActionRow.tsx
@@ -19,6 +19,7 @@ interface DogEventActionRowProps {
   onPress: (type: WalkEventType, dogId: string) => void;
 }
 
+// 複数犬の散歩中に、犬ごとのイベント回数と記録ボタンを 1 行にまとめます。
 export function DogEventActionRow({
   dog,
   counts,
@@ -57,6 +58,7 @@ export function DogEventActionRow({
         </Text>
       </View>
       <View style={styles.buttons}>
+        {/* イベント種別の表示順は共通定義に合わせ、画面間で操作順を揃えます。 */}
         {EVENT_ORDER.map((type) => (
           <Pressable
             key={type}

--- a/apps/mobile/components/walk/DogPickerCard.tsx
+++ b/apps/mobile/components/walk/DogPickerCard.tsx
@@ -18,6 +18,7 @@ interface DogPickerCardProps {
 const AVATAR_SIZE = 44;
 const SEPARATOR_INSET = AVATAR_SIZE + spacing.md + spacing.md;
 
+// 散歩前の犬選択カードです。複数選択と単体表示の差分だけをここで吸収します。
 export function DogPickerCard({
   dogs,
   selectedIds,
@@ -25,6 +26,7 @@ export function DogPickerCard({
   variant = 'multi',
 }: DogPickerCardProps) {
   const theme = useColors();
+  // 「前回の散歩」表示がレンダー中に揺れないよう、基準時刻を固定します。
   const now = useMemo(() => new Date(), []);
   const interactive = variant === 'multi';
 
@@ -89,6 +91,7 @@ function DogPickerRow({
 }: DogPickerRowProps) {
   const theme = useColors();
   const { t } = useTranslation();
+  // 犬ごとの最新散歩日時を、現在時刻から見た相対的な文言に整えます。
   const lastWalkText = formatLastWalk(dog.latestWalk?.endedAt, now, t);
 
   return (
@@ -118,6 +121,7 @@ function DogPickerRow({
 function SelectionIndicator({ isSelected }: { isSelected: boolean }) {
   const theme = useColors();
 
+  // 未選択時は空の円だけを表示し、選択済みとの差を明確にします。
   if (!isSelected) {
     return (
       <View

--- a/apps/mobile/components/walk/EventPill.tsx
+++ b/apps/mobile/components/walk/EventPill.tsx
@@ -12,6 +12,7 @@ export interface EventPillProps {
   countColor: string;
 }
 
+// 単独犬の散歩で、イベント種別ごとの記録ボタンと現在回数を表示します。
 export function EventPill({
   label,
   emoji,

--- a/apps/mobile/components/walk/NoDogsBody.tsx
+++ b/apps/mobile/components/walk/NoDogsBody.tsx
@@ -4,12 +4,14 @@ import { useTranslation } from 'react-i18next';
 import { useColors } from '@/hooks/use-colors';
 import { radius, spacing, typography } from '@/theme/tokens';
 
+// 登録済みの犬がいない場合の案内と、犬登録画面への導線を表示します。
 export function NoDogsBody() {
   const { t } = useTranslation();
   const theme = useColors();
   const router = useRouter();
 
   const ctaLabel = t('walk.ready.noDogsCta');
+  // 空状態からすぐ散歩準備へ戻れるよう、犬の新規登録へ送ります。
   const handleAdd = () => router.push('/dogs/new');
 
   return (

--- a/apps/mobile/components/walk/PerDogSummaryCard.tsx
+++ b/apps/mobile/components/walk/PerDogSummaryCard.tsx
@@ -15,6 +15,7 @@ interface PerDogSummaryCardProps {
 
 const AVATAR = 36;
 
+// 散歩終了後に、犬ごとのイベント集計を一覧で確認できるカードです。
 export function PerDogSummaryCard({
   dogs,
   events,
@@ -45,6 +46,7 @@ export function PerDogSummaryCard({
 
       <GroupedCard>
         {dogs.map((dog, i) => {
+          // 表示直前に犬 ID でイベントを絞り込み、犬別の回数だけを集計します。
           const counts = countEventsByType(events, { dogId: dog.id });
           return (
             <View key={dog.id}>

--- a/apps/mobile/components/walk/WalkControls.tsx
+++ b/apps/mobile/components/walk/WalkControls.tsx
@@ -15,10 +15,11 @@ interface WalkControlsProps {
   dogs: Dog[];
   onStop: () => void;
   isStopping: boolean;
-  /** Pee/Poo/Photo controls — supplied by <WalkEventActions /> from walk.tsx. */
+  /** Pee/Poo/Photo 操作は walk.tsx から <WalkEventActions /> として差し込みます。 */
   children?: ReactNode;
 }
 
+// 記録中の下部パネルとして、犬の表示、メトリクス、イベント操作、停止操作をまとめます。
 export function WalkControls({ dogs, onStop, isStopping, children }: WalkControlsProps) {
   const { t } = useTranslation();
   const startedAt = useWalkStore((s) => s.startedAt);
@@ -31,12 +32,14 @@ export function WalkControls({ dogs, onStop, isStopping, children }: WalkControl
   const pausedAtMsRef = useRef<number | null>(null);
   const elapsedSec = useWalkElapsed({ startedAt, isPaused, totalPausedMs });
 
+  // 新しい散歩が始まったら、一時停止状態を前回セッションから持ち越さないよう初期化します。
   useEffect(() => {
     pausedAtMsRef.current = null;
     setIsPaused(false);
     setTotalPausedMs(0);
   }, [startedAtMs]);
 
+  // 一時停止の開始時刻だけを ref に残し、再開時に累計停止時間へ加算します。
   const togglePause = () => {
     if (isPaused && pausedAtMsRef.current !== null) {
       setTotalPausedMs((ms) => ms + (Date.now() - pausedAtMsRef.current!));
@@ -48,6 +51,7 @@ export function WalkControls({ dogs, onStop, isStopping, children }: WalkControl
     }
   };
 
+  // 記録中パネルのメトリクスは、設定単位に合わせた表示文字列へ変換して渡します。
   const { value: distanceValue, unit: distanceUnit } = formatDistanceParts(totalDistanceM, units);
   const pace = formatPace(elapsedSec, totalDistanceM, units);
   const metrics = [
@@ -61,6 +65,7 @@ export function WalkControls({ dogs, onStop, isStopping, children }: WalkControl
   ];
 
   const isSingleDog = dogs.length === 1;
+  // 単独散歩では時間帯ラベル、複数犬ではグループ散歩ラベルを表示します。
   const title = isSingleDog ? dogs[0].name : dogs.map((d) => d.name).join(' + ');
   const subtitle = isSingleDog
     ? contextualWalkLabel(startedAt, t)
@@ -84,6 +89,7 @@ export function WalkControls({ dogs, onStop, isStopping, children }: WalkControl
 }
 
 function contextualWalkLabel(startedAt: Date | null, t: (key: string) => string) {
+  // 散歩開始時刻を使って、朝・昼・夜の自然なラベルに切り替えます。
   const hour = (startedAt ?? new Date()).getHours();
   if (hour < 12) return t('walk.recording.morningWalk');
   if (hour < 18) return t('walk.recording.afternoonWalk');

--- a/apps/mobile/components/walk/WalkControlsActions.tsx
+++ b/apps/mobile/components/walk/WalkControlsActions.tsx
@@ -11,6 +11,7 @@ interface WalkControlsActionsProps {
   onStop: () => void;
 }
 
+// 記録中パネル下部の一時停止/再開と終了操作を表示します。
 export function WalkControlsActions({
   isPaused,
   isStopping,

--- a/apps/mobile/components/walk/WalkEventActions.tsx
+++ b/apps/mobile/components/walk/WalkEventActions.tsx
@@ -18,6 +18,7 @@ interface WalkEventActionsProps {
   dogs: Dog[];
 }
 
+// 記録中の Pee/Poo/Photo イベントを、単独犬と複数犬の UI に分けて提供します。
 export function WalkEventActions({ dogs }: WalkEventActionsProps) {
   const { t } = useTranslation();
   const theme = useColors();
@@ -31,6 +32,7 @@ export function WalkEventActions({ dogs }: WalkEventActionsProps) {
 
   const isSingleDog = dogs.length === 1;
   const singleDogId = isSingleDog ? dogs[0].id : undefined;
+  // イベントには直近の GPS 座標を付与し、地図上のマーカーと履歴に反映できるようにします。
   const latestPoint = points.length
     ? {
         lat: points[points.length - 1].lat,
@@ -44,6 +46,7 @@ export function WalkEventActions({ dogs }: WalkEventActionsProps) {
   });
   const isDisabled = !walkId || isPending;
 
+  // Pee/Poo は共通のイベント記録フックに委譲し、失敗時の復旧処理も同じ経路に寄せます。
   const handlePeeOrPoo = useCallback(
     async (eventType: Extract<WalkEventType, 'pee' | 'poo'>, dogId?: string) => {
       await commitEvent(() => recordEvent(eventType, dogId));
@@ -51,6 +54,7 @@ export function WalkEventActions({ dogs }: WalkEventActionsProps) {
     [commitEvent, recordEvent],
   );
 
+  // 写真イベントは権限確認、カメラ起動、アップロード付きイベント記録を順番に実行します。
   const handlePhoto = useCallback(
     async (dogId?: string) => {
       if (!walkId) return;
@@ -88,6 +92,7 @@ export function WalkEventActions({ dogs }: WalkEventActionsProps) {
     [walkId, t, runWithAlert, commitEvent, recordPhoto],
   );
 
+  // 画面遷移時に渡されたカメラ起動要求を、記録画面の準備完了後に処理します。
   useCameraEventTrigger({
     cameraRequestedAt,
     walkId,
@@ -96,6 +101,7 @@ export function WalkEventActions({ dogs }: WalkEventActionsProps) {
     triggerPhoto: handlePhoto,
   });
 
+  // UI 側はイベント種別だけを渡し、写真と通常イベントの実行経路をここで振り分けます。
   const fire = useCallback(
     (type: WalkEventType, dogId?: string) => {
       if (type === 'photo') {
@@ -108,8 +114,10 @@ export function WalkEventActions({ dogs }: WalkEventActionsProps) {
     [handlePhoto, handlePeeOrPoo],
   );
 
+  // 犬がいない状態ではイベントの紐付け先がないため、操作 UI を出しません。
   if (dogs.length === 0) return null;
 
+  // 単独犬ではイベント種別ごとの横並びボタンで、現在回数も一緒に見せます。
   if (isSingleDog) {
     const counts = countEventsByType(events);
     return (
@@ -131,6 +139,7 @@ export function WalkEventActions({ dogs }: WalkEventActionsProps) {
     );
   }
 
+  // 複数犬では犬ごとの行に分け、押した行の犬 ID へイベントを紐付けます。
   return (
     <View style={styles.multiList}>
       {dogs.map((dog, index) => {

--- a/apps/mobile/components/walk/WalkEventTimeline.tsx
+++ b/apps/mobile/components/walk/WalkEventTimeline.tsx
@@ -18,17 +18,20 @@ interface WalkEventTimelineProps {
   events: WalkEvent[];
 }
 
+// 散歩中に記録したイベントを時系列で並べ、写真は全画面プレビューへつなげます。
 export function WalkEventTimeline({ events }: WalkEventTimelineProps) {
   const { t } = useTranslation();
   const theme = useColors();
   const insets = useSafeAreaInsets();
   const [fullScreenPhoto, setFullScreenPhoto] = useState<string | null>(null);
 
+  // 表示するイベントがない場合は、タイムライン領域自体を省略します。
   if (events.length === 0) return null;
 
   return (
     <View style={styles.container}>
       {events.map((event) => {
+        // イベント種別から表示アイコンと翻訳ラベルを決め、発生時刻と一緒に表示します。
         const config = EVENT_CONFIG[event.eventType];
         const label = t(`walk.event.${event.eventType}`);
         const time = formatClockTime(event.occurredAt);
@@ -38,6 +41,7 @@ export function WalkEventTimeline({ events }: WalkEventTimelineProps) {
             <Text style={styles.time}>{time}</Text>
             <Text style={styles.emoji}>{config.emoji}</Text>
             <Text style={[styles.label, { color: theme.onSurface }]}>{label}</Text>
+            {/* 写真イベントだけサムネイルを押せるようにし、通常イベントは文字表示に留めます。 */}
             {event.eventType === 'photo' && event.photoUrl ? (
               <Pressable
                 onPress={() => {
@@ -63,6 +67,7 @@ export function WalkEventTimeline({ events }: WalkEventTimelineProps) {
         );
       })}
 
+      {/* サムネイル選択中だけ、セーフエリアを考慮した写真プレビューを重ねます。 */}
       <Modal
         visible={fullScreenPhoto !== null}
         animationType="fade"

--- a/apps/mobile/components/walk/WalkHistoryItem.tsx
+++ b/apps/mobile/components/walk/WalkHistoryItem.tsx
@@ -11,6 +11,7 @@ interface WalkHistoryItemProps {
   walk: Walk;
 }
 
+// 散歩履歴の 1 件を、日付・犬・担当者・主要メトリクスに絞って表示します。
 export function WalkHistoryItem({ walk }: WalkHistoryItemProps) {
   const { t, i18n } = useTranslation();
   const router = useRouter();
@@ -22,6 +23,7 @@ export function WalkHistoryItem({ walk }: WalkHistoryItemProps) {
   const dogNames = walk.dogs.map((d) => d.name).join(', ');
 
   const walker = walk.walker;
+  // 担当者の画像がない場合に備え、表示名の先頭文字をフォールバックにします。
   const walkerInitial = walker?.displayName?.charAt(0)?.toUpperCase() ?? '?';
 
   return (

--- a/apps/mobile/components/walk/WalkIdentityHeader.tsx
+++ b/apps/mobile/components/walk/WalkIdentityHeader.tsx
@@ -13,6 +13,7 @@ interface WalkIdentityHeaderProps {
 
 const AVATAR = 32;
 
+// 記録中パネルのヘッダーとして、散歩中の犬と LIVE 状態を簡潔に示します。
 export function WalkIdentityHeader({ dogs, title, subtitle }: WalkIdentityHeaderProps) {
   const theme = useColors();
 

--- a/apps/mobile/components/walk/WalkMap.tsx
+++ b/apps/mobile/components/walk/WalkMap.tsx
@@ -5,21 +5,18 @@ import { useWalkStore } from '@/stores/walk-store';
 import { MAP_EVENT_EMOJIS } from '@/lib/walk/events';
 import { TOKYO_STATION_COORDINATE } from '@/lib/walk/constants';
 
-/**
- * Live recording map. Reads both the GPS trail (`points`) and recorded events
- * from `walk-store` so the entire visible state comes from one source of
- * truth. Event markers update in lockstep with `WalkEventActions` writes.
- */
 interface WalkMapProps {
   mode?: 'preview' | 'recording';
 }
 
+// 散歩マップは GPS 軌跡と記録イベントを store から読み、地図表示の単一の情報源にします。
 export function WalkMap({ mode = 'recording' }: WalkMapProps) {
   const theme = useColors();
   const points = useWalkStore((s) => s.points);
   const events = useWalkStore((s) => s.events);
   const isRecording = mode === 'recording';
 
+  // 地図ライブラリ用の座標形式へ変換し、最後の地点を現在地表示の基準にします。
   const coordinates = points.map((p) => ({ latitude: p.lat, longitude: p.lng }));
   const lastPoint = coordinates[coordinates.length - 1];
 
@@ -29,6 +26,7 @@ export function WalkMap({ mode = 'recording' }: WalkMapProps) {
         style={styles.map}
         showsUserLocation={isRecording}
         followsUserLocation={isRecording}
+        // 位置情報がまだないプレビューでは東京駅を初期表示にして、空の地図を避けます。
         initialRegion={
           lastPoint
             ? {
@@ -53,6 +51,7 @@ export function WalkMap({ mode = 'recording' }: WalkMapProps) {
           />
         ) : null}
         {isRecording && lastPoint ? <Marker coordinate={lastPoint} /> : null}
+        {/* 座標を持つイベントだけをマーカー化し、記録操作と地図表示を同期させます。 */}
         {isRecording
           ? events
               .filter((e) => e.lat != null && e.lng != null)

--- a/apps/mobile/components/walk/WalkMapShell.tsx
+++ b/apps/mobile/components/walk/WalkMapShell.tsx
@@ -9,6 +9,7 @@ interface WalkMapShellProps {
   bottom?: ReactNode;
 }
 
+// マップを全面に敷き、上部チップと下部パネルをセーフエリア込みで重ねます。
 export function WalkMapShell({ map, top, bottom }: WalkMapShellProps) {
   const insets = useSafeAreaInsets();
 
@@ -16,10 +17,12 @@ export function WalkMapShell({ map, top, bottom }: WalkMapShellProps) {
     <View style={styles.container}>
       {map}
 
+      {/* 上部オーバーレイはステータスバーに重ならない位置へ逃がします。 */}
       {top ? (
         <View style={[styles.topOverlay, { top: insets.top + spacing.xs }]}>{top}</View>
       ) : null}
 
+      {/* 下部オーバーレイはホームインジケータ分の余白を最低限確保します。 */}
       {bottom ? (
         <View
           style={[

--- a/apps/mobile/components/walk/WalkMetricsRow.tsx
+++ b/apps/mobile/components/walk/WalkMetricsRow.tsx
@@ -13,6 +13,7 @@ interface WalkMetricsRowProps {
   metrics: WalkMetricItem[];
 }
 
+// 記録中メトリクスを横並びで表示し、各セルの色は現在テーマに合わせます。
 export function WalkMetricsRow({ metrics }: WalkMetricsRowProps) {
   const theme = useColors();
 

--- a/apps/mobile/components/walk/WalkMinimizedControls.tsx
+++ b/apps/mobile/components/walk/WalkMinimizedControls.tsx
@@ -16,6 +16,7 @@ interface WalkMinimizedControlsProps {
 
 const AVATAR = 28;
 
+// 記録中パネルを畳んだ状態で、経過時間と距離を確認しながら再展開できます。
 export function WalkMinimizedControls({ dogs }: WalkMinimizedControlsProps) {
   const { t } = useTranslation();
   const theme = useColors();
@@ -25,6 +26,7 @@ export function WalkMinimizedControls({ dogs }: WalkMinimizedControlsProps) {
   const units = useSettingsStore((s) => s.units);
   const elapsedSec = useWalkElapsed({ startedAt, isPaused: false, totalPausedMs: 0 });
 
+  // ミニ表示全体を 1 つの再展開ボタンとして扱います。
   const expand = () => setMinimized(false);
 
   return (

--- a/apps/mobile/components/walk/WalkQuickActions.tsx
+++ b/apps/mobile/components/walk/WalkQuickActions.tsx
@@ -15,11 +15,7 @@ interface WalkQuickActionsProps {
   dogs: Dog[];
 }
 
-/**
- * Compact floating event pills shown above the minimized walk panel.
- * Single dog → Pee / Poop pills (labelled) + Photo icon.
- * Multi dog → `💧 <name>` + `💩 <name>` per dog + one shared Photo icon.
- */
+// ミニ表示中でも使えるイベント記録ボタンです。犬の数に応じて表示粒度を切り替えます。
 export function WalkQuickActions({ dogs }: WalkQuickActionsProps) {
   const { t } = useTranslation();
   const theme = useColors();
@@ -33,6 +29,7 @@ export function WalkQuickActions({ dogs }: WalkQuickActionsProps) {
   const latestPoint = points[points.length - 1];
   const isDisabled = !walkId || recordWalkEvent.isPending || photoUpload.isPending;
 
+  // Pee/Poo は最新位置と一緒に API へ送り、成功したイベントをローカル store に反映します。
   const handlePeeOrPoo = useCallback(
     async (eventType: 'pee' | 'poo', dogId?: string) => {
       if (!walkId) return;
@@ -56,6 +53,7 @@ export function WalkQuickActions({ dogs }: WalkQuickActionsProps) {
     [walkId, latestPoint, recordWalkEvent, addEvent, runWithAlert],
   );
 
+  // 写真は権限確認、撮影、アップロード、イベント登録までを 1 つの操作として扱います。
   const handlePhoto = useCallback(
     async (dogId?: string) => {
       if (!walkId) return;
@@ -110,6 +108,7 @@ export function WalkQuickActions({ dogs }: WalkQuickActionsProps) {
     [walkId, latestPoint, t, photoUpload, addEvent, runWithAlert],
   );
 
+  // 犬が選ばれていない場合は、記録先がないためクイック操作を隠します。
   if (dogs.length === 0) return null;
 
   return (
@@ -119,6 +118,7 @@ export function WalkQuickActions({ dogs }: WalkQuickActionsProps) {
       contentContainerStyle={styles.content}
       style={styles.scroll}
     >
+      {/* 単独犬はイベント名、複数犬は犬名を前面に出して誤記録を防ぎます。 */}
       {isSingleDog ? (
         <>
           <Pill
@@ -189,6 +189,7 @@ interface PillProps {
   compact?: boolean;
 }
 
+// クイック操作の各ボタンは、非同期処理でも Pressable 側へ Promise を漏らさないよう包みます。
 function Pill({ label, onPress, disabled, bg, border, color, accessibilityLabel, compact }: PillProps) {
   return (
     <Pressable

--- a/apps/mobile/components/walk/WalkReadyStatsRow.tsx
+++ b/apps/mobile/components/walk/WalkReadyStatsRow.tsx
@@ -10,11 +10,13 @@ interface StatCell {
   icon?: string;
 }
 
+// 散歩開始前に、今日の距離・連続日数・目標進捗を小さくまとめて表示します。
 export function WalkReadyStatsRow() {
   const { t } = useTranslation();
   const theme = useColors();
   const pack = usePackProgress();
 
+  // pack progress の数値を、表示用の短い統計セルに変換します。
   const cells: StatCell[] = [
     {
       label: t('walk.ready.stats.today'),

--- a/apps/mobile/components/walk/WalkReadyView.tsx
+++ b/apps/mobile/components/walk/WalkReadyView.tsx
@@ -20,6 +20,7 @@ interface WalkReadyViewProps {
   isStarting: boolean;
 }
 
+// 散歩開始前の画面です。犬の選択、統計、開始ボタンをマップ上の下部カードにまとめます。
 export function WalkReadyView({ onStart, isStarting }: WalkReadyViewProps) {
   const { t } = useTranslation();
   const theme = useColors();
@@ -31,7 +32,7 @@ export function WalkReadyView({ onStart, isStarting }: WalkReadyViewProps) {
 
   const isSingleDog = dogs.length === 1;
 
-  // With a single dog, there is no picker — keep the selection in sync so START works.
+  // 犬が 1 匹だけのときは選択 UI を出さないため、開始できるよう選択状態を同期します。
   useEffect(() => {
     if (isSingleDog && selectedDogIds.length === 0) {
       setSelectedDogs([dogs[0].id]);
@@ -41,6 +42,7 @@ export function WalkReadyView({ onStart, isStarting }: WalkReadyViewProps) {
   const allSelected =
     dogs.length > 0 && dogs.every((d) => selectedDogIds.includes(d.id));
 
+  // 複数犬の選択をまとめて切り替え、全選択済みなら解除にします。
   const handleSelectAll = useCallback(() => {
     if (allSelected) {
       setSelectedDogs([]);
@@ -70,6 +72,7 @@ export function WalkReadyView({ onStart, isStarting }: WalkReadyViewProps) {
           >
             <View style={[styles.grabber, { backgroundColor: theme.textDisabled }]} />
 
+            {/* 犬の登録状態と頭数に応じて、空状態・単体・複数選択の表示を切り替えます。 */}
             {dogs.length === 0 ? (
               <NoDogsBody />
             ) : isSingleDog ? (

--- a/apps/mobile/components/walk/WalkRoutePreview.tsx
+++ b/apps/mobile/components/walk/WalkRoutePreview.tsx
@@ -19,6 +19,7 @@ interface WalkRoutePreviewProps {
 const MAP_HEIGHT = 180;
 const DOT_SIZE = 14;
 
+// 散歩終了後に、記録されたルートと主要メトリクスをコンパクトにプレビューします。
 export function WalkRoutePreview({
   points,
   totalDistanceM,
@@ -26,10 +27,12 @@ export function WalkRoutePreview({
 }: WalkRoutePreviewProps) {
   const theme = useColors();
 
+  // 記録点を地図座標へ変換し、ルートの始点と終点をマーカー表示に使います。
   const coordinates = points.map((p) => ({ latitude: p.lat, longitude: p.lng }));
   const start = coordinates[0];
   const end = coordinates[coordinates.length - 1];
 
+  // ルートがない場合も地図が安定して表示されるよう、東京駅をフォールバックにします。
   const region = start
     ? {
         latitude: (start.latitude + (end?.latitude ?? start.latitude)) / 2,
@@ -112,6 +115,7 @@ interface PillProps {
   theme: ReturnType<typeof useColors>;
 }
 
+// 地図上に重ねる読み取り専用のメトリクス表示です。
 function Pill({ label, theme }: PillProps) {
   return (
     <View

--- a/apps/mobile/components/walk/WalkStartButton.tsx
+++ b/apps/mobile/components/walk/WalkStartButton.tsx
@@ -9,6 +9,7 @@ interface WalkStartButtonProps {
   loading?: boolean;
 }
 
+// 散歩開始の主操作ボタンです。開始中は押せない状態にして二重実行を防ぎます。
 export function WalkStartButton({ onPress, disabled, loading }: WalkStartButtonProps) {
   const { t } = useTranslation();
   const theme = useColors();
@@ -31,6 +32,7 @@ export function WalkStartButton({ onPress, disabled, loading }: WalkStartButtonP
         elevation.accentStart,
       ]}
     >
+      {/* 開始処理中だけローディング表示に切り替え、通常時のラベルは保ちます。 */}
       {loading ? (
         <ActivityIndicator color={theme.onInteractive} />
       ) : (

--- a/apps/mobile/components/walk/WalkSummaryCard.tsx
+++ b/apps/mobile/components/walk/WalkSummaryCard.tsx
@@ -15,6 +15,7 @@ import type { Dog } from '@/types/graphql';
 
 const AVATAR = 22;
 
+// 散歩終了直後のサマリー画面です。ルート、犬別集計、保存導線をまとめます。
 export function WalkSummaryCard() {
   const router = useRouter();
   const { t } = useTranslation();
@@ -30,6 +31,7 @@ export function WalkSummaryCard() {
   const reset = useWalkStore((s) => s.reset);
 
   const { data: me } = useMe();
+  // 終了時点で選択されていた犬だけを、プロフィール情報から引き直して表示します。
   const dogs = useMemo<Dog[]>(
     () => (me?.dogs ?? []).filter((d) => selectedDogIds.includes(d.id)),
     [me?.dogs, selectedDogIds],
@@ -42,6 +44,7 @@ export function WalkSummaryCard() {
 
   const isSingle = dogs.length <= 1;
   const firstDog = dogs[0];
+  // 単独犬と複数犬で、完了メッセージと保存メモの文脈を切り替えます。
   const title = isSingle
     ? t('walk.finished.titleSingle', { name: firstDog?.name ?? '' })
     : t('walk.finished.titleMulti');
@@ -64,6 +67,7 @@ export function WalkSummaryCard() {
         b: dogs[1]?.name ?? '',
       });
 
+  // 保存後は記録中 store をリセットしてから、保存済み散歩の詳細へ移動します。
   const handleSave = () => {
     const id = walkId;
     reset();
@@ -107,6 +111,7 @@ export function WalkSummaryCard() {
           elapsedSec={elapsedSec}
         />
 
+        {/* 複数犬の散歩だけ、犬ごとのイベント内訳を追加で表示します。 */}
         {!isSingle ? (
           <PerDogSummaryCard
             dogs={dogs}
@@ -145,6 +150,7 @@ interface AvatarStackProps {
 }
 
 function AvatarStack({ dogs, borderColor }: AvatarStackProps) {
+  // 犬が取得できない場合は、サブタイトル横のアバターだけを省略します。
   if (dogs.length === 0) return null;
   return (
     <View style={styles.avatars}>
@@ -165,6 +171,7 @@ function AvatarStack({ dogs, borderColor }: AvatarStackProps) {
 }
 
 function joinNames(dogs: Dog[], t: (key: string) => string): string {
+  // 複数犬の名前を、翻訳された接続詞を使って自然な文章にします。
   if (dogs.length === 0) return '';
   if (dogs.length === 1) return dogs[0].name;
   const joiner = t('walk.finished.joinerAnd');

--- a/apps/mobile/components/walk/WalkTopChip.tsx
+++ b/apps/mobile/components/walk/WalkTopChip.tsx
@@ -12,13 +12,16 @@ interface WalkTopChipProps {
 
 const AVATAR = 22;
 
+// マップ上部に、散歩対象の犬または固定ラベルを小さなチップとして表示します。
 export function WalkTopChip({ dogs, label }: WalkTopChipProps) {
   const { t } = useTranslation();
   const theme = useColors();
 
+  // 表示する犬も固定ラベルもない場合は、上部チップ自体を出しません。
   if (dogs.length === 0 && !label) return null;
 
   const isSingle = dogs.length === 1;
+  // 親から明示ラベルが渡された場合は、犬の頭数よりもその文言を優先します。
   const displayLabel =
     label ??
     (isSingle

--- a/apps/mobile/hooks/use-accept-invitation.ts
+++ b/apps/mobile/hooks/use-accept-invitation.ts
@@ -4,6 +4,7 @@ import { ACCEPT_DOG_INVITATION_MUTATION } from '@/lib/graphql/mutations/dog';
 import { useInvalidateUserQueries } from './use-invalidate-user-queries';
 import type { Dog, AcceptDogInvitationResponse } from '@/types/graphql';
 
+// 招待トークンを受け入れ、犬・ユーザー関連のキャッシュを更新します。
 export function useAcceptInvitation() {
   const invalidateUserQueries = useInvalidateUserQueries();
   return useMutation<Dog, Error, string>({

--- a/apps/mobile/hooks/use-accept-invite-flow.ts
+++ b/apps/mobile/hooks/use-accept-invite-flow.ts
@@ -6,6 +6,7 @@ import { savePendingInviteToken } from '@/lib/auth/pending-invite-token';
 import { extractGraphQLErrorMessage } from '@/lib/graphql/errors';
 import { mapInviteErrorKey, type InviteErrorKey } from '@/lib/errors/invite-error-map';
 
+// 招待受け入れ画面で表示する状態を表します。
 export type AcceptInviteStatus = 'idle' | 'loading' | 'success' | 'error';
 export type AcceptInviteErrorKey = InviteErrorKey | 'invite.error.saveFailed';
 
@@ -21,6 +22,7 @@ const INITIAL_STATE: AcceptInviteFlowState = {
   errorKey: null,
 };
 
+// 認証状態に応じて、招待トークンの保存・ログイン誘導・受け入れを切り替えます。
 export function useAcceptInviteFlow(token: string | undefined) {
   const isAuthenticated = useIsAuthenticated();
   const acceptInvitation = useAcceptInvitation();
@@ -28,6 +30,7 @@ export function useAcceptInviteFlow(token: string | undefined) {
 
   const [state, setState] = useState<AcceptInviteFlowState>(INITIAL_STATE);
 
+  // GraphQL エラーは画面で翻訳できるキーへ寄せてから状態へ反映します。
   const runAccept = useCallback(
     async (inviteToken: string) => {
       setState({ status: 'loading', dogName: null, errorKey: null });
@@ -42,6 +45,7 @@ export function useAcceptInviteFlow(token: string | undefined) {
     [acceptInvitation],
   );
 
+  // 未ログイン時は招待トークンを保留し、ログイン後に再開できるようにします。
   useEffect(() => {
     if (!token) return;
 

--- a/apps/mobile/hooks/use-auth.ts
+++ b/apps/mobile/hooks/use-auth.ts
@@ -2,6 +2,7 @@ import { useAuthStore } from '@/stores/auth-store';
 import * as authApi from '@/lib/auth/api';
 import type { SignUpResult } from '@/lib/auth/api';
 
+// 認証 API と永続化ストアをつなぎ、画面側へ認証状態と操作を提供します。
 export function useAuth() {
   const { isAuthenticated, isLoading, accessToken, setAuth, clearAuth } = useAuthStore();
 
@@ -23,6 +24,7 @@ export function useAuth() {
   }
 
   async function signOut(): Promise<void> {
+    // アクセストークンがある場合だけ、サーバーへサインアウトを通知します。
     if (accessToken) {
       await authApi.signOut(accessToken);
     }

--- a/apps/mobile/hooks/use-ble-session.ts
+++ b/apps/mobile/hooks/use-ble-session.ts
@@ -5,12 +5,14 @@ interface BleAdvertiser {
   stop: () => void;
 }
 
+// 散歩中の BLE スキャンとアドバタイズのライフサイクルを管理します。
 export function useBleSession() {
   const scannerRef = useRef<BleScanner | null>(null);
   const advertiserRef = useRef<BleAdvertiser | null>(null);
 
   const start = useCallback(
     async (walkId: string, onDetected: (detectedWalkId: string) => void) => {
+      // 他の端末を探しながら、自分の散歩 ID も周囲へ広告します。
       const s = await startScanning(onDetected);
       const a = await startAdvertising(walkId);
       scannerRef.current = s;
@@ -19,6 +21,7 @@ export function useBleSession() {
     [],
   );
 
+  // 画面終了や散歩終了時に、BLE リソースを確実に解放します。
   const stop = useCallback(() => {
     scannerRef.current?.stop();
     scannerRef.current = null;

--- a/apps/mobile/hooks/use-camera-event-trigger.ts
+++ b/apps/mobile/hooks/use-camera-event-trigger.ts
@@ -9,6 +9,7 @@ interface UseCameraEventTriggerArgs {
   triggerPhoto: (dogId?: string) => void | Promise<void>;
 }
 
+// 画面遷移で受け取ったカメラ起動要求を、アプリが active になってから実行します。
 export function useCameraEventTrigger({
   cameraRequestedAt,
   walkId,
@@ -18,6 +19,7 @@ export function useCameraEventTrigger({
 }: UseCameraEventTriggerArgs) {
   const cameraTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // カメラ画面へ戻った直後の競合を避けるため、短い遅延を置いて写真操作を起動します。
   useEffect(() => {
     if (cameraTimerRef.current !== null) {
       clearTimeout(cameraTimerRef.current);

--- a/apps/mobile/hooks/use-color-scheme.ts
+++ b/apps/mobile/hooks/use-color-scheme.ts
@@ -1,6 +1,7 @@
 import { useColorScheme as useSystemColorScheme } from 'react-native';
 import { useSettingsStore } from '@/stores/settings-store';
 
+// ユーザー設定を優先し、未指定時は OS のカラースキームに追従します。
 export function useColorScheme(): 'light' | 'dark' {
   const systemScheme = useSystemColorScheme();
   const theme = useSettingsStore((s) => s.theme);

--- a/apps/mobile/hooks/use-color-scheme.web.ts
+++ b/apps/mobile/hooks/use-color-scheme.web.ts
@@ -1,9 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useColorScheme as useRNColorScheme } from 'react-native';
 
-/**
- * To support static rendering, this value needs to be re-calculated on the client side for web
- */
+// Web の静的レンダリング後に、クライアント側で OS のカラースキームを反映します。
 export function useColorScheme() {
   const [hasHydrated, setHasHydrated] = useState(false);
 
@@ -13,6 +11,7 @@ export function useColorScheme() {
 
   const colorScheme = useRNColorScheme();
 
+  // ハイドレーション前はサーバー出力と一致させるため light を返します。
   if (hasHydrated) {
     return colorScheme;
   }

--- a/apps/mobile/hooks/use-colors.ts
+++ b/apps/mobile/hooks/use-colors.ts
@@ -1,6 +1,7 @@
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { colors, type ColorTokens } from '@/theme/tokens';
 
+// 現在のカラースキームに対応するテーマトークンを返します。
 export function useColors(): ColorTokens {
   const colorScheme = useColorScheme();
   return colors[colorScheme ?? 'light'];

--- a/apps/mobile/hooks/use-commit-walk-event.ts
+++ b/apps/mobile/hooks/use-commit-walk-event.ts
@@ -3,15 +3,7 @@ import * as Haptics from 'expo-haptics';
 import { useWalkStore } from '@/stores/walk-store';
 import type { WalkEvent } from '@/types/graphql';
 
-/**
- * Facade for the post-mutation step of recording a walk event: append the
- * server-confirmed event to the walk-store cache and fire the user-feedback
- * haptic. Wraps the previously inline `commitEvent` helper from
- * `WalkEventActions.tsx` so consumers don't have to know about the store
- * shape or the exact haptic style — they call `commit(() => recordEvent(...))`
- * and get back the recorded event (or `null` if the mutation didn't return
- * one).
- */
+// 散歩イベント記録後のストア反映とハプティック通知をまとめるフックです。
 export function useCommitWalkEvent() {
   const addEvent = useWalkStore((s) => s.addEvent);
 
@@ -20,6 +12,7 @@ export function useCommitWalkEvent() {
       const event = await run();
       if (!event) return null;
 
+      // サーバー確定済みイベントだけをストアへ追加し、UI の件数表示と触覚反応を揃えます。
       addEvent(event);
       void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
       return event;

--- a/apps/mobile/hooks/use-dog-detail-authorization.ts
+++ b/apps/mobile/hooks/use-dog-detail-authorization.ts
@@ -1,10 +1,12 @@
 import { useMemo } from 'react';
 import type { DogWithStats, User } from '@/types/graphql';
 
+// 犬詳細画面で現在ユーザーに許可される操作を表します。
 export interface DogDetailAuthorization {
   isOwner: boolean;
 }
 
+// メンバー情報から、現在ユーザーが犬のオーナーかどうかを判定します。
 export function useDogDetailAuthorization(
   dog: DogWithStats | undefined,
   me: User | undefined,

--- a/apps/mobile/hooks/use-dog-detail-view-model.ts
+++ b/apps/mobile/hooks/use-dog-detail-view-model.ts
@@ -9,6 +9,7 @@ import { usePackProgress } from '@/hooks/use-pack-progress';
 import { useMyWalks } from '@/hooks/use-walks';
 import type { Dog, DogWithStats, Walk } from '@/types/graphql';
 
+// 犬の生年月日から、詳細画面に出す短い年齢表示を作ります。
 function computeAgeLabel(birthDate: Dog['birthDate'], now: Date = new Date()): string | null {
   if (!birthDate?.year) return null;
   const month = birthDate.month ?? 1;
@@ -31,6 +32,7 @@ function buildMeta(dog: Dog): string {
   return parts.join(' · ');
 }
 
+// Dog 詳細画面で loading/ready を分岐するための ViewModel です。
 interface DogDetailLoadingViewModel {
   status: 'loading';
 }
@@ -54,6 +56,7 @@ interface DogDetailReadyViewModel {
 
 export type DogDetailViewModel = DogDetailLoadingViewModel | DogDetailReadyViewModel;
 
+// URL パラメータを起点に犬詳細、散歩履歴、権限、操作ハンドラを集約します。
 export function useDogDetailViewModel(): DogDetailViewModel {
   const { id: rawId } = useLocalSearchParams<{ id: string }>();
   const dogId = Array.isArray(rawId) ? rawId[0] : rawId;
@@ -68,6 +71,7 @@ export function useDogDetailViewModel(): DogDetailViewModel {
   const { isOwner } = useDogDetailAuthorization(dog ?? undefined, me ?? undefined);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
+  // 全散歩履歴から、現在表示している犬が参加した散歩だけを抽出します。
   const dogWalks = useMemo(
     () => (dog ? walks.filter((walk) => walk.dogs.some((walkDog) => walkDog.id === dog.id)) : []),
     [dog, walks],
@@ -98,6 +102,7 @@ export function useDogDetailViewModel(): DogDetailViewModel {
     setShowDeleteConfirm(false);
   }, []);
 
+  // 削除は共通のアラート処理を通し、成功時だけ犬一覧へ戻します。
   const handleDelete = useCallback(async () => {
     if (!dogId) return;
     const ok = await runWithAlert(() => deleteDog(dogId), 'dogs.detail.deleteError');
@@ -106,6 +111,7 @@ export function useDogDetailViewModel(): DogDetailViewModel {
     }
   }, [deleteDog, dogId, router, runWithAlert]);
 
+  // 詳細表示に必要なデータが揃うまで、画面側へ loading として返します。
   if (isLoading || !dog) {
     return { status: 'loading' };
   }

--- a/apps/mobile/hooks/use-dog-encounters.ts
+++ b/apps/mobile/hooks/use-dog-encounters.ts
@@ -5,6 +5,7 @@ import { encounterKeys } from '@/lib/graphql/keys';
 import { useIsAuthenticated } from './use-is-authenticated';
 import type { DogEncountersResponse, Encounter } from '@/types/graphql';
 
+// 犬ごとの遭遇履歴をページング条件つきで取得します。
 export function useDogEncounters(dogId: string, limit = 20, offset = 0) {
   const isAuthenticated = useIsAuthenticated();
   return useQuery<Encounter[]>({

--- a/apps/mobile/hooks/use-dog-friends.ts
+++ b/apps/mobile/hooks/use-dog-friends.ts
@@ -5,6 +5,7 @@ import { friendshipKeys } from '@/lib/graphql/keys';
 import { useIsAuthenticated } from './use-is-authenticated';
 import type { DogFriendsResponse, Friendship } from '@/types/graphql';
 
+// 認証済みかつ犬 ID がある場合だけ、犬の友だち一覧を取得します。
 export function useDogFriends(dogId: string) {
   const isAuthenticated = useIsAuthenticated();
   return useQuery<Friendship[]>({

--- a/apps/mobile/hooks/use-dog-member-mutations.ts
+++ b/apps/mobile/hooks/use-dog-member-mutations.ts
@@ -13,6 +13,7 @@ import type {
   LeaveDogResponse,
 } from '@/types/graphql';
 
+// 犬へメンバーを招待するためのトークンを発行します。
 export function useGenerateInvitation() {
   return useMutation<DogInvitation, Error, string>({
     mutationFn: async (dogId) => {
@@ -25,6 +26,7 @@ export function useGenerateInvitation() {
   });
 }
 
+// メンバー削除後は所属情報が変わるため、ユーザー関連キャッシュを更新します。
 export function useRemoveMember() {
   const invalidateUserQueries = useInvalidateUserQueries();
   return useMutation<boolean, Error, { dogId: string; userId: string }>({
@@ -39,6 +41,7 @@ export function useRemoveMember() {
   });
 }
 
+// 現在ユーザーが犬から抜けた後、所属犬一覧を最新化します。
 export function useLeaveDog() {
   const invalidateUserQueries = useInvalidateUserQueries();
   return useMutation<boolean, Error, string>({

--- a/apps/mobile/hooks/use-dog-mutations.ts
+++ b/apps/mobile/hooks/use-dog-mutations.ts
@@ -18,6 +18,7 @@ import type {
   GenerateDogPhotoUploadUrlResponse,
 } from '@/types/graphql';
 
+// 犬の作成後、ユーザー関連キャッシュを更新して一覧へ反映します。
 export function useCreateDog() {
   const invalidateUserQueries = useInvalidateUserQueries();
   return useMutation<Dog, Error, CreateDogInput>({
@@ -29,6 +30,7 @@ export function useCreateDog() {
   });
 }
 
+// 犬のプロフィール更新後、詳細と一覧で使うユーザー関連キャッシュを更新します。
 export function useUpdateDog() {
   const invalidateUserQueries = useInvalidateUserQueries();
   return useMutation<Dog, Error, { id: string; input: UpdateDogInput }>({
@@ -43,6 +45,7 @@ export function useUpdateDog() {
   });
 }
 
+// 犬の削除後、所属犬一覧が変わるためユーザー関連キャッシュを更新します。
 export function useDeleteDog() {
   const invalidateUserQueries = useInvalidateUserQueries();
   return useMutation<boolean, Error, string>({
@@ -54,6 +57,7 @@ export function useDeleteDog() {
   });
 }
 
+// 犬プロフィール写真を直接アップロードするための署名付き URL を発行します。
 export function useGeneratePhotoUploadUrl() {
   return useMutation<PresignedUrl, Error, { dogId: string; contentType: string }>({
     mutationFn: async ({ dogId, contentType }) => {

--- a/apps/mobile/hooks/use-dog.ts
+++ b/apps/mobile/hooks/use-dog.ts
@@ -4,6 +4,7 @@ import { DOG_QUERY } from '@/lib/graphql/queries/dog';
 import { dogKeys } from '@/lib/graphql/keys';
 import type { DogResponse, DogWithStats, StatsPeriod } from '@/types/graphql';
 
+// 犬の詳細と期間別統計を取得し、ID が未確定の間は問い合わせを止めます。
 export function useDog(id: string, period: StatsPeriod = 'ALL') {
   return useQuery<DogWithStats | null>({
     queryKey: dogKeys.detail(id, period),

--- a/apps/mobile/hooks/use-dogs-screen-view-model.ts
+++ b/apps/mobile/hooks/use-dogs-screen-view-model.ts
@@ -4,6 +4,7 @@ import { useMe } from '@/hooks/use-me';
 import { usePackProgress } from '@/hooks/use-pack-progress';
 import type { Dog } from '@/types/graphql';
 
+// Dogs 画面へ渡す犬一覧、パック進捗、画面操作をまとめた ViewModel です。
 export interface DogsScreenViewModel {
   dogs: Dog[];
   pack: ReturnType<typeof usePackProgress>;
@@ -13,6 +14,7 @@ export interface DogsScreenViewModel {
   handleRefresh: () => void;
 }
 
+// 現在ユーザーの犬一覧と画面遷移ハンドラを Dogs 画面向けに組み立てます。
 export function useDogsScreenViewModel(): DogsScreenViewModel {
   const router = useRouter();
   const { data: me, isLoading, refetch } = useMe();

--- a/apps/mobile/hooks/use-encounter-mutations.ts
+++ b/apps/mobile/hooks/use-encounter-mutations.ts
@@ -11,6 +11,7 @@ import type {
   UpdateEncounterDurationResponse,
 } from '@/types/graphql';
 
+// 犬同士の遭遇を記録し、友だち・遭遇関連のキャッシュを更新します。
 export function useRecordEncounter() {
   const queryClient = useQueryClient();
   return useMutation<Encounter[], Error, { myWalkId: string; theirWalkId: string }>({
@@ -28,6 +29,7 @@ export function useRecordEncounter() {
   });
 }
 
+// 確定した遭遇時間をサーバーへ反映します。
 export function useUpdateEncounterDuration() {
   return useMutation<
     boolean,

--- a/apps/mobile/hooks/use-encounter-session.ts
+++ b/apps/mobile/hooks/use-encounter-session.ts
@@ -5,11 +5,13 @@ import {
   useUpdateEncounterDuration,
 } from './use-encounter-mutations';
 
+// BLE で検知した相手の散歩 ID を、遭遇開始・終了イベントへ変換します。
 export function useEncounterSession() {
   const recordEncounter = useRecordEncounter();
   const updateEncounterDuration = useUpdateEncounterDuration();
   const trackerRef = useRef<EncounterTracker | null>(null);
 
+  // EncounterTracker のコールバックで、遭遇記録と滞在時間更新をサーバーへ送ります。
   const start = useCallback(
     (walkId: string) => {
       const tracker = new EncounterTracker({
@@ -30,10 +32,12 @@ export function useEncounterSession() {
     [recordEncounter, updateEncounterDuration],
   );
 
+  // BLE スキャナーからの検知通知を、現在の tracker インスタンスへ渡します。
   const onDeviceDetected = useCallback((theirWalkId: string) => {
     trackerRef.current?.onDeviceDetected(theirWalkId);
   }, []);
 
+  // 散歩終了時に tracker を停止し、重複検知が残らないようにします。
   const stop = useCallback(() => {
     trackerRef.current?.stop();
     trackerRef.current = null;

--- a/apps/mobile/hooks/use-flush-walk-event-outbox.ts
+++ b/apps/mobile/hooks/use-flush-walk-event-outbox.ts
@@ -12,18 +12,7 @@ export interface FlushOutcome {
   remaining: number;
 }
 
-/**
- * Replay queued walk events one-by-one. Stops on the first failure on the
- * assumption that we are still offline (or the server is unhappy); the
- * remaining items stay in the outbox for the next attempt.
- *
- * Each successfully replayed event is appended to the in-memory walk store
- * and triggers a light haptic so the UI counter and feedback match what the
- * user did at the original tap. This intentionally mirrors the post-mutation
- * step in `WalkEventActions` rather than going through `useCommitWalkEvent`,
- * which is part of a separate facade refactor (M1) that may not be merged
- * yet.
- */
+// outbox に残った散歩イベントを順番に再送し、最初の失敗で次回へ持ち越します。
 export function useFlushWalkEventOutbox() {
   const recordWalkEvent = useRecordWalkEvent();
   const addEvent = useWalkStore((s) => s.addEvent);
@@ -33,6 +22,7 @@ export function useFlushWalkEventOutbox() {
     let flushed = 0;
     for (const item of pending) {
       try {
+        // 再送に成功したイベントはストアにも反映し、元のタップ操作と同じ触覚反応を返します。
         const event = await recordWalkEvent.mutateAsync({
           walkId: item.walkId,
           ...(item.dogId !== undefined ? { dogId: item.dogId } : {}),
@@ -47,6 +37,7 @@ export function useFlushWalkEventOutbox() {
         await removePendingEvent(item.id);
         flushed += 1;
       } catch {
+        // まだオフラインまたはサーバー側で失敗している前提で、残りは outbox に残します。
         break;
       }
     }

--- a/apps/mobile/hooks/use-friendship.ts
+++ b/apps/mobile/hooks/use-friendship.ts
@@ -5,6 +5,7 @@ import { friendshipKeys } from '@/lib/graphql/keys';
 import { useIsAuthenticated } from './use-is-authenticated';
 import type { FriendshipResponse, Friendship } from '@/types/graphql';
 
+// 2 頭の犬の友だち関係を、両方の ID が揃ったときだけ取得します。
 export function useFriendship(dogId1: string, dogId2: string) {
   const isAuthenticated = useIsAuthenticated();
   return useQuery<Friendship | null>({

--- a/apps/mobile/hooks/use-invalidate-user-queries.ts
+++ b/apps/mobile/hooks/use-invalidate-user-queries.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { meKeys, dogKeys } from '@/lib/graphql/keys';
 
+// ユーザー情報と犬一覧に影響する変更後、関連クエリをまとめて無効化します。
 export function useInvalidateUserQueries(): () => Promise<void> {
   const queryClient = useQueryClient();
   return useCallback(async () => {

--- a/apps/mobile/hooks/use-is-authenticated.ts
+++ b/apps/mobile/hooks/use-is-authenticated.ts
@@ -1,5 +1,6 @@
 import { useAuthStore } from '@/stores/auth-store';
 
+// 認証済みかどうかだけを購読し、不要な再描画を避けるための軽量フックです。
 export function useIsAuthenticated(): boolean {
   return useAuthStore((s) => s.isAuthenticated);
 }

--- a/apps/mobile/hooks/use-me.ts
+++ b/apps/mobile/hooks/use-me.ts
@@ -5,6 +5,7 @@ import { meKeys } from '@/lib/graphql/keys';
 import { useIsAuthenticated } from './use-is-authenticated';
 import type { MeResponse, User } from '@/types/graphql';
 
+// 認証済みのときだけ現在ユーザー情報を取得します。
 export function useMe() {
   const isAuthenticated = useIsAuthenticated();
   return useQuery<User>({

--- a/apps/mobile/hooks/use-mutation-with-alert.ts
+++ b/apps/mobile/hooks/use-mutation-with-alert.ts
@@ -5,15 +5,14 @@ import { useTranslation } from 'react-i18next';
 type ErrorMessageKey = string;
 type ErrorMessageResolver = (error: unknown) => ErrorMessageKey;
 
+// ミューテーション失敗時のアラート表示を共通化し、成功時だけ結果を返します。
 export function useMutationWithAlert() {
   const { t } = useTranslation();
   return useCallback(
     async <T>(
       fn: () => Promise<T>,
       errorMessage: ErrorMessageKey | ErrorMessageResolver,
-      // Retained on the signature for back-compat with callers that pass
-      // observability metadata; it has no effect now that the Sentry
-      // integration has been removed.
+      // 監視用メタデータを渡す既存呼び出しとの互換性のために残しています。
       _context?: Record<string, unknown>,
     ): Promise<T | null> => {
       try {

--- a/apps/mobile/hooks/use-otp-input.ts
+++ b/apps/mobile/hooks/use-otp-input.ts
@@ -1,6 +1,7 @@
 import { useCallback, useRef, useState } from 'react';
 import type { TextInput } from 'react-native';
 
+// OTP 入力欄の数字配列、フォーカス移動、完了判定をまとめて管理します。
 export function useOtpInput(length: number) {
   const [digits, setDigits] = useState<string[]>(() =>
     new Array<string>(length).fill(''),
@@ -12,6 +13,7 @@ export function useOtpInput(length: number) {
 
   const setDigit = useCallback(
     (index: number, value: string) => {
+      // 貼り付けやキーボード入力から数字 1 桁だけを採用し、次の欄へ進めます。
       const digit = value.replace(/[^0-9]/g, '').slice(-1);
       setDigits((prev) => {
         const next = [...prev];
@@ -25,6 +27,7 @@ export function useOtpInput(length: number) {
     [length],
   );
 
+  // 空欄で Backspace を押したときは、前の入力欄へ戻します。
   const handleKeyPress = useCallback(
     (index: number, key: string) => {
       if (key === 'Backspace' && digits[index] === '' && index > 0) {

--- a/apps/mobile/hooks/use-pack-progress.ts
+++ b/apps/mobile/hooks/use-pack-progress.ts
@@ -3,12 +3,14 @@ import { DEFAULT_DAILY_GOAL_KM } from '@/constants/walk';
 import { useMyWalks } from './use-walks';
 import type { Walk } from '@/types/graphql';
 
+// 犬ごとの今日の距離、総散歩数、継続日数を表します。
 export interface DogProgress {
   todayKm: number;
   totalWalks: number;
   streakDays: number;
 }
 
+// パック全体と犬ごとの散歩進捗を、ホームや犬一覧で使う形にまとめた値です。
 export interface PackProgress {
   todayKm: number;
   goalKm: number;
@@ -38,6 +40,7 @@ function shiftDay(date: Date, delta: number): Date {
   return new Date(date.getFullYear(), date.getMonth(), date.getDate() + delta);
 }
 
+// ローカル日付で連続散歩日数を計算し、昨日まで継続中の場合も streak として扱います。
 function computeStreak(dayKeys: Set<string>, now: Date): number {
   if (dayKeys.size === 0) return 0;
   const today = localDayKey(now);
@@ -54,6 +57,7 @@ function computeStreak(dayKeys: Set<string>, now: Date): number {
   return streak;
 }
 
+// 散歩履歴から、パック全体と犬ごとの今日の進捗・連続日数を集計します。
 export function aggregatePackProgress(
   walks: Walk[],
   goalKm: number = DEFAULT_DAILY_GOAL_KM,
@@ -67,6 +71,7 @@ export function aggregatePackProgress(
   const dogTodayM = new Map<string, number>();
   const dogTotalWalks = new Map<string, number>();
 
+  // 散歩単位の距離をパック全体へ、参加犬ごとには個別進捗へ積み上げます。
   for (const walk of walks) {
     const dayKey = toLocalDayKey(walk.startedAt);
     const distanceM = walk.distanceM ?? 0;
@@ -106,6 +111,7 @@ export function aggregatePackProgress(
   return { todayKm, goalKm, progressPct, packStreakDays, perDog };
 }
 
+// 最新の散歩履歴をもとに、パック進捗をメモ化して返します。
 export function usePackProgress(goalKm: number = DEFAULT_DAILY_GOAL_KM): PackProgress {
   const { data, isLoading } = useMyWalks(100);
   return useMemo(() => {

--- a/apps/mobile/hooks/use-photo-upload.test.ts
+++ b/apps/mobile/hooks/use-photo-upload.test.ts
@@ -9,6 +9,7 @@ jest.mock('./use-walk-event-mutations', () => ({
 }));
 
 jest.mock('@/lib/upload', () => ({
+  normalizeImageContentType: jest.requireActual('@/lib/upload').normalizeImageContentType,
   uploadToPresignedUrl: jest.fn(),
 }));
 
@@ -103,6 +104,31 @@ describe('usePhotoUpload', () => {
       walkId: 'walk-1',
       contentType: 'image/jpeg',
     });
+  });
+
+  it('normalizes native image MIME aliases before presigning and uploading', async () => {
+    mockPresignMutateAsync.mockResolvedValue({ url: 'u', key: 'k', expiresAt: 'e' });
+    (upload.uploadToPresignedUrl as jest.Mock).mockResolvedValue(undefined);
+    mockRecordMutateAsync.mockResolvedValue({ id: 'e' });
+
+    const { result } = renderHook(() => usePhotoUpload());
+
+    await act(async () => {
+      await result.current.uploadPhoto({
+        walkId: 'walk-1',
+        asset: { uri: 'file:///photo.jpg', mimeType: 'image/jpg' },
+      });
+    });
+
+    expect(mockPresignMutateAsync).toHaveBeenCalledWith({
+      walkId: 'walk-1',
+      contentType: 'image/jpeg',
+    });
+    expect(upload.uploadToPresignedUrl).toHaveBeenCalledWith(
+      'u',
+      'file:///photo.jpg',
+      'image/jpeg',
+    );
   });
 
   it('omits lat/lng when latestPoint is not given', async () => {

--- a/apps/mobile/hooks/use-photo-upload.ts
+++ b/apps/mobile/hooks/use-photo-upload.ts
@@ -3,11 +3,13 @@ import {
   useGenerateWalkEventPhotoUploadUrl,
   useRecordWalkEvent,
 } from '@/hooks/use-walk-event-mutations';
-import { uploadToPresignedUrl } from '@/lib/upload';
+import { normalizeImageContentType, uploadToPresignedUrl } from '@/lib/upload';
 import type { WalkEvent } from '@/types/graphql';
 
+// 写真アップロード処理のどの段階で失敗したかを表します。
 export type PhotoUploadPhase = 'presign' | 'upload' | 'record';
 
+// アラート文言を切り替えるため、失敗した段階を保持するエラーです。
 export class PhotoUploadError extends Error {
   readonly phase: PhotoUploadPhase;
   override readonly cause: unknown;
@@ -27,6 +29,7 @@ interface UploadPhotoArgs {
   latestPoint?: { lat: number; lng: number };
 }
 
+// 署名付き URL の発行、画像アップロード、写真イベント記録を順に実行します。
 export function usePhotoUpload() {
   const generatePhotoUploadUrl = useGenerateWalkEventPhotoUploadUrl();
   const recordWalkEvent = useRecordWalkEvent();
@@ -35,7 +38,8 @@ export function usePhotoUpload() {
     async (args: UploadPhotoArgs): Promise<WalkEvent> => {
       let phase: PhotoUploadPhase = 'presign';
       try {
-        const contentType = args.asset.mimeType ?? 'image/jpeg';
+        // 各段階の直前に phase を更新し、失敗箇所を呼び出し元へ伝えます。
+        const contentType = normalizeImageContentType(args.asset.mimeType);
         const { url, key } = await generatePhotoUploadUrl.mutateAsync({
           walkId: args.walkId,
           contentType,
@@ -50,14 +54,13 @@ export function usePhotoUpload() {
           dogId: args.dogId,
           eventType: 'photo',
           occurredAt: new Date().toISOString(),
-          ...(args.latestPoint
-            ? { lat: args.latestPoint.lat, lng: args.latestPoint.lng }
-            : {}),
+          ...(args.latestPoint ?? {}),
           photoKey: key,
         });
 
         return event;
       } catch (cause) {
+        // 元の例外は cause に残し、UI では phase ごとの文言に変換できるようにします。
         throw new PhotoUploadError(phase, cause);
       }
     },

--- a/apps/mobile/hooks/use-settings-screen-view-model.ts
+++ b/apps/mobile/hooks/use-settings-screen-view-model.ts
@@ -14,11 +14,13 @@ interface SettingsScreenReadyViewModel extends SettingsScreenBaseViewModel {
   me: User;
 }
 
+// Settings 画面が loading/error/ready を分岐するための ViewModel です。
 export type SettingsScreenViewModel =
   | (SettingsScreenBaseViewModel & { status: 'loading' })
   | (SettingsScreenBaseViewModel & { status: 'error' })
   | SettingsScreenReadyViewModel;
 
+// ユーザー情報取得と再試行操作を Settings 画面向けにまとめます。
 export function useSettingsScreenViewModel(): SettingsScreenViewModel {
   const { data: me, isLoading, error, refetch } = useMe();
 
@@ -26,6 +28,7 @@ export function useSettingsScreenViewModel(): SettingsScreenViewModel {
     void refetch();
   }, [refetch]);
 
+  // 画面側がデータ有無を意識せず表示分岐できるよう、状態ごとに返却形を固定します。
   if (isLoading) {
     return { status: 'loading', handleRetry };
   }

--- a/apps/mobile/hooks/use-themed-styles.ts
+++ b/apps/mobile/hooks/use-themed-styles.ts
@@ -5,6 +5,7 @@ import { colors, type ColorTokens } from '@/theme/tokens';
 
 type StyleFactory<T extends StyleSheet.NamedStyles<T>> = (theme: ColorTokens) => T;
 
+// 現在のテーマ色を渡して StyleSheet を生成し、テーマ変更時だけ再計算します。
 export function useThemedStyles<T extends StyleSheet.NamedStyles<T>>(factory: StyleFactory<T>): T {
   const colorScheme = useColorScheme();
   const theme = colors[colorScheme ?? 'light'];

--- a/apps/mobile/hooks/use-walk-detail-view-model.ts
+++ b/apps/mobile/hooks/use-walk-detail-view-model.ts
@@ -10,6 +10,7 @@ import {
 } from '@/lib/walk/format';
 import type { Walk, WalkEvent } from '@/types/graphql';
 
+// Walk 詳細画面に必要な表示用データをまとめた ViewModel です。
 export interface WalkDetailViewModel {
   coordinates: { latitude: number; longitude: number }[];
   events: WalkEvent[];
@@ -30,10 +31,12 @@ export interface WalkDetailViewModel {
   } | null;
 }
 
+// 散歩データを距離・時間・地図・イベント表示用の値へ整形します。
 export function useWalkDetailViewModel(walk: Walk | null | undefined): WalkDetailViewModel | null {
   const { i18n } = useTranslation();
 
   return useMemo(() => {
+    // データ取得前は画面側が空状態として扱えるよう null を返します。
     if (!walk) return null;
 
     const distanceM = walk.distanceM ?? 0;

--- a/apps/mobile/hooks/use-walk-elapsed.ts
+++ b/apps/mobile/hooks/use-walk-elapsed.ts
@@ -6,6 +6,7 @@ interface UseWalkElapsedOptions {
   totalPausedMs: number;
 }
 
+// 一時停止時間を差し引いた散歩の経過秒数を、1 秒ごとに更新します。
 export function useWalkElapsed({
   startedAt,
   isPaused,
@@ -14,6 +15,7 @@ export function useWalkElapsed({
   const [elapsedSec, setElapsedSec] = useState(0);
   const pausedAtRef = useRef<number | null>(null);
 
+  // 一時停止中は時刻を固定し、再開時にタイマー表示が進みすぎないようにします。
   useEffect(() => {
     if (!startedAt) {
       pausedAtRef.current = null;

--- a/apps/mobile/hooks/use-walk-event-mutations.ts
+++ b/apps/mobile/hooks/use-walk-event-mutations.ts
@@ -12,6 +12,7 @@ import type {
   GenerateWalkEventPhotoUploadUrlResponse,
 } from '@/types/graphql';
 
+// 散歩中のイベントをサーバーへ記録します。
 export function useRecordWalkEvent() {
   return useMutation<WalkEvent, Error, RecordWalkEventInput>({
     mutationFn: async (input) => {
@@ -24,6 +25,7 @@ export function useRecordWalkEvent() {
   });
 }
 
+// 散歩イベント写真を直接アップロードするための署名付き URL を発行します。
 export function useGenerateWalkEventPhotoUploadUrl() {
   return useMutation<PresignedUrl, Error, { walkId: string; contentType: string }>({
     mutationFn: async ({ walkId, contentType }) => {

--- a/apps/mobile/hooks/use-walk-event-recorder.ts
+++ b/apps/mobile/hooks/use-walk-event-recorder.ts
@@ -17,6 +17,7 @@ interface RecordPhotoArgs {
   asset: { uri: string; mimeType?: string | null };
 }
 
+// 散歩イベントの即時記録、写真アップロード、オフライン時の outbox 保存をまとめます。
 export function useWalkEventRecorder({
   walkId,
   latestPoint,
@@ -27,15 +28,14 @@ export function useWalkEventRecorder({
   const runWithAlert = useMutationWithAlert();
   const flushOutbox = useFlushWalkEventOutbox();
 
-  // Drain any events queued during a previous offline session as soon as
-  // the recorder mounts (typically when the user reopens the recording sheet
-  // after coming back online).
+  // レコーダー起動時に、過去のオフライン操作で溜まったイベントを再送します。
   useEffect(() => {
     void flushOutbox().catch(() => {
-      /* swallow — best-effort, will retry on next successful record */
+      /* ベストエフォートのため、次回の記録成功時に再試行します。 */
     });
   }, [flushOutbox]);
 
+  // 通常イベントは失敗時に outbox へ積み、オンライン復帰後に再送できるようにします。
   const recordEvent = useCallback(
     async (eventType: Extract<WalkEventType, 'pee' | 'poo'>, dogId?: string) => {
       if (!walkId) return null;
@@ -55,7 +55,7 @@ export function useWalkEventRecorder({
       );
 
       if (!result) {
-        // Mutation failed — persist for retry. Photo events stay online-only.
+        // 失敗した通常イベントだけを再送対象として保存します。写真イベントはオンライン専用です。
         await enqueuePendingEvent({
           walkId,
           ...(dogId !== undefined ? { dogId } : {}),
@@ -63,20 +63,21 @@ export function useWalkEventRecorder({
           occurredAt,
           ...(latestPoint ? { lat: latestPoint.lat, lng: latestPoint.lng } : {}),
         }).catch(() => {
-          /* swallow — alert already shown to the user */
+          /* アラート表示済みのため、保存失敗はここでは握りつぶします。 */
         });
         return null;
       }
 
-      // Success — opportunistically drain any backlog from earlier failures.
+      // 成功時に、以前の失敗で残っているイベントも可能な範囲で再送します。
       void flushOutbox().catch(() => {
-        /* swallow */
+        /* ベストエフォートのため握りつぶします。 */
       });
       return result;
     },
     [walkId, latestPoint, recordWalkEvent, runWithAlert, source, flushOutbox],
   );
 
+  // 写真イベントは presign/upload/record のどこで失敗したかをアラート文言へ反映します。
   const recordPhoto = useCallback(
     async ({ dogId, asset }: RecordPhotoArgs) => {
       if (!walkId) return null;

--- a/apps/mobile/hooks/use-walk-mutations.ts
+++ b/apps/mobile/hooks/use-walk-mutations.ts
@@ -14,6 +14,7 @@ import type {
   AddWalkPointsResponse,
 } from '@/types/graphql';
 
+// 選択した犬 ID で散歩を開始します。
 export function useStartWalk() {
   return useMutation<Walk, Error, string[]>({
     mutationFn: async (dogIds) => {
@@ -26,6 +27,7 @@ export function useStartWalk() {
   });
 }
 
+// 散歩終了後、散歩一覧・詳細のキャッシュを更新します。
 export function useFinishWalk() {
   const queryClient = useQueryClient();
   return useMutation<Walk, Error, { walkId: string; distanceM?: number }>({
@@ -42,6 +44,7 @@ export function useFinishWalk() {
   });
 }
 
+// GPS 点をサーバーへまとめて追加します。
 export function useAddWalkPoints() {
   return useMutation<boolean, Error, { walkId: string; points: WalkPointInput[] }>({
     mutationFn: async ({ walkId, points }) => {

--- a/apps/mobile/hooks/use-walk-permissions.ts
+++ b/apps/mobile/hooks/use-walk-permissions.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import { requestPermission } from '@/lib/walk/gps-tracker';
 import { requestBluetoothPermission } from '@/lib/ble/permissions';
 
+// 散歩開始時に必要な GPS/BLE 権限要求を画面から呼びやすい形で提供します。
 export function useWalkPermissions() {
   const requestGpsPermission = useCallback(() => requestPermission(), []);
   const requestBlePermission = useCallback(() => requestBluetoothPermission(), []);

--- a/apps/mobile/hooks/use-walk-screen-view-model.ts
+++ b/apps/mobile/hooks/use-walk-screen-view-model.ts
@@ -9,12 +9,14 @@ import { useWalkPermissions } from '@/hooks/use-walk-permissions';
 import { useWalkSession } from '@/hooks/use-walk-session';
 import { useWalkStore } from '@/stores/walk-store';
 
+// Walk 画面へ渡す表示状態と操作をまとめた ViewModel の型です。
 export interface WalkScreenViewModel {
   phase: 'ready' | 'recording' | 'finished';
   isStarting: boolean;
   handleStart: () => Promise<void>;
 }
 
+// Walk 画面で必要な状態取得、画面遷移、散歩開始処理をまとめるフックです。
 export function useWalkScreenViewModel(): WalkScreenViewModel {
   const { t } = useTranslation();
   const router = useRouter();
@@ -28,6 +30,7 @@ export function useWalkScreenViewModel(): WalkScreenViewModel {
   const encounterSession = useEncounterSession();
   const permissions = useWalkPermissions();
 
+  // 散歩記録中になったら、必要なアクションを引き継いで記録画面へ移動します。
   useEffect(() => {
     if (phase !== 'recording') return;
     router.push({
@@ -36,6 +39,7 @@ export function useWalkScreenViewModel(): WalkScreenViewModel {
     });
   }, [action, phase]);
 
+  // 散歩開始時は GPS 権限を確認し、散歩セッションと必要に応じて遭遇検知を開始します。
   const handleStart = useCallback(async () => {
     const gpsGranted = await permissions.requestGpsPermission();
     if (!gpsGranted) {
@@ -44,12 +48,14 @@ export function useWalkScreenViewModel(): WalkScreenViewModel {
     }
 
     try {
+      // Live Activity に表示する文言は、選択中の犬の数に合わせて切り替えます。
       const liveActivityDogName =
         selectedDogIds.length === 1
           ? t('walk.liveActivity.walking')
           : t('walk.liveActivity.walkingWithDogs', { count: selectedDogIds.length });
       const walkId = await walkSession.start({ selectedDogIds, liveActivityDogName });
 
+      // ユーザー設定で有効な場合のみ、BLE 権限を確認して犬同士の遭遇検知を開始します。
       if (me?.encounterDetectionEnabled ?? true) {
         const bleGranted = await permissions.requestBlePermission();
         if (bleGranted) {
@@ -62,6 +68,7 @@ export function useWalkScreenViewModel(): WalkScreenViewModel {
     }
   }, [bleSession, encounterSession, me, permissions, selectedDogIds, t, walkSession]);
 
+  // 画面側が表示分岐と開始ボタン制御に使う値だけを返します。
   return {
     phase,
     isStarting: walkSession.isStarting,

--- a/apps/mobile/hooks/use-walk-session.ts
+++ b/apps/mobile/hooks/use-walk-session.ts
@@ -19,15 +19,18 @@ import { useAddWalkPoints, useFinishWalk, useStartWalk } from './use-walk-mutati
 
 export { MAX_POINTS_PER_BATCH, PERIODIC_FLUSH_INTERVAL_MS };
 
+// テストや再初期化時に、散歩トラッキング側の内部状態をリセットします。
 export function resetWalkSessionTrackingState() {
   resetWalkTrackingState();
 }
 
+// 散歩開始時に必要な犬 ID と Live Activity 表示名です。
 export interface WalkSessionStartOptions {
   selectedDogIds: string[];
   liveActivityDogName: string;
 }
 
+// 散歩の開始・終了、GPS トラッキング、Live Activity 更新を一括で管理します。
 export function useWalkSession() {
   const startWalkMutation = useStartWalk();
   const finishWalkMutation = useFinishWalk();
@@ -37,6 +40,7 @@ export function useWalkSession() {
 
   const start = useCallback(
     async ({ selectedDogIds, liveActivityDogName }: WalkSessionStartOptions): Promise<string> => {
+      // 既存の GPS 監視を止めてから、新しい散歩と端末側の記録状態を開始します。
       stopWalkTracking();
 
       const walk = await startWalkMutation.mutateAsync(selectedDogIds);
@@ -54,12 +58,12 @@ export function useWalkSession() {
         useWalkStore.getState().setLiveActivity({
           activityId,
           startedAt,
-          // 0 so the first GPS-driven distance update fires immediately rather
-          // than being debounced for ~10 seconds.
+          // 初回の GPS 距離更新はデバウンスせず、すぐ Live Activity へ反映します。
           lastUpdateAt: 0,
         });
       }
 
+      // GPS 点はストアへ即時反映し、永続化は tracking-manager 側のバッチ送信に任せます。
       await beginWalkTracking({
         walkId: walk.id,
         addWalkPoints: addWalkPointsMutation.mutateAsync,
@@ -71,8 +75,7 @@ export function useWalkSession() {
           if (!la) return;
           const now = Date.now();
           if (now - la.lastUpdateAt < UPDATE_DEBOUNCE_MS) return;
-          // Bump first so a slow native update doesn't let a second GPS tick
-          // through the gate while we're still in flight.
+          // ネイティブ更新が遅い間に次の GPS tick が通らないよう、先に時刻を更新します。
           useWalkStore.getState().bumpLiveActivityUpdateAt(now);
           void updateLiveActivityDistance(la.activityId, distanceM);
         },
@@ -85,6 +88,7 @@ export function useWalkSession() {
 
   const stop = useCallback(
     async (walkId: string) => {
+      // 未送信の GPS 点を送ってから、サーバー上の散歩を終了状態にします。
       stopWalkTracking();
 
       const currentPoints = useWalkStore.getState().points;

--- a/apps/mobile/hooks/use-walks.ts
+++ b/apps/mobile/hooks/use-walks.ts
@@ -5,6 +5,7 @@ import { walkKeys } from '@/lib/graphql/keys';
 import { useIsAuthenticated } from './use-is-authenticated';
 import type { Walk, WalkResponse, MyWalksResponse } from '@/types/graphql';
 
+// 認証済みかつ散歩 ID がある場合だけ、散歩詳細を取得します。
 export function useWalk(id: string) {
   const isAuthenticated = useIsAuthenticated();
   return useQuery<Walk | null>({
@@ -17,6 +18,7 @@ export function useWalk(id: string) {
   });
 }
 
+// 現在ユーザーの散歩履歴を、指定件数まで取得します。
 export function useMyWalks(limit = 20) {
   const isAuthenticated = useIsAuthenticated();
   return useQuery<Walk[]>({

--- a/apps/mobile/lib/upload.test.ts
+++ b/apps/mobile/lib/upload.test.ts
@@ -1,40 +1,40 @@
-import { uploadToPresignedUrl } from './upload';
+import { normalizeImageContentType, uploadToPresignedUrl } from './upload';
+import * as FileSystem from 'expo-file-system/legacy';
 
-global.fetch = jest.fn();
+jest.mock('expo-file-system/legacy', () => ({
+  FileSystemUploadType: { BINARY_CONTENT: 0 },
+  uploadAsync: jest.fn(),
+}));
 
 describe('uploadToPresignedUrl', () => {
-  beforeEach(() => (fetch as jest.Mock).mockClear());
+  beforeEach(() => jest.clearAllMocks());
 
-  it('sends PUT request with binary data to the URL', async () => {
-    (fetch as jest.Mock)
-      .mockResolvedValueOnce({ blob: () => Promise.resolve(new Blob()) }) // uriToBlob
-      .mockResolvedValueOnce({ ok: true, status: 200 }); // PUT request
+  it('uploads the local file as a binary PUT request', async () => {
+    (FileSystem.uploadAsync as jest.Mock).mockResolvedValue({ status: 200 });
 
     await uploadToPresignedUrl('https://s3.example.com/key', 'file:///tmp/photo.jpg', 'image/jpeg');
 
-    expect(fetch).toHaveBeenCalledWith(
+    expect(FileSystem.uploadAsync).toHaveBeenCalledWith(
       'https://s3.example.com/key',
-      expect.objectContaining({
-        method: 'PUT',
+      'file:///tmp/photo.jpg',
+      {
+        httpMethod: 'PUT',
+        uploadType: FileSystem.FileSystemUploadType.BINARY_CONTENT,
         headers: { 'Content-Type': 'image/jpeg' },
-      })
+      },
     );
   });
 
-  it('throws on non-OK response', async () => {
-    (fetch as jest.Mock)
-      .mockResolvedValueOnce({ blob: () => Promise.resolve(new Blob()) }) // uriToBlob
-      .mockResolvedValueOnce({ ok: false, status: 403, statusText: 'Forbidden' }); // PUT request
+  it('throws on non-2xx response', async () => {
+    (FileSystem.uploadAsync as jest.Mock).mockResolvedValue({ status: 403 });
 
     await expect(
       uploadToPresignedUrl('https://s3.example.com/key', 'file:///tmp/photo.jpg', 'image/jpeg')
-    ).rejects.toThrow('Upload failed: 403 Forbidden');
+    ).rejects.toThrow('Upload failed: 403');
   });
 
   it('passes through MinIO presigned URLs unchanged', async () => {
-    (fetch as jest.Mock)
-      .mockResolvedValueOnce({ blob: () => Promise.resolve(new Blob()) }) // uriToBlob
-      .mockResolvedValueOnce({ ok: true, status: 200 }); // PUT request
+    (FileSystem.uploadAsync as jest.Mock).mockResolvedValue({ status: 204 });
 
     await uploadToPresignedUrl(
       'http://minio:9000/dog-photos/key?X-Amz-Signature=test',
@@ -42,9 +42,26 @@ describe('uploadToPresignedUrl', () => {
       'image/jpeg'
     );
 
-    expect(fetch).toHaveBeenCalledWith(
+    expect(FileSystem.uploadAsync).toHaveBeenCalledWith(
       'http://minio:9000/dog-photos/key?X-Amz-Signature=test',
-      expect.objectContaining({ method: 'PUT' })
+      'file:///tmp/photo.jpg',
+      expect.objectContaining({ httpMethod: 'PUT' }),
     );
+  });
+});
+
+describe('normalizeImageContentType', () => {
+  it.each([
+    [null, 'image/jpeg'],
+    [undefined, 'image/jpeg'],
+    ['', 'image/jpeg'],
+    ['image/jpg', 'image/jpeg'],
+    ['image/pjpeg', 'image/jpeg'],
+    ['image/x-png', 'image/png'],
+    ['IMAGE/JPEG', 'image/jpeg'],
+    ['image/jpeg; charset=binary', 'image/jpeg'],
+    ['image/heic', 'image/heic'],
+  ])('normalizes %p to %p', (input, expected) => {
+    expect(normalizeImageContentType(input)).toBe(expected);
   });
 });

--- a/apps/mobile/lib/upload.ts
+++ b/apps/mobile/lib/upload.ts
@@ -1,26 +1,36 @@
+import * as FileSystem from 'expo-file-system/legacy';
+
 /**
  * Uploads a local file to an S3 presigned URL using HTTP PUT.
- * The presigned URL is obtained from the API via generateDogPhotoUploadUrl mutation.
  */
 export async function uploadToPresignedUrl(
   presignedUrl: string,
   fileUri: string,
   contentType: string
 ): Promise<void> {
-  const blob = await uriToBlob(fileUri);
-
-  const response = await fetch(presignedUrl, {
-    method: 'PUT',
+  const response = await FileSystem.uploadAsync(presignedUrl, fileUri, {
+    httpMethod: 'PUT',
+    uploadType: FileSystem.FileSystemUploadType.BINARY_CONTENT,
     headers: { 'Content-Type': contentType },
-    body: blob,
   });
 
-  if (!response.ok) {
-    throw new Error(`Upload failed: ${response.status} ${response.statusText}`);
+  if (response.status < 200 || response.status >= 300) {
+    throw new Error(`Upload failed: ${response.status}`);
   }
 }
 
-async function uriToBlob(uri: string): Promise<Blob> {
-  const response = await fetch(uri);
-  return response.blob();
+export function normalizeImageContentType(contentType?: string | null): string {
+  const normalized = contentType?.split(';', 1)[0]?.trim().toLowerCase();
+
+  if (!normalized) return 'image/jpeg';
+
+  switch (normalized) {
+    case 'image/jpg':
+    case 'image/pjpeg':
+      return 'image/jpeg';
+    case 'image/x-png':
+      return 'image/png';
+    default:
+      return normalized;
+  }
 }

--- a/apps/mobile/package-lock.json
+++ b/apps/mobile/package-lock.json
@@ -20,6 +20,7 @@
         "expo-build-properties": "~55.0.13",
         "expo-constants": "~55.0.15",
         "expo-dev-client": "~55.0.28",
+        "expo-file-system": "55.0.17",
         "expo-font": "~55.0.6",
         "expo-haptics": "~55.0.14",
         "expo-image": "~55.0.9",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -33,6 +33,7 @@
     "expo-build-properties": "~55.0.13",
     "expo-constants": "~55.0.15",
     "expo-dev-client": "~55.0.28",
+    "expo-file-system": "55.0.17",
     "expo-font": "~55.0.6",
     "expo-haptics": "~55.0.14",
     "expo-image": "~55.0.9",
@@ -91,6 +92,17 @@
     },
     "transformIgnorePatterns": [
       "node_modules/(?!((jest-)?react-native|@react-native(-community)?|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg))"
+    ],
+    "collectCoverageFrom": [
+      "app/**/*.{ts,tsx}",
+      "hooks/**/*.{ts,tsx}",
+      "lib/**/*.{ts,tsx}",
+      "components/**/*.{ts,tsx}",
+      "!**/*.d.ts"
+    ],
+    "coverageReporters": [
+      "json-summary",
+      "text"
     ]
   },
   "private": true


### PR DESCRIPTION
## Overview

Added code coverage metrics collection and reporting to GitHub Actions workflows for both Rust (API) and TypeScript (Mobile) codebases.

## Changes

### Mobile (TypeScript) — Jest
- Added `collectCoverageFrom` to jest config in package.json
- Added `coverageReporters: ["json-summary", "text"]`
- Modified test-mobile.yml to run with `--coverage` flag
- Coverage summary (Lines/Branches/Functions/Statements) reported to GitHub Step Summary

### API (Rust) — cargo-llvm-cov
- Modified test-api.yml to use Rust toolchain on runner (not Docker)
- Installed cargo-llvm-cov via taiki-e/install-action for fast setup
- Services (postgres, dynamodb, minio, elasticmq) still run via Docker
- Set environment variables to point to localhost for runner access
- Coverage summary reported to GitHub Step Summary

## Test Plan

1. Create a test PR and verify coverage tables appear in PR Summary tab
2. Run locally:
   - Mobile: \`npm test -- --coverage\` in apps/mobile/
   - API: \`cargo llvm-cov --features test-utils --summary-only\` in apps/api/

## Notes

- Baseline metrics are now recorded — thresholds can be added in follow-up PR
- \`taiki-e/install-action\` downloads prebuilt binaries (seconds, not minutes)
- No changes to production build or Docker image required