### PR TITLE
feat(mobile): log reproducible GraphQL requests in dev builds

### DIFF
--- a/apps/mobile/lib/graphql/client.ts
+++ b/apps/mobile/lib/graphql/client.ts
@@ -4,6 +4,7 @@ import {
   createRefreshMiddleware,
   type RefreshHandler,
 } from './middleware/refresh-on-401';
+import { logReproducibleRequest } from './request-log';
 
 type Variables = Record<string, unknown>;
 type GraphQLResult = {
@@ -118,6 +119,13 @@ export const graphqlClient = {
       `[graphql] → ${op.kind} ${op.name} ${endpoint}`,
       variables ? { variableKeys: Object.keys(variables) } : '',
     );
+    logReproducibleRequest({
+      endpoint,
+      document,
+      variables,
+      operationKind: op.kind,
+      operationName: op.name,
+    });
 
     const headers: HeadersInit = {
       'Content-Type': 'application/json',

--- a/apps/mobile/lib/graphql/request-log.test.ts
+++ b/apps/mobile/lib/graphql/request-log.test.ts
@@ -1,0 +1,97 @@
+import { logReproducibleRequest } from './request-log';
+
+const endpoint = 'http://localhost:3000/graphql';
+const document = 'query Me { me { id name } }';
+
+const env = process.env as { NODE_ENV?: string };
+const originalNodeEnv = env.NODE_ENV;
+
+let logSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  env.NODE_ENV = 'development';
+});
+
+afterEach(() => {
+  logSpy.mockRestore();
+  env.NODE_ENV = originalNodeEnv;
+});
+
+describe('logReproducibleRequest', () => {
+  it('does nothing in production builds', () => {
+    env.NODE_ENV = 'production';
+
+    logReproducibleRequest({
+      endpoint,
+      document,
+      operationKind: 'query',
+      operationName: 'Me',
+    });
+
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('logs a reproducible request block in development', () => {
+    logReproducibleRequest({
+      endpoint,
+      document,
+      variables: { id: 'user-id' },
+      operationKind: 'query',
+      operationName: 'Me',
+    });
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const output = logSpy.mock.calls[0][0] as string;
+    expect(output).toContain(`reproduce query Me`);
+    expect(output).toContain(`POST ${endpoint}`);
+    expect(output).toContain(`curl -sS '${endpoint}'`);
+    expect(output).toContain(`-d '`);
+    expect(output).toContain('query Me { me { id name } }');
+    expect(output).toContain(JSON.stringify({ id: 'user-id' }, null, 2));
+  });
+
+  it('renders "(none)" when there are no variables', () => {
+    logReproducibleRequest({
+      endpoint,
+      document,
+      operationKind: 'query',
+      operationName: 'Me',
+    });
+
+    const output = logSpy.mock.calls[0][0] as string;
+    expect(output).toContain('variables:');
+    expect(output).toContain('(none)');
+    // The body sent for a variable-less request has no `variables` key.
+    expect(output).toContain(`-d '${JSON.stringify({ query: document })}'`);
+  });
+
+  it('never logs an actual Authorization token, only a placeholder', () => {
+    logReproducibleRequest({
+      endpoint,
+      document,
+      operationKind: 'query',
+      operationName: 'Me',
+    });
+
+    const output = logSpy.mock.calls[0][0] as string;
+    // The `$TOKEN` placeholder is allowed; a real bearer value would not be.
+    expect(output).toContain('$TOKEN');
+    expect(output).not.toMatch(/Bearer (?!\$TOKEN)\S/);
+  });
+
+  it('shell-escapes single quotes in the curl -d payload', () => {
+    logReproducibleRequest({
+      endpoint,
+      document,
+      variables: { name: "O'Brien" },
+      operationKind: 'mutation',
+      operationName: 'UpdateUser',
+    });
+
+    const output = logSpy.mock.calls[0][0] as string;
+    // JSON body contains "name":"O'Brien"; the single quote must be escaped as '\''.
+    expect(output).toContain(`'\\''`);
+    expect(output).not.toContain(`"name":"O'Brien"`);
+  });
+});

--- a/apps/mobile/lib/graphql/request-log.ts
+++ b/apps/mobile/lib/graphql/request-log.ts
@@ -1,0 +1,84 @@
+type Variables = Record<string, unknown>;
+
+type ReproducibleRequest = {
+  endpoint: string;
+  document: string;
+  variables?: Variables;
+  operationKind: string;
+  operationName: string;
+};
+
+// Authorization is intentionally never logged — only this placeholder is shown so the
+// developer knows to add the header themselves when reproducing an authenticated request.
+const AUTH_HEADER_COMMENT = '# Authorization: Bearer $TOKEN  (add manually if auth is required)';
+const AUTH_CURL_COMMENT = '# add when auth is required: -H "Authorization: Bearer $TOKEN"';
+
+/** Wrap a value in single quotes for a POSIX shell, escaping embedded single quotes as '\''. */
+function shellSingleQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+/** Build the exact JSON body that `graphqlClient.request` sends, so the curl reproduces it byte-for-byte. */
+function buildRequestBody(document: string, variables?: Variables): string {
+  return JSON.stringify({
+    query: document,
+    ...(variables ? { variables } : {}),
+  });
+}
+
+function buildCurl(endpoint: string, body: string): string {
+  return [
+    `curl -sS ${shellSingleQuote(endpoint)} \\`,
+    `  -H 'Content-Type: application/json' \\`,
+    `  -d ${shellSingleQuote(body)}`,
+    `  ${AUTH_CURL_COMMENT}`,
+  ].join('\n');
+}
+
+function indent(text: string, spaces: number): string {
+  const pad = ' '.repeat(spaces);
+  return text
+    .split('\n')
+    .map((line) => (line ? pad + line : line))
+    .join('\n');
+}
+
+/**
+ * In development builds, log a self-contained, copy-pasteable description of a GraphQL
+ * request so a developer can reproduce it in a GraphQL client (GraphiQL / Insomnia / curl).
+ *
+ * Emits the endpoint, headers (Authorization intentionally omitted — only a placeholder
+ * comment), the full query document, the full variables, and a ready-to-run curl command.
+ * Does nothing in production builds, since variables may contain PII (e.g. location track points).
+ */
+export function logReproducibleRequest({
+  endpoint,
+  document,
+  variables,
+  operationKind,
+  operationName,
+}: ReproducibleRequest): void {
+  if (process.env.NODE_ENV === 'production') {
+    return;
+  }
+
+  const body = buildRequestBody(document, variables);
+  const curl = buildCurl(endpoint, body);
+  const variablesText = variables ? JSON.stringify(variables, null, 2) : '(none)';
+
+  const block = [
+    `[graphql] ⟲ reproduce ${operationKind} ${operationName}`,
+    `  endpoint: POST ${endpoint}`,
+    `  headers:`,
+    `    Content-Type: application/json`,
+    `    ${AUTH_HEADER_COMMENT}`,
+    `  query:`,
+    indent(document.trim(), 4),
+    `  variables:`,
+    indent(variablesText, 4),
+    `  curl:`,
+    indent(curl, 4),
+  ].join('\n');
+
+  console.log(block);
+}


### PR DESCRIPTION
## Summary
- Adds `apps/mobile/lib/graphql/request-log.ts` — `logReproducibleRequest()` logs a copy‑pasteable description of each GraphQL request (endpoint, headers, full query, full variables, `curl` one‑liner) in dev builds only.
- Wires it into `graphqlClient.request` right after the existing `[graphql] →` summary log. Request body / headers / existing logs are unchanged.
- The Authorization token is **never** logged (only a `$TOKEN` placeholder). Guarded by `process.env.NODE_ENV !== 'production'` since variables can contain PII (e.g. location track points), so it is a no‑op in production builds.
- Adds `request-log.test.ts` (5 cases: prod no‑op, dev block contents, `(none)` variables, no token leak, single‑quote shell escaping).

## Verification
Not run in this worktree (no `node_modules`). Run in a dev env / CI:
- `cd apps/mobile && npm run typecheck && npm run lint && npm test`
- `npm run ios:sim:local` → trigger a request → check the Metro console for a `[graphql] ⟲ reproduce …` block; copy the `curl`, add `-H "Authorization: Bearer <token>"`, run it.
- `npm run ios:sim:prod` → confirm `⟲ reproduce` does **not** appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)