### PR TITLE
fix(mobile): surface walks-fetch errors on Dog detail screen

### DIFF
--- a/apps/mobile/.claude/rules/common/patterns.md
+++ b/apps/mobile/.claude/rules/common/patterns.md
@@ -57,3 +57,4 @@ features/
 - Graceful degradation (offline placeholder, retry button)
 - Report errors to monitoring (Sentry/Crashlytics)
 - Never swallow errors silently
+- **Never render a success / empty / zero state when a data fetch failed.** Every data-fetching screen MUST surface fetch errors to the user — a visible message plus a Retry affordance. Don't drop `.error` (or equivalent) from `useQuery` / data hooks: thread it through the view-model into the screen, and branch the UI on it. In `__DEV__` builds, also show the underlying error detail (e.g. `error.message`) so the cause is visible during development. An empty/zero UI must mean "the fetch succeeded and there is no data", never "the fetch failed".

--- a/apps/mobile/app/dogs/[id]/_layout.tsx
+++ b/apps/mobile/app/dogs/[id]/_layout.tsx
@@ -19,12 +19,13 @@ export default function DogDetailLayout() {
         }}
       />
       <Stack.Screen
-        name="friends"
+        name="friends/index"
         options={{
           title: t('dogs.friends.title', 'Friends'),
           headerStyle: { backgroundColor: theme.background },
         }}
       />
