### PR TITLE
fix(api): resolve build errors from batch track_point write

### DIFF
--- a/apps/api/src/bin/track_point_worker.rs
+++ b/apps/api/src/bin/track_point_worker.rs
@@ -137,8 +137,8 @@ async fn process_batch(
 }
 
 async fn delete_message(sqs_client: &aws_sdk_sqs::Client, queue_url: &str, message: &Message) {
-    if let Some(receipt_handle) = message.receipt_handle() {
-        if let Err(error) = sqs_client
+    if let Some(receipt_handle) = message.receipt_handle()
+        && let Err(error) = sqs_client
             .delete_message()
             .queue_url(queue_url)
             .receipt_handle(receipt_handle)
@@ -147,7 +147,6 @@ async fn delete_message(sqs_client: &aws_sdk_sqs::Client, queue_url: &str, messa
         {
             error!(?error, "failed to delete message from queue");
         }
-    }
 }
 
 async fn delete_message_batch(

--- a/apps/api/src/entity/track_point.rs
+++ b/apps/api/src/entity/track_point.rs
@@ -113,7 +113,7 @@ impl Model {
 
                 let remaining = output
                     .unprocessed_items()
-                    .get(&table_name)
+                    .and_then(|items| items.get(&table_name))
                     .cloned()
                     .unwrap_or_default();
 

--- a/apps/api/src/graphql/error.rs
+++ b/apps/api/src/graphql/error.rs
@@ -100,6 +100,11 @@ impl ErrorExtensions for TrackPointError {
                 e.set("code", 500);
                 e.set("message", put_item_error.message());
             }
+            TrackPointError::BatchWriteItemError(batch_write_item_error) => {
+                error!("Batch write item error: {:?}", batch_write_item_error);
+                e.set("code", 500);
+                e.set("message", batch_write_item_error.message());
+            }
             TrackPointError::QueryError(query_error) => {
                 error!("Query error: {:?}", query_error);
                 e.set("code", 500);

--- a/apps/api/src/graphql/mutation/walk.rs
+++ b/apps/api/src/graphql/mutation/walk.rs
@@ -5,7 +5,7 @@ use sea_orm::{
 };
 use uuid::Uuid;
 
-use crate::entity::{dog, track_point, user, user_dog};
+use crate::entity::{dog, user, user_dog};
 use crate::graphql::{error::AppError, guard::AuthGuard, object::walk::Walk};
 
 #[derive(Default, Debug)]

--- a/apps/api/src/graphql/object/user.rs
+++ b/apps/api/src/graphql/object/user.rs
@@ -2,7 +2,7 @@ use async_graphql::{
     ComplexObject, Context, Result, SimpleObject,
     connection::{Connection, Edge, EmptyFields, query},
 };
-use sea_orm::{ColumnTrait, EntityTrait, PaginatorTrait, QueryFilter, QueryOrder};
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QueryOrder};
 use url::Url;
 use uuid::Uuid;
 


### PR DESCRIPTION
## Summary
- `BatchWriteItemOutput::unprocessed_items()` returns `Option<&HashMap<…>>` in aws-sdk-dynamodb 1.111.0 — `.get(&table_name)` now goes through `.and_then(...)`
- added the missing `TrackPointError::BatchWriteItemError(_)` match arm in `impl ErrorExtensions for TrackPointError` (mirrors the `PutItemError` arm)
- removed now-unused imports (`PaginatorTrait` in `graphql/object/user.rs`, `track_point` in `graphql/mutation/walk.rs`)
- collapsed nested `if let` in `track_point_worker::delete_message`

Both compile errors were leftovers from #216 — `apps/api` did not build on `main`.

## Test plan
- [x] `docker compose exec api cargo build --all-targets` — compiles clean
- [x] `docker compose exec api cargo test --features test-utils -- --test-threads=1` — 7 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)