### PR TITLE
feat(api): batch write track_points for improved throughput

### DIFF
--- a/apps/api/src/bin/track_point_worker.rs
+++ b/apps/api/src/bin/track_point_worker.rs
@@ -3,7 +3,8 @@ use std::{env, sync::Arc};
 use anyhow::Result;
 use aws_sdk_sqs::types::Message;
 use tokio::{sync::Semaphore, task::JoinSet, time::Duration};
-use tracing::{error, info};
+use tracing::{error, info, warn};
+use walking_dog::entity::track_point;
 use walking_dog::queue::track_point::{TrackPointMessage, TrackPointQueueError};
 
 const DEFAULT_WORKER_CONCURRENCY: usize = 10;
@@ -56,18 +57,16 @@ async fn run_worker(
             continue;
         }
 
-        for message in messages {
-            let permit = Arc::clone(&semaphore).acquire_owned().await?;
-            let sqs_client = sqs_client.clone();
-            let dynamodb_client = dynamodb_client.clone();
+        let permit = Arc::clone(&semaphore).acquire_owned().await?;
+        let sqs_client = sqs_client.clone();
+        let dynamodb_client = dynamodb_client.clone();
 
-            tasks.spawn(async move {
-                let _permit = permit;
-                if let Err(error) = process_message(&sqs_client, &dynamodb_client, message).await {
-                    error!(?error, "failed to process track point message");
-                }
-            });
-        }
+        tasks.spawn(async move {
+            let _permit = permit;
+            if let Err(error) = process_batch(&sqs_client, &dynamodb_client, messages).await {
+                error!(?error, "failed to process track point batch");
+            }
+        });
     }
 }
 
@@ -87,35 +86,110 @@ async fn receive_messages(
     Ok(output.messages().to_vec())
 }
 
