### PR TITLE
chore(skills): add copilot-delegate skill for GitHub Copilot CLI delegation

### DIFF
--- a/.claude/skills/copilot-delegate/SKILL.md
+++ b/.claude/skills/copilot-delegate/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: copilot-delegate
+description: >
+  GitHub Copilot CLI (`copilot -p`) に実装タスクを委譲して、並列実装の分担・重い単発タスクの代行・セカンドオピニオン取得を行う。
+  Use whenever the user says 「Copilot に実装させて」「Copilot に投げて」「Copilot で並列実装」「Copilot にセカンドオピニオン」「/copilot-delegate」「delegate to copilot」「run copilot in parallel」など、
+  Claude 以外のエージェント（GitHub Copilot CLI）へ実装を切り出したいと示したとき。
+  Claude のコンテキストを節約しつつ、独立タスクを並列実行したり代替案を比較したりするのに使う。
+---
+
+# Copilot Delegate Skill
+
+GitHub Copilot CLI に実装タスクを委譲する。Claude が「監督者」、Copilot が「実装者」という分担で動く。
+
+## When to Use
+
+- 独立した実装タスクを **複数同時に** 進めたい（並列実装）
+- 1 つの実装タスクが大きすぎて Claude の context を圧迫しそう（heavy single）
+- Claude が書いた実装に対し、別エージェントの **代替案** が欲しい（second-opinion）
+- ユーザーが明示的に `/copilot-delegate` か「Copilot に投げて」と指示した
+
+## When NOT to Use
+
+- タスクが小さく Claude が直接書いた方が速い（1〜数行の編集）
+- 設計判断やヒアリングが必要な段階 — Copilot は与えられたタスクを実行するだけ、要件詰めには向かない
+- 強い security 配慮が必要（秘密鍵を含むファイル操作など）— Claude が直接扱う
+- 既に作業中のセッションがあり、worktree が散らかる懸念があるとき
+
+## Prerequisites
+
+| 項目 | 確認方法 |
+|---|---|
+| `copilot` CLI インストール済み | `which copilot`（`/Users/.../.local/bin/copilot` 想定） |
+| 認証済み | 初回 `copilot` 起動で対話的に GitHub にログイン |
+| git worktree が動く | `git worktree list` で既存 worktree を確認 |
+
+未インストールなら `npm install -g @github/copilot` で導入。
+
+## Modes / モード
+
+3 モードを選んで実行する。詳細フローは `references/modes.md` を参照。
+
+| Mode | 用途 | Worktree |
+|---|---|---|
+| `parallel` | 独立タスクの同時実装 | タスクごとに 1 つ作成 |
+| `single` | 重い単発タスクを丸投げ | 現在の worktree を流用 |
+| `second-opinion` | 代替実装を比較取得 | 1 つ新規作成 |
+
+ユーザーが mode を指定しなかった場合は、タスク数・内容から推測して提案する：
+- タスクが 2 つ以上独立して書ける → `parallel`
+- タスクが 1 つで実装範囲が広い → `single`
+- 既に実装済みコードに対する要望 → `second-opinion`
+
+## Core Flow
+
+### 1. タスク定義の作成
+
+`tasks/copilot/<session-slug>/tasks.yaml` を作る。`<session-slug>` は短い kebab-case (例: `dog-form-refactor`)。
+
+```yaml
+session: dog-form-refactor
+mode: parallel              # parallel | single | second-opinion
+language: typescript        # rust | typescript | terraform — references/permissions.md と対応
+project_root: /Users/matsuokashuhei/Development/walking-dog
+tasks:
+  - id: rename-fields
+    description: |
+      apps/mobile/src/screens/DogForm.tsx の state 変数名を camelCase から snake_case に変えて、
+      GraphQL mutation の引数名に揃える。テストも更新。
+  - id: extract-validator
+    description: |
+      apps/mobile/src/screens/DogForm.tsx の validation ロジックを apps/mobile/src/validators/dog.ts に抽出し、
+      DogForm から import するように差し替え。
+```
+
+`single` / `second-opinion` の場合は `tasks:` を 1 要素にする。
+
+### 2. Worktree の準備
+
+`references/worktree.md` の手順に従い、各 task について：
+
+```bash
+git worktree add ".claude/worktrees/copilot-${TASK_ID}" -b "copilot/${TASK_ID}"
+```
+
+`single` モードは既存 worktree を流用するので作成不要。
+
+### 3. Copilot CLI の起動
+
+`references/permissions.md` の言語別テンプレを使って組み立てる。骨格：
+
+```bash
+copilot -p "${TASK_DESCRIPTION}" \
+  -C "${WORKTREE_PATH}" \
+  --add-dir "${PROJECT_ROOT}" \
+  ${ALLOW_TOOLS} \
+  ${DENY_TOOLS} \
+  > "tasks/copilot/${SESSION}/logs/${TASK_ID}.log" 2>&1
+```
+
+**parallel モードでは Bash の `run_in_background: true` で全タスクを同時起動する。** Bash tool は完了通知を返すので、各通知が来たら次の処理に進める（poll しない）。
+
+**common allow/deny（全モード共通）**：
+- `--allow-tool='write'` — ファイル編集を許可
+- `--allow-tool='shell(git:*)'` — `git add`/`commit`/`diff` などローカル git は許可
+- `--deny-tool='shell(git push)'` — push は禁止（worktree 隔離のため）
+- `--deny-tool='shell(rm -rf)'` — 危険な削除は禁止
+- `--deny-tool='shell(sudo)'` — 権限昇格は禁止
+
+言語別の追加は `references/permissions.md`。
+
+### 4. 進捗監視 & 結果収集
+
+各 task の完了通知を受けたら：
+
+1. 終了コードと最後の数行をログから読む
+2. `git -C <worktree> diff --stat` で変更サマリを取得
+3. `tasks/copilot/<session>/results.md` に下記フォーマットで追記：
+
+```markdown
+## ${TASK_ID}
+- status: success | failed
+- duration: 4m23s
+- diff:
+  - apps/mobile/src/screens/DogForm.tsx (+12 -8)
+  - apps/mobile/src/validators/dog.ts (new, +34)
+- notes: テスト1件失敗、Copilot ログ末尾参照
+```
+
+### 5. レビューと結合判断
+
+`parallel` の場合、各 worktree の diff を Claude が読み、矛盾や品質を判定。問題なければユーザーに結合方針を提示（cherry-pick / merge / rebase）。
+
+`second-opinion` の場合、元実装と Copilot の代替案を side-by-side で比較し、長所短所をまとめてユーザーに返す。
+
+### 6. クリーンアップ
+
+採用しなかった worktree は：
+
+```bash
+git worktree remove ".claude/worktrees/copilot-${TASK_ID}" --force
+git branch -D "copilot/${TASK_ID}"
+```
+
+採用したものは `feedback_worktree_when_parallel_agents` のルールに従って残す。
+
+## Error Handling
+
+Copilot が失敗した場合、**エラーを握りつぶさない**：
+
+- ログ全文を `tasks/copilot/<session>/logs/<task-id>.log` に保存
+- `results.md` の `status: failed` 行に最終エラー行をそのまま転記
+- Claude が原因を解析し、(a) Copilot に再投入、(b) Claude 自身で実装に切り替え、(c) ユーザーに判断を仰ぐ — のいずれかを提案
+
+エラーを隠すような optional 化・try/catch 追加・fallback 値での "修正" は禁止（プロジェクトルール）。
+
+## Project-Specific Constraints
+
+walking-dog プロジェクトで Copilot に渡すタスクには以下を必ず伝える：
+
+| 制約 | 反映方法 |
+|---|---|
+| Rust は `cargo` 直叩き禁止、Docker Compose 経由 | タスク説明に「`docker compose run --rm api cargo test` を使う」と明記、`--deny-tool='shell(cargo:*)'` |
+| npm も Docker 経由（モバイルは例外あり） | タスク説明で開発手順を指定 |
+| iOS sim は `APP_ENV=local` 必須 | タスク説明に明記 |
+| theme/tokens.ts のトークンを使う（magic number 禁止） | タスク説明に「tokens.ts のトークンのみ使用、値がなければトークン追加」と明記 |
+| 認証は Rust API 経由（Cognito 直接 NG） | 認証絡みのタスクで明記 |
+
+これらは Copilot にはプロジェクト memory が見えないため、Claude が毎回タスク説明に注入する責任を持つ。
+
+## Quick Reference
+
+### よくある呼び出し例
+
+**single:**
+```
+ユーザー: 「/copilot-delegate single  apps/api/src/graphql/dog.rs を SeaORM 0.13 の API に移行して」
+Claude: mode=single, language=rust, deny cargo direct → docker compose で test 走らせるタスク説明に変換して copilot -p 起動
+```
+
+**parallel:**
+```
+ユーザー: 「次の3つを並列で: (1) MeScreen の余白統一、(2) MyDogScreen の戻るボタン追加、(3) common ヘッダー抽出」
+Claude: mode=parallel, 3 つの task_id を切って 3 worktree、3 つの copilot -p を run_in_background で同時起動
+```
+
+**second-opinion:**
+```
+ユーザー: 「今書いた WalkSummary.tsx、Copilot にも書かせて比較したい」
+Claude: 元のコミット sha を控え、新 worktree で同じ仕様を Copilot に再実装させ、diff を並べて返す
+```
+
+詳細は `references/modes.md` を参照。