+      {/* friends/[friendDogId] は Expo Router の自動検出に任せ、既定の Stack ヘッダー（戻るボタン付き）を使います。 */}
       <Stack.Screen
         name="encounters"
         options={{

--- a/apps/mobile/app/dogs/[id]/index.tsx
+++ b/apps/mobile/app/dogs/[id]/index.tsx
@@ -37,14 +37,20 @@ export default function DogDetailScreen() {
           ) : null}
         </View>
 
-        {vm.dog.walkStats ? (
+        {/* 散歩取得に失敗しているときは 0/0/0 の誤った統計を出さず、エラーだけ見せます。 */}
+        {vm.dog.walkStats && !vm.walksError ? (
           <View style={styles.statsSection}>
             <DogStatsCard stats={vm.dog.walkStats} streakDays={vm.streakDays} />
           </View>
         ) : null}
 
         <View style={styles.walksSection}>
-          <DogWalksList walks={vm.dogWalks} onPressWalk={vm.handleOpenWalk} />
+          <DogWalksList
+            walks={vm.dogWalks}
+            onPressWalk={vm.handleOpenWalk}
+            error={vm.walksError}
+            onRetry={vm.retryWalks}
+          />
         </View>
 
         <GroupedCard style={styles.group}>

--- a/apps/mobile/components/dogs/DogWalksList.test.tsx
+++ b/apps/mobile/components/dogs/DogWalksList.test.tsx
@@ -1,0 +1,75 @@
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { DogWalksList } from './DogWalksList';
+import type { Walk } from '@/types/graphql';
+
+jest.mock('@/hooks/use-color-scheme', () => ({
+  useColorScheme: () => 'light',
+}));
+
+const walk: Walk = {
+  id: 'walk-1',
+  dogs: [
+    {
+      id: 'dog-1',
+      name: 'Coco',
+      breed: 'Toy Poodle',
+      gender: 'FEMALE',
+      birthday: null,
+      photoUrl: null,
+      createdAt: '2026-01-01T00:00:00Z',
+    },
+  ],
+  status: 'FINISHED',
+  distanceM: 1000,
+  durationSec: 1200,
+  startedAt: '2026-04-20T08:00:00Z',
+  endedAt: '2026-04-20T08:20:00Z',
+  events: [],
+};
+
+describe('DogWalksList', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-04-20T12:00:00Z'));
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  it('shows the empty state when there are no walks and no error', () => {
+    render(<DogWalksList walks={[]} />);
+
+    expect(screen.getByText('No walks yet. Start your first walk!')).toBeTruthy();
+    expect(screen.queryByText("Couldn't load walks.")).toBeNull();
+  });
+
+  it('shows an error message and a Retry button when error is set, and calls onRetry', () => {
+    const onRetry = jest.fn();
+
+    render(<DogWalksList walks={[]} error={new Error('boom')} onRetry={onRetry} />);
+
+    expect(screen.getByText("Couldn't load walks.")).toBeTruthy();
+    // The empty state must NOT be shown while there is an error.
+    expect(screen.queryByText('No walks yet. Start your first walk!')).toBeNull();
+
+    fireEvent.press(screen.getByRole('button', { name: 'Retry' }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the underlying error detail in dev builds', () => {
+    render(
+      <DogWalksList walks={[]} error={new Error('GraphQL field "trackPoints" failed')} onRetry={jest.fn()} />,
+    );
+
+    expect(screen.getByText('GraphQL field "trackPoints" failed')).toBeTruthy();
+  });
+
+  it('renders walk rows when walks are present and no error', () => {
+    render(<DogWalksList walks={[walk]} />);
+
+    expect(screen.queryByText("Couldn't load walks.")).toBeNull();
+    expect(screen.queryByText('No walks yet. Start your first walk!')).toBeNull();
+    expect(screen.getByText(/Today/)).toBeTruthy();
+  });
+});

--- a/apps/mobile/components/dogs/DogWalksList.tsx
+++ b/apps/mobile/components/dogs/DogWalksList.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useColors } from '@/hooks/use-colors';
 import { spacing, typography } from '@/theme/tokens';
 import { GroupedCard } from '@/components/ui/GroupedCard';
+import { Button } from '@/components/ui/Button';
 import { DogWalkRow } from './DogWalkRow';
 import type { Walk } from '@/types/graphql';
 
@@ -11,6 +12,9 @@ interface DogWalksListProps {
   onPressWalk?: (id: string) => void;
   onSeeAll?: () => void;
   maxRows?: number;
+  // 散歩履歴の取得に失敗したとき、空表示の代わりにエラーと再試行導線を出します。
+  error?: Error | null;
+  onRetry?: () => void;
 }
 
 export function DogWalksList({
@@ -18,6 +22,8 @@ export function DogWalksList({
   onPressWalk,
   onSeeAll,
   maxRows = 5,
+  error,
+  onRetry,
 }: DogWalksListProps) {
   const { t } = useTranslation();
   const theme = useColors();
@@ -29,7 +35,7 @@ export function DogWalksList({
         <Text style={[styles.title, { color: theme.onSurface }]}>
           {t('dogs.detail.walks')}
         </Text>
-        {onSeeAll && walks.length > 0 ? (
+        {onSeeAll && !error && walks.length > 0 ? (
           <Pressable
             accessibilityRole="button"
             accessibilityLabel={t('dogs.detail.seeAll')}
@@ -43,7 +49,28 @@ export function DogWalksList({
         ) : null}
       </View>
 
-      {visible.length === 0 ? (
+      {error ? (
+        <GroupedCard elevated>
+          <View style={styles.errorBody}>
+            <Text style={[styles.errorText, { color: theme.error }]}>
+              {t('dogs.detail.walksError')}
+            </Text>
+            {__DEV__ ? (
+              <Text style={[styles.errorDetail, { color: theme.onSurfaceVariant }]}>
+                {error.message}
+              </Text>
+            ) : null}
+            {onRetry ? (
+              <Button
+                label={t('common.retry')}
+                variant="secondary"
+                onPress={onRetry}
+                style={styles.retryButton}
+              />
+            ) : null}
+          </View>
+        </GroupedCard>
+      ) : visible.length === 0 ? (
         <GroupedCard elevated>
           <View style={styles.empty}>
             <Text style={[styles.emptyText, { color: theme.onSurfaceVariant }]}>
@@ -91,5 +118,22 @@ const styles = StyleSheet.create({
   },
   emptyText: {
     ...typography.footnote,
+  },
+  errorBody: {
+    padding: spacing.lg,
+    alignItems: 'center',
+  },
+  errorText: {
+    ...typography.body,
+    textAlign: 'center',
+  },
+  errorDetail: {
+    ...typography.footnote,
+    textAlign: 'center',
+    marginTop: spacing.xs,
+  },
+  retryButton: {
+    marginTop: spacing.md,
+    alignSelf: 'stretch',
   },
 });

--- a/apps/mobile/hooks/use-dog-detail-view-model.test.ts
+++ b/apps/mobile/hooks/use-dog-detail-view-model.test.ts
@@ -6,6 +6,8 @@ const mockPush = jest.fn();
 const mockReplace = jest.fn();
 const mockDeleteDog = jest.fn();
 const mockRunWithAlert = jest.fn();
+const mockRefetchWalks = jest.fn();
+let mockWalksError: Error | null = null;
 
 let mockDog: DogWithStats | null = {
   id: 'dog-1',
@@ -99,7 +101,7 @@ jest.mock('@/hooks/use-dog', () => ({
 }));
 
 jest.mock('@/hooks/use-walks', () => ({
-  useMyWalks: () => ({ data: mockWalks }),
+  useMyWalks: () => ({ data: mockWalks, error: mockWalksError, refetch: mockRefetchWalks }),
 }));
 
 jest.mock('@/hooks/use-pack-progress', () => ({
@@ -225,6 +227,7 @@ describe('useDogDetailViewModel', () => {
     };
     mockMe = { id: 'user-1' };
     mockIsOwner = true;
+    mockWalksError = null;
     mockDeleteDog.mockResolvedValue(true);
     mockRunWithAlert.mockImplementation(async (fn: () => Promise<unknown>) => fn());
   });
@@ -247,6 +250,27 @@ describe('useDogDetailViewModel', () => {
     expect(vm.streakDays).toBe(5);
     expect(vm.dogWalks.map((walk) => walk.id)).toEqual(['walk-1']);
     expect(vm.isOwner).toBe(true);
+  });
+
+  it('has no walks error when the walks query succeeds', () => {
+    const { result } = renderHook(() => useDogDetailViewModel());
+
+    expect(expectReadyViewModel(result.current).walksError).toBeNull();
+  });
+
+  it('exposes the walks error and a retry that refetches the walks query', () => {
+    mockWalksError = new Error('GraphQL Walks failed');
+
+    const { result } = renderHook(() => useDogDetailViewModel());
+    const vm = expectReadyViewModel(result.current);
+
+    expect(vm.walksError).toBe(mockWalksError);
+
+    act(() => {
+      vm.retryWalks();
+    });
+
+    expect(mockRefetchWalks).toHaveBeenCalledTimes(1);
   });
 
   it('exposes walk navigation and disables unsupported members/friends navigation', () => {

--- a/apps/mobile/hooks/use-dog-detail-view-model.ts
+++ b/apps/mobile/hooks/use-dog-detail-view-model.ts
@@ -44,6 +44,9 @@ interface DogDetailReadyViewModel {
   memberCount: number;
   streakDays: number;
   dogWalks: Walk[];
+  // 散歩履歴の取得に失敗したときだけ非 null。空配列と「失敗」を画面側で区別するために持ちます。
+  walksError: Error | null;
+  retryWalks: () => void;
   isOwner: boolean;
   showDeleteConfirm: boolean;
   handleOpenWalk: (walkId: string) => void;
@@ -64,7 +67,8 @@ export function useDogDetailViewModel(): DogDetailViewModel {
 
   const { data: dog, isLoading } = useDog(dogId ?? '', 'ALL');
   const { data: me } = useMe();
-  const { data: walks = [] } = useMyWalks(100);
+  const { data: walks = [], error: walksErrorRaw, refetch: refetchWalks } = useMyWalks(100);
+  const walksError = walksErrorRaw ?? null;
   const pack = usePackProgress();
   const { mutateAsync: deleteDog } = useDeleteDog();
   const runWithAlert = useMutationWithAlert();
@@ -83,6 +87,10 @@ export function useDogDetailViewModel(): DogDetailViewModel {
     },
     [router],
   );
+
+  const retryWalks = useCallback(() => {
+    void refetchWalks?.();
+  }, [refetchWalks]);
 
   const handleOpenMembers = useCallback(() => {
     return;
@@ -121,6 +129,8 @@ export function useDogDetailViewModel(): DogDetailViewModel {
     memberCount: 0,
     streakDays: pack.perDog[dog.id]?.streakDays ?? 0,
     dogWalks,
+    walksError,
+    retryWalks,
     isOwner,
     showDeleteConfirm,
     handleOpenWalk,

--- a/apps/mobile/lib/i18n/locales/en.json
+++ b/apps/mobile/lib/i18n/locales/en.json
@@ -98,6 +98,7 @@
       "membersCount": "{{count}} members",
       "manageMembers": "Manage Members",
       "walks": "Walks",
+      "walksError": "Couldn't load walks.",
       "seeAll": "See all",
       "streakLabel": "Streak",
       "streakDays": "{{days}}d",

--- a/apps/mobile/lib/i18n/locales/ja.json
+++ b/apps/mobile/lib/i18n/locales/ja.json
@@ -98,6 +98,7 @@
       "membersCount": "{{count}}人のメンバー",
       "manageMembers": "メンバー管理",
       "walks": "散歩",
+      "walksError": "散歩を読み込めませんでした。",
       "seeAll": "すべて見る",
       "streakLabel": "連続",
       "streakDays": "{{days}}日",


### PR DESCRIPTION
## Summary
- Dog detail screen now shows an error card + **Retry** when the `Walks` GraphQL query fails, instead of a fake-empty "No walks yet" / 0·0m·0d state. In `__DEV__` the underlying error message is shown too.
- The misleading 0/0/0 stats card is hidden when the walks query failed (those numbers are derived from the failed data).
- Fixed the Expo Router `[Layout children]: No route named "friends" exists` warning — `<Stack.Screen name="friends">` → `name="friends/index"`; `friends/[friendDogId]` left to auto-discovery so it keeps its default header/back button.
- Added a rule to `apps/mobile/.claude/rules/common/patterns.md`: never render a success/empty/zero state when a fetch failed — always surface the error + a Retry, don't drop `.error`.
- Out of scope: the backend cause of `query Walks ... with 1 errors` (likely the `track_points` DynamoDB resolver or `birthday` deserialization) — follow-up.

## Test plan
- [x] `npx tsc --noEmit` (mobile) — clean
- [x] `npx expo lint` — clean
- [x] `npx jest` — 665/665 across 105 suites; added `components/dogs/DogWalksList.test.tsx` (error variant: message shown, empty state suppressed, Retry calls `onRetry`, dev detail shown) and extended `hooks/use-dog-detail-view-model.test.ts` (`walksError` exposed; `retryWalks` refetches)
- [ ] iOS sim: open Dog screen → no `[Layout children]` warning in Metro
- [ ] iOS sim: point `EXPO_PUBLIC_API_URL` at a bad host → Walks section shows error card + Retry, stats card hidden, dog name still renders; Retry refetches after restoring API

🤖 Generated with [Claude Code](https://claude.com/claude-code)