### PR TITLE
feat(mobile): redesign dog form to 02b layout with Cancel/Save header

### DIFF
--- a/apps/mobile/app/dogs/[id]/_layout.tsx
+++ b/apps/mobile/app/dogs/[id]/_layout.tsx
@@ -10,13 +10,7 @@ export default function DogDetailLayout() {
   return (
     <Stack>
       <Stack.Screen name="index" options={{ headerShown: false }} />
-      <Stack.Screen
-        name="edit"
-        options={{
-          title: t('dogs.edit.title'),
-          headerStyle: { backgroundColor: theme.background },
-        }}
-      />
+      <Stack.Screen name="edit" options={{ headerShown: false }} />
       <Stack.Screen
         name="members"
         options={{

--- a/apps/mobile/app/dogs/[id]/edit.tsx
+++ b/apps/mobile/app/dogs/[id]/edit.tsx
@@ -1,32 +1,60 @@
 import { useState } from 'react';
-import { ScrollView, StyleSheet } from 'react-native';
+import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useDog } from '@/hooks/use-dog';
 import { useUpdateDog, useGeneratePhotoUploadUrl } from '@/hooks/use-dog-mutations';
 import { useMutationWithAlert } from '@/hooks/use-mutation-with-alert';
-import { DogForm, type DogFormValues } from '@/components/dogs/DogForm';
+import { DogForm, isDogFormValid, type DogFormValues } from '@/components/dogs/DogForm';
 import { PhotoPicker } from '@/components/dogs/PhotoPicker';
 import { LoadingScreen } from '@/components/ui/LoadingScreen';
 import { normalizeImageContentType, uploadToPresignedUrl } from '@/lib/upload';
 import { useColors } from '@/hooks/use-colors';
-import { spacing } from '@/theme/tokens';
+import { spacing, typography } from '@/theme/tokens';
 
-// 犬編集画面はプロフィールフォームと写真アップロードを同じ route で扱います。
+// 犬編集画面 — 02b. Dog edit に合わせた Cancel/Save の自前 nav bar を持つ。
+// dog データのロード待ちは外側、form state 初期化は内側コンポーネントに分離して
+// React Hooks ルールを守りつつ initial values を一発で確定する。
 export default function EditDogScreen() {
-  const { t } = useTranslation();
   const { id } = useLocalSearchParams<{ id: string }>();
+  const { data: dog, isLoading } = useDog(id, 'ALL');
+
+  if (isLoading || !dog) return <LoadingScreen />;
+
+  return (
+    <EditDogContent
+      id={id}
+      initialValues={{
+        name: dog.name,
+        breed: dog.breed ?? '',
+        gender: dog.gender ?? '',
+      }}
+      currentPhotoUrl={dog.photoUrl ?? null}
+    />
+  );
+}
+
+interface EditDogContentProps {
+  id: string;
+  initialValues: DogFormValues;
+  currentPhotoUrl: string | null;
+}
+
+function EditDogContent({ id, initialValues, currentPhotoUrl }: EditDogContentProps) {
+  const { t } = useTranslation();
   const router = useRouter();
   const theme = useColors();
-
-  const { data: dog, isLoading } = useDog(id, 'ALL');
   const { mutateAsync: updateDog } = useUpdateDog();
   const { mutateAsync: generateUploadUrl } = useGeneratePhotoUploadUrl();
   const runWithAlert = useMutationWithAlert();
+
+  const [values, setValues] = useState<DogFormValues>(initialValues);
+  const [submitting, setSubmitting] = useState(false);
   const [photoLoading, setPhotoLoading] = useState(false);
   const [previewUri, setPreviewUri] = useState<string | null>(null);
 
-  if (isLoading || !dog) return <LoadingScreen />;
+  const canSave = isDogFormValid(values) && !submitting;
 
   // 写真は先に署名付き URL へアップロードし、成功した key だけを犬プロフィールへ保存します。
   async function handlePhotoChange(uri: string, contentType: string) {
@@ -49,41 +77,83 @@ export default function EditDogScreen() {
   }
 
   // 基本情報の更新後は元の詳細画面へ戻り、変更結果は query の再取得に任せます。
-  async function handleSubmit(values: DogFormValues) {
-    await updateDog({
-      id,
-      input: {
-        name: values.name,
-        breed: values.breed || undefined,
-        gender: values.gender || undefined,
-      },
-    });
-    router.back();
+  async function handleSave() {
+    if (!canSave) return;
+    setSubmitting(true);
+    try {
+      await updateDog({
+        id,
+        input: {
+          name: values.name.trim(),
+          breed: values.breed.trim() || undefined,
+          gender: values.gender.trim() || undefined,
+        },
+      });
+      router.back();
+    } finally {
+      setSubmitting(false);
+    }
   }
 
   return (
-    <ScrollView
-      contentContainerStyle={[styles.container, { backgroundColor: theme.background }]}
-      keyboardShouldPersistTaps="handled"
-    >
-      <PhotoPicker
-        currentPhotoUrl={previewUri ?? dog.photoUrl ?? null}
-        onPick={handlePhotoChange}
-        loading={photoLoading}
-      />
-      <DogForm
-        onSubmit={handleSubmit}
-        submitLabel={t('dogs.edit.submit')}
-        initialValues={{
-          name: dog.name,
-          breed: dog.breed ?? '',
-          gender: dog.gender ?? '',
-        }}
-      />
-    </ScrollView>
+    <SafeAreaView edges={['top']} style={[styles.safeArea, { backgroundColor: theme.background }]}>
+      <View style={styles.navBar}>
+        <Pressable
+          onPress={() => router.back()}
+          hitSlop={12}
+          accessibilityRole="button"
+          accessibilityLabel={t('dogs.action.cancel')}
+        >
+          <Text style={[styles.navAction, { color: theme.interactive }]}>
+            {t('dogs.action.cancel')}
+          </Text>
+        </Pressable>
+        <Text style={[styles.navTitle, { color: theme.onSurface }]}>{t('dogs.edit.title')}</Text>
+        <Pressable
+          onPress={handleSave}
+          disabled={!canSave}
+          hitSlop={12}
+          accessibilityRole="button"
+          accessibilityLabel={t('dogs.action.save')}
+          accessibilityState={{ disabled: !canSave }}
+        >
+          <Text
+            style={[
+              styles.navActionStrong,
+              { color: canSave ? theme.interactive : theme.textDisabled },
+            ]}
+          >
+            {t('dogs.action.save')}
+          </Text>
+        </Pressable>
+      </View>
+      <ScrollView
+        contentContainerStyle={styles.scrollContent}
+        keyboardShouldPersistTaps="handled"
+      >
+        <PhotoPicker
+          currentPhotoUrl={previewUri ?? currentPhotoUrl}
+          onPick={handlePhotoChange}
+          loading={photoLoading}
+        />
+        <DogForm values={values} onChange={setValues} />
+      </ScrollView>
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flexGrow: 1, padding: spacing.lg },
+  safeArea: { flex: 1 },
+  navBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.step12,
+    minHeight: 44,
+  },
+  navTitle: { ...typography.headline },
+  navAction: { ...typography.body },
+  navActionStrong: { ...typography.body, fontWeight: '600' },
+  scrollContent: { flexGrow: 1, padding: spacing.lg },
 });

--- a/apps/mobile/app/dogs/_layout.tsx
+++ b/apps/mobile/app/dogs/_layout.tsx
@@ -1,13 +1,12 @@
 import { Stack } from 'expo-router';
-import { useTranslation } from 'react-i18next';
 
 // 犬関連 route は新規登録と詳細配下の Stack をここで束ねます。
+// 02b. Dog edit デザインに合わせて、各画面が自前で Cancel/Save の nav bar を描画する形にしたため
+// Stack の標準 header はすべて非表示。
 export default function DogsLayout() {
-  const { t } = useTranslation();
-
   return (
     <Stack>
-      <Stack.Screen name="new" options={{ title: t('dogs.new.title') }} />
+      <Stack.Screen name="new" options={{ headerShown: false }} />
       <Stack.Screen name="[id]" options={{ headerShown: false }} />
     </Stack>
   );

--- a/apps/mobile/app/dogs/new.tsx
+++ b/apps/mobile/app/dogs/new.tsx
@@ -1,39 +1,129 @@
-import { ScrollView, StyleSheet } from 'react-native';
+import { useState } from 'react';
+import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
-import { useCreateDog } from '@/hooks/use-dog-mutations';
-import { DogForm, type DogFormValues } from '@/components/dogs/DogForm';
+import {
+  useCreateDog,
+  useGeneratePhotoUploadUrl,
+  useUpdateDog,
+} from '@/hooks/use-dog-mutations';
+import { useMutationWithAlert } from '@/hooks/use-mutation-with-alert';
+import { DogForm, isDogFormValid, type DogFormValues } from '@/components/dogs/DogForm';
+import { PhotoPicker } from '@/components/dogs/PhotoPicker';
 import { useColors } from '@/hooks/use-colors';
-import { spacing } from '@/theme/tokens';
+import { normalizeImageContentType, uploadToPresignedUrl } from '@/lib/upload';
+import { spacing, typography } from '@/theme/tokens';
 
-// 新規犬登録画面はフォーム送信後、作成した犬の詳細へ遷移します。
+// 新規犬登録画面 — 02b. Dog edit に合わせた Cancel/Save の自前 nav bar を持つ。
+// 写真は dog ID が未確定のため 2-stage flow: ローカル URI 保持 → createDog 後にアップロード。
 export default function NewDogScreen() {
   const { t } = useTranslation();
   const router = useRouter();
   const theme = useColors();
   const { mutateAsync: createDog } = useCreateDog();
+  const { mutateAsync: updateDog } = useUpdateDog();
+  const { mutateAsync: generateUploadUrl } = useGeneratePhotoUploadUrl();
+  const runWithAlert = useMutationWithAlert();
 
-  // フォーム値を API 入力へ整え、作成完了後にモーダルを閉じて詳細画面へ進みます。
-  async function handleSubmit(values: DogFormValues) {
-    const dog = await createDog({
-      name: values.name,
-      breed: values.breed || undefined,
-      gender: values.gender || undefined,
-    });
-    router.dismiss();
-    router.push(`/dogs/${dog.id}`);
+  const [values, setValues] = useState<DogFormValues>({ name: '', breed: '', gender: '' });
+  const [submitting, setSubmitting] = useState(false);
+  const [pendingPhoto, setPendingPhoto] = useState<{ uri: string; contentType: string } | null>(
+    null,
+  );
+
+  const canSave = isDogFormValid(values) && !submitting;
+
+  // Stage 1: 写真選択時はローカル URI のみ保持。S3 アップロードは createDog 後に行う。
+  async function handlePhotoSelected(uri: string, contentType: string) {
+    setPendingPhoto({ uri, contentType: normalizeImageContentType(contentType) });
+  }
+
+  async function handleSave() {
+    if (!canSave) return;
+    setSubmitting(true);
+    try {
+      const dog = await createDog({
+        name: values.name.trim(),
+        breed: values.breed.trim() || undefined,
+        gender: values.gender.trim() || undefined,
+      });
+
+      // Stage 2: ユーザーが写真を選択していれば、登録した犬に紐付ける。
+      // 失敗しても dog は既に作成済みなので、エラー通知のうえ詳細画面へ遷移する。
+      if (pendingPhoto) {
+        await runWithAlert(async () => {
+          const { url, key } = await generateUploadUrl({
+            dogId: dog.id,
+            contentType: pendingPhoto.contentType,
+          });
+          await uploadToPresignedUrl(url, pendingPhoto.uri, pendingPhoto.contentType);
+          await updateDog({ id: dog.id, input: { photoUrl: key } });
+        }, 'dogs.new.photoUploadError');
+      }
+
+      router.dismiss();
+      router.push(`/dogs/${dog.id}`);
+    } finally {
+      setSubmitting(false);
+    }
   }
 
   return (
-    <ScrollView
-      contentContainerStyle={[styles.container, { backgroundColor: theme.background }]}
-      keyboardShouldPersistTaps="handled"
-    >
-      <DogForm onSubmit={handleSubmit} submitLabel={t('dogs.new.submit')} />
-    </ScrollView>
+    <SafeAreaView edges={['top']} style={[styles.safeArea, { backgroundColor: theme.background }]}>
+      <View style={styles.navBar}>
+        <Pressable
+          onPress={() => router.back()}
+          hitSlop={12}
+          accessibilityRole="button"
+          accessibilityLabel={t('dogs.action.cancel')}
+        >
+          <Text style={[styles.navAction, { color: theme.interactive }]}>
+            {t('dogs.action.cancel')}
+          </Text>
+        </Pressable>
+        <Text style={[styles.navTitle, { color: theme.onSurface }]}>{t('dogs.new.title')}</Text>
+        <Pressable
+          onPress={handleSave}
+          disabled={!canSave}
+          hitSlop={12}
+          accessibilityRole="button"
+          accessibilityLabel={t('dogs.action.save')}
+          accessibilityState={{ disabled: !canSave }}
+        >
+          <Text
+            style={[
+              styles.navActionStrong,
+              { color: canSave ? theme.interactive : theme.textDisabled },
+            ]}
+          >
+            {t('dogs.action.save')}
+          </Text>
+        </Pressable>
+      </View>
+      <ScrollView
+        contentContainerStyle={styles.scrollContent}
+        keyboardShouldPersistTaps="handled"
+      >
+        <PhotoPicker currentPhotoUrl={pendingPhoto?.uri ?? null} onPick={handlePhotoSelected} />
+        <DogForm values={values} onChange={setValues} />
+      </ScrollView>
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flexGrow: 1, padding: spacing.lg },
+  safeArea: { flex: 1 },
+  navBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.step12,
+    minHeight: 44,
+  },
+  navTitle: { ...typography.headline },
+  navAction: { ...typography.body },
+  navActionStrong: { ...typography.body, fontWeight: '600' },
+  scrollContent: { flexGrow: 1, padding: spacing.lg },
 });

--- a/apps/mobile/components/dogs/DogForm.test.tsx
+++ b/apps/mobile/components/dogs/DogForm.test.tsx
@@ -1,64 +1,64 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react-native';
-import { DogForm } from './DogForm';
+import { render, screen, fireEvent } from '@testing-library/react-native';
+import { DogForm, isDogFormValid, type DogFormValues } from './DogForm';
 
 describe('DogForm', () => {
-  it('renders name field', () => {
-    render(<DogForm onSubmit={jest.fn()} submitLabel="Register" />);
+  function setup(initial: DogFormValues = { name: '', breed: '', gender: '' }) {
+    const onChange = jest.fn();
+    const utils = render(<DogForm values={initial} onChange={onChange} />);
+    return { onChange, ...utils };
+  }
+
+  it('renders name/breed/gender fields', () => {
+    setup();
     expect(screen.getByLabelText('Name')).toBeTruthy();
+    expect(screen.getByLabelText('Breed')).toBeTruthy();
+    expect(screen.getByLabelText('Gender')).toBeTruthy();
   });
 
-  it('disables submit when name is empty', () => {
-    render(<DogForm onSubmit={jest.fn()} submitLabel="Register" />);
-    expect(screen.getByRole('button', { name: 'Register' })).toBeDisabled();
-  });
-
-  it('disables submit when gender is empty', () => {
-    render(
-      <DogForm
-        onSubmit={jest.fn()}
-        submitLabel="Register"
-        initialValues={{ name: 'Hana' }}
-      />
-    );
-    expect(screen.getByRole('button', { name: 'Register' })).toBeDisabled();
-  });
-
-  it('enables submit when both name and gender are filled', () => {
-    render(
-      <DogForm
-        onSubmit={jest.fn()}
-        submitLabel="Register"
-        initialValues={{ name: 'Hana', gender: 'male' }}
-      />
-    );
-    expect(screen.getByRole('button', { name: 'Register' })).not.toBeDisabled();
-  });
-
-  it('calls onSubmit with form values', async () => {
-    const onSubmit = jest.fn().mockResolvedValue(undefined);
-    render(<DogForm onSubmit={onSubmit} submitLabel="Register" />);
-
+  it('calls onChange with patched values when name changes', () => {
+    const { onChange } = setup({ name: '', breed: 'Poodle', gender: 'male' });
     fireEvent.changeText(screen.getByLabelText('Name'), 'Hana');
-    fireEvent.changeText(screen.getByLabelText('Breed'), 'Poodle');
-    fireEvent.changeText(screen.getByLabelText('Gender'), 'male');
-    fireEvent.press(screen.getByRole('button', { name: 'Register' }));
-
-    await waitFor(() => {
-      expect(onSubmit).toHaveBeenCalledWith(
-        expect.objectContaining({ name: 'Hana', breed: 'Poodle' })
-      );
-    });
+    expect(onChange).toHaveBeenCalledWith({ name: 'Hana', breed: 'Poodle', gender: 'male' });
   });
 
-  it('pre-fills initial values when editing', () => {
-    render(
-      <DogForm
-        onSubmit={jest.fn()}
-        submitLabel="Update"
-        initialValues={{ name: 'Kuro', breed: 'Labrador' }}
-      />
-    );
+  it('calls onChange with patched values when breed changes', () => {
+    const { onChange } = setup({ name: 'Hana', breed: '', gender: 'male' });
+    fireEvent.changeText(screen.getByLabelText('Breed'), 'Poodle');
+    expect(onChange).toHaveBeenCalledWith({ name: 'Hana', breed: 'Poodle', gender: 'male' });
+  });
+
+  it('calls onChange with patched values when gender changes', () => {
+    const { onChange } = setup({ name: 'Hana', breed: 'Poodle', gender: '' });
+    fireEvent.changeText(screen.getByLabelText('Gender'), 'male');
+    expect(onChange).toHaveBeenCalledWith({ name: 'Hana', breed: 'Poodle', gender: 'male' });
+  });
+
+  it('pre-fills initial values', () => {
+    setup({ name: 'Kuro', breed: 'Labrador', gender: 'male' });
     expect(screen.getByDisplayValue('Kuro')).toBeTruthy();
     expect(screen.getByDisplayValue('Labrador')).toBeTruthy();
+    expect(screen.getByDisplayValue('male')).toBeTruthy();
+  });
+});
+
+describe('isDogFormValid', () => {
+  it('returns false when name is empty', () => {
+    expect(isDogFormValid({ name: '', breed: '', gender: 'male' })).toBe(false);
+  });
+
+  it('returns false when name is whitespace only', () => {
+    expect(isDogFormValid({ name: '   ', breed: '', gender: 'male' })).toBe(false);
+  });
+
+  it('returns false when gender is empty', () => {
+    expect(isDogFormValid({ name: 'Hana', breed: '', gender: '' })).toBe(false);
+  });
+
+  it('returns false when gender is whitespace only', () => {
+    expect(isDogFormValid({ name: 'Hana', breed: '', gender: '  ' })).toBe(false);
+  });
+
+  it('returns true when both name and gender are filled', () => {
+    expect(isDogFormValid({ name: 'Hana', breed: '', gender: 'male' })).toBe(true);
   });
 });

--- a/apps/mobile/components/dogs/DogForm.tsx
+++ b/apps/mobile/components/dogs/DogForm.tsx
@@ -1,9 +1,7 @@
-import { useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
-import { Button } from '@/components/ui/Button';
+import { GroupedCard } from '@/components/ui/GroupedCard';
 import { TextInput } from '@/components/ui/TextInput';
-import { spacing } from '@/theme/tokens';
 
 export interface DogFormValues {
   name: string;
@@ -12,66 +10,52 @@ export interface DogFormValues {
 }
 
 interface DogFormProps {
-  onSubmit: (values: DogFormValues) => Promise<void>;
-  submitLabel: string;
-  initialValues?: Partial<DogFormValues>;
+  values: DogFormValues;
+  onChange: (values: DogFormValues) => void;
 }
 
-export function DogForm({ onSubmit, submitLabel, initialValues }: DogFormProps) {
+// 02b. Dog edit の inset-grouped 形式: 1 枚のカードに行を積み上げ、hairline で区切る。
+// 純粋な controlled component — values と onChange のみ受け取る。Submit / loading は呼び出し元の
+// 画面（Cancel/Save header）が担う。
+export function DogForm({ values, onChange }: DogFormProps) {
   const { t } = useTranslation();
-  const [name, setName] = useState(initialValues?.name ?? '');
-  const [breed, setBreed] = useState(initialValues?.breed ?? '');
-  const [gender, setGender] = useState(initialValues?.gender ?? '');
-  const [loading, setLoading] = useState(false);
-
-  const isValid = name.trim().length > 0 && gender.trim().length > 0;
-
-  async function handleSubmit() {
-    if (!isValid) return;
-    setLoading(true);
-    try {
-      await onSubmit({
-        name: name.trim(),
-        breed: breed.trim(),
-        gender: gender.trim(),
-      });
-    } finally {
-      setLoading(false);
-    }
-  }
+  const set = (patch: Partial<DogFormValues>) => onChange({ ...values, ...patch });
 
   return (
     <View style={styles.container}>
-      <TextInput
-        label={t('dogs.form.name')}
-        value={name}
-        onChangeText={setName}
-        placeholder={t('dogs.form.namePlaceholder')}
-      />
-      <TextInput
-        label={t('dogs.form.breed')}
-        value={breed}
-        onChangeText={setBreed}
-        placeholder={t('dogs.form.breedPlaceholder')}
-      />
-      <TextInput
-        label={t('dogs.form.gender')}
-        value={gender}
-        onChangeText={setGender}
-        placeholder={t('dogs.form.genderPlaceholder')}
-      />
-      <Button
-        label={submitLabel}
-        onPress={handleSubmit}
-        loading={loading}
-        disabled={!isValid}
-        style={styles.button}
-      />
+      <GroupedCard>
+        <TextInput
+          label={t('dogs.form.name')}
+          labelPosition="inline"
+          separator
+          value={values.name}
+          onChangeText={(name) => set({ name })}
+          placeholder={t('dogs.form.namePlaceholder')}
+        />
+        <TextInput
+          label={t('dogs.form.breed')}
+          labelPosition="inline"
+          separator
+          value={values.breed}
+          onChangeText={(breed) => set({ breed })}
+          placeholder={t('dogs.form.breedPlaceholder')}
+        />
+        <TextInput
+          label={t('dogs.form.gender')}
+          labelPosition="inline"
+          value={values.gender}
+          onChangeText={(gender) => set({ gender })}
+          placeholder={t('dogs.form.genderPlaceholder')}
+        />
+      </GroupedCard>
     </View>
   );
 }
 
+export function isDogFormValid(values: DogFormValues): boolean {
+  return values.name.trim().length > 0 && values.gender.trim().length > 0;
+}
+
 const styles = StyleSheet.create({
   container: { width: '100%' },
-  button: { marginTop: spacing.sm },
 });

--- a/apps/mobile/components/dogs/PhotoPicker.tsx
+++ b/apps/mobile/components/dogs/PhotoPicker.tsx
@@ -1,9 +1,15 @@
-import { Pressable, StyleSheet, Text } from 'react-native';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import * as ImagePicker from 'expo-image-picker';
 import { Image } from 'expo-image';
+import { Ionicons } from '@expo/vector-icons';
 import { useColors } from '@/hooks/use-colors';
 import { spacing, radius, typography } from '@/theme/tokens';
+
+// 02b camera badge — 写真円 (120) の右下にオーバーレイ。tokens.ts に sizing 系トークンが
+// 無いため UI 慣性のためのローカル定数とする。
+const BADGE_SIZE = 32;
+const BADGE_ICON_SIZE = 16;
 
 interface PhotoPickerProps {
   currentPhotoUrl: string | null;
@@ -14,6 +20,7 @@ interface PhotoPickerProps {
 export function PhotoPicker({ currentPhotoUrl, onPick, loading = false }: PhotoPickerProps) {
   const { t } = useTranslation();
   const theme = useColors();
+  const ctaLabel = currentPhotoUrl ? t('dogs.photo.change') : t('dogs.photo.add');
 
   async function handlePress() {
     const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
@@ -34,48 +41,78 @@ export function PhotoPicker({ currentPhotoUrl, onPick, loading = false }: PhotoP
   }
 
   return (
-    <Pressable
-      accessibilityRole="button"
-      accessibilityLabel={t('dogs.photo.change')}
-      onPress={handlePress}
-      disabled={loading}
-      style={[styles.container, { borderColor: theme.border }]}
-    >
-      {currentPhotoUrl ? (
-        <Image
-          source={currentPhotoUrl}
-          style={styles.photo}
-          contentFit="cover"
-          cachePolicy="memory-disk"
-        />
-      ) : (
-        <Text style={[styles.placeholder, { color: theme.onSurfaceVariant }]}>
-          {t('dogs.photo.add')}
-        </Text>
-      )}
-    </Pressable>
+    <View style={styles.wrapper}>
+      <View style={styles.photoFrame}>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={ctaLabel}
+          onPress={handlePress}
+          disabled={loading}
+          style={[styles.circle, { borderColor: theme.border }]}
+        >
+          {currentPhotoUrl ? (
+            <Image
+              source={currentPhotoUrl}
+              style={styles.photo}
+              contentFit="cover"
+              cachePolicy="memory-disk"
+            />
+          ) : null}
+        </Pressable>
+        <View
+          style={[
+            styles.badge,
+            { backgroundColor: theme.interactive, borderColor: theme.surface },
+          ]}
+          pointerEvents="none"
+        >
+          <Ionicons name="camera" size={BADGE_ICON_SIZE} color={theme.onInteractive} />
+        </View>
+      </View>
+      <Text style={[styles.cta, { color: theme.interactive }]}>{ctaLabel}</Text>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
+  wrapper: {
+    alignItems: 'center',
+    marginBottom: spacing.lg,
+  },
+  // photoFrame は relative 容器。circle 側だけが overflow:'hidden' で写真をクロップし、
+  // badge はその外側に絶対配置するため clip されない。
+  photoFrame: {
+    position: 'relative',
     width: 120,
     height: 120,
+  },
+  circle: {
+    width: '100%',
+    height: '100%',
     borderRadius: radius.full,
     borderWidth: 2,
     borderStyle: 'dashed',
-    alignSelf: 'center',
     alignItems: 'center',
     justifyContent: 'center',
-    marginBottom: spacing.lg,
     overflow: 'hidden',
+  },
+  badge: {
+    position: 'absolute',
+    bottom: 0,
+    right: 0,
+    width: BADGE_SIZE,
+    height: BADGE_SIZE,
+    borderRadius: BADGE_SIZE / 2,
+    borderWidth: 2,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   photo: {
     width: '100%',
     height: '100%',
   },
-  placeholder: {
-    ...typography.caption,
-    textAlign: 'center',
+  cta: {
+    ...typography.subheadline,
+    marginTop: spacing.sm,
   },
 });

--- a/apps/mobile/components/ui/TextInput.tsx
+++ b/apps/mobile/components/ui/TextInput.tsx
@@ -114,7 +114,7 @@ const inlineStyles = StyleSheet.create({
     alignItems: 'center',
     gap: 10,
     paddingHorizontal: spacing.md,
-    paddingVertical: 14,
+    paddingVertical: spacing.step14,
     minHeight: 44,
   },
   label: {

--- a/apps/mobile/lib/i18n/locales/en.json
+++ b/apps/mobile/lib/i18n/locales/en.json
@@ -79,9 +79,13 @@
       "streak": "🔥 {{days}}d",
       "todayStats": "{{km}} km today · {{count}} walks"
     },
+    "action": {
+      "cancel": "Cancel",
+      "save": "Save"
+    },
     "new": {
-      "title": "Register New Dog",
-      "submit": "Register"
+      "title": "Register dog",
+      "photoUploadError": "Failed to upload photo. You can try again from Edit."
     },
     "detail": {
       "title": "Dog Profile",
@@ -117,8 +121,7 @@
       "leaveError": "Failed to leave group"
     },
     "edit": {
-      "title": "Edit Dog Profile",
-      "submit": "Update",
+      "title": "Edit dog",
       "photoUploadError": "Failed to upload photo. Please try again."
     },
     "form": {

--- a/apps/mobile/lib/i18n/locales/ja.json
+++ b/apps/mobile/lib/i18n/locales/ja.json
@@ -79,9 +79,13 @@
       "streak": "🔥 {{days}}日",
       "todayStats": "今日 {{km}} km · {{count}}回"
     },
+    "action": {
+      "cancel": "キャンセル",
+      "save": "保存"
+    },
     "new": {
-      "title": "新しい犬を登録",
-      "submit": "登録"
+      "title": "犬を登録",
+      "photoUploadError": "写真のアップロードに失敗しました。Edit 画面から再度お試しください。"
     },
     "detail": {
       "title": "犬のプロフィール",
@@ -117,8 +121,7 @@
       "leaveError": "グループの離脱に失敗しました"
     },
     "edit": {
-      "title": "犬のプロフィールを編集",
-      "submit": "更新",
+      "title": "犬を編集",
       "photoUploadError": "写真のアップロードに失敗しました。もう一度お試しください。"
     },
     "form": {

--- a/apps/mobile/theme/tokens.ts
+++ b/apps/mobile/theme/tokens.ts
@@ -94,6 +94,7 @@ export const spacing = {
   xxl: 48,
 
   step12: 12, // between sm and md — Precise row gap
+  step14: 14, // 02b inset-grouped row vertical padding (Edit dog rows)
   step20: 20, // between lg and xl — Precise screen padding
   step44: 44, // tap target minimum
   step60: 60, // Precise huge (section margin)


### PR DESCRIPTION
## Summary
- Redesign Register New Dog and Edit Dog screens to the iOS Inset Grouped "02b. Dog edit" layout (single card with hairline rows + custom Cancel/Save nav bar)
- Refactor DogForm into a stateless controlled component; lift values to the screen so Save lives in the nav bar
- Add 02b camera badge overlay and state-aware Add/Change photo CTA; enable 2-stage photo upload on Register

## Test plan
- [ ] npm run --prefix apps/mobile lint — 0 errors
- [ ] npm run --prefix apps/mobile typecheck — pass
- [ ] npm run --prefix apps/mobile test — 643 tests pass
- [ ] iOS Simulator: Register screen shows Cancel | Register dog | Save header; Save toggles enabled when Name + Gender are filled
- [ ] iOS Simulator: Edit screen shows Cancel | Edit dog | Save header (no double header)
- [ ] iOS Simulator: photo circle shows full camera badge (not clipped) with state-aware Add photo / Change photo CTA below

Generated with Claude Code (https://claude.com/claude-code)