--- a/.claude/skills/copilot-delegate/references/modes.md
+++ b/.claude/skills/copilot-delegate/references/modes.md
@@ -1,0 +1,169 @@
+# Modes Detail
+
+3 モードそれぞれの詳細フロー。SKILL.md の Core Flow を補足する。
+
+## parallel — 並列実装の分担
+
+**前提**: 2 つ以上の **互いに独立した** タスク。同じファイルを触る競合があれば parallel ではなく single を選ぶ。
+
+### 手順
+
+1. **タスク分割の検証**
+   - 各 task の影響ファイルが重ならないか確認（重なる場合は分割し直す）
+   - 各 task は **15 分以内に Copilot が完結できる粒度** を目安にする（長すぎると失敗時の再投入コストが高い）
+
+2. **session ディレクトリの作成**
+   ```bash
+   SESSION="$(date +%Y%m%d-%H%M)-${SHORT_NAME}"   # 例: 20260516-1500-dog-form
+   mkdir -p "tasks/copilot/${SESSION}/logs"
+   ```
+
+3. **tasks.yaml を書く**
+   - SKILL.md のフォーマット参照
+   - `mode: parallel`, `language: ...`
+
+4. **worktree を全 task 分作成**
+   ```bash
+   for TASK_ID in rename-fields extract-validator; do
+     git worktree add ".claude/worktrees/copilot-${TASK_ID}" -b "copilot/${TASK_ID}"
+   done
+   ```
+
+5. **全 task を `run_in_background: true` で同時起動**
+   - 同じ message で複数の Bash tool 呼び出しを並べる
+   - 各 Bash は `copilot -p ...` を 1 つ起動して即終了する形に組み立てる
+   - 出力は `tasks/copilot/${SESSION}/logs/${TASK_ID}.log` に redirect
+
+6. **完了通知を待つ**
+   - 各バックグラウンドプロセスから完了通知が届くたびに：
+     - 終了コードをチェック
+     - `git -C <worktree> diff --stat` を取る
+     - `results.md` に 1 ブロック追記
+   - 通知が来るまで poll しない（指示違反）
+
+7. **結合判断**
+   - 全 task 完了後、各 worktree の diff を **Claude が直接 Read で読む**
+   - 矛盾・スタイル不一致・テスト破壊などを検出
+   - ユーザーに「3 つとも採用」「2 つ採用 1 つ修正」など方針を提示
+
+### Failure handling
+
+1 task が失敗しても他は続行。failed task は `results.md` に `status: failed` で記録、ユーザーに再投入 or 撤退を相談。
+
+---
+
+## single — 重い単発タスク
+
+**用途**: 1 つの実装が大きく、Claude のコンテキストを圧迫しそうなとき。worktree は **現在のもの** を流用する（新規作成しない）。
+
+### 手順
+
+1. **session 作成（worktree は流用なので軽量）**
+   ```bash
+   SESSION="$(date +%Y%m%d-%H%M)-${SHORT_NAME}"
+   mkdir -p "tasks/copilot/${SESSION}/logs"
+   ```
+
+2. **タスク説明を厚めに書く**
+   - Copilot はプロジェクトの memory を見えないので、**Claude が context を圧縮して渡す** 必要がある
+   - 含めるべき要素:
+     - 触るべきファイル一覧（絶対パス or プロジェクトルートからの相対）
+     - 関連する型定義・interface
+     - プロジェクトルール（Docker 経由、tokens.ts 利用など — `Project-Specific Constraints` から該当分を抜粋）
+     - 受け入れ基準（テストが通る、Lint clean、UI で見て自然 など）
+
+3. **Copilot 起動（フォアグラウンドでも非同期でも可）**
+   ```bash
+   copilot -p "${TASK_DESCRIPTION}" \
+     -C "$(pwd)" \
+     ${COMMON_ALLOW_DENY} \
+     ${LANGUAGE_SPECIFIC_ALLOW_DENY} \
+     | tee "tasks/copilot/${SESSION}/logs/main.log"
+   ```
+
+4. **完了後の検証**
+   - Claude が `git status` / `git diff` で変更を確認
+   - 必要なら lint / test を走らせる
+   - 不備があれば Copilot に追加指示するか、Claude が手当てする
+
+### Failure handling
+
+`single` で失敗した場合、現在の worktree が中途半端な状態になりうる。
+- `git stash` で Copilot の変更を一旦退避してから判断
+- 完全に捨てるなら `git restore --staged --worktree .`
+- 部分採用するなら hunk 単位で `git add -p`
+
+---
+
+## second-opinion — 代替実装の比較
+
+**用途**: 既に実装済みのコード（Claude 産 or 人間産）に対し、Copilot の代替案を取って比較したいとき。
+
+### 手順
+
+1. **基準コミット sha を控える**
+   ```bash
+   BASELINE_SHA=$(git rev-parse HEAD)
+   echo "${BASELINE_SHA}" > "tasks/copilot/${SESSION}/baseline.sha"
+   ```
+
+2. **代替案用 worktree を作成**
+   - 元実装の **直前のコミット** から分岐するのがポイント（Copilot が元実装を見ずに同じ仕様を実装できる状態にする）
+   ```bash
+   # 元実装が HEAD のみのコミットだった場合
+   PRE_SHA=$(git rev-parse HEAD^)
+   git worktree add ".claude/worktrees/copilot-alt" "${PRE_SHA}"
+   cd ".claude/worktrees/copilot-alt"
+   git checkout -b copilot/alternative
+   ```
+
+3. **タスク説明には「仕様だけ」を書く**
+   - 元の実装コードは渡さない（バイアスが入る）
+   - 仕様・受け入れ基準・触るべきファイル一覧だけ
+
+4. **Copilot 起動 → 完了待ち**
+   - `single` と同様
+
+5. **比較レポート作成**
+
+   ```markdown
+   # Second Opinion: ${TOPIC}
+
+   ## Baseline (Claude / 人間 実装)
+   - 行数: 87
+   - 抽象化: 関数 3 つ
+   - 依存追加: なし
+
+   ## Alternative (Copilot)
+   - 行数: 64
+   - 抽象化: 関数 1 つ + クラス
+   - 依存追加: lodash
+
+   ## 差分要約
+   - Copilot は lodash で簡潔だがプロジェクトポリシーで lodash 不使用
+   - Claude 版は依存ゼロだが冗長
+   ```
+
+6. **判断をユーザーに返す**
+   - Claude が一方的に採用判断しない
+   - 長所短所と推奨を述べて user に decide してもらう
+
+### Failure handling
+
+代替案が失敗した場合は worktree を破棄して終了。baseline は元のまま残っているので影響なし。
+
+---
+
+## Mode 選択の補助
+
+ユーザーが mode を明示しなかったとき、Claude は以下のフローで提案する：
+
+```
+1. タスク数 = N
+2. N >= 2 かつ 各タスクが独立 → parallel を提案
+3. N == 1 かつ 影響範囲広い → single を提案
+4. N == 1 かつ 「比較」「代替」「セカンドオピニオン」キーワード → second-opinion を提案
+5. 上記いずれも当てはまらない → ユーザーに mode を聞く
+```
+
+迷ったら **`single` がデフォルト**（worktree 作成不要で副作用が小さい）。