-async fn process_message(
+async fn process_batch(
     sqs_client: &aws_sdk_sqs::Client,
     dynamodb_client: &aws_sdk_dynamodb::Client,
-    message: Message,
+    messages: Vec<Message>,
 ) -> Result<()> {
-    let message_id = message.message_id().unwrap_or("unknown");
-    let body = message.body().ok_or(TrackPointQueueError::MissingBody)?;
-    let receipt_handle = message
-        .receipt_handle()
-        .ok_or(TrackPointQueueError::MissingReceiptHandle)?;
-    let track_point_message = TrackPointMessage::from_json(body)?;
-    let track_point = walking_dog::entity::track_point::Model::from(track_point_message.clone());
-
     let queue_url = std::env::var("AWS_SQS_QUEUE_URL_TRACK_POINT").unwrap();
-    track_point.put(dynamodb_client).await?;
-    sqs_client
-        .delete_message()
-        .queue_url(&queue_url)
-        .receipt_handle(receipt_handle)
+
+    let mut models = Vec::with_capacity(messages.len());
+    let mut successful_messages: Vec<&Message> = Vec::with_capacity(messages.len());
+
+    for message in &messages {
+        let body = match message.body() {
+            Some(b) => b,
+            None => {
+                warn!(message_id = message.message_id(), "message has no body, skipping");
+                delete_message(sqs_client, &queue_url, message).await;
+                continue;
+            }
+        };
+
+        match TrackPointMessage::from_json(body) {
+            Ok(track_point_message) => {
+                models.push(track_point::Model::from(track_point_message));
+                successful_messages.push(message);
+            }
+            Err(error) => {
+                warn!(
+                    message_id = message.message_id(),
+                    ?error,
+                    "failed to deserialize message, skipping"
+                );
+                delete_message(sqs_client, &queue_url, message).await;
+            }
+        }
+    }
+
+    if models.is_empty() {
+        return Ok(());
+    }
+
+    let batch_size = models.len();
+    track_point::Model::batch_put_write(dynamodb_client, &models).await?;
+
+    delete_message_batch(sqs_client, &queue_url, &successful_messages).await?;
+
+    info!(batch_size, "processed track point batch");
+
+    Ok(())
+}
+
+async fn delete_message(sqs_client: &aws_sdk_sqs::Client, queue_url: &str, message: &Message) {
+    if let Some(receipt_handle) = message.receipt_handle() {
+        if let Err(error) = sqs_client
+            .delete_message()
+            .queue_url(queue_url)
+            .receipt_handle(receipt_handle)
+            .send()
+            .await
+        {
+            error!(?error, "failed to delete message from queue");
+        }
+    }
+}
+
+async fn delete_message_batch(
+    sqs_client: &aws_sdk_sqs::Client,
+    queue_url: &str,
+    messages: &[&Message],
+) -> Result<()> {
+    use aws_sdk_sqs::types::DeleteMessageBatchRequestEntry;
+
+    let entries: Vec<DeleteMessageBatchRequestEntry> = messages
+        .iter()
+        .enumerate()
+        .filter_map(|(i, msg)| {
+            msg.receipt_handle().map(|handle| {
+                DeleteMessageBatchRequestEntry::builder()
+                    .id(i.to_string())
+                    .receipt_handle(handle)
+                    .build()
+                    .expect("DeleteMessageBatchRequestEntry build should not fail")
+            })
+        })
+        .collect();
+
+    if entries.is_empty() {
+        return Ok(());
+    }
+
+    let output = sqs_client
+        .delete_message_batch()
+        .queue_url(queue_url)
+        .set_entries(Some(entries))
         .send()
         .await
-        .map_err(|error| TrackPointQueueError::DeleteMessage(error.into_service_error()))?;
+        .map_err(|e| TrackPointQueueError::DeleteMessageBatch(e.into_service_error()))?;
 
-    info!(
-        message_id,
-        walk_id = %track_point_message.walk_id,
-        tracked_at = %track_point_message.tracked_at,
-        "processed track point message"
-    );
+    let failed = output.failed();
+    if !failed.is_empty() {
+        warn!(
+            failed_count = failed.len(),
+            "some messages failed to delete from queue"
+        );
+    }
 
     Ok(())
 }

--- a/apps/api/src/entity/track_point.rs
+++ b/apps/api/src/entity/track_point.rs
@@ -1,18 +1,19 @@
 use anyhow::{Result, anyhow};
-// use aws_sdk_dynamodb::operation::put_item::PutItemError;
-// use aws_sdk_dynamodb::operation::query::QueryError;
 use aws_sdk_dynamodb::{
     operation::{
-        put_item::{PutItemError, PutItemOutput},
+        batch_write_item::BatchWriteItemError,
+        put_item::PutItemError,
         query::QueryError,
     },
-    types::AttributeValue,
+    types::{AttributeValue, PutRequest, WriteRequest},
 };
 use std::collections::HashMap;
+use tokio::time::{Duration, sleep};
 use tracing::{error, warn};
 use uuid::Uuid;
 
-use crate::entity;
+const DYNAMO_BATCH_WRITE_MAX: usize = 25;
+const BATCH_WRITE_MAX_RETRIES: u32 = 3;
 
 pub struct Model {
     pub walk_id: Uuid,
@@ -36,9 +37,9 @@ impl Model {
         }
     }
 
-    pub async fn put(&self, client: &aws_sdk_dynamodb::Client) -> Result<Model> {
+    pub async fn put(&self, client: &aws_sdk_dynamodb::Client) -> Result<()> {
         let table_name = std::env::var("AWS_DYNAMODB_TABLE_TRACK_POINT").unwrap();
-        let _ = client
+        client
             .put_item()
             .table_name(table_name)
             .item("walk_id", AttributeValue::S(self.walk_id.to_string()))
@@ -51,19 +52,99 @@ impl Model {
             .send()
             .await
             .map_err(|e| TrackPointError::PutItemError(e.into_service_error()))?;
-        let output = entity::track_point::Model::find_by_walk_id_and_tracked_at(
-            client,
-            self.walk_id,
-            self.tracked_at,
-        )
-        .await?;
-        output.ok_or_else(|| {
-            error!(
-                "Failed to find track point after insert for walk_id {} at tracked_at {}",
-                self.walk_id, self.tracked_at
-            );
-            anyhow!("Failed to find inserted track point")
-        })
+        Ok(())
+    }
+
+    pub async fn batch_put_write(
+        client: &aws_sdk_dynamodb::Client,
+        models: &[Model],
+    ) -> Result<()> {
+        if models.is_empty() {
+            return Ok(());
+        }
+
+        let table_name = std::env::var("AWS_DYNAMODB_TABLE_TRACK_POINT").unwrap();
+
+        for chunk in models.chunks(DYNAMO_BATCH_WRITE_MAX) {
+            let write_requests: Vec<WriteRequest> = chunk
+                .iter()
+                .map(|model| {
+                    WriteRequest::builder()
+                        .put_request(
+                            PutRequest::builder()
+                                .item("walk_id", AttributeValue::S(model.walk_id.to_string()))
+                                .item(
+                                    "tracked_at",
+                                    AttributeValue::N(
+                                        model.tracked_at.timestamp_micros().to_string(),
+                                    ),
+                                )
+                                .item(
+                                    "latitude",
+                                    AttributeValue::N(model.latitude.to_string()),
+                                )
+                                .item(
+                                    "longitude",
+                                    AttributeValue::N(model.longitude.to_string()),
+                                )
+                                .build()
+                                .expect("PutRequest build should not fail"),
+                        )
+                        .build()
+                })
+                .collect();
+
+            let mut unprocessed = Some(write_requests);
+
+            for attempt in 0..=BATCH_WRITE_MAX_RETRIES {
+                let requests = match unprocessed.take() {
+                    Some(r) if !r.is_empty() => r,
+                    _ => break,
+                };
+
+                let output = client
+                    .batch_write_item()
+                    .request_items(&table_name, requests)
+                    .send()
+                    .await
+                    .map_err(|e| {
+                        TrackPointError::BatchWriteItemError(e.into_service_error())
+                    })?;
+
+                let remaining = output
+                    .unprocessed_items()
+                    .get(&table_name)
+                    .cloned()
+                    .unwrap_or_default();
+
+                if remaining.is_empty() {
+                    break;
+                }
+
+                if attempt == BATCH_WRITE_MAX_RETRIES {
+                    error!(
+                        remaining_count = remaining.len(),
+                        "batch_put_write: unprocessed items remain after max retries"
+                    );
+                    return Err(anyhow!(
+                        "batch_put_write failed: {} items unprocessed after {} retries",
+                        remaining.len(),
+                        BATCH_WRITE_MAX_RETRIES
+                    ));
+                }
+
+                warn!(
+                    attempt,
+                    remaining_count = remaining.len(),
+                    "batch_put_write: retrying unprocessed items"
+                );
+                let backoff = Duration::from_millis(100 * 2u64.pow(attempt));
+                sleep(backoff).await;
+                unprocessed = Some(remaining);
+            }
+        }
+
+        Ok(())
     }
 
     pub async fn find_by_walk_id_and_tracked_at(
@@ -181,21 +262,12 @@ impl TryFrom<&HashMap<String, AttributeValue>> for Model {
     }
 }
 
-impl TryFrom<PutItemOutput> for Model {
-    type Error = anyhow::Error;
-
-    fn try_from(output: PutItemOutput) -> Result<Self> {
-        let attributes = output
-            .attributes
-            .ok_or_else(|| anyhow!("PutItemOutput missing attributes"))?;
-        Model::try_from(&attributes)
-    }
-}
-
 #[derive(Debug, thiserror::Error)]
 pub enum TrackPointError {
     #[error("Put item error: {0}")]
     PutItemError(PutItemError),
+    #[error("Batch write item error: {0}")]
+    BatchWriteItemError(BatchWriteItemError),
     #[error("Query error: {0}")]
     QueryError(QueryError),
 }

--- a/apps/api/src/queue/track_point.rs
+++ b/apps/api/src/queue/track_point.rs
@@ -1,6 +1,6 @@
 use aws_sdk_sqs::operation::{
-    delete_message::DeleteMessageError, receive_message::ReceiveMessageError,
-    send_message::SendMessageError,
+    delete_message::DeleteMessageError, delete_message_batch::DeleteMessageBatchError,
+    receive_message::ReceiveMessageError, send_message::SendMessageError,
 };
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -93,6 +93,8 @@ pub enum TrackPointQueueError {
     ReceiveMessage(ReceiveMessageError),
     #[error("SQS delete message error: {0}")]
     DeleteMessage(DeleteMessageError),
+    #[error("SQS delete message batch error: {0}")]
+    DeleteMessageBatch(DeleteMessageBatchError),
     #[error("SQS message has no body")]
     MissingBody,
     #[error("SQS message has no receipt handle")]


### PR DESCRIPTION
  ## Summary
  - `entity::track_point` に `batch_put_write()` を追加（DynamoDB `batch_write_item` 使用、25件チャンク + 指数バックオフリトライ）
  - `put()` から不要な read-back verification を削���
  - Worker を per-message → per-batch 処理に変更（`batch_put_write()` + SQS `delete_message_batch`）

  ## Performance
  | 指標 | Before | After |
  |------|--------|-------|
  | DynamoDB コール/10msg | 20回 (put×10 + read×10) | 1回 (batch_write×1) |
  | SQS delete コール/10msg | 10回 | 1回 (delete_batch×1) |
  | ネットワークラウンドトリップ | 30回 | 2回 |

  ## Test plan
  - [ ] `cargo build` が通ること
  - [ ] `cargo test` が通ること
  - [ ] `cargo clippy` で警告なし
  - [ ] docker compose で track-point-worker を起動し、SQS にメッセージ投入後 DynamoDB に正しく書き込まれることを確認

  🤖 Generated with [Claude Code](https://claude.com/claude-code)