### PR TITLE
Unify mobile screen headers

### DIFF
--- a/apps/mobile/__tests__/app/dogs/edit.test.tsx
+++ b/apps/mobile/__tests__/app/dogs/edit.test.tsx
@@ -1,0 +1,77 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import EditDogScreen from '../../../app/dogs/[id]/edit';
+import type { DogWithStats } from '@/types/graphql';
+
+const mockBack = jest.fn();
+const mockUpdateDog = jest.fn();
+
+jest.mock('@/hooks/use-color-scheme', () => ({
+  useColorScheme: () => 'light',
+}));
+
+jest.mock('expo-router', () => ({
+  useLocalSearchParams: () => ({ id: 'dog-1' }),
+  useRouter: () => ({ back: mockBack }),
+}));
+
+const mockDog = {
+  id: 'dog-1',
+  name: 'Buddy',
+  breed: 'Golden Retriever',
+  gender: 'MALE',
+  birthday: null,
+  photoUrl: null,
+  createdAt: '2026-01-01',
+  walkStats: null,
+  members: [],
+} satisfies DogWithStats;
+
+jest.mock('@/hooks/use-dog', () => ({
+  useDog: () => ({ data: mockDog, isLoading: false }),
+}));
+
+jest.mock('@/hooks/use-dog-mutations', () => ({
+  useUpdateDog: () => ({ mutateAsync: mockUpdateDog }),
+}));
+
+describe('EditDogScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUpdateDog.mockResolvedValue(mockDog);
+  });
+
+  it('renders the inline ScreenHeader title and common actions', () => {
+    render(<EditDogScreen />);
+
+    expect(screen.getByRole('header', { name: 'Edit dog' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Save' })).toBeTruthy();
+  });
+
+  it('uses the ScreenHeader cancel action to go back', () => {
+    render(<EditDogScreen />);
+
+    fireEvent.press(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(mockBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('saves the existing form values and returns to the dog detail', async () => {
+    render(<EditDogScreen />);
+
+    fireEvent.press(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(mockUpdateDog).toHaveBeenCalledWith({
+        id: 'dog-1',
+        input: {
+          name: 'Buddy',
+          breed: 'Golden Retriever',
+          gender: 'MALE',
+          birthday: null,
+        },
+      });
+    });
+    expect(mockBack).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/mobile/__tests__/app/dogs/new.test.tsx
+++ b/apps/mobile/__tests__/app/dogs/new.test.tsx
@@ -1,0 +1,53 @@
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import NewDogScreen from '../../../app/dogs/new';
+
+const mockBack = jest.fn();
+const mockDismiss = jest.fn();
+const mockPush = jest.fn();
+const mockCreateDog = jest.fn();
+
+jest.mock('@/hooks/use-color-scheme', () => ({
+  useColorScheme: () => 'light',
+}));
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({
+    back: mockBack,
+    dismiss: mockDismiss,
+    push: mockPush,
+  }),
+}));
+
+jest.mock('@/hooks/use-dog-mutations', () => ({
+  useCreateDog: () => ({ mutateAsync: mockCreateDog }),
+}));
+
+describe('NewDogScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the inline ScreenHeader title and common actions', () => {
+    render(<NewDogScreen />);
+
+    expect(screen.getByRole('header', { name: 'Register dog' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Save' })).toBeTruthy();
+  });
+
+  it('uses the ScreenHeader cancel action to go back', () => {
+    render(<NewDogScreen />);
+
+    fireEvent.press(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(mockBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps Save disabled until the dog form is valid', () => {
+    render(<NewDogScreen />);
+
+    const save = screen.getByRole('button', { name: 'Save' });
+
+    expect(save.props.accessibilityState?.disabled).toBe(true);
+  });
+});

--- a/apps/mobile/__tests__/app/dogs/push-headers.test.tsx
+++ b/apps/mobile/__tests__/app/dogs/push-headers.test.tsx
@@ -1,3 +1,4 @@
+import type { ReactElement } from 'react';
 import { fireEvent, render, screen } from '@testing-library/react-native';
 import DogDetailLayout from '../../../app/dogs/[id]/_layout';
 import DogEncountersScreen from '../../../app/dogs/[id]/encounters';
@@ -13,17 +14,30 @@ jest.mock('@/hooks/use-color-scheme', () => ({
 
 jest.mock('expo-router', () => {
   const React = jest.requireActual<typeof import('react')>('react');
-  const StackScreen = jest.fn(() => null);
+  const { Text } = jest.requireActual<typeof import('react-native')>('react-native');
 
   function Stack({ children }: { children: React.ReactNode }) {
     return <>{children}</>;
+  }
+
+  function StackScreen({
+    name,
+    options,
+  }: {
+    name: string;
+    options?: { headerShown?: boolean; title?: string };
+  }) {
+    if (options?.headerShown === false) {
+      return null;
+    }
+
+    return <Text accessibilityRole="header">{options?.title ?? name}</Text>;
   }
 
   Stack.Screen = StackScreen;
 
   return {
     Stack,
-    __mockStackScreen: StackScreen,
     useLocalSearchParams: () => ({ id: 'dog-1' }),
     useRouter: () => ({ back: mockBack, push: mockPush, replace: mockReplace }),
   };
@@ -84,46 +98,44 @@ describe('dog push screen headers', () => {
     jest.clearAllMocks();
   });
 
-  it('disables native Stack headers for screens migrated to ScreenHeader', () => {
-    render(<DogDetailLayout />);
+  it('renders Members with exactly one inline ScreenHeader and back action', () => {
+    renderWithLayout(<DogMembersScreen />);
 
-    expectStackHeaderHidden('members');
-    expectStackHeaderHidden('friends/index');
-    expectStackHeaderHidden('encounters');
-  });
-
-  it('renders Members with an inline ScreenHeader back action', () => {
-    render(<DogMembersScreen />);
-
-    expect(screen.getByRole('header', { name: 'Members' })).toBeTruthy();
+    expectSingleHeader('Members');
     fireEvent.press(screen.getByRole('button', { name: 'Back' }));
 
     expect(mockBack).toHaveBeenCalledTimes(1);
   });
 
-  it('renders Encounter History with an inline ScreenHeader back action', () => {
-    render(<DogEncountersScreen />);
+  it('renders Encounter History with exactly one inline ScreenHeader and back action', () => {
+    renderWithLayout(<DogEncountersScreen />);
 
-    expect(screen.getByRole('header', { name: 'Encounter History' })).toBeTruthy();
+    expectSingleHeader('Encounter History');
     fireEvent.press(screen.getByRole('button', { name: 'Back' }));
 
     expect(mockBack).toHaveBeenCalledTimes(1);
   });
 
-  it('renders Friends with an inline ScreenHeader back action', () => {
-    render(<DogFriendsScreen />);
+  it('renders Friends with exactly one inline ScreenHeader and back action', () => {
+    renderWithLayout(<DogFriendsScreen />);
 
-    expect(screen.getByRole('header', { name: 'Friends' })).toBeTruthy();
+    expectSingleHeader('Friends');
     fireEvent.press(screen.getByRole('button', { name: 'Back' }));
 
     expect(mockBack).toHaveBeenCalledTimes(1);
   });
 });
 
-function expectStackHeaderHidden(name: string) {
-  const { __mockStackScreen } = jest.requireMock('expo-router') as {
-    __mockStackScreen: jest.Mock;
-  };
-  const call = __mockStackScreen.mock.calls.find(([props]) => props?.name === name);
-  expect(call?.[0]?.options?.headerShown).toBe(false);
+function renderWithLayout(screenElement: ReactElement) {
+  render(
+    <>
+      <DogDetailLayout />
+      {screenElement}
+    </>,
+  );
+}
+
+function expectSingleHeader(name: string) {
+  expect(screen.getAllByRole('header')).toHaveLength(1);
+  expect(screen.getByRole('header', { name })).toBeTruthy();
 }

--- a/apps/mobile/__tests__/app/dogs/push-headers.test.tsx
+++ b/apps/mobile/__tests__/app/dogs/push-headers.test.tsx
@@ -1,0 +1,129 @@
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import DogDetailLayout from '../../../app/dogs/[id]/_layout';
+import DogEncountersScreen from '../../../app/dogs/[id]/encounters';
+import DogFriendsScreen from '../../../app/dogs/[id]/friends';
+import DogMembersScreen from '../../../app/dogs/[id]/members';
+
+const mockBack = jest.fn();
+const mockPush = jest.fn();
+const mockReplace = jest.fn();
+jest.mock('@/hooks/use-color-scheme', () => ({
+  useColorScheme: () => 'light',
+}));
+
+jest.mock('expo-router', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+  const StackScreen = jest.fn(() => null);
+
+  function Stack({ children }: { children: React.ReactNode }) {
+    return <>{children}</>;
+  }
+
+  Stack.Screen = StackScreen;
+
+  return {
+    Stack,
+    __mockStackScreen: StackScreen,
+    useLocalSearchParams: () => ({ id: 'dog-1' }),
+    useRouter: () => ({ back: mockBack, push: mockPush, replace: mockReplace }),
+  };
+});
+
+jest.mock('expo-image', () => ({
+  Image: 'Image',
+}));
+
+const mockDog = {
+  id: 'dog-1',
+  name: 'Buddy',
+  breed: 'Golden Retriever',
+  gender: 'MALE',
+  birthday: null,
+  photoUrl: null,
+  createdAt: '2026-01-01',
+  walkStats: null,
+  members: [
+    {
+      id: 'member-1',
+      userId: 'user-1',
+      role: 'owner' as const,
+      user: { displayName: 'Alice', avatarUrl: null },
+      createdAt: '2026-01-01',
+    },
+  ],
+};
+
+jest.mock('@/hooks/use-dog', () => ({
+  useDog: () => ({ data: mockDog, isLoading: false }),
+}));
+
+jest.mock('@/hooks/use-me', () => ({
+  useMe: () => ({ data: { id: 'user-1' }, isLoading: false }),
+}));
+
+jest.mock('@/hooks/use-dog-member-mutations', () => ({
+  useGenerateInvitation: () => ({ mutateAsync: jest.fn(), isPending: false }),
+  useRemoveMember: () => ({ mutateAsync: jest.fn(), isPending: false }),
+  useLeaveDog: () => ({ mutateAsync: jest.fn(), isPending: false }),
+}));
+
+jest.mock('@/hooks/use-mutation-with-alert', () => ({
+  useMutationWithAlert: () => async (run: () => Promise<unknown>) => run(),
+}));
+
+jest.mock('@/hooks/use-dog-encounters', () => ({
+  useDogEncounters: () => ({ data: [], isLoading: false }),
+}));
+
+jest.mock('@/hooks/use-dog-friends', () => ({
+  useDogFriends: () => ({ data: [], isLoading: false }),
+}));
+
+describe('dog push screen headers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('disables native Stack headers for screens migrated to ScreenHeader', () => {
+    render(<DogDetailLayout />);
+
+    expectStackHeaderHidden('members');
+    expectStackHeaderHidden('friends/index');
+    expectStackHeaderHidden('encounters');
+  });
+
+  it('renders Members with an inline ScreenHeader back action', () => {
+    render(<DogMembersScreen />);
+
+    expect(screen.getByRole('header', { name: 'Members' })).toBeTruthy();
+    fireEvent.press(screen.getByRole('button', { name: 'Back' }));
+
+    expect(mockBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders Encounter History with an inline ScreenHeader back action', () => {
+    render(<DogEncountersScreen />);
+
+    expect(screen.getByRole('header', { name: 'Encounter History' })).toBeTruthy();
+    fireEvent.press(screen.getByRole('button', { name: 'Back' }));
+
+    expect(mockBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders Friends with an inline ScreenHeader back action', () => {
+    render(<DogFriendsScreen />);
+
+    expect(screen.getByRole('header', { name: 'Friends' })).toBeTruthy();
+    fireEvent.press(screen.getByRole('button', { name: 'Back' }));
+
+    expect(mockBack).toHaveBeenCalledTimes(1);
+  });
+});
+
+function expectStackHeaderHidden(name: string) {
+  const { __mockStackScreen } = jest.requireMock('expo-router') as {
+    __mockStackScreen: jest.Mock;
+  };
+  const call = __mockStackScreen.mock.calls.find(([props]) => props?.name === name);
+  expect(call?.[0]?.options?.headerShown).toBe(false);
+}

--- a/apps/mobile/__tests__/app/tabs/dogs.test.tsx
+++ b/apps/mobile/__tests__/app/tabs/dogs.test.tsx
@@ -60,7 +60,11 @@ describe('DogsScreen', () => {
 
   it('renders Dogs as the shared screen header', () => {
     render(<DogsScreen />);
+
     expect(screen.getByRole('header', { name: 'My Dogs' })).toBeTruthy();
+    expect(screen.getByTestId('dogs-header-large-title-row')).toBeTruthy();
+    expect(screen.getByTestId('dogs-header-left-action-slot')).toBeTruthy();
+    expect(screen.getByTestId('dogs-header-right-action-slot')).toBeTruthy();
   });
 
   it('renders Today walking goal rollup title', () => {

--- a/apps/mobile/__tests__/app/tabs/dogs.test.tsx
+++ b/apps/mobile/__tests__/app/tabs/dogs.test.tsx
@@ -58,9 +58,9 @@ describe('DogsScreen', () => {
     expect(screen.getByText('YOUR PACK')).toBeTruthy();
   });
 
-  it('renders Dogs heading', () => {
+  it('renders Dogs as the shared screen header', () => {
     render(<DogsScreen />);
-    expect(screen.getByText('My Dogs')).toBeTruthy();
+    expect(screen.getByRole('header', { name: 'My Dogs' })).toBeTruthy();
   });
 
   it('renders Today walking goal rollup title', () => {
@@ -70,6 +70,6 @@ describe('DogsScreen', () => {
 
   it('renders header + Add CTA', () => {
     render(<DogsScreen />);
-    expect(screen.getByRole('button', { name: 'Add Dog' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: '+ Add' })).toBeTruthy();
   });
 });

--- a/apps/mobile/__tests__/app/tabs/settings.test.tsx
+++ b/apps/mobile/__tests__/app/tabs/settings.test.tsx
@@ -45,8 +45,8 @@ jest.mock('@/components/settings/SignOutRow', () => ({
 }));
 
 describe('SettingsScreen', () => {
-  it('renders the Me large-title heading', () => {
+  it('renders Me as the shared screen header', () => {
     render(<SettingsScreen />);
-    expect(screen.getByText('Me')).toBeTruthy();
+    expect(screen.getByRole('header', { name: 'Me' })).toBeTruthy();
   });
 });

--- a/apps/mobile/__tests__/app/tabs/settings.test.tsx
+++ b/apps/mobile/__tests__/app/tabs/settings.test.tsx
@@ -47,6 +47,10 @@ jest.mock('@/components/settings/SignOutRow', () => ({
 describe('SettingsScreen', () => {
   it('renders Me as the shared screen header', () => {
     render(<SettingsScreen />);
+
     expect(screen.getByRole('header', { name: 'Me' })).toBeTruthy();
+    expect(screen.getByTestId('settings-header-large-title-row')).toBeTruthy();
+    expect(screen.getByTestId('settings-header-left-action-slot')).toBeTruthy();
+    expect(screen.getByTestId('settings-header-right-action-slot')).toBeTruthy();
   });
 });

--- a/apps/mobile/__tests__/app/tabs/walk.test.tsx
+++ b/apps/mobile/__tests__/app/tabs/walk.test.tsx
@@ -98,6 +98,7 @@ describe('Walk tab route', () => {
   it('shows the NoDogsBody CTA when there are zero dogs', () => {
     mockDogs = [];
     render(<WalkScreen />);
+    expect(screen.getByRole('header', { name: 'Walk' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Add your first dog' })).toBeTruthy();
   });
 

--- a/apps/mobile/app/(tabs)/dogs.tsx
+++ b/apps/mobile/app/(tabs)/dogs.tsx
@@ -1,4 +1,4 @@
-import { FlatList, Pressable, StyleSheet, Text, View } from 'react-native';
+import { FlatList, StyleSheet, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import { useDogsScreenViewModel } from '@/hooks/use-dogs-screen-view-model';
@@ -6,9 +6,10 @@ import { DogListItem } from '@/components/dogs/DogListItem';
 import { PackRollupCard } from '@/components/dogs/PackRollupCard';
 import { EmptyState } from '@/components/ui/EmptyState';
 import { LoadingScreen } from '@/components/ui/LoadingScreen';
+import { ScreenHeader } from '@/components/ui/ScreenHeader';
 import { SectionHeader } from '@/components/ui/SectionHeader';
 import { useColors } from '@/hooks/use-colors';
-import { spacing, typography } from '@/theme/tokens';
+import { spacing } from '@/theme/tokens';
 
 // 犬一覧タブは pack 全体の進捗と登録済み犬の一覧操作を view-model へ委譲します。
 export default function DogsScreen() {
@@ -18,25 +19,9 @@ export default function DogsScreen() {
 
   if (vm.isLoading) return <LoadingScreen />;
 
-  // 一覧の先頭には画面タイトル、追加導線、pack の集計カードをまとめて表示します。
+  // 一覧の先頭には pack の集計カードとセクション見出しをまとめて表示します。
   const ListHeader = (
     <View style={styles.headerContainer}>
-      <View style={styles.titleRow}>
-        <Text style={[styles.heroTitle, { color: theme.onSurface }]}>
-          {t('dogs.list.title')}
-        </Text>
-        <Pressable
-          accessibilityRole="button"
-          accessibilityLabel={t('dogs.list.addDog')}
-          onPress={vm.handleAddDog}
-          hitSlop={12}
-        >
-          <Text style={[styles.addCta, { color: theme.interactive }]}>
-            {t('dogs.list.addCta')}
-          </Text>
-        </Pressable>
-      </View>
-
       <View style={styles.rollupWrap}>
         <PackRollupCard
           todayKm={vm.pack.todayKm}
@@ -57,6 +42,10 @@ export default function DogsScreen() {
       edges={['top']}
       style={[styles.container, { backgroundColor: theme.background }]}
     >
+      <ScreenHeader
+        title={t('dogs.list.title')}
+        rightAction={{ label: t('dogs.list.addCta'), onPress: vm.handleAddDog }}
+      />
       <FlatList
         data={vm.dogs}
         keyExtractor={(dog) => dog.id}
@@ -90,18 +79,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing.lg,
     paddingTop: spacing.sm,
     paddingBottom: spacing.md,
-  },
-  titleRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    marginBottom: spacing.lg,
-  },
-  heroTitle: {
-    ...typography.largeTitle,
-  },
-  addCta: {
-    ...typography.body,
   },
   rollupWrap: {
     marginBottom: spacing.xl,

--- a/apps/mobile/app/(tabs)/dogs.tsx
+++ b/apps/mobile/app/(tabs)/dogs.tsx
@@ -44,6 +44,7 @@ export default function DogsScreen() {
     >
       <ScreenHeader
         title={t('dogs.list.title')}
+        testID="dogs-header"
         rightAction={{ label: t('dogs.list.addCta'), onPress: vm.handleAddDog }}
       />
       <FlatList

--- a/apps/mobile/app/(tabs)/settings.tsx
+++ b/apps/mobile/app/(tabs)/settings.tsx
@@ -1,11 +1,12 @@
-import { ScrollView, StyleSheet, Text } from 'react-native';
+import { ScrollView, StyleSheet } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import { useColors } from '@/hooks/use-colors';
-import { spacing, typography } from '@/theme/tokens';
+import { spacing } from '@/theme/tokens';
 import { useSettingsScreenViewModel } from '@/hooks/use-settings-screen-view-model';
 import { LoadingScreen } from '@/components/ui/LoadingScreen';
 import { ErrorScreen } from '@/components/ui/ErrorScreen';
+import { ScreenHeader } from '@/components/ui/ScreenHeader';
 import { ProfileCard } from '@/components/settings/ProfileCard';
 import { PreferencesSection } from '@/components/settings/PreferencesSection';
 import { LegalSection } from '@/components/settings/LegalSection';
@@ -25,11 +26,8 @@ export default function SettingsScreen() {
 
   return (
     <SafeAreaView edges={['top']} style={[styles.safeArea, { backgroundColor: theme.background }]}>
+      <ScreenHeader title={t('settings.title')} />
       <ScrollView style={styles.container} contentContainerStyle={styles.content}>
-        <Text style={[styles.heroTitle, { color: theme.onSurface }]}>
-          {t('settings.title')}
-        </Text>
-
         <ProfileCard displayName={vm.me.name ?? vm.me.displayName ?? null} />
         <PreferencesSection />
         <LegalSection />
@@ -45,9 +43,5 @@ const styles = StyleSheet.create({
   content: {
     padding: spacing.lg,
     paddingBottom: spacing.xxl,
-  },
-  heroTitle: {
-    ...typography.largeTitle,
-    marginBottom: spacing.lg,
   },
 });

--- a/apps/mobile/app/(tabs)/settings.tsx
+++ b/apps/mobile/app/(tabs)/settings.tsx
@@ -26,7 +26,7 @@ export default function SettingsScreen() {
 
   return (
     <SafeAreaView edges={['top']} style={[styles.safeArea, { backgroundColor: theme.background }]}>
-      <ScreenHeader title={t('settings.title')} />
+      <ScreenHeader title={t('settings.title')} testID="settings-header" />
       <ScrollView style={styles.container} contentContainerStyle={styles.content}>
         <ProfileCard displayName={vm.me.name ?? vm.me.displayName ?? null} />
         <PreferencesSection />

--- a/apps/mobile/app/(tabs)/walk.tsx
+++ b/apps/mobile/app/(tabs)/walk.tsx
@@ -1,22 +1,31 @@
 import { StyleSheet } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { useTranslation } from 'react-i18next';
 import { useColors } from '@/hooks/use-colors';
 import { useWalkScreenViewModel } from '@/hooks/use-walk-screen-view-model';
+import { ScreenHeader } from '@/components/ui/ScreenHeader';
 import { WalkReadyView } from '@/components/walk/WalkReadyView';
 import { WalkSummaryCard } from '@/components/walk/WalkSummaryCard';
 
 // 散歩タブは現在の散歩フェーズに応じて、開始前または終了後サマリーを表示します。
 export default function WalkScreen() {
+  const { t } = useTranslation();
   const theme = useColors();
   const vm = useWalkScreenViewModel();
 
   if (vm.phase === 'ready') {
     // 開始前はマップ付きの準備画面に開始操作を委譲します。
-    return <WalkReadyView onStart={vm.handleStart} isStarting={vm.isStarting} />;
+    return (
+      <SafeAreaView edges={['top']} style={[styles.container, { backgroundColor: theme.background }]}>
+        <ScreenHeader title={t('tabs.walk')} />
+        <WalkReadyView onStart={vm.handleStart} isStarting={vm.isStarting} />
+      </SafeAreaView>
+    );
   }
 
   return (
     <SafeAreaView edges={['top']} style={[styles.container, { backgroundColor: theme.background }]}>
+      <ScreenHeader title={t('tabs.walk')} />
       {vm.phase === 'finished' && <WalkSummaryCard />}
     </SafeAreaView>
   );

--- a/apps/mobile/app/dogs/[id]/_layout.tsx
+++ b/apps/mobile/app/dogs/[id]/_layout.tsx
@@ -1,38 +1,15 @@
 import { Stack } from 'expo-router';
-import { useTranslation } from 'react-i18next';
-import { useColors } from '@/hooks/use-colors';
 
 // 犬詳細配下の編集、メンバー、友達、遭遇履歴 route のヘッダー設定を集約します。
 export default function DogDetailLayout() {
-  const { t } = useTranslation();
-  const theme = useColors();
-
   return (
     <Stack>
       <Stack.Screen name="index" options={{ headerShown: false }} />
       <Stack.Screen name="edit" options={{ headerShown: false }} />
-      <Stack.Screen
-        name="members"
-        options={{
-          title: t('dogs.members.title'),
-          headerStyle: { backgroundColor: theme.background },
-        }}
-      />
-      <Stack.Screen
-        name="friends/index"
-        options={{
-          title: t('dogs.friends.title', 'Friends'),
-          headerStyle: { backgroundColor: theme.background },
-        }}
-      />
+      <Stack.Screen name="members" options={{ headerShown: false }} />
+      <Stack.Screen name="friends/index" options={{ headerShown: false }} />
       {/* friends/[friendDogId] は Expo Router の自動検出に任せ、既定の Stack ヘッダー（戻るボタン付き）を使います。 */}
-      <Stack.Screen
-        name="encounters"
-        options={{
-          title: t('dogs.encounters.title', 'Encounter History'),
-          headerStyle: { backgroundColor: theme.background },
-        }}
-      />
+      <Stack.Screen name="encounters" options={{ headerShown: false }} />
     </Stack>
   );
 }

--- a/apps/mobile/app/dogs/[id]/edit.tsx
+++ b/apps/mobile/app/dogs/[id]/edit.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { ScrollView, StyleSheet } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
@@ -13,10 +13,11 @@ import {
   type DogFormValues,
 } from '@/components/dogs/DogForm';
 import { LoadingScreen } from '@/components/ui/LoadingScreen';
+import { ScreenHeader } from '@/components/ui/ScreenHeader';
 import { useColors } from '@/hooks/use-colors';
-import { spacing, typography } from '@/theme/tokens';
+import { spacing } from '@/theme/tokens';
 
-// 犬編集画面 — 02b. Dog edit に合わせた Cancel/Save の自前 nav bar を持つ。
+// 犬編集画面 — inline ScreenHeader でフォームの Cancel/Save を提供します。
 // dog データのロード待ちは外側、form state 初期化は内側コンポーネントに分離して
 // React Hooks ルールを守りつつ initial values を一発で確定する。
 export default function EditDogScreen() {
@@ -76,36 +77,17 @@ function EditDogContent({ id, initialValues }: EditDogContentProps) {
 
   return (
     <SafeAreaView edges={['top']} style={[styles.safeArea, { backgroundColor: theme.background }]}>
-      <View style={styles.navBar}>
-        <Pressable
-          onPress={() => router.back()}
-          hitSlop={12}
-          accessibilityRole="button"
-          accessibilityLabel={t('dogs.action.cancel')}
-        >
-          <Text style={[styles.navAction, { color: theme.interactive }]}>
-            {t('dogs.action.cancel')}
-          </Text>
-        </Pressable>
-        <Text style={[styles.navTitle, { color: theme.onSurface }]}>{t('dogs.edit.title')}</Text>
-        <Pressable
-          onPress={handleSave}
-          disabled={!canSave}
-          hitSlop={12}
-          accessibilityRole="button"
-          accessibilityLabel={t('dogs.action.save')}
-          accessibilityState={{ disabled: !canSave }}
-        >
-          <Text
-            style={[
-              styles.navActionStrong,
-              { color: canSave ? theme.interactive : theme.textDisabled },
-            ]}
-          >
-            {t('dogs.action.save')}
-          </Text>
-        </Pressable>
-      </View>
+      <ScreenHeader
+        variant="inline"
+        title={t('dogs.edit.title')}
+        leftAction={{ label: t('common.action.cancel'), onPress: () => router.back() }}
+        rightAction={{
+          label: t('common.action.save'),
+          onPress: handleSave,
+          strong: true,
+          disabled: !canSave,
+        }}
+      />
       <ScrollView
         contentContainerStyle={styles.scrollContent}
         keyboardShouldPersistTaps="handled"
@@ -118,16 +100,5 @@ function EditDogContent({ id, initialValues }: EditDogContentProps) {
 
 const styles = StyleSheet.create({
   safeArea: { flex: 1 },
-  navBar: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    paddingHorizontal: spacing.md,
-    paddingVertical: spacing.step12,
-    minHeight: spacing.step44,
-  },
-  navTitle: { ...typography.headline },
-  navAction: { ...typography.body },
-  navActionStrong: { ...typography.body, fontWeight: typography.headline.fontWeight },
   scrollContent: { flexGrow: 1, padding: spacing.lg },
 });

--- a/apps/mobile/app/dogs/[id]/encounters.tsx
+++ b/apps/mobile/app/dogs/[id]/encounters.tsx
@@ -1,12 +1,14 @@
-import { FlatList, StyleSheet, Text, View } from 'react-native';
+import { FlatList, StyleSheet } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { useLocalSearchParams } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useDogEncounters } from '@/hooks/use-dog-encounters';
 import { EncounterCard } from '@/components/dogs/EncounterCard';
 import { LoadingScreen } from '@/components/ui/LoadingScreen';
 import { EmptyState } from '@/components/ui/EmptyState';
+import { ScreenHeader } from '@/components/ui/ScreenHeader';
 import { useColors } from '@/hooks/use-colors';
-import { spacing, typography } from '@/theme/tokens';
+import { spacing } from '@/theme/tokens';
 import type { Encounter } from '@/types/graphql';
 
 // 遭遇履歴画面は指定された犬 ID の encounter 一覧を取得して時系列カードで表示します。
@@ -20,16 +22,12 @@ export default function DogEncountersScreen() {
   if (isLoading) return <LoadingScreen />;
 
   return (
-    <View style={[styles.container, { backgroundColor: theme.background }]}>
-      <View style={styles.header}>
-        <Text style={[styles.sectionLabel, { color: theme.onSurfaceVariant }]}>
-          {t('dogs.encounters.sectionLabel', 'HISTORY').toUpperCase()}
-        </Text>
-        <Text style={[styles.heroTitle, { color: theme.onSurface }]}>
-          {t('dogs.encounters.title', 'Encounters')}
-        </Text>
-      </View>
-
+    <SafeAreaView edges={['top']} style={[styles.container, { backgroundColor: theme.background }]}>
+      <ScreenHeader
+        variant="inline"
+        title={t('dogs.encounters.title')}
+        leftAction="back"
+      />
       {!encounters || encounters.length === 0 ? (
         // まだ散歩中の遭遇がない場合は、履歴リストの代わりに空状態を表示します。
         <EmptyState
@@ -45,25 +43,15 @@ export default function DogEncountersScreen() {
           contentContainerStyle={styles.list}
         />
       )}
-    </View>
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
   container: { flex: 1 },
-  header: {
-    padding: spacing.lg,
-    paddingBottom: spacing.md,
-  },
-  sectionLabel: {
-    ...typography.metricLabel,
-    marginBottom: spacing.xs,
-  },
-  heroTitle: {
-    ...typography.title1,
-  },
   list: {
     paddingHorizontal: spacing.lg,
+    paddingTop: spacing.lg,
     paddingBottom: spacing.xxl,
   },
 });

--- a/apps/mobile/app/dogs/[id]/friends/index.tsx
+++ b/apps/mobile/app/dogs/[id]/friends/index.tsx
@@ -1,12 +1,14 @@
-import { FlatList, StyleSheet, Text, View } from 'react-native';
+import { FlatList, StyleSheet } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useDogFriends } from '@/hooks/use-dog-friends';
 import { FriendCard } from '@/components/dogs/FriendCard';
 import { LoadingScreen } from '@/components/ui/LoadingScreen';
 import { EmptyState } from '@/components/ui/EmptyState';
+import { ScreenHeader } from '@/components/ui/ScreenHeader';
 import { useColors } from '@/hooks/use-colors';
-import { spacing, typography } from '@/theme/tokens';
+import { spacing } from '@/theme/tokens';
 import type { Friendship } from '@/types/graphql';
 
 // 友達一覧画面は遭遇から生まれた犬同士の関係を一覧化し、個別詳細へつなげます。
@@ -21,16 +23,12 @@ export default function DogFriendsScreen() {
   if (isLoading) return <LoadingScreen />;
 
   return (
-    <View style={[styles.container, { backgroundColor: theme.background }]}>
-      <View style={styles.header}>
-        <Text style={[styles.sectionLabel, { color: theme.onSurfaceVariant }]}>
-          {t('dogs.friends.sectionLabel', 'FRIENDS').toUpperCase()}
-        </Text>
-        <Text style={[styles.heroTitle, { color: theme.onSurface }]}>
-          {t('dogs.friends.title', 'Friends')}
-        </Text>
-      </View>
-
+    <SafeAreaView edges={['top']} style={[styles.container, { backgroundColor: theme.background }]}>
+      <ScreenHeader
+        variant="inline"
+        title={t('dogs.friends.title')}
+        leftAction="back"
+      />
       {!friends || friends.length === 0 ? (
         // 友達がまだいない場合は、散歩開始を促す空状態だけを表示します。
         <EmptyState
@@ -49,25 +47,15 @@ export default function DogFriendsScreen() {
           contentContainerStyle={styles.list}
         />
       )}
-    </View>
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
   container: { flex: 1 },
-  header: {
-    padding: spacing.lg,
-    paddingBottom: spacing.md,
-  },
-  sectionLabel: {
-    ...typography.metricLabel,
-    marginBottom: spacing.xs,
-  },
-  heroTitle: {
-    ...typography.title1,
-  },
   list: {
     paddingHorizontal: spacing.lg,
+    paddingTop: spacing.lg,
     paddingBottom: spacing.xxl,
   },
 });

--- a/apps/mobile/app/dogs/[id]/members.tsx
+++ b/apps/mobile/app/dogs/[id]/members.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { ScrollView, Share, StyleSheet, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useDog } from '@/hooks/use-dog';
@@ -14,6 +15,7 @@ import { DogMembersList } from '@/components/dogs/DogMembersList';
 import { Button } from '@/components/ui/Button';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { LoadingScreen } from '@/components/ui/LoadingScreen';
+import { ScreenHeader } from '@/components/ui/ScreenHeader';
 import { useColors } from '@/hooks/use-colors';
 import { spacing } from '@/theme/tokens';
 
@@ -76,33 +78,40 @@ export default function DogMembersScreen() {
   }
 
   return (
-    <ScrollView style={[styles.container, { backgroundColor: theme.background }]}>
-      <View style={styles.listSection}>
-        <DogMembersList
-          members={members}
-          currentUserId={currentUserId}
-          isOwner={isOwner}
-          onRemove={(userId, name) => setConfirmRemove({ userId, name })}
-        />
-      </View>
+    <SafeAreaView edges={['top']} style={[styles.safeArea, { backgroundColor: theme.background }]}>
+      <ScreenHeader
+        variant="inline"
+        title={t('dogs.members.title')}
+        leftAction="back"
+      />
+      <ScrollView style={styles.container}>
+        <View style={styles.listSection}>
+          <DogMembersList
+            members={members}
+            currentUserId={currentUserId}
+            isOwner={isOwner}
+            onRemove={(userId, name) => setConfirmRemove({ userId, name })}
+          />
+        </View>
 
-      <View style={styles.actions}>
-        {/* owner は招待、member は退出だけを表示して誤操作を防ぎます。 */}
-        {isOwner ? (
-          <Button
-            label={t('dogs.members.invite')}
-            onPress={handleInvite}
-            loading={generateInvitation.isPending}
-          />
-        ) : (
-          <Button
-            label={t('dogs.members.leave')}
-            variant="destructive"
-            onPress={() => setShowLeaveConfirm(true)}
-            loading={leaveDog.isPending}
-          />
-        )}
-      </View>
+        <View style={styles.actions}>
+          {/* owner は招待、member は退出だけを表示して誤操作を防ぎます。 */}
+          {isOwner ? (
+            <Button
+              label={t('dogs.members.invite')}
+              onPress={handleInvite}
+              loading={generateInvitation.isPending}
+            />
+          ) : (
+            <Button
+              label={t('dogs.members.leave')}
+              variant="destructive"
+              onPress={() => setShowLeaveConfirm(true)}
+              loading={leaveDog.isPending}
+            />
+          )}
+        </View>
+      </ScrollView>
 
       <ConfirmDialog
         visible={confirmRemove !== null}
@@ -123,11 +132,12 @@ export default function DogMembersScreen() {
         onCancel={() => setShowLeaveConfirm(false)}
         destructive
       />
-    </ScrollView>
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
+  safeArea: { flex: 1 },
   container: { flex: 1 },
   listSection: { padding: spacing.lg },
   actions: { padding: spacing.lg, paddingTop: spacing.xs - spacing.xs },

--- a/apps/mobile/app/dogs/new.tsx
+++ b/apps/mobile/app/dogs/new.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { ScrollView, StyleSheet } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
@@ -10,10 +10,11 @@ import {
   isDogFormValid,
   type DogFormValues,
 } from '@/components/dogs/DogForm';
+import { ScreenHeader } from '@/components/ui/ScreenHeader';
 import { useColors } from '@/hooks/use-colors';
-import { spacing, typography } from '@/theme/tokens';
+import { spacing } from '@/theme/tokens';
 
-// 新規犬登録画面 — 02b. Dog edit に合わせた Cancel/Save の自前 nav bar を持つ。
+// 新規犬登録画面 — inline ScreenHeader でフォームの Cancel/Save を提供します。
 export default function NewDogScreen() {
   const { t } = useTranslation();
   const router = useRouter();
@@ -52,36 +53,17 @@ export default function NewDogScreen() {
 
   return (
     <SafeAreaView edges={['top']} style={[styles.safeArea, { backgroundColor: theme.background }]}>
-      <View style={styles.navBar}>
-        <Pressable
-          onPress={() => router.back()}
-          hitSlop={12}
-          accessibilityRole="button"
-          accessibilityLabel={t('dogs.action.cancel')}
-        >
-          <Text style={[styles.navAction, { color: theme.interactive }]}>
-            {t('dogs.action.cancel')}
-          </Text>
-        </Pressable>
-        <Text style={[styles.navTitle, { color: theme.onSurface }]}>{t('dogs.new.title')}</Text>
-        <Pressable
-          onPress={handleSave}
-          disabled={!canSave}
-          hitSlop={12}
-          accessibilityRole="button"
-          accessibilityLabel={t('dogs.action.save')}
-          accessibilityState={{ disabled: !canSave }}
-        >
-          <Text
-            style={[
-              styles.navActionStrong,
-              { color: canSave ? theme.interactive : theme.textDisabled },
-            ]}
-          >
-            {t('dogs.action.save')}
-          </Text>
-        </Pressable>
-      </View>
+      <ScreenHeader
+        variant="inline"
+        title={t('dogs.new.title')}
+        leftAction={{ label: t('common.action.cancel'), onPress: () => router.back() }}
+        rightAction={{
+          label: t('common.action.save'),
+          onPress: handleSave,
+          strong: true,
+          disabled: !canSave,
+        }}
+      />
       <ScrollView
         contentContainerStyle={styles.scrollContent}
         keyboardShouldPersistTaps="handled"
@@ -94,16 +76,5 @@ export default function NewDogScreen() {
 
 const styles = StyleSheet.create({
   safeArea: { flex: 1 },
-  navBar: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    paddingHorizontal: spacing.md,
-    paddingVertical: spacing.step12,
-    minHeight: spacing.step44,
-  },
-  navTitle: { ...typography.headline },
-  navAction: { ...typography.body },
-  navActionStrong: { ...typography.body, fontWeight: typography.headline.fontWeight },
   scrollContent: { flexGrow: 1, padding: spacing.lg },
 });

--- a/apps/mobile/components/ui/ScreenHeader.test.tsx
+++ b/apps/mobile/components/ui/ScreenHeader.test.tsx
@@ -32,20 +32,21 @@ describe('ScreenHeader', () => {
     render(<ScreenHeader title="My Dogs" testID="header" />);
 
     const title = screen.getByRole('header', { name: 'My Dogs' });
-    const header = getTestNode('header');
+    const actionRow = screen.getByTestId('header-action-row');
+    const titleRow = screen.getByTestId('header-large-title-row');
 
     expect(title).toBeTruthy();
+    expect(actionRow).toBeTruthy();
+    expect(titleRow).toBeTruthy();
     expect(flattenStyle(title.props.style).fontSize).toBe(
       typography.largeTitle.fontSize,
     );
-    expect(header.children).toHaveLength(2);
   });
 
   it('keeps the largeTitle action row and slot frames when no actions are provided', () => {
     render(<ScreenHeader title="Me" testID="header" />);
 
-    const header = getTestNode('header');
-    const actionRow = childAt(header, 0);
+    const actionRow = screen.getByTestId('header-action-row');
     const leftSlot = screen.getByTestId('header-left-action-slot');
     const rightSlot = screen.getByTestId('header-right-action-slot');
 
@@ -53,18 +54,33 @@ describe('ScreenHeader', () => {
     expect(screen.getByRole('header', { name: 'Me' })).toBeTruthy();
     expect(flattenStyle(actionRow.props.style).height).toBe(layout.navBar);
     expect(flattenStyle(leftSlot.props.style).minWidth).toBe(spacing.step60);
+    expect(flattenStyle(leftSlot.props.style).minHeight).toBe(layout.navBar);
     expect(flattenStyle(rightSlot.props.style).minWidth).toBe(spacing.step60);
+    expect(flattenStyle(rightSlot.props.style).minHeight).toBe(layout.navBar);
   });
 
   it('renders inline as one row with header title typography', () => {
     render(<ScreenHeader variant="inline" title="Edit dog" testID="header" />);
 
-    const header = getTestNode('header');
+    const actionRow = screen.getByTestId('header-action-row');
     const title = screen.getByRole('header', { name: 'Edit dog' });
 
-    expect(header.children).toHaveLength(1);
+    expect(actionRow).toBeTruthy();
+    expect(screen.queryByTestId('header-large-title-row')).toBeNull();
+    expect(flattenStyle(actionRow.props.style).height).toBe(layout.navBar);
     expect(title).toBeTruthy();
     expect(flattenStyle(title.props.style).fontSize).toBe(typography.headline.fontSize);
+  });
+
+  it('renders the back shortcut in largeTitle variant', () => {
+    render(<ScreenHeader title="Detail" leftAction="back" testID="header" />);
+
+    expect(screen.getByText('chevron.backward')).toBeTruthy();
+    expect(screen.getByTestId('header-left-action-slot')).toBeTruthy();
+
+    fireEvent.press(screen.getByRole('button', { name: 'Back' }));
+
+    expect(mockBack).toHaveBeenCalledTimes(1);
   });
 
   it('renders the English back shortcut with chevron and calls router.back', () => {
@@ -94,9 +110,11 @@ describe('ScreenHeader', () => {
       />,
     );
 
+    const label = screen.getByText('Cancel');
     fireEvent.press(screen.getByRole('button', { name: 'Cancel' }));
 
     expect(onPress).toHaveBeenCalledTimes(1);
+    expect(flattenStyle(label.props.style).color).toBe(colors.light.interactive);
   });
 
   it('renders a strong right action with headline font weight', () => {
@@ -135,14 +153,29 @@ describe('ScreenHeader', () => {
     expect(flattenStyle(label.props.style).color).toBe(colors.light.textDisabled);
   });
 
-  it('renders no buttons when both actions are null while keeping the header visible', () => {
+  it('lets disabled visual state override strong emphasis', () => {
+    const onPress = jest.fn();
     render(
       <ScreenHeader
-        title="Me"
-        leftAction={null}
-        rightAction={null}
+        variant="inline"
+        title="Register dog"
+        rightAction={{ label: 'Save', onPress, strong: true, disabled: true }}
       />,
     );
+
+    const button = screen.getByRole('button', { name: 'Save' });
+    const labelStyle = flattenStyle(screen.getByText('Save').props.style);
+
+    fireEvent.press(button);
+
+    expect(onPress).not.toHaveBeenCalled();
+    expect(button.props.accessibilityState?.disabled).toBe(true);
+    expect(labelStyle.color).toBe(colors.light.textDisabled);
+    expect(labelStyle.fontWeight).toBe(typography.body.fontWeight);
+  });
+
+  it('renders no buttons when actions are omitted while keeping the header visible', () => {
+    render(<ScreenHeader title="Me" />);
 
     expect(screen.queryByRole('button')).toBeNull();
     expect(screen.getByRole('header', { name: 'Me' })).toBeTruthy();
@@ -163,27 +196,24 @@ describe('ScreenHeader', () => {
 
     expect(cancel.props.accessibilityLabel).toBe('Cancel');
     expect(save.props.accessibilityLabel).toBe('Save');
-    expect(cancel.props.hitSlop).toBe(12);
-    expect(save.props.hitSlop).toBe(12);
+    expect(cancel.props.hitSlop).toBe(spacing.step12);
+    expect(save.props.hitSlop).toBe(spacing.step12);
     expect(flattenStyle(cancel.props.style).minHeight).toBe(layout.navBar);
     expect(flattenStyle(save.props.style).minHeight).toBe(layout.navBar);
   });
+
+  it('applies the largeTitle row vertical padding tokens', () => {
+    render(<ScreenHeader title="Dogs" testID="header" />);
+
+    const titleRow = screen.getByTestId('header-large-title-row');
+    const rowStyle = flattenStyle(titleRow.props.style);
+
+    expect(rowStyle.paddingTop).toBe(spacing.step6);
+    expect(rowStyle.paddingBottom).toBe(spacing.step10);
+  });
 });
 
-interface TestNode {
-  props: Record<string, unknown>;
-  children: unknown[];
-}
-
 type StyleRecord = Record<string, unknown>;
-
-function getTestNode(testID: string): TestNode {
-  return screen.getByTestId(testID) as unknown as TestNode;
-}
-
-function childAt(node: TestNode, index: number): TestNode {
-  return node.children[index] as TestNode;
-}
 
 function flattenStyle(style: unknown): StyleRecord {
   const flattened = StyleSheet.flatten(style);

--- a/apps/mobile/components/ui/ScreenHeader.test.tsx
+++ b/apps/mobile/components/ui/ScreenHeader.test.tsx
@@ -1,0 +1,191 @@
+import { StyleSheet } from 'react-native';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { changeLanguage } from 'i18next';
+import { colors, layout, spacing, typography } from '@/theme/tokens';
+import { ScreenHeader } from './ScreenHeader';
+
+const mockBack = jest.fn();
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ back: mockBack }),
+}));
+
+jest.mock('@/hooks/use-color-scheme', () => ({
+  useColorScheme: () => 'light',
+}));
+
+jest.mock('@/components/ui/icon-symbol', () => {
+  const { Text } = jest.requireActual<typeof import('react-native')>('react-native');
+
+  return {
+    IconSymbol: ({ name }: { name: string }) => <Text>{name}</Text>,
+  };
+});
+
+describe('ScreenHeader', () => {
+  beforeEach(async () => {
+    mockBack.mockClear();
+    await changeLanguage('en');
+  });
+
+  it('renders the default largeTitle title as a header with large title typography', () => {
+    render(<ScreenHeader title="My Dogs" testID="header" />);
+
+    const title = screen.getByRole('header', { name: 'My Dogs' });
+    const header = getTestNode('header');
+
+    expect(title).toBeTruthy();
+    expect(flattenStyle(title.props.style).fontSize).toBe(
+      typography.largeTitle.fontSize,
+    );
+    expect(header.children).toHaveLength(2);
+  });
+
+  it('keeps the largeTitle action row and slot frames when no actions are provided', () => {
+    render(<ScreenHeader title="Me" testID="header" />);
+
+    const header = getTestNode('header');
+    const actionRow = childAt(header, 0);
+    const leftSlot = screen.getByTestId('header-left-action-slot');
+    const rightSlot = screen.getByTestId('header-right-action-slot');
+
+    expect(screen.queryByRole('button')).toBeNull();
+    expect(screen.getByRole('header', { name: 'Me' })).toBeTruthy();
+    expect(flattenStyle(actionRow.props.style).height).toBe(layout.navBar);
+    expect(flattenStyle(leftSlot.props.style).minWidth).toBe(spacing.step60);
+    expect(flattenStyle(rightSlot.props.style).minWidth).toBe(spacing.step60);
+  });
+
+  it('renders inline as one row with header title typography', () => {
+    render(<ScreenHeader variant="inline" title="Edit dog" testID="header" />);
+
+    const header = getTestNode('header');
+    const title = screen.getByRole('header', { name: 'Edit dog' });
+
+    expect(header.children).toHaveLength(1);
+    expect(title).toBeTruthy();
+    expect(flattenStyle(title.props.style).fontSize).toBe(typography.headline.fontSize);
+  });
+
+  it('renders the English back shortcut with chevron and calls router.back', () => {
+    render(<ScreenHeader variant="inline" title="Members" leftAction="back" />);
+
+    expect(screen.getByText('chevron.backward')).toBeTruthy();
+    fireEvent.press(screen.getByRole('button', { name: 'Back' }));
+
+    expect(mockBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the Japanese back shortcut label from i18n', async () => {
+    await changeLanguage('ja');
+
+    render(<ScreenHeader variant="inline" title="メンバー" leftAction="back" />);
+
+    expect(screen.getByRole('button', { name: '戻る' })).toBeTruthy();
+  });
+
+  it('calls a custom left action once when pressed', () => {
+    const onPress = jest.fn();
+    render(
+      <ScreenHeader
+        variant="inline"
+        title="Register dog"
+        leftAction={{ label: 'Cancel', onPress }}
+      />,
+    );
+
+    fireEvent.press(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders a strong right action with headline font weight', () => {
+    render(
+      <ScreenHeader
+        variant="inline"
+        title="Register dog"
+        rightAction={{ label: 'Save', onPress: jest.fn(), strong: true }}
+      />,
+    );
+
+    const label = screen.getByText('Save');
+
+    expect(flattenStyle(label.props.style).fontWeight).toBe(
+      typography.headline.fontWeight,
+    );
+  });
+
+  it('disables a disabled right action visually and semantically', () => {
+    const onPress = jest.fn();
+    render(
+      <ScreenHeader
+        variant="inline"
+        title="Register dog"
+        rightAction={{ label: 'Save', onPress, disabled: true }}
+      />,
+    );
+
+    const button = screen.getByRole('button', { name: 'Save' });
+    const label = screen.getByText('Save');
+
+    fireEvent.press(button);
+
+    expect(onPress).not.toHaveBeenCalled();
+    expect(button.props.accessibilityState?.disabled).toBe(true);
+    expect(flattenStyle(label.props.style).color).toBe(colors.light.textDisabled);
+  });
+
+  it('renders no buttons when both actions are null while keeping the header visible', () => {
+    render(
+      <ScreenHeader
+        title="Me"
+        leftAction={null}
+        rightAction={null}
+      />,
+    );
+
+    expect(screen.queryByRole('button')).toBeNull();
+    expect(screen.getByRole('header', { name: 'Me' })).toBeTruthy();
+  });
+
+  it('gives every action an accessibility role, label, hit slop, and 44pt target', () => {
+    render(
+      <ScreenHeader
+        variant="inline"
+        title="Edit dog"
+        leftAction={{ label: 'Cancel', onPress: jest.fn() }}
+        rightAction={{ label: 'Save', onPress: jest.fn() }}
+      />,
+    );
+
+    const cancel = screen.getByRole('button', { name: 'Cancel' });
+    const save = screen.getByRole('button', { name: 'Save' });
+
+    expect(cancel.props.accessibilityLabel).toBe('Cancel');
+    expect(save.props.accessibilityLabel).toBe('Save');
+    expect(cancel.props.hitSlop).toBe(12);
+    expect(save.props.hitSlop).toBe(12);
+    expect(flattenStyle(cancel.props.style).minHeight).toBe(layout.navBar);
+    expect(flattenStyle(save.props.style).minHeight).toBe(layout.navBar);
+  });
+});
+
+interface TestNode {
+  props: Record<string, unknown>;
+  children: unknown[];
+}
+
+type StyleRecord = Record<string, unknown>;
+
+function getTestNode(testID: string): TestNode {
+  return screen.getByTestId(testID) as unknown as TestNode;
+}
+
+function childAt(node: TestNode, index: number): TestNode {
+  return node.children[index] as TestNode;
+}
+
+function flattenStyle(style: unknown): StyleRecord {
+  const flattened = StyleSheet.flatten(style);
+  return flattened && typeof flattened === 'object' ? (flattened as StyleRecord) : {};
+}

--- a/apps/mobile/components/ui/ScreenHeader.tsx
+++ b/apps/mobile/components/ui/ScreenHeader.tsx
@@ -1,0 +1,250 @@
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { useRouter } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { useColors } from '@/hooks/use-colors';
+import { layout, spacing, typography } from '@/theme/tokens';
+import { IconSymbol } from './icon-symbol';
+
+export interface ScreenHeaderProps {
+  /** 表示タイトル。i18n 済みの文字列を渡す。 */
+  title: string;
+
+  /**
+   * - `'largeTitle'` (default): 2-row. Row 1 reserves 44px frame with left/right
+   *   action slots (each minWidth: spacing.step60). Row 2 shows the title with
+   *   `typography.largeTitle`, padding top spacing.step6 bottom spacing.step10.
+   * - `'inline'`: 1-row, height layout.navBar (44px). Title centered with
+   *   `typography.headline`.
+   */
+  variant?: 'largeTitle' | 'inline';
+
+  /**
+   * - `null` / undefined: no button, but the slot frame is still rendered to
+   *   preserve row height.
+   * - `'back'`: SF Symbol chevron.backward + t('common.action.back'). Pressing
+   *   it calls router.back() from useRouter().
+   * - object: explicit label and onPress.
+   */
+  leftAction?: ScreenHeaderAction | 'back' | null;
+
+  /**
+   * - `null` / undefined: no button, frame still rendered.
+   * - object: explicit label and onPress. `strong: true` applies
+   *   `typography.headline.fontWeight` ('600').
+   */
+  rightAction?: ScreenHeaderAction | null;
+
+  /** Wrapper testID. */
+  testID?: string;
+}
+
+export interface ScreenHeaderAction {
+  label: string;
+  onPress: () => void;
+  /** fontWeight '600' for primary CTAs like Save. default: false */
+  strong?: boolean;
+  /** Disabled visual + accessibilityState.disabled. onPress is not called. */
+  disabled?: boolean;
+}
+
+interface ResolvedScreenHeaderAction extends ScreenHeaderAction {
+  icon?: 'chevron.backward';
+}
+
+type ActionSide = 'left' | 'right';
+
+export function ScreenHeader({
+  title,
+  variant = 'largeTitle',
+  leftAction,
+  rightAction,
+  testID,
+}: ScreenHeaderProps) {
+  const router = useRouter();
+  const { t } = useTranslation();
+  const theme = useColors();
+  const resolvedLeftAction =
+    leftAction === 'back'
+      ? {
+          label: t('common.action.back'),
+          onPress: () => router.back(),
+          icon: 'chevron.backward' as const,
+        }
+      : leftAction ?? null;
+  const resolvedRightAction = rightAction ?? null;
+
+  const renderActionSlot = (
+    action: ResolvedScreenHeaderAction | null,
+    side: ActionSide,
+    inline: boolean,
+    slotTestID?: string,
+  ) => {
+    const isDisabled = action?.disabled === true;
+    const actionColor = isDisabled ? theme.textDisabled : theme.interactive;
+
+    return (
+      <View
+        testID={slotTestID}
+        style={[
+          styles.actionSlot,
+          inline ? styles.inlineActionSlot : null,
+          side === 'left' ? styles.leftSlot : styles.rightSlot,
+        ]}
+      >
+        {action ? (
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={action.label}
+            accessibilityState={{ disabled: isDisabled }}
+            disabled={isDisabled}
+            hitSlop={spacing.step12}
+            onPress={action.onPress}
+            style={[
+              styles.actionButton,
+              side === 'left' ? styles.leftActionButton : styles.rightActionButton,
+            ]}
+          >
+            {action.icon ? (
+              <IconSymbol
+                name={action.icon}
+                size={typography.body.fontSize}
+                color={actionColor}
+              />
+            ) : null}
+            <Text
+              style={[
+                styles.actionLabel,
+                action.strong === true ? styles.strongActionLabel : null,
+                { color: actionColor },
+              ]}
+            >
+              {action.label}
+            </Text>
+          </Pressable>
+        ) : null}
+      </View>
+    );
+  };
+
+  if (variant === 'inline') {
+    return (
+      <View testID={testID}>
+        <View style={styles.inlineRow}>
+          {renderActionSlot(
+            resolvedLeftAction,
+            'left',
+            true,
+            slotTestID(testID, 'left'),
+          )}
+          <Text
+            accessibilityRole="header"
+            numberOfLines={1}
+            style={[styles.inlineTitle, { color: theme.onSurface }]}
+          >
+            {title}
+          </Text>
+          {renderActionSlot(
+            resolvedRightAction,
+            'right',
+            true,
+            slotTestID(testID, 'right'),
+          )}
+        </View>
+      </View>
+    );
+  }
+
+  return (
+    <View testID={testID}>
+      <View style={styles.largeTitleActionRow}>
+        {renderActionSlot(
+          resolvedLeftAction,
+          'left',
+          false,
+          slotTestID(testID, 'left'),
+        )}
+        {renderActionSlot(
+          resolvedRightAction,
+          'right',
+          false,
+          slotTestID(testID, 'right'),
+        )}
+      </View>
+      <View style={styles.largeTitleRow}>
+        <Text
+          accessibilityRole="header"
+          numberOfLines={1}
+          style={[styles.largeTitle, { color: theme.onSurface }]}
+        >
+          {title}
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+function slotTestID(testID: string | undefined, side: ActionSide): string | undefined {
+  return testID ? `${testID}-${side}-action-slot` : undefined;
+}
+
+const styles = StyleSheet.create({
+  largeTitleActionRow: {
+    height: layout.navBar,
+    paddingHorizontal: spacing.md,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  largeTitleRow: {
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.step6,
+    paddingBottom: spacing.step10,
+  },
+  largeTitle: {
+    ...typography.largeTitle,
+  },
+  inlineRow: {
+    height: layout.navBar,
+    paddingHorizontal: spacing.md,
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  inlineTitle: {
+    ...typography.headline,
+    flexShrink: 1,
+    textAlign: 'center',
+  },
+  actionSlot: {
+    minWidth: spacing.step60,
+    minHeight: layout.navBar,
+    justifyContent: 'center',
+  },
+  inlineActionSlot: {
+    flex: 1,
+  },
+  leftSlot: {
+    alignItems: 'flex-start',
+  },
+  rightSlot: {
+    alignItems: 'flex-end',
+  },
+  actionButton: {
+    minWidth: spacing.step60,
+    minHeight: layout.navBar,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.step6,
+  },
+  leftActionButton: {
+    justifyContent: 'flex-start',
+  },
+  rightActionButton: {
+    justifyContent: 'flex-end',
+  },
+  actionLabel: {
+    ...typography.body,
+  },
+  strongActionLabel: {
+    fontWeight: typography.headline.fontWeight,
+  },
+});

--- a/apps/mobile/components/ui/ScreenHeader.tsx
+++ b/apps/mobile/components/ui/ScreenHeader.tsx
@@ -10,29 +10,29 @@ export interface ScreenHeaderProps {
   title: string;
 
   /**
-   * - `'largeTitle'` (default): 2-row. Row 1 reserves 44px frame with left/right
-   *   action slots (each minWidth: spacing.step60). Row 2 shows the title with
-   *   `typography.largeTitle`, padding top spacing.step6 bottom spacing.step10.
-   * - `'inline'`: 1-row, height layout.navBar (44px). Title centered with
+   * - `'largeTitle'` (default): 2-row. Row 1 reserves a `layout.navBar`
+   *   high frame with `spacing.step60`-wide action slots. Row 2 shows the title with
+   *   `typography.largeTitle`.
+   * - `'inline'`: 1-row, height `layout.navBar`. Title centered with
    *   `typography.headline`.
    */
   variant?: 'largeTitle' | 'inline';
 
   /**
-   * - `null` / undefined: no button, but the slot frame is still rendered to
+   * - undefined / omitted: no button, but the slot frame is still rendered to
    *   preserve row height.
    * - `'back'`: SF Symbol chevron.backward + t('common.action.back'). Pressing
    *   it calls router.back() from useRouter().
    * - object: explicit label and onPress.
    */
-  leftAction?: ScreenHeaderAction | 'back' | null;
+  leftAction?: ScreenHeaderAction | 'back';
 
   /**
-   * - `null` / undefined: no button, frame still rendered.
+   * - undefined / omitted: no button, frame still rendered.
    * - object: explicit label and onPress. `strong: true` applies
-   *   `typography.headline.fontWeight` ('600').
+   *   `typography.headline.fontWeight`.
    */
-  rightAction?: ScreenHeaderAction | null;
+  rightAction?: ScreenHeaderAction;
 
   /** Wrapper testID. */
   testID?: string;
@@ -41,7 +41,7 @@ export interface ScreenHeaderProps {
 export interface ScreenHeaderAction {
   label: string;
   onPress: () => void;
-  /** fontWeight '600' for primary CTAs like Save. default: false */
+  /** Emphasized font weight for primary CTAs like Save. default: false */
   strong?: boolean;
   /** Disabled visual + accessibilityState.disabled. onPress is not called. */
   disabled?: boolean;
@@ -70,16 +70,17 @@ export function ScreenHeader({
           onPress: () => router.back(),
           icon: 'chevron.backward' as const,
         }
-      : leftAction ?? null;
-  const resolvedRightAction = rightAction ?? null;
+      : leftAction;
+  const resolvedRightAction = rightAction;
 
   const renderActionSlot = (
-    action: ResolvedScreenHeaderAction | null,
+    action: ResolvedScreenHeaderAction | undefined,
     side: ActionSide,
     inline: boolean,
     slotTestID?: string,
   ) => {
     const isDisabled = action?.disabled === true;
+    const isStrong = action?.strong === true && !isDisabled;
     const actionColor = isDisabled ? theme.textDisabled : theme.interactive;
 
     return (
@@ -114,7 +115,7 @@ export function ScreenHeader({
             <Text
               style={[
                 styles.actionLabel,
-                action.strong === true ? styles.strongActionLabel : null,
+                isStrong ? styles.strongActionLabel : null,
                 { color: actionColor },
               ]}
             >
@@ -129,7 +130,7 @@ export function ScreenHeader({
   if (variant === 'inline') {
     return (
       <View testID={testID}>
-        <View style={styles.inlineRow}>
+        <View testID={derivedTestID(testID, 'action-row')} style={styles.inlineRow}>
           {renderActionSlot(
             resolvedLeftAction,
             'left',
@@ -156,7 +157,10 @@ export function ScreenHeader({
 
   return (
     <View testID={testID}>
-      <View style={styles.largeTitleActionRow}>
+      <View
+        testID={derivedTestID(testID, 'action-row')}
+        style={styles.largeTitleActionRow}
+      >
         {renderActionSlot(
           resolvedLeftAction,
           'left',
@@ -170,7 +174,10 @@ export function ScreenHeader({
           slotTestID(testID, 'right'),
         )}
       </View>
-      <View style={styles.largeTitleRow}>
+      <View
+        testID={derivedTestID(testID, 'large-title-row')}
+        style={styles.largeTitleRow}
+      >
         <Text
           accessibilityRole="header"
           numberOfLines={1}
@@ -185,6 +192,10 @@ export function ScreenHeader({
 
 function slotTestID(testID: string | undefined, side: ActionSide): string | undefined {
   return testID ? `${testID}-${side}-action-slot` : undefined;
+}
+
+function derivedTestID(testID: string | undefined, suffix: string): string | undefined {
+  return testID ? `${testID}-${suffix}` : undefined;
 }
 
 const styles = StyleSheet.create({
@@ -214,6 +225,7 @@ const styles = StyleSheet.create({
     flexShrink: 1,
     textAlign: 'center',
   },
+  // minWidth/minHeight の予約枠は、My Dog と Me の縦ズレ再発を防ぐために維持する。
   actionSlot: {
     minWidth: spacing.step60,
     minHeight: layout.navBar,

--- a/apps/mobile/lib/i18n/locales/en.json
+++ b/apps/mobile/lib/i18n/locales/en.json
@@ -1,7 +1,12 @@
 {
   "common": {
     "error": "Error",
-    "retry": "Retry"
+    "retry": "Retry",
+    "action": {
+      "back": "Back",
+      "cancel": "Cancel",
+      "save": "Save"
+    }
   },
   "tabs": {
     "dogs": "Dogs",
@@ -79,10 +84,6 @@
       "streak": "🔥 {{days}}d",
       "todayStats": "{{km}} km today · {{count}} walks"
     },
-    "action": {
-      "cancel": "Cancel",
-      "save": "Save"
-    },
     "new": {
       "title": "Register dog",
       "photoUploadError": "Failed to upload photo. You can try again from Edit."
@@ -120,6 +121,12 @@
       "leaveTitle": "Leave Group",
       "leaveConfirm": "Leave {{name}} group? You will no longer see this dog.",
       "leaveError": "Failed to leave group"
+    },
+    "encounters": {
+      "title": "Encounter History"
+    },
+    "friends": {
+      "title": "Friends"
     },
     "edit": {
       "title": "Edit dog",

--- a/apps/mobile/lib/i18n/locales/ja.json
+++ b/apps/mobile/lib/i18n/locales/ja.json
@@ -1,7 +1,12 @@
 {
   "common": {
     "error": "エラー",
-    "retry": "再試行"
+    "retry": "再試行",
+    "action": {
+      "back": "戻る",
+      "cancel": "キャンセル",
+      "save": "保存"
+    }
   },
   "tabs": {
     "dogs": "愛犬",
@@ -79,10 +84,6 @@
       "streak": "🔥 {{days}}日",
       "todayStats": "今日 {{km}} km · {{count}}回"
     },
-    "action": {
-      "cancel": "キャンセル",
-      "save": "保存"
-    },
     "new": {
       "title": "犬を登録",
       "photoUploadError": "写真のアップロードに失敗しました。Edit 画面から再度お試しください。"
@@ -120,6 +121,12 @@
       "leaveTitle": "グループを離れる",
       "leaveConfirm": "{{name}}のグループを離れますか？この犬は表示されなくなります。",
       "leaveError": "グループの離脱に失敗しました"
+    },
+    "encounters": {
+      "title": "遭遇履歴"
+    },
+    "friends": {
+      "title": "友達"
     },
     "edit": {
       "title": "犬を編集",

--- a/docs/mobile/screen-header-audit.md
+++ b/docs/mobile/screen-header-audit.md
@@ -1,0 +1,131 @@
+# 画面ベース部分の共通化 — 改善点の洗い出し / Screen header unification — improvement audit
+
+## Context / 背景
+
+`apps/mobile` の各画面で「最上部の両端ボタン（Cancel / + Add / ‹ Back / Save）」と「その下の画面タイトル」が画面ごとに別実装になっている。とくに **My Dog（Dogs 一覧タブ）** と **Me（Settings タブ）** で同じはずのヘッダー構造が揃っていない。
+
+ユーザーは `docs/design.html` を基準に共通化したいと考えており、今回のスコープは「**改善点の洗い出し**」まで。実装は別ステップで行う。
+
+`docs/design.html` は Babel で実行される単一 HTML プロトタイプで、内部で `NavBar` という共通プリミティブを定義し、すべての画面で同じ関数を呼んでいる。**設計上は共通化済み**だが、それが React Native 側に取り込まれていない、というのが問題の本質。
+
+## design.html が定義する正解仕様 / Design source of truth
+
+`docs/design.html` 内の `NavBar({ title, left, right, c, large = true })`（decoded line 1088 相当）：
+
+| variant | 構造 | 行1 (top:54, h:44) | 行2 | 例 |
+|---|---|---|---|---|
+| **large** (ルートタブ画面) | 2段 | `[left 17px tint, minWidth:60]` ⟷ `[right 17px tint, minWidth:60]` | `title 34/700/-0.6, padding 6/0/10/0` | `<NavBar title="Dogs" right="+ Add" />`, `<NavBar title="Me" />` |
+| **modal** (Add Dog / Edit dog / Edit profile) | 1段 | `Cancel 17 tint` — `title 17 600 center` — `Save 17 tint 600` | — | Edit dog / Edit profile |
+| **inline** (Stack push 画面 / Sign Up 風) | 1段 | `‹ Back 17 tint` left のみ | — | Sign Up |
+
+**ポイント**: large variant では、右ボタンが無くても上段の枠（`minWidth:60`）は確保される → タイトル行の高さ・左寄せ位置が**右ボタン有無に関わらず常に揃う**。
+
+座標は [apps/mobile/theme/tokens.ts](apps/mobile/theme/tokens.ts) の `layout` トークンと完全一致：
+- `statusBar: 54` / `navBar: 44` / `largeTitleBlock: 52` / `safeTop: 54`
+
+## 現状の実装サマリー / Current state per screen
+
+| 画面 | 実装場所 | 左ボタン | 右ボタン | タイトル表示 | design 仕様との差分 |
+|---|---|---|---|---|---|
+| **Dogs (My Dog) 一覧** | [apps/mobile/app/(tabs)/dogs.tsx:22](apps/mobile/app/(tabs)/dogs.tsx) | — | `+ Add`（タイトル**と同じ行**） | FlatList の `ListHeaderComponent` 内に `largeTitle` | **+ Add が上段ではなく largeTitle と同行**。design 仕様（上段 right）と構造が違う。共通コンポーネント未使用 |
+| **Me (Settings) タブ** | [apps/mobile/app/(tabs)/settings.tsx:26](apps/mobile/app/(tabs)/settings.tsx) | — | — | ScrollView 直下に `largeTitle` | **上段の枠そのものが存在しない**。Dogs と比較するとタイトル行の高さ・上余白が違って見える |
+| **Walk タブ** | [apps/mobile/app/(tabs)/walk.tsx](apps/mobile/app/(tabs)/walk.tsx) | — | — | （タイトル文字列なし） | **タイトル無し**。design.html では `<NavBar title="Walk" />` 想定 |
+| **New Dog (Add Dog)** | [apps/mobile/app/dogs/new.tsx:54](apps/mobile/app/dogs/new.tsx) | `Cancel`（自前 Pressable） | `Save`（自前 Pressable） | `headline 17/600` 中央 | 仕様一致だが**自前 navBar の重複実装** |
+| **Edit Dog** | [apps/mobile/app/dogs/[id]/edit.tsx:78](apps/mobile/app/dogs/[id]/edit.tsx) | `Cancel` | `Save` | `headline 17/600` 中央 | new.tsx と**完全に同じコードが二重定義** |
+| **Dog Detail** | [apps/mobile/app/dogs/[id]/index.tsx](apps/mobile/app/dogs/[id]/index.tsx) + [DogHeroNavBar.tsx](apps/mobile/components/dogs/DogHeroNavBar.tsx) | カスタム Back | 条件付き Edit | Hero 画像オーバーレイ | 画面固有の特殊ヘッダー。共通化対象外として扱う |
+| **Members / Encounters / Friends** | [apps/mobile/app/dogs/[id]/_layout.tsx:14](apps/mobile/app/dogs/[id]/_layout.tsx) | Stack 標準 Back | — | Stack 標準（`title:`） | inline variant 想定だが、**自前 ScreenHeader を使う他画面と見た目が混在** |
+
+## 識別された改善点 / Improvement points
+
+### 主要不揃い（ユーザー指摘）
+
+1. **Dogs 一覧の `+ Add` 位置がデザインと違う**
+   - 現状: largeTitle と同じ行に並列（[dogs.tsx](apps/mobile/app/(tabs)/dogs.tsx) の `titleRow` style）
+   - 正解: 上段 row1 の右側、`+ Add 17px tint, minWidth:60`
+   - 影響: 上段の高さが Me と揃わず、タイトル行ベースラインがズレる
+
+2. **Me に上段（ボタン枠）が無い**
+   - 現状: 直接 largeTitle がトップに来る
+   - 正解: 右/左ともボタン無しでも、上段 44px の空枠を確保 → Dogs と同じ縦位置で largeTitle が描画される
+   - これが「My Dog 画面と Me 画面で揃っていない」感の根本原因
+
+3. **共通プリミティブが無い**
+   - design.html の `NavBar` に相当するコンポーネントが React Native 側に未存在
+   - 結果として Dogs / Me / new / edit がそれぞれ独立に書かれる
+   - `components/ui/` 配下に共通ヘッダーコンポーネントを新設すべき
+
+### 副次的不揃い
+
+4. **New Dog と Edit Dog のヘッダーコードが二重定義**（[new.tsx](apps/mobile/app/dogs/new.tsx) と [edit.tsx](apps/mobile/app/dogs/[id]/edit.tsx) がほぼ同一）
+5. **Walk タブにタイトルが無い**（design.html では `Walk` のタイトルが入っている）
+6. **Members / Encounters / Friends が Stack 標準ヘッダー**を使い、他の自前ヘッダー画面とフォント・余白・戻るボタン形状が微妙に違う
+7. **iOS large title の scroll-collapse 動作を捨てている**（自前実装のためスクロール時に縮小・消滅しない）— ただし design.html は常時 large title 表示なので、これは**意図通り**として現状維持で OK
+8. **Stack ヘッダーが画面によって on/off 混在**（[app/_layout.tsx](apps/mobile/app/_layout.tsx) で全 group が `headerShown: false`、子 layout で再有効化）→ 共通コンポーネントに統一すれば整理できる
+
+## 統一方針（推奨） / Recommended unification strategy
+
+**共通コンポーネント `ScreenHeader` を `apps/mobile/components/ui/` に新設し、全画面でこれだけを使う。**
+
+設計イメージ（実装フェーズで確定）：
+
+```tsx
+interface ScreenHeaderProps {
+  title: string;
+  variant?: 'large' | 'modal' | 'inline';   // default: 'large'
+  leftAction?: { label: string; onPress: () => void } | 'back' | null;
+  rightAction?: { label: string; onPress: () => void; strong?: boolean; disabled?: boolean } | null;
+}
+```
+
+- **layout/typography トークンを使う**: `layout.navBar`, `typography.largeTitle`, `typography.headline`, `typography.body`, `spacing.md`（既存トークンで充足）
+- **上段は常に minWidth:60 のプレースホルダを左右に確保**（design.html と同じ）→ 右ボタン無しでも縦位置が固定
+- **`SafeAreaView edges={['top']}` を内部に取り込む**か、外側のレイアウト規約として残すかは実装フェーズで決定
+- **Stack header と共存しない**: 全画面 `headerShown: false` に揃え、ScreenHeader を body の先頭に置く（[app/_layout.tsx](apps/mobile/app/_layout.tsx) で全 group が `headerShown: false` のためルートはほぼそのまま）
+
+### 採用後の各画面の使い方（イメージ）
+
+| 画面 | 使い方 |
+|---|---|
+| Dogs | `<ScreenHeader title={t('dogs.list.title')} rightAction={{ label: t('dogs.list.addCta'), onPress: addDog }} />` |
+| Me | `<ScreenHeader title={t('settings.title')} />` |
+| Walk | `<ScreenHeader title={t('tabs.walk')} />` |
+| New Dog | `<ScreenHeader variant="modal" title={t('dogs.new.title')} leftAction={{ label: t('dogs.action.cancel'), onPress: back }} rightAction={{ label: t('dogs.action.save'), onPress: save, strong: true, disabled: !canSave }} />` |
+| Edit Dog | 同上（title だけ `dogs.edit.title`） |
+| Members / Encounters / Friends | `<ScreenHeader variant="inline" title={...} leftAction="back" />` + `Stack.Screen options={{ headerShown: false }}` に変更 |
+| Dog Detail | Hero 専用ヘッダー（DogHeroNavBar）はそのまま。将来「Hero variant」を ScreenHeader に取り込む選択肢は残す |
+
+### 棄却した代替案
+
+- **Stack の `headerLargeTitle` に寄せる案**: native の縮小アニメは魅力的だが、Android で挙動が違い、design.html の「常時 large title」とも噛み合わない。`headerLeft / headerRight` のスタイルも JSX で各画面に書くため重複削減効果が薄い。
+
+## 影響ファイル / Files in scope
+
+実装フェーズで触る予定のファイル（今回の plan では編集しない）：
+
+- **新規**: `apps/mobile/components/ui/ScreenHeader.tsx`（+ テスト）
+- **更新**: 
+  - [apps/mobile/app/(tabs)/dogs.tsx](apps/mobile/app/(tabs)/dogs.tsx) — `titleRow` を ScreenHeader に置き換え
+  - [apps/mobile/app/(tabs)/settings.tsx](apps/mobile/app/(tabs)/settings.tsx) — `heroTitle` を ScreenHeader に置き換え
+  - [apps/mobile/app/(tabs)/walk.tsx](apps/mobile/app/(tabs)/walk.tsx) — ScreenHeader を追加
+  - [apps/mobile/app/dogs/new.tsx](apps/mobile/app/dogs/new.tsx) — 自前 navBar 削除、ScreenHeader 採用
+  - [apps/mobile/app/dogs/[id]/edit.tsx](apps/mobile/app/dogs/[id]/edit.tsx) — 同上
+  - [apps/mobile/app/dogs/[id]/_layout.tsx](apps/mobile/app/dogs/[id]/_layout.tsx) — members / encounters / friends を `headerShown: false` に変更し、子画面側に `ScreenHeader variant="inline"` を追加
+- **参照のみ**: [apps/mobile/theme/tokens.ts](apps/mobile/theme/tokens.ts)（既存 `layout.*` / `typography.*` をそのまま利用）
+
+## 検証 / Verification
+
+実装後の検証（今回のスコープ外、参考メモ）：
+
+- iOS Simulator で Dogs ⇄ Me ⇄ Walk タブを切り替え、**largeTitle の Y 座標が完全に一致**することを目視確認（タブ切替時の上下ブレが無い）
+- New Dog / Edit Dog のモーダル ヘッダーが同じ高さ・同じフォントで表示されることを確認
+- Dog Detail から Members / Encounters / Friends に push 遷移したとき、ヘッダーが Stack 標準ではなく `ScreenHeader variant="inline"` で統一されることを確認
+- Dark mode / Light mode 両方で色トークンが正しく適用されることを確認
+- `apps/mobile/components/ui/ScreenHeader.test.tsx` を追加し、3つの variant それぞれで a11y label と minimum touch target (44pt) が満たされることをテスト
+- `npm run typecheck && npm run lint` (Docker 経由) が通ること
+
+## 次のアクション / Next step for the user
+
+このプランでは「**改善点の洗い出し**」までを完了した。次は：
+
+1. この洗い出し内容で合意できれば、続いて `ScreenHeader` コンポーネントの **インターフェース設計** に進む（variant 名・プロパティ形状・back ボタンの label を i18n でどう扱うか等）
+2. その後、共通コンポーネント実装 → 各画面の置き換え → 視覚確認、の順で進める（各ステップで PR を分けるのが安全）

--- a/docs/mobile/screen-header-audit.md
+++ b/docs/mobile/screen-header-audit.md
@@ -1,5 +1,12 @@
 # 画面ベース部分の共通化 — 改善点の洗い出し / Screen header unification — improvement audit
 
+> **Status: Historical (Pre-PR #230 planning record).**
+> This document describes the screen-header inconsistencies that existed
+> **before** PR #230 "Unify mobile screen headers" was merged. The "現状"
+> tables capture the codebase state at the time of the audit. For the
+> shipped component, see [screen-header-interface.md](screen-header-interface.md)
+> and `apps/mobile/components/ui/ScreenHeader.tsx`.
+
 ## Context / 背景
 
 `apps/mobile` の各画面で「最上部の両端ボタン（Cancel / + Add / ‹ Back / Save）」と「その下の画面タイトル」が画面ごとに別実装になっている。とくに **My Dog（Dogs 一覧タブ）** と **Me（Settings タブ）** で同じはずのヘッダー構造が揃っていない。

--- a/docs/mobile/screen-header-interface.md
+++ b/docs/mobile/screen-header-interface.md
@@ -1,0 +1,266 @@
+# `ScreenHeader` — Interface Design / インターフェース設計
+
+## Context / 背景
+
+[screen-header-audit.md](screen-header-audit.md) で洗い出した不揃いを解消するため、`apps/mobile/components/ui/ScreenHeader.tsx` という共通プリミティブを新設する。本ドキュメントはその**インターフェース設計（API 形と命名の確定）**を扱う。実装は別ステップ。
+
+## 1. Variant の決定 / Variant decisions
+
+**結論: 2 つの variant に集約する。`largeTitle` (default) と `inline` の 2 つ。**
+
+| variant | 用途 | 構造 | 例 |
+|---|---|---|---|
+| `largeTitle` (default) | ルートタブ画面 (Dogs / Me / Walk) | 行1: 左/右ボタンの44px枠（**ボタン無しでも常に予約**）／ 行2: 34/700 large title 左寄せ | Dogs, Me, Walk |
+| `inline` | push 画面・modal 画面 | 1行: 左ボタン — 中央タイトル 17/600 — 右ボタン | New Dog (modal), Edit Dog (modal), Members, Encounters, Friends |
+
+### Rationale / 設計判断
+
+- 当初案の3 variant (large/modal/inline) を検討したが、`modal` は `inline` + `leftAction=cancel` + `rightAction=save (strong)` で完全に表現できるため**冗長**
+- variant を「視覚的レイアウトの違い」に絞ることで直交性が上がり、ユースケース（push vs modal）の判断はコンポーネント外（呼び出し側の `presentation:` 等）に任せられる
+- iOS HIG の `largeTitleDisplayMode = .always | .never` の二分法とも一致
+
+### 棄却した代替
+
+- **3 variant 案**: `modal` を専用 variant にすると caller が「これは modal だから modal variant」とコンテキストを保ったまま記述できる利点はあるが、`inline` との内部実装の重複が大きく保守コストが見合わない
+- **scroll-collapse 対応 variant**: iOS native の large title 縮小は魅力的だが、design.html は常時表示前提・Android では挙動が異なるため対象外（将来拡張）
+
+---
+
+## 2. TypeScript インターフェース / Interface
+
+```ts
+// apps/mobile/components/ui/ScreenHeader.tsx
+
+/**
+ * 画面最上部のナビゲーションバー兼タイトル領域。
+ * design.html の `NavBar` プリミティブを RN 化したもの。
+ */
+export interface ScreenHeaderProps {
+  /** 表示タイトル。i18n 済みの文字列を渡す。 */
+  title: string;
+
+  /**
+   * レイアウト variant。
+   * - `largeTitle` (default): 2行構造、行2に 34px の大見出し。ルートタブ画面向け。
+   * - `inline`: 1行構造、中央 17/600 のタイトル。push / modal 画面向け。
+   */
+  variant?: 'largeTitle' | 'inline';
+
+  /**
+   * 左側のアクション。
+   * - `null` / 省略: 左ボタン無し（ただし上段枠は予約される）
+   * - `'back'`: 共通 back ショートカット。chevron + `common.action.back` で
+   *   `router.back()` を呼ぶ。
+   * - object: 任意のラベルとハンドラを指定。
+   */
+  leftAction?: ScreenHeaderAction | 'back' | null;
+
+  /**
+   * 右側のアクション。
+   * - `null` / 省略: 右ボタン無し（ただし上段枠は予約される）
+   * - object: 任意のラベルとハンドラを指定。
+   *   `strong: true` で fontWeight 600 になる（Save 等の主要 CTA 想定）。
+   */
+  rightAction?: ScreenHeaderAction | null;
+
+  /** テスト・E2E 用 ID。ScreenHeader 自体の View に付与される。 */
+  testID?: string;
+}
+
+export interface ScreenHeaderAction {
+  /** ボタンのラベル。アクセシビリティラベルも兼ねる。 */
+  label: string;
+  /** タップハンドラ。 */
+  onPress: () => void;
+  /** true なら fontWeight 600（Save 等の primary CTA 用）。default: false */
+  strong?: boolean;
+  /** true なら無効化表示（textDisabled 色 + accessibilityState.disabled）。 */
+  disabled?: boolean;
+}
+```
+
+### Prop 設計の根拠 / Rationale per prop
+
+| prop | 設計判断 | 採用理由 |
+|---|---|---|
+| `title: string` | 必須・文字列のみ（ReactNode 不可） | design.html ですべて文字列。柔軟性を捨てて API を狭く保つ |
+| `variant` | union 2 値 / default `'largeTitle'` | 利用頻度の高い root tab を default に。文字列リテラル union は既存 `Button.tsx` の `variant` 流儀と一致 |
+| `leftAction` | union: object \| `'back'` \| `null` | `'back'` は出現頻度が高いショートカット。i18n と `router.back()` を内包 |
+| `rightAction` | union: object \| `null`（`'back'` 等のショートカット無し） | 右側は文脈依存（Save / +Add / Done など多様）でショートカット定義の意味が薄い |
+| `strong` on rightAction | boolean | design.html では Save のみ fontWeight 600。「右側は強調可能」というセマンティクスを直接表す |
+| `disabled` on rightAction | boolean | フォーム未入力時の Save 無効化に必須 |
+| **SafeAreaView は内包しない** | 呼び出し側が引き続き `SafeAreaView edges={['top']}` でラップ | 既存 6 画面がすべてそうしている。内包すると padding 重複や入れ子のリスク |
+| **Stack header は使わない** | 全画面 `headerShown: false` 前提 | [app/_layout.tsx](apps/mobile/app/_layout.tsx) と整合。Stack の `headerLeft / headerRight` と二重実装にしない |
+
+### 棄却した API 案
+
+- **`backShorthand?: boolean` プロパティ**: `leftAction='back'` のほうが「左にこれを置く」という意図と一致して読みやすい
+- **`actions: { left?, right? }` ネスト**: 一段深くなるだけで読みづらくなる。フラットな `leftAction` / `rightAction` のほうが型推論的にも素直
+- **`onLeftPress` / `leftLabel` の分割 prop**: ラベルとハンドラが別 prop だと「片方だけ渡したらどうなるか」が曖昧。object にまとめることで揃って渡る前提を型で強制できる
+
+---
+
+## 3. 使用例（全画面） / Usage examples
+
+```tsx
+// (tabs)/dogs.tsx — Dogs (My Dog) 一覧
+<ScreenHeader
+  title={t('dogs.list.title')}
+  rightAction={{ label: t('dogs.list.addCta'), onPress: vm.handleAddDog }}
+/>
+
+// (tabs)/settings.tsx — Me
+<ScreenHeader title={t('settings.title')} />
+
+// (tabs)/walk.tsx — Walk
+<ScreenHeader title={t('tabs.walk')} />
+
+// dogs/new.tsx — New Dog (modal)
+<ScreenHeader
+  variant="inline"
+  title={t('dogs.new.title')}
+  leftAction={{ label: t('common.action.cancel'), onPress: () => router.back() }}
+  rightAction={{
+    label: t('common.action.save'),
+    onPress: handleSave,
+    strong: true,
+    disabled: !canSave,
+  }}
+/>
+
+// dogs/[id]/edit.tsx — Edit Dog (modal) — new.tsx と同じパターン
+<ScreenHeader
+  variant="inline"
+  title={t('dogs.edit.title')}
+  leftAction={{ label: t('common.action.cancel'), onPress: () => router.back() }}
+  rightAction={{ label: t('common.action.save'), onPress: handleSave, strong: true, disabled: !canSave }}
+/>
+
+// dogs/[id]/members.tsx — Members (Stack push)
+<ScreenHeader variant="inline" title={t('dogs.members.title')} leftAction="back" />
+
+// dogs/[id]/encounters.tsx — Encounter History
+<ScreenHeader variant="inline" title={t('dogs.encounters.title')} leftAction="back" />
+
+// dogs/[id]/friends/index.tsx — Friends
+<ScreenHeader variant="inline" title={t('dogs.friends.title')} leftAction="back" />
+```
+
+---
+
+## 4. i18n キー追加 / i18n keys to add
+
+`common` 名前空間に共通アクションを追加する。両ロケールで同期。
+
+```json
+// apps/mobile/lib/i18n/locales/en.json
+{
+  "common": {
+    "error": "Error",
+    "retry": "Retry",
+    "action": {
+      "back": "Back",
+      "cancel": "Cancel",
+      "save": "Save"
+    }
+  }
+}
+
+// apps/mobile/lib/i18n/locales/ja.json
+{
+  "common": {
+    "error": "エラー",
+    "retry": "再試行",
+    "action": {
+      "back": "戻る",
+      "cancel": "キャンセル",
+      "save": "保存"
+    }
+  }
+}
+```
+
+### 既存キーの扱い
+
+| 既存キー | 扱い | 理由 |
+|---|---|---|
+| `dogs.action.cancel` / `dogs.action.save` | **削除して `common.action.*` に統合** | dog 限定の文言ではない。共通化が自然 |
+| `auth.signup.back` | 既存のまま保持（auth フロー固有の文脈） | 今回のリファクタ範囲外 |
+| `dogs.detail.back: "Dogs"` | 既存のまま保持 | Dog 詳細から戻るときに敢えて「Dogs」と表示している文脈。`leftAction={{ label: t('dogs.detail.back'), onPress: () => router.back() }}` でオーバーライド使用 |
+
+---
+
+## 5. アクセシビリティ / Accessibility
+
+ScreenHeader は内部で以下を担保する：
+
+- 左右の Pressable に `accessibilityRole='button'` と `accessibilityLabel=action.label`
+- `rightAction.disabled` のとき `accessibilityState={{ disabled: true }}`
+- `hitSlop={12}` で 44pt のタップターゲットを保証（[apps/mobile/.claude/rules/common/accessibility.md](apps/mobile/.claude/rules/common/accessibility.md) 準拠）
+- タイトル Text に `accessibilityRole='header'` を付与（VoiceOver のローター対応）
+
+---
+
+## 6. トークン使用マッピング / Token mapping
+
+すべて [apps/mobile/theme/tokens.ts](apps/mobile/theme/tokens.ts) の既存トークンで充足。**新規トークン追加は不要**。
+
+| 役割 | トークン | 値 |
+|---|---|---|
+| 行1 の高さ | `layout.navBar` | 44 |
+| 左右ボタンの minWidth 枠 | `spacing.step60` | 60 |
+| 行1/行2 の左右 padding | `spacing.md` | 16 |
+| 行2 (largeTitle) のフォント | `typography.largeTitle` | 34/700/-0.6/41 |
+| 行2 の縦 padding | top `spacing.step6`(6) + bottom `spacing.step10`(10) | 6 / 10 |
+| inline タイトルのフォント | `typography.headline` | 17/600/22 |
+| 通常ボタンのフォント | `typography.body` | 17/400/22 |
+| strong ボタンの fontWeight | `typography.headline.fontWeight` | '600' |
+| 通常テキスト色 | `theme.interactive` (青 tint) | #0a84ff |
+| 無効テキスト色 | `theme.textDisabled` | rgba(...0.3) |
+
+---
+
+## 7. 今回 API に**含めない**もの / Out of scope (deferred)
+
+| 機能 | 理由 |
+|---|---|
+| **scroll-collapse アニメーション** | design.html は常時 large title 表示。Reanimated 連携が必要で複雑度が増す |
+| **left/right に複数アクション** | design.html は左右各1つ。現状 UI で必要無し |
+| **アイコンのみのアクション** (label 無し) | 当面はテキストラベルで統一 |
+| **背景色のカスタマイズ** | テーマで自動。透過 / blur 対応は将来 |
+| **タイトル下のサブタイトル** | design.html に該当なし |
+| **Hero variant** (Dog Detail の写真オーバーレイ) | [DogHeroNavBar.tsx](apps/mobile/components/dogs/DogHeroNavBar.tsx) は固有需要が強く別コンポーネントのまま |
+
+---
+
+## 8. オープン質問 / Open questions
+
+実装前にユーザーの判断が必要なポイント：
+
+1. **back chevron の表示**
+   - `leftAction='back'` のとき、design.html のような literal `‹` テキストか、SF Symbol の chevron アイコンか？
+   - 推奨: **SF Symbol** (`icon-symbol` コンポーネント使用)。iOS HIG 準拠で他画面 (DogHeroNavBar 等) と整合
+   - 代替: 見た目を design.html に厳密に合わせるなら literal `‹` テキスト
+
+2. **`dogs.action.{cancel, save}` の即時削除**
+   - `common.action.{cancel, save}` に統合する案だが、置き換え PR と同時にキー削除するか、後続 PR で削除するか？
+   - 推奨: **同時削除**（dead key を残さない / `feedback_same_scope_legacy_cleanup` ルール）
+
+3. **`(tabs)/walk.tsx` にタイトル「Walk」を追加するか？**
+   - 現状はタイトル無し。design.html では `Walk`。追加すると見た目が変わる
+   - 推奨: **追加する**（design.html に合わせる）。が、UX 判断としてユーザーの確認を取る
+
+4. **`leftAction='back'` のデフォルトラベルを `'Back'` 固定にするか、画面ごとに上書きしやすくするか？**
+   - 推奨: ショートカット `'back'` はデフォルトで `t('common.action.back')`。固有ラベルが必要なら object 形式で渡せばよい（API ですでに対応済み）
+
+---
+
+## 9. 次のステップ / Next step
+
+このインターフェース設計でユーザー合意が取れたら：
+
+1. オープン質問 1〜4 に回答をもらう
+2. `ScreenHeader.tsx` + `ScreenHeader.test.tsx` を TDD で実装（RED → GREEN → REFACTOR）
+3. i18n キー (`common.action.*`) を追加
+4. 1画面ずつ置き換え（PR 分割推奨: tab 群 / dogs new+edit / detail 配下）
+5. iOS Simulator で Dogs ⇄ Me ⇄ Walk の縦位置一致を目視確認

--- a/docs/mobile/screen-header-interface.md
+++ b/docs/mobile/screen-header-interface.md
@@ -2,7 +2,7 @@
 
 ## Context / 背景
 
-[screen-header-audit.md](screen-header-audit.md) で洗い出した不揃いを解消するため、`apps/mobile/components/ui/ScreenHeader.tsx` という共通プリミティブを新設する。本ドキュメントはその**インターフェース設計（API 形と命名の確定）**を扱う。実装は別ステップ。
+[screen-header-audit.md](screen-header-audit.md) で洗い出した不揃いを解消するため、`apps/mobile/components/ui/ScreenHeader.tsx` という共通プリミティブを新設した。本ドキュメントは PR #230 で shipped された **インターフェース設計（API 形と命名の確定）** の記録として扱う。
 
 ## 1. Variant の決定 / Variant decisions
 
@@ -48,20 +48,20 @@ export interface ScreenHeaderProps {
 
   /**
    * 左側のアクション。
-   * - `null` / 省略: 左ボタン無し（ただし上段枠は予約される）
+   * - undefined / 省略: 左ボタン無し（ただし上段枠は予約される）
    * - `'back'`: 共通 back ショートカット。chevron + `common.action.back` で
    *   `router.back()` を呼ぶ。
    * - object: 任意のラベルとハンドラを指定。
    */
-  leftAction?: ScreenHeaderAction | 'back' | null;
+  leftAction?: ScreenHeaderAction | 'back';
 
   /**
    * 右側のアクション。
-   * - `null` / 省略: 右ボタン無し（ただし上段枠は予約される）
+   * - undefined / 省略: 右ボタン無し（ただし上段枠は予約される）
    * - object: 任意のラベルとハンドラを指定。
    *   `strong: true` で fontWeight 600 になる（Save 等の主要 CTA 想定）。
    */
-  rightAction?: ScreenHeaderAction | null;
+  rightAction?: ScreenHeaderAction;
 
   /** テスト・E2E 用 ID。ScreenHeader 自体の View に付与される。 */
   testID?: string;
@@ -85,8 +85,8 @@ export interface ScreenHeaderAction {
 |---|---|---|
 | `title: string` | 必須・文字列のみ（ReactNode 不可） | design.html ですべて文字列。柔軟性を捨てて API を狭く保つ |
 | `variant` | union 2 値 / default `'largeTitle'` | 利用頻度の高い root tab を default に。文字列リテラル union は既存 `Button.tsx` の `variant` 流儀と一致 |
-| `leftAction` | union: object \| `'back'` \| `null` | `'back'` は出現頻度が高いショートカット。i18n と `router.back()` を内包 |
-| `rightAction` | union: object \| `null`（`'back'` 等のショートカット無し） | 右側は文脈依存（Save / +Add / Done など多様）でショートカット定義の意味が薄い |
+| `leftAction` | union: object \| `'back'`、省略で action 無し | `'back'` は出現頻度が高いショートカット。i18n と `router.back()` を内包 |
+| `rightAction` | union: object、省略で action 無し（`'back'` 等のショートカット無し） | 右側は文脈依存（Save / +Add / Done など多様）でショートカット定義の意味が薄い |
 | `strong` on rightAction | boolean | design.html では Save のみ fontWeight 600。「右側は強調可能」というセマンティクスを直接表す |
 | `disabled` on rightAction | boolean | フォーム未入力時の Save 無効化に必須 |
 | **SafeAreaView は内包しない** | 呼び出し側が引き続き `SafeAreaView edges={['top']}` でラップ | 既存 6 画面がすべてそうしている。内包すると padding 重複や入れ子のリスク |
@@ -233,34 +233,23 @@ ScreenHeader は内部で以下を担保する：
 
 ---
 
-## 8. オープン質問 / Open questions
+## 8. 決定事項 / Resolved decisions
 
-実装前にユーザーの判断が必要なポイント：
+All open questions raised during interface design were resolved before
+implementation. PR #230 ships with:
 
-1. **back chevron の表示**
-   - `leftAction='back'` のとき、design.html のような literal `‹` テキストか、SF Symbol の chevron アイコンか？
-   - 推奨: **SF Symbol** (`icon-symbol` コンポーネント使用)。iOS HIG 準拠で他画面 (DogHeroNavBar 等) と整合
-   - 代替: 見た目を design.html に厳密に合わせるなら literal `‹` テキスト
-
-2. **`dogs.action.{cancel, save}` の即時削除**
-   - `common.action.{cancel, save}` に統合する案だが、置き換え PR と同時にキー削除するか、後続 PR で削除するか？
-   - 推奨: **同時削除**（dead key を残さない / `feedback_same_scope_legacy_cleanup` ルール）
-
-3. **`(tabs)/walk.tsx` にタイトル「Walk」を追加するか？**
-   - 現状はタイトル無し。design.html では `Walk`。追加すると見た目が変わる
-   - 推奨: **追加する**（design.html に合わせる）。が、UX 判断としてユーザーの確認を取る
-
-4. **`leftAction='back'` のデフォルトラベルを `'Back'` 固定にするか、画面ごとに上書きしやすくするか？**
-   - 推奨: ショートカット `'back'` はデフォルトで `t('common.action.back')`。固有ラベルが必要なら object 形式で渡せばよい（API ですでに対応済み）
+| # | Decision | Outcome |
+|---|---|---|
+| 1 | Back button glyph | SF Symbol `chevron.backward` via `icon-symbol`. |
+| 2 | `dogs.action.{cancel, save}` removal | Removed in the same PR, replaced by `common.action.{cancel, save}`. |
+| 3 | Walk tab title | Added (`title='Walk'`) per design.html. |
+| 4 | `leftAction='back'` default label | `t('common.action.back')`. |
 
 ---
 
-## 9. 次のステップ / Next step
+## 9. Status / 状況
 
-このインターフェース設計でユーザー合意が取れたら：
-
-1. オープン質問 1〜4 に回答をもらう
-2. `ScreenHeader.tsx` + `ScreenHeader.test.tsx` を TDD で実装（RED → GREEN → REFACTOR）
-3. i18n キー (`common.action.*`) を追加
-4. 1画面ずつ置き換え（PR 分割推奨: tab 群 / dogs new+edit / detail 配下）
-5. iOS Simulator で Dogs ⇄ Me ⇄ Walk の縦位置一致を目視確認
+Shipped in PR #230 "Unify mobile screen headers" on branch
+`claude/hopeful-lederberg-0d3dcc`. See `apps/mobile/components/ui/ScreenHeader.tsx`
+and `apps/mobile/components/ui/ScreenHeader.test.tsx` for the implementation
+and test coverage.


### PR DESCRIPTION
## Summary
- add shared mobile `ScreenHeader` with large-title and inline variants
- migrate root tab, dog modal, and dog push-screen headers to the shared component
- add/update i18n keys and tests for header behavior and locale parity

## Validation
- docker compose inline node:22-slim runner: `npm test -- ScreenHeader`
- docker compose inline node:22-slim runner: `npm test -- translations`
- docker compose inline node:22-slim runner: focused root-tab, dog modal, and push-header tests
- docker compose inline node:22-slim runner: `npm run typecheck`
- docker compose inline node:22-slim runner: `npm run lint`