--- a/.claude/skills/copilot-delegate/references/permissions.md
+++ b/.claude/skills/copilot-delegate/references/permissions.md
@@ -1,0 +1,129 @@
+# Permissions — Allow / Deny Tool Sets
+
+`copilot -p` 呼び出し時の `--allow-tool` / `--deny-tool` 推奨セット。
+言語・フレームワークごとに異なる。
+
+## Common (全モード・全言語共通)
+
+必ず付ける：
+
+```bash
+# Allow
+--allow-tool='write'
+--allow-tool='shell(git:add)'
+--allow-tool='shell(git:status)'
+--allow-tool='shell(git:diff)'
+--allow-tool='shell(git:log)'
+--allow-tool='shell(git:commit)'
+--allow-tool='shell(git:checkout)'
+--allow-tool='shell(git:branch)'
+--allow-tool='shell(git:restore)'
+--allow-tool='shell(cat)'
+--allow-tool='shell(ls)'
+--allow-tool='shell(mkdir)'
+--allow-tool='shell(find)'
+--allow-tool='shell(grep)'
+
+# Deny — 全モードで絶対禁止
+--deny-tool='shell(git push)'
+--deny-tool='shell(git push:*)'
+--deny-tool='shell(rm:-rf)'
+--deny-tool='shell(sudo)'
+--deny-tool='shell(curl)'           # 外部送信を防ぐ
+--deny-tool='shell(wget)'
+--deny-tool='shell(scp)'
+--deny-tool='shell(ssh)'
+```
+
+注: `--deny-tool` の構文は Copilot CLI のバージョンで `shell(git push)` か `shell(git:push)` か差がある。`copilot --help` で実機の構文を確認してから書く。
+
+---
+
+## Rust (apps/api)
+
+`cargo` 直叩きを禁止し Docker Compose 経由を強制する。
+
+```bash
+# Allow
+--allow-tool='shell(docker:compose:*)'
+--allow-tool='shell(docker:*)'
+
+# Deny — cargo 直叩きは禁止（feedback_rust_docker memory 遵守）
+--deny-tool='shell(cargo:*)'
+--deny-tool='shell(rustc)'
+--deny-tool='shell(rustup)'
+```
+
+タスク説明には必ず明記：
+> ビルド・テストは `docker compose run --rm api cargo build` / `cargo test` のように **Docker Compose 経由のみ**。ホスト直 `cargo` 実行は禁止。
+
+---
+
+## TypeScript / React Native (apps/mobile, apps/web)
+
+`npm` は Docker 経由が原則だがモバイルは Expo の都合で例外あり。
+
+```bash
+# Allow
+--allow-tool='shell(npm:*)'
+--allow-tool='shell(npx:*)'
+--allow-tool='shell(node:*)'
+--allow-tool='shell(yarn:*)'         # 念のため
+--allow-tool='shell(tsc:*)'
+
+# Deny — モバイルの secure-store 不一致防止
+--deny-tool='shell(expo:prebuild)'   # APP_ENV 漏れ防止、prebuild は Claude 側で実行
+```
+
+タスク説明に必ず明記:
+> - `apps/mobile/theme/tokens.ts` のトークンを使う。magic number 直書き禁止。値がなければトークンを追加してから使う。
+> - 認証は Rust API 経由。`@aws-amplify/auth` 等で Cognito に直接通信しない。
+
+---
+
+## Terraform (infra)
+
+ローカルに Terraform がインストールされていないため、Docker (`hashicorp/terraform:1.14`) 経由のみ。
+
+```bash
+# Allow
+--allow-tool='shell(docker:*)'
+--allow-tool='shell(terraform:fmt)'    # fmt のみ host で許可（安全）
+
+# Deny — host 直 terraform は禁止（feedback_terraform_docker memory 遵守）
+--deny-tool='shell(terraform:init)'
+--deny-tool='shell(terraform:plan)'
+--deny-tool='shell(terraform:apply)'
+--deny-tool='shell(terraform:destroy)'
+```
+
+タスク説明に必ず明記:
+> Terraform コマンドは `docker run --rm -v $(pwd):/work -w /work hashicorp/terraform:1.14 plan` のように Docker 経由で。`apply` / `destroy` は **Copilot から実行禁止、Claude が最終確認後にユーザーへ伺いを立てる**。
+
+---
+
+## URL / Network
+
+```bash
+# Allow (必要に応じて)
+--allow-url='github.com'
+--allow-url='registry.npmjs.org'
+--allow-url='crates.io'
+
+# Deny
+--deny-url='*'                         # 上記以外は禁止
+```
+
+タスクが外部 API ドキュメントを参照する必要があるときのみ、追加で `--allow-url` を加える。
+
+---
+
+## まとめ — Mode × Language マトリクス
+
+| Mode \ Language | Common | + Rust | + TS | + Terraform |
+|---|---|---|---|---|
+| parallel | ✓ | task ごとに切替 | task ごとに切替 | task ごとに切替 |
+| single | ✓ | 適用 | 適用 | 適用 |
+| second-opinion | ✓ | 適用 | 適用 | 適用 |
+
+実装時は **Common + Language** を文字列連結して `copilot -p` に渡す。

--- a/.claude/skills/copilot-delegate/references/worktree.md
+++ b/.claude/skills/copilot-delegate/references/worktree.md
@@ -1,0 +1,147 @@
+# Worktree — Setup & Cleanup
+
+git worktree を使った隔離環境の作成・破棄手順。
+
+## Why worktree?
+
+- **並列実行の隔離**: 複数の Copilot プロセスが同じ working tree を編集すると競合する
+- **採否判断の遅延**: Copilot の変更を main ブランチに直接出さず、別ブランチで保留してレビュー可能
+- **プロジェクトルール**: `feedback_worktree_when_parallel_agents` で並列エージェント実行時の worktree 使用が必須
+
+## 命名規則
+
+| パターン | 用途 |
+|---|---|
+| `.claude/worktrees/copilot-<task-id>` | parallel / second-opinion で各タスク用 |
+| `.claude/worktrees/copilot-alt` | second-opinion の代替案専用（task-id 不明時） |
+
+`<task-id>` は kebab-case 短文字列（例: `rename-fields`, `extract-validator`）。
+ブランチ名は `copilot/<task-id>` で揃える（slash 区切りで Copilot 作業を見分けやすく）。
+
+## Worktree 作成
+
+### parallel: 各タスクごとに作成
+
+```bash
+PROJECT_ROOT="/Users/matsuokashuhei/Development/walking-dog"
+cd "${PROJECT_ROOT}"
+
+for TASK_ID in rename-fields extract-validator; do
+  git worktree add ".claude/worktrees/copilot-${TASK_ID}" -b "copilot/${TASK_ID}"
+done
+```
+
+**注**: ベースブランチを指定したい場合：
+```bash
+git worktree add ".claude/worktrees/copilot-${TASK_ID}" -b "copilot/${TASK_ID}" main
+```
+
+### single: 作成しない
+
+`single` モードは現在の作業 worktree を流用する。`pwd` をそのまま `-C` に渡せばよい。
+
+### second-opinion: baseline 直前から分岐
+
+```bash
+PRE_SHA=$(git rev-parse HEAD^)        # baseline の直前
+git worktree add ".claude/worktrees/copilot-alt" "${PRE_SHA}"
+cd ".claude/worktrees/copilot-alt"
+git checkout -b copilot/alternative
+```
+
+これで Copilot は元実装を見ない状態で同じ仕様を実装することになる。
+
+## Worktree の確認
+
+```bash
+git worktree list
+```
+
+出力例：
+```
+/Users/matsuokashuhei/Development/walking-dog                                  abc1234 [main]
+/Users/matsuokashuhei/Development/walking-dog/.claude/worktrees/elegant-...    def5678 [claude/elegant-questing-dahl]
+/Users/matsuokashuhei/Development/walking-dog/.claude/worktrees/copilot-...    9abcdef [copilot/rename-fields]
+```
+
+## Copilot に渡すときの作業ディレクトリ
+
+```bash
+copilot -p "${TASK_DESCRIPTION}" \
+  -C ".claude/worktrees/copilot-${TASK_ID}" \
+  --add-dir "${PROJECT_ROOT}" \           # メインリポジトリも参照可能に
+  ...
+```
+
+`-C` で Copilot の cwd を worktree にし、`--add-dir` で `PROJECT_ROOT`（メインリポジトリ）の **読み取り** を許可する。これで Copilot は他 worktree のコードを参照できないが、共通の docs / packages は読める。
+
+## Worktree のクリーンアップ
+
+### 採用しなかったとき（破棄）
+
+```bash
+TASK_ID="rename-fields"
+PROJECT_ROOT="/Users/matsuokashuhei/Development/walking-dog"
+cd "${PROJECT_ROOT}"
+
+# 1. worktree を削除（中身ごと消える）
+git worktree remove ".claude/worktrees/copilot-${TASK_ID}" --force
+
+# 2. ブランチも削除
+git branch -D "copilot/${TASK_ID}"
+```
+
+`--force` は uncommitted changes があっても削除する。Copilot の変更を完全に捨てる前提なので付ける。
+
+### 採用したとき（結合）
+
+3 つの選択肢：
+
+**Option A — cherry-pick:**
+```bash
+git -C "${PROJECT_ROOT}" checkout main
+git cherry-pick copilot/${TASK_ID}
+```
+
+**Option B — merge:**
+```bash
+git -C "${PROJECT_ROOT}" checkout main
+git merge --no-ff copilot/${TASK_ID}
+```
+
+**Option C — そのまま worktree で続行:**
+- worktree をそのまま開発ブランチとして使う場合は何もしない
+- 後で PR を切るときに `git push origin copilot/${TASK_ID}` する（worktree 外から push）
+
+採用後の worktree も用済みなら：
+```bash
+git worktree remove ".claude/worktrees/copilot-${TASK_ID}"
+# ブランチは残す（履歴のため）
+```
+
+### 一括クリーンアップ
+
+セッション終了時にまとめて掃除：
+
+```bash
+git worktree list | awk '/copilot-/ {print $1}' | while read WT; do
+  TASK_ID=$(basename "${WT}" | sed 's/^copilot-//')
+  git worktree remove "${WT}" --force 2>/dev/null || true
+  git branch -D "copilot/${TASK_ID}" 2>/dev/null || true
+done
+git worktree prune
+```
+
+## Trouble shooting
+
+| 症状 | 原因 | 対処 |
+|---|---|---|
+| `fatal: <path> already exists` | 前回の残骸 | `git worktree remove <path> --force` で消してから再試行 |
+| `fatal: invalid reference` | branch 名が既存 | `git branch -D copilot/<task-id>` で消してから再試行 |
+| `git worktree list` に幽霊エントリ | 手動で削除した残骸 | `git worktree prune` |
+| Copilot が `--add-dir` 外を触りたがる | タスク範囲が広すぎ | タスクを分割するか、`--add-dir` を追加 |
+
+## メイン CLAUDE.md / feedback memory との整合
+
+- `feedback_worktree_when_parallel_agents.md` — 並列実行時 worktree 必須（本スキル準拠）
+- `feedback_no_redundant_cd.md` — 不要な `cd <project-root>` を避ける。worktree 内で完結する操作はそのまま実行


### PR DESCRIPTION
## Summary
- Add `copilot-delegate` skill that delegates implementation tasks to the standalone GitHub Copilot CLI (`copilot -p`)
- Supports 3 modes: `parallel` (multi-task via git worktrees), `single` (one heavy task), `second-opinion` (alternative implementation for comparison)
- Enforces restricted permissions (deny `git push`, `rm -rf`, `sudo`, `curl`, etc.) and project-specific constraints (Docker-only `cargo`, `tokens.ts` usage, auth via Rust API)

## Test plan
- [ ] Verify `/copilot-delegate` appears in available skills after Claude Code restart
- [ ] Run `single` mode with a small task and confirm changes land in the current worktree
- [ ] Run `parallel` mode with 2 independent tasks; confirm separate worktrees created and diffs produced for each
- [ ] Confirm a `git push` attempted by Copilot is denied
- [ ] Run `second-opinion` mode against an existing implementation and confirm a side-by-side comparison is produced

🤖 Generated with [Claude Code](https://claude.com/claude-code)