### PR TITLE
feat(api): migrate track point worker to sqs consumer

### DIFF
--- a/apps/api/Cargo.lock
+++ b/apps/api/Cargo.lock
@@ -2919,7 +2919,7 @@ version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
 dependencies = [
- "nix",
+ "nix 0.29.0",
  "serde",
  "winapi",
 ]
@@ -3046,6 +3046,18 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -4761,6 +4773,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-sqs",
  "futures",
+ "nix 0.30.1",
  "thiserror",
  "tokio",
  "tracing",

--- a/apps/api/Cargo.lock
+++ b/apps/api/Cargo.lock
@@ -4754,6 +4754,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqs-consumer"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "aws-config",
+ "aws-sdk-sqs",
+ "futures",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5393,6 +5406,7 @@ dependencies = [
  "anyhow",
  "async-graphql",
  "async-graphql-axum",
+ "async-trait",
  "aws-config",
  "aws-sdk-cognitoidentityprovider",
  "aws-sdk-dynamodb",
@@ -5407,6 +5421,7 @@ dependencies = [
  "sea-orm",
  "serde",
  "serde_json",
+ "sqs-consumer",
  "thiserror",
  "tokio",
  "tracing",

--- a/apps/api/Cargo.toml
+++ b/apps/api/Cargo.toml
@@ -11,11 +11,13 @@ test-utils = []
 
 [dependencies]
 migration = { path = "./migration" }
+sqs-consumer = { path = "./sqs-consumer" }
 
 axum = { version = "0.8.9" }
 axum-extra = { version = "0.12.6", features = ["typed-header"] }
 async-graphql = { version = "7.2.1", features = ["chrono", "uuid", "url", "tracing"] }
 async-graphql-axum = { version = "7.2.1" }
+async-trait = "0.1.89"
 tokio = { version = "1.52.3", features = ["macros", "rt-multi-thread", "sync", "time"] }
 tracing = { version = "0.1.44" }
 tracing-subscriber = { version = "0.3.23" }
@@ -55,4 +57,4 @@ features = [
 serde_json = { version = "1.0.103" }
 
 [workspace]
-members = [".", "migration"]
+members = [".", "migration", "sqs-consumer"]

--- a/apps/api/sqs-consumer/Cargo.toml
+++ b/apps/api/sqs-consumer/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "sqs-consumer"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+async-trait = "0.1.89"
+aws-sdk-sqs = "1.98.0"
+futures = "0.3.31"
+thiserror = "2.0.18"
+tokio = { version = "1.52.3", features = ["macros", "rt-multi-thread", "sync", "time", "signal", "test-util"] }
+tracing = "0.1.44"
+
+[dev-dependencies]
+aws-config = { version = "1.8.16", features = ["behavior-version-latest"] }

--- a/apps/api/sqs-consumer/Cargo.toml
+++ b/apps/api/sqs-consumer/Cargo.toml
@@ -13,3 +13,4 @@ tracing = "0.1.44"
 
 [dev-dependencies]
 aws-config = { version = "1.8.16", features = ["behavior-version-latest"] }
+nix = { version = "0.30", features = ["signal"] }

--- a/apps/api/sqs-consumer/src/backend.rs
+++ b/apps/api/sqs-consumer/src/backend.rs
@@ -5,7 +5,7 @@ use aws_sdk_sqs::{
         change_message_visibility::ChangeMessageVisibilityError,
         delete_message_batch::DeleteMessageBatchError, receive_message::ReceiveMessageError,
     },
-    types::{DeleteMessageBatchRequestEntry, Message},
+    types::{DeleteMessageBatchRequestEntry, Message, MessageSystemAttributeName},
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -31,6 +31,8 @@ pub(crate) trait SqsBackend: Send + Sync + 'static {
         max_number_of_messages: i32,
         wait_time_seconds: i32,
         visibility_timeout: Option<i32>,
+        attribute_names: &[MessageSystemAttributeName],
+        message_attribute_names: &[String],
     ) -> Result<Vec<Message>, BackendError>;
 
     async fn delete_message_batch(
@@ -65,17 +67,23 @@ impl SqsBackend for AwsSqsBackend {
         max_number_of_messages: i32,
         wait_time_seconds: i32,
         visibility_timeout: Option<i32>,
+        attribute_names: &[MessageSystemAttributeName],
+        message_attribute_names: &[String],
     ) -> Result<Vec<Message>, BackendError> {
         let mut request = self
             .client
             .receive_message()
             .queue_url(queue_url)
             .max_number_of_messages(max_number_of_messages)
-            .wait_time_seconds(wait_time_seconds)
-            .message_attribute_names("All")
-            .message_system_attribute_names(aws_sdk_sqs::types::MessageSystemAttributeName::All);
+            .wait_time_seconds(wait_time_seconds);
         if let Some(visibility_timeout) = visibility_timeout {
             request = request.visibility_timeout(visibility_timeout);
+        }
+        if !attribute_names.is_empty() {
+            request = request.set_message_system_attribute_names(Some(attribute_names.to_vec()));
+        }
+        if !message_attribute_names.is_empty() {
+            request = request.set_message_attribute_names(Some(message_attribute_names.to_vec()));
         }
         let output = request
             .send()

--- a/apps/api/sqs-consumer/src/backend.rs
+++ b/apps/api/sqs-consumer/src/backend.rs
@@ -14,8 +14,8 @@ pub(crate) enum BackendError {
     Receive(#[source] Box<ReceiveMessageError>),
     #[error("delete message batch failed")]
     DeleteBatch(#[source] Box<DeleteMessageBatchError>),
-    #[error("delete message batch returned failed entries: {0:?}")]
-    DeleteBatchFailed(Vec<String>),
+    #[error("delete message batch returned failed entry indexes: {0:?}")]
+    DeleteBatchFailed(Vec<usize>),
     #[error("change message visibility failed")]
     ChangeVisibility(#[source] Box<ChangeMessageVisibilityError>),
     #[cfg(test)]
@@ -36,7 +36,7 @@ pub(crate) trait SqsBackend: Send + Sync + 'static {
     async fn delete_message_batch(
         &self,
         queue_url: &str,
-        entries: Vec<DeleteMessageBatchRequestEntry>,
+        entries: Vec<(String, String)>,
     ) -> Result<(), BackendError>;
 
     async fn change_message_visibility(
@@ -87,11 +87,21 @@ impl SqsBackend for AwsSqsBackend {
     async fn delete_message_batch(
         &self,
         queue_url: &str,
-        entries: Vec<DeleteMessageBatchRequestEntry>,
+        entries: Vec<(String, String)>,
     ) -> Result<(), BackendError> {
         if entries.is_empty() {
             return Ok(());
         }
+        let entries = entries
+            .into_iter()
+            .map(|(id, receipt_handle)| {
+                DeleteMessageBatchRequestEntry::builder()
+                    .id(id)
+                    .receipt_handle(receipt_handle)
+                    .build()
+                    .expect("DeleteMessageBatchRequestEntry build should not fail")
+            })
+            .collect::<Vec<_>>();
         let output = self
             .client
             .delete_message_batch()
@@ -104,7 +114,7 @@ impl SqsBackend for AwsSqsBackend {
         let failed = output
             .failed()
             .iter()
-            .map(|entry| entry.id().to_owned())
+            .filter_map(|entry| entry.id().parse::<usize>().ok())
             .collect::<Vec<_>>();
         if failed.is_empty() {
             Ok(())

--- a/apps/api/sqs-consumer/src/backend.rs
+++ b/apps/api/sqs-consumer/src/backend.rs
@@ -1,0 +1,134 @@
+use async_trait::async_trait;
+use aws_sdk_sqs::{
+    Client,
+    operation::{
+        change_message_visibility::ChangeMessageVisibilityError,
+        delete_message_batch::DeleteMessageBatchError, receive_message::ReceiveMessageError,
+    },
+    types::{DeleteMessageBatchRequestEntry, Message},
+};
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum BackendError {
+    #[error("receive message failed")]
+    Receive(#[source] Box<ReceiveMessageError>),
+    #[error("delete message batch failed")]
+    DeleteBatch(#[source] Box<DeleteMessageBatchError>),
+    #[error("delete message batch returned failed entries: {0:?}")]
+    DeleteBatchFailed(Vec<String>),
+    #[error("change message visibility failed")]
+    ChangeVisibility(#[source] Box<ChangeMessageVisibilityError>),
+    #[cfg(test)]
+    #[error("test backend error: {0}")]
+    Test(String),
+}
+
+#[async_trait]
+pub(crate) trait SqsBackend: Send + Sync + 'static {
+    async fn receive_messages(
+        &self,
+        queue_url: &str,
+        max_number_of_messages: i32,
+        wait_time_seconds: i32,
+        visibility_timeout: Option<i32>,
+    ) -> Result<Vec<Message>, BackendError>;
+
+    async fn delete_message_batch(
+        &self,
+        queue_url: &str,
+        entries: Vec<DeleteMessageBatchRequestEntry>,
+    ) -> Result<(), BackendError>;
+
+    async fn change_message_visibility(
+        &self,
+        queue_url: &str,
+        receipt_handle: &str,
+        visibility_timeout: i32,
+    ) -> Result<(), BackendError>;
+}
+
+pub(crate) struct AwsSqsBackend {
+    client: Client,
+}
+
+impl AwsSqsBackend {
+    pub(crate) fn new(client: Client) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait]
+impl SqsBackend for AwsSqsBackend {
+    async fn receive_messages(
+        &self,
+        queue_url: &str,
+        max_number_of_messages: i32,
+        wait_time_seconds: i32,
+        visibility_timeout: Option<i32>,
+    ) -> Result<Vec<Message>, BackendError> {
+        let mut request = self
+            .client
+            .receive_message()
+            .queue_url(queue_url)
+            .max_number_of_messages(max_number_of_messages)
+            .wait_time_seconds(wait_time_seconds)
+            .message_attribute_names("All")
+            .message_system_attribute_names(aws_sdk_sqs::types::MessageSystemAttributeName::All);
+        if let Some(visibility_timeout) = visibility_timeout {
+            request = request.visibility_timeout(visibility_timeout);
+        }
+        let output = request
+            .send()
+            .await
+            .map_err(|error| BackendError::Receive(Box::new(error.into_service_error())))?;
+        Ok(output.messages().to_vec())
+    }
+
+    async fn delete_message_batch(
+        &self,
+        queue_url: &str,
+        entries: Vec<DeleteMessageBatchRequestEntry>,
+    ) -> Result<(), BackendError> {
+        if entries.is_empty() {
+            return Ok(());
+        }
+        let output = self
+            .client
+            .delete_message_batch()
+            .queue_url(queue_url)
+            .set_entries(Some(entries))
+            .send()
+            .await
+            .map_err(|error| BackendError::DeleteBatch(Box::new(error.into_service_error())))?;
+
+        let failed = output
+            .failed()
+            .iter()
+            .map(|entry| entry.id().to_owned())
+            .collect::<Vec<_>>();
+        if failed.is_empty() {
+            Ok(())
+        } else {
+            Err(BackendError::DeleteBatchFailed(failed))
+        }
+    }
+
+    async fn change_message_visibility(
+        &self,
+        queue_url: &str,
+        receipt_handle: &str,
+        visibility_timeout: i32,
+    ) -> Result<(), BackendError> {
+        self.client
+            .change_message_visibility()
+            .queue_url(queue_url)
+            .receipt_handle(receipt_handle)
+            .visibility_timeout(visibility_timeout)
+            .send()
+            .await
+            .map_err(|error| {
+                BackendError::ChangeVisibility(Box::new(error.into_service_error()))
+            })?;
+        Ok(())
+    }
+}

--- a/apps/api/sqs-consumer/src/consumer.rs
+++ b/apps/api/sqs-consumer/src/consumer.rs
@@ -12,7 +12,8 @@ use crate::{
     error::ConsumerError,
     handler::{BatchMessageHandler, BatchOutcome, HandleOutcome, MessageHandler},
     heartbeat::{
-        HeartbeatSpawn, HeartbeatTask, spawn_heartbeat, spawn_heartbeat_with_failure_channel,
+        HeartbeatFailure, HeartbeatSpawn, HeartbeatTask, spawn_heartbeat,
+        spawn_heartbeat_with_failure_channel,
     },
     listener::{ConsumerListener, NoopListener},
     options::{
@@ -36,6 +37,17 @@ where
         MessageHandler::handle_message(self, message)
             .await
             .map_err(|error| ConsumerError::Processing(Box::new(error)))
+    }
+}
+
+#[cfg(unix)]
+async fn shutdown_signal_with_ready(on_ready: impl FnOnce()) -> Result<(), std::io::Error> {
+    let mut sigint = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt())?;
+    let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())?;
+    on_ready();
+    tokio::select! {
+        _ = sigint.recv() => Ok(()),
+        _ = sigterm.recv() => Ok(()),
     }
 }
 
@@ -417,13 +429,13 @@ impl Consumer {
                     self.listener.on_error(&error, Some(&messages));
                     graceful_timeout = None;
                 }
-                failed_message_id = heartbeats.recv_failure(), if heartbeats.has_failure_channel() => {
-                    let Some(message_id) = failed_message_id else {
+                heartbeat_failure = heartbeats.recv_failure(), if heartbeats.has_failure_channel() => {
+                    let Some(heartbeat_failure) = heartbeat_failure else {
                         heartbeats.clear_failure_channel();
                         continue;
                     };
                     handler_task.abort();
-                    return Err(ConsumerError::HeartbeatFailed { message_id });
+                    return Err(map_heartbeat_failure(heartbeat_failure));
                 }
             }
         }
@@ -658,13 +670,13 @@ async fn handle_one(
                 handler_task.abort();
                 break Err(ConsumerError::Timeout);
             }
-            failed_message_id = heartbeats.recv_failure(), if heartbeats.has_failure_channel() => {
-                let Some(message_id) = failed_message_id else {
+            heartbeat_failure = heartbeats.recv_failure(), if heartbeats.has_failure_channel() => {
+                let Some(heartbeat_failure) = heartbeat_failure else {
                     heartbeats.clear_failure_channel();
                     continue;
                 };
                 handler_task.abort();
-                break Err(ConsumerError::HeartbeatFailed { message_id });
+                break Err(map_heartbeat_failure(heartbeat_failure));
             }
         }
     };
@@ -675,7 +687,7 @@ async fn handle_one(
 #[derive(Default)]
 struct HeartbeatGuard {
     tasks: Vec<HeartbeatTask>,
-    failure_rx: Option<mpsc::UnboundedReceiver<String>>,
+    failure_rx: Option<mpsc::UnboundedReceiver<HeartbeatFailure>>,
 }
 
 impl FromIterator<HeartbeatTask> for HeartbeatGuard {
@@ -692,7 +704,7 @@ impl HeartbeatGuard {
         self.failure_rx.is_some()
     }
 
-    async fn recv_failure(&mut self) -> Option<String> {
+    async fn recv_failure(&mut self) -> Option<HeartbeatFailure> {
         match &mut self.failure_rx {
             Some(failure_rx) => failure_rx.recv().await,
             None => None,
@@ -746,15 +758,17 @@ fn map_visibility_error(error: BackendError) -> ConsumerError {
     ConsumerError::ChangeMessageVisibility(Box::new(error))
 }
 
+fn map_heartbeat_failure(failure: HeartbeatFailure) -> ConsumerError {
+    ConsumerError::HeartbeatFailed {
+        message_id: failure.message_id,
+        source: Box::new(failure.source),
+    }
+}
+
 pub async fn shutdown_signal() -> Result<(), std::io::Error> {
     #[cfg(unix)]
     {
-        let mut sigterm =
-            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())?;
-        tokio::select! {
-            signal = tokio::signal::ctrl_c() => signal,
-            _ = sigterm.recv() => Ok(()),
-        }
+        shutdown_signal_with_ready(|| {}).await
     }
 
     #[cfg(not(unix))]
@@ -765,13 +779,25 @@ pub async fn shutdown_signal() -> Result<(), std::io::Error> {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::VecDeque, sync::Arc, time::Duration};
+    use std::{collections::VecDeque, error::Error as _, sync::Arc, time::Duration};
+    #[cfg(unix)]
+    use std::{process::Command, time::Instant};
 
     use async_trait::async_trait;
+    #[cfg(unix)]
+    use nix::{
+        sys::signal::{self, Signal},
+        unistd::Pid,
+    };
     use tokio::sync::Mutex;
 
     use super::*;
     use crate::{options::ConsumerOptions, options::HeartbeatConfig};
+
+    #[cfg(unix)]
+    const SIGNAL_CHILD_ENV: &str = "SQS_CONSUMER_SIGNAL_CHILD";
+    #[cfg(unix)]
+    const SIGNAL_READY_PATH_ENV: &str = "SQS_CONSUMER_SIGNAL_READY_PATH";
 
     #[derive(Default)]
     struct MockBackend {
@@ -1012,7 +1038,7 @@ mod tests {
                     .unwrap()
                     .push(message_id.to_owned());
             }
-            if let Some(ConsumerError::HeartbeatFailed { message_id }) =
+            if let Some(ConsumerError::HeartbeatFailed { message_id, .. }) =
                 error.downcast_ref::<ConsumerError>()
             {
                 self.heartbeat_failed_message_ids
@@ -1381,8 +1407,13 @@ mod tests {
         tokio::time::advance(Duration::from_secs(1)).await;
         let error = task.await.unwrap().unwrap_err();
 
-        assert!(
-            matches!(error, ConsumerError::HeartbeatFailed { message_id } if message_id == "1")
+        assert!(matches!(
+            error,
+            ConsumerError::HeartbeatFailed { ref message_id, .. } if message_id == "1"
+        ));
+        assert_eq!(
+            error.source().map(ToString::to_string),
+            Some("test backend error: visibility failed".to_string())
         );
         assert!(backend.deleted.lock().await.is_empty());
     }
@@ -1671,32 +1702,80 @@ mod tests {
     }
 
     #[cfg(unix)]
-    #[tokio::test]
-    async fn shutdown_signal_completes_on_sigterm() {
-        let signal_task = tokio::spawn(shutdown_signal());
-        tokio::time::sleep(Duration::from_millis(50)).await;
+    #[test]
+    fn shutdown_signal_completes_on_sigterm() {
+        assert_shutdown_signal_child_exits_after(Signal::SIGTERM);
+    }
 
-        nix::sys::signal::raise(nix::sys::signal::Signal::SIGTERM).unwrap();
+    #[cfg(unix)]
+    #[test]
+    fn shutdown_signal_completes_on_sigint() {
+        assert_shutdown_signal_child_exits_after(Signal::SIGINT);
+    }
 
-        tokio::time::timeout(Duration::from_secs(1), signal_task)
-            .await
-            .unwrap()
-            .unwrap()
+    #[cfg(unix)]
+    fn assert_shutdown_signal_child_exits_after(signal: Signal) {
+        let ready_path = std::env::temp_dir().join(format!(
+            "sqs-consumer-signal-ready-{}-{}",
+            std::process::id(),
+            signal as i32
+        ));
+        let _ = std::fs::remove_file(&ready_path);
+        let mut child = Command::new(std::env::current_exe().unwrap())
+            .arg("--ignored")
+            .arg("--nocapture")
+            .arg("shutdown_signal_child_waits_for_signal")
+            .env(SIGNAL_CHILD_ENV, "1")
+            .env(SIGNAL_READY_PATH_ENV, &ready_path)
+            .spawn()
             .unwrap();
+
+        let ready_deadline = Instant::now() + Duration::from_secs(5);
+        while !ready_path.exists() {
+            if let Some(status) = child.try_wait().unwrap() {
+                panic!("shutdown signal child exited before readiness: {status}");
+            }
+            if Instant::now() >= ready_deadline {
+                let _ = child.kill();
+                let _ = child.wait();
+                panic!("shutdown signal child did not report readiness");
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        signal::kill(Pid::from_raw(child.id() as i32), signal).unwrap();
+
+        let exit_deadline = Instant::now() + Duration::from_secs(5);
+        let status = loop {
+            if let Some(status) = child.try_wait().unwrap() {
+                break status;
+            }
+            if Instant::now() >= exit_deadline {
+                let _ = child.kill();
+                let _ = child.wait();
+                panic!("shutdown signal child did not exit after {signal:?}");
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        };
+        let _ = std::fs::remove_file(&ready_path);
+        assert!(
+            status.success(),
+            "shutdown signal child exited unsuccessfully: {status}"
+        );
     }
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn shutdown_signal_completes_on_sigint() {
-        let signal_task = tokio::spawn(shutdown_signal());
-        tokio::time::sleep(Duration::from_millis(50)).await;
-
-        nix::sys::signal::raise(nix::sys::signal::Signal::SIGINT).unwrap();
-
-        tokio::time::timeout(Duration::from_secs(1), signal_task)
-            .await
-            .unwrap()
-            .unwrap()
-            .unwrap();
+    #[ignore]
+    async fn shutdown_signal_child_waits_for_signal() {
+        if std::env::var_os(SIGNAL_CHILD_ENV).is_none() {
+            return;
+        }
+        let ready_path = std::env::var_os(SIGNAL_READY_PATH_ENV).unwrap();
+        shutdown_signal_with_ready(|| {
+            std::fs::write(&ready_path, b"ready").unwrap();
+        })
+        .await
+        .unwrap();
     }
 }

--- a/apps/api/sqs-consumer/src/consumer.rs
+++ b/apps/api/sqs-consumer/src/consumer.rs
@@ -371,13 +371,14 @@ impl Consumer {
         self.run_loop().await
     }
 
-    pub async fn run_until_ctrl_c(self) -> Result<(), ConsumerError> {
+    pub async fn run_until_shutdown_signal(self) -> Result<(), ConsumerError> {
         let shutdown = self.shutdown_handle();
         let mut task = tokio::spawn(async move { self.run().await });
         tokio::select! {
             result = &mut task => result.map_err(ConsumerError::Join)?,
-            signal = tokio::signal::ctrl_c() => {
+            signal = shutdown_signal() => {
                 signal.map_err(ConsumerError::ShutdownSignal)?;
+                tracing::info!("graceful shutdown triggered");
                 shutdown.graceful();
                 task.await.map_err(ConsumerError::Join)?
             }
@@ -564,6 +565,23 @@ fn map_delete_error(error: BackendError) -> ConsumerError {
 
 fn map_visibility_error(error: BackendError) -> ConsumerError {
     ConsumerError::ChangeMessageVisibility(Box::new(error))
+}
+
+pub async fn shutdown_signal() -> Result<(), std::io::Error> {
+    #[cfg(unix)]
+    {
+        let mut sigterm =
+            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())?;
+        tokio::select! {
+            signal = tokio::signal::ctrl_c() => signal,
+            _ = sigterm.recv() => Ok(()),
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        tokio::signal::ctrl_c().await
+    }
 }
 
 #[cfg(test)]

--- a/apps/api/sqs-consumer/src/consumer.rs
+++ b/apps/api/sqs-consumer/src/consumer.rs
@@ -1669,4 +1669,34 @@ mod tests {
         assert_eq!(*timed_out_message_ids.lock().unwrap(), vec![vec!["1"]]);
         assert_eq!(*backend.deleted.lock().await, vec![vec!["r1"]]);
     }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn shutdown_signal_completes_on_sigterm() {
+        let signal_task = tokio::spawn(shutdown_signal());
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        nix::sys::signal::raise(nix::sys::signal::Signal::SIGTERM).unwrap();
+
+        tokio::time::timeout(Duration::from_secs(1), signal_task)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn shutdown_signal_completes_on_sigint() {
+        let signal_task = tokio::spawn(shutdown_signal());
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        nix::sys::signal::raise(nix::sys::signal::Signal::SIGINT).unwrap();
+
+        tokio::time::timeout(Duration::from_secs(1), signal_task)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+    }
 }

--- a/apps/api/sqs-consumer/src/consumer.rs
+++ b/apps/api/sqs-consumer/src/consumer.rs
@@ -1,0 +1,734 @@
+use std::{collections::HashSet, sync::Arc};
+
+use aws_sdk_sqs::types::{DeleteMessageBatchRequestEntry, Message};
+use futures::{StreamExt, stream::FuturesUnordered};
+use tokio::{sync::watch, task::JoinSet};
+
+use crate::{
+    backend::{AwsSqsBackend, BackendError, SqsBackend},
+    error::ConsumerError,
+    handler::{BatchMessageHandler, BatchOutcome, HandleOutcome, MessageHandler},
+    heartbeat::spawn_heartbeat,
+    listener::{ConsumerListener, NoopListener},
+    options::{ConsumerOptions, TerminateVisibility},
+    shutdown::{ShutdownHandle, ShutdownState},
+};
+
+pub(crate) enum HandlerKind<H> {
+    Message(Arc<H>),
+    Batch(Arc<H>),
+}
+
+pub struct Consumer<H> {
+    options: ConsumerOptions,
+    backend: Arc<dyn SqsBackend>,
+    handler: HandlerKind<H>,
+    listener: Arc<dyn ConsumerListener>,
+    shutdown_handle: ShutdownHandle,
+    shutdown_rx: watch::Receiver<ShutdownState>,
+}
+
+impl<H> Consumer<H> {
+    pub fn listener<L>(mut self, listener: L) -> Self
+    where
+        L: ConsumerListener,
+    {
+        self.listener = Arc::new(listener);
+        self
+    }
+
+    pub fn shutdown_handle(&self) -> ShutdownHandle {
+        self.shutdown_handle.clone()
+    }
+
+    async fn receive_once(&self) -> Result<Vec<Message>, ConsumerError> {
+        self.backend
+            .receive_messages(
+                &self.options.queue_url,
+                self.options.batch_size,
+                self.options.wait_time_seconds,
+                self.options.visibility_timeout,
+            )
+            .await
+            .map_err(map_receive_error)
+    }
+
+    async fn delete_acked(&self, messages: &[Message]) -> Result<(), ConsumerError> {
+        if !self.options.should_delete_messages || messages.is_empty() {
+            return Ok(());
+        }
+        let entries = messages
+            .iter()
+            .enumerate()
+            .map(|(index, message)| {
+                let Some(receipt_handle) = message.receipt_handle() else {
+                    return Err(ConsumerError::MissingReceiptHandle {
+                        message_id: message.message_id().map(ToOwned::to_owned),
+                    });
+                };
+                DeleteMessageBatchRequestEntry::builder()
+                    .id(index.to_string())
+                    .receipt_handle(receipt_handle)
+                    .build()
+                    .map_err(|error| ConsumerError::InvalidOptions(error.to_string()))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        self.backend
+            .delete_message_batch(&self.options.queue_url, entries)
+            .await
+            .map_err(map_delete_error)
+    }
+
+    async fn terminate_visibility(&self, messages: &[Message]) -> Result<(), ConsumerError> {
+        for message in messages {
+            let timeout = match &self.options.terminate_visibility {
+                TerminateVisibility::Off => continue,
+                TerminateVisibility::Reset => 0,
+                TerminateVisibility::Fixed(value) => *value,
+                TerminateVisibility::Dynamic(resolver) => resolver(message),
+            };
+            let Some(receipt_handle) = message.receipt_handle() else {
+                return Err(ConsumerError::MissingReceiptHandle {
+                    message_id: message.message_id().map(ToOwned::to_owned),
+                });
+            };
+            if let Err(error) = self
+                .backend
+                .change_message_visibility(&self.options.queue_url, receipt_handle, timeout)
+                .await
+            {
+                self.listener.on_visibility_error(message, &error);
+                return Err(map_visibility_error(error));
+            }
+        }
+        Ok(())
+    }
+
+    async fn run_loop(mut self) -> Result<(), ConsumerError>
+    where
+        H: MessageHandler + BatchMessageHandler,
+    {
+        self.listener.on_started();
+        loop {
+            if *self.shutdown_rx.borrow() != ShutdownState::Running {
+                break;
+            }
+            let messages = match self.receive_once().await {
+                Ok(messages) => messages,
+                Err(error) => {
+                    self.listener.on_error(&error);
+                    tokio::select! {
+                        _ = tokio::time::sleep(self.options.receive_error_backoff) => {}
+                        _ = self.shutdown_rx.changed() => {}
+                    }
+                    continue;
+                }
+            };
+            if messages.is_empty() {
+                self.listener.on_empty();
+                continue;
+            }
+            for message in &messages {
+                self.listener.on_message_received(message);
+            }
+            if let Err(error) = self.dispatch_and_ack(messages).await {
+                self.listener.on_error(&error);
+            }
+            self.listener.on_response_processed();
+        }
+        if *self.shutdown_rx.borrow() == ShutdownState::Abort {
+            self.listener.on_aborted();
+        } else {
+            let _polling_complete_wait_time = self.options.polling_complete_wait_time;
+            self.listener.on_stopped();
+        }
+        Ok(())
+    }
+
+    async fn dispatch_and_ack(&self, messages: Vec<Message>) -> Result<(), ConsumerError>
+    where
+        H: MessageHandler + BatchMessageHandler,
+    {
+        match &self.handler {
+            HandlerKind::Message(handler) => {
+                self.dispatch_messages(handler.clone(), messages).await
+            }
+            HandlerKind::Batch(handler) => self.dispatch_batch(handler.clone(), messages).await,
+        }
+    }
+
+    async fn dispatch_messages(
+        &self,
+        handler: Arc<H>,
+        messages: Vec<Message>,
+    ) -> Result<(), ConsumerError>
+    where
+        H: MessageHandler,
+    {
+        let mut futures = FuturesUnordered::new();
+        for message in messages {
+            let handler = handler.clone();
+            let options = self.options.clone();
+            let backend = self.backend.clone();
+            let listener = self.listener.clone();
+            futures.push(async move {
+                let outcome =
+                    handle_one(handler, backend, listener.clone(), options, message.clone()).await;
+                (message, outcome)
+            });
+        }
+
+        let mut acked = Vec::new();
+        let mut nacked = Vec::new();
+        while let Some((message, outcome)) = futures.next().await {
+            match outcome {
+                Ok(HandleOutcome::Ack) => acked.push(message),
+                Ok(HandleOutcome::Nack) => nacked.push(message),
+                Err(error) => {
+                    self.listener.on_processing_error(&message, &error);
+                    nacked.push(message);
+                }
+            }
+        }
+        if self.options.always_acknowledge {
+            acked.extend(nacked);
+            nacked = Vec::new();
+        }
+        self.terminate_visibility(&nacked).await?;
+        self.delete_acked(&acked).await
+    }
+
+    async fn dispatch_batch(
+        &self,
+        handler: Arc<H>,
+        messages: Vec<Message>,
+    ) -> Result<(), ConsumerError>
+    where
+        H: BatchMessageHandler,
+    {
+        let heartbeat_handles = self.start_heartbeats(&messages);
+        let result = if let Some(timeout) = self.options.handle_message_timeout {
+            match tokio::time::timeout(timeout, handler.handle_batch(messages.clone())).await {
+                Ok(result) => result.map_err(|error| ConsumerError::Processing(Box::new(error))),
+                Err(_) => {
+                    for message in &messages {
+                        self.listener.on_timeout_error(message);
+                    }
+                    Err(ConsumerError::Timeout)
+                }
+            }
+        } else {
+            handler
+                .handle_batch(messages.clone())
+                .await
+                .map_err(|error| ConsumerError::Processing(Box::new(error)))
+        };
+        stop_heartbeats(heartbeat_handles).await;
+
+        let (mut acked, nacked) = match result {
+            Ok(BatchOutcome::AckAll) => (messages.clone(), Vec::new()),
+            Ok(BatchOutcome::NackAll) => (Vec::new(), messages.clone()),
+            Ok(BatchOutcome::Partial { ack_message_ids }) => {
+                let ids = ack_message_ids.into_iter().collect::<HashSet<_>>();
+                let acked = messages
+                    .iter()
+                    .filter(|message| message.message_id().is_some_and(|id| ids.contains(id)))
+                    .cloned()
+                    .collect::<Vec<_>>();
+                let nacked = messages
+                    .iter()
+                    .filter(|message| !message.message_id().is_some_and(|id| ids.contains(id)))
+                    .cloned()
+                    .collect::<Vec<_>>();
+                (acked, nacked)
+            }
+            Err(error) => {
+                for message in &messages {
+                    self.listener.on_processing_error(message, &error);
+                }
+                if self.options.always_acknowledge {
+                    (messages.clone(), Vec::new())
+                } else {
+                    self.terminate_visibility(&messages).await?;
+                    return Err(error);
+                }
+            }
+        };
+        if !nacked.is_empty() {
+            self.terminate_visibility(&nacked).await?;
+        }
+        if self.options.always_acknowledge {
+            acked = messages;
+        }
+        self.delete_acked(&acked).await
+    }
+
+    fn start_heartbeats(
+        &self,
+        messages: &[Message],
+    ) -> Vec<(
+        tokio::sync::watch::Sender<bool>,
+        tokio::task::JoinHandle<()>,
+    )> {
+        let Some(config) = &self.options.heartbeat else {
+            return Vec::new();
+        };
+        let visibility_timeout = config
+            .visibility_timeout
+            .or(self.options.visibility_timeout)
+            .expect("heartbeat validation requires visibility_timeout");
+        messages
+            .iter()
+            .filter_map(|message| {
+                spawn_heartbeat(
+                    self.backend.clone(),
+                    self.listener.clone(),
+                    self.options.queue_url.clone(),
+                    message.clone(),
+                    config.interval,
+                    visibility_timeout,
+                )
+            })
+            .collect()
+    }
+}
+
+impl<H> Consumer<H>
+where
+    H: MessageHandler + BatchMessageHandler,
+{
+    pub async fn run(self) -> Result<(), ConsumerError> {
+        self.run_loop().await
+    }
+
+    pub async fn run_until_ctrl_c(self) -> Result<(), ConsumerError> {
+        let shutdown = self.shutdown_handle();
+        let task = tokio::spawn(async move { self.run().await });
+        tokio::signal::ctrl_c()
+            .await
+            .map_err(ConsumerError::ShutdownSignal)?;
+        shutdown.graceful();
+        task.await.map_err(ConsumerError::Join)?
+    }
+
+    pub async fn run_once(&self) -> Result<(), ConsumerError> {
+        let messages = self.receive_once().await?;
+        if messages.is_empty() {
+            self.listener.on_empty();
+            return Ok(());
+        }
+        for message in &messages {
+            self.listener.on_message_received(message);
+        }
+        let result = self.dispatch_and_ack(messages).await;
+        self.listener.on_response_processed();
+        result
+    }
+}
+
+impl<H> Consumer<H>
+where
+    H: MessageHandler + BatchMessageHandler,
+{
+    pub fn with_handler(options: ConsumerOptions, handler: H) -> Result<Self, ConsumerError> {
+        let client = options
+            .sqs_client
+            .clone()
+            .ok_or_else(|| ConsumerError::InvalidOptions("sqs_client is required".into()))?;
+        Ok(Self::new(
+            options,
+            Arc::new(AwsSqsBackend::new(client)),
+            HandlerKind::Message(Arc::new(handler)),
+        ))
+    }
+
+    pub fn with_batch_handler(options: ConsumerOptions, handler: H) -> Result<Self, ConsumerError> {
+        let client = options
+            .sqs_client
+            .clone()
+            .ok_or_else(|| ConsumerError::InvalidOptions("sqs_client is required".into()))?;
+        Ok(Self::new(
+            options,
+            Arc::new(AwsSqsBackend::new(client)),
+            HandlerKind::Batch(Arc::new(handler)),
+        ))
+    }
+
+    fn new(
+        options: ConsumerOptions,
+        backend: Arc<dyn SqsBackend>,
+        handler: HandlerKind<H>,
+    ) -> Self {
+        let (shutdown_handle, shutdown_rx) = ShutdownHandle::new();
+        Self {
+            options,
+            backend,
+            handler,
+            listener: Arc::new(NoopListener),
+            shutdown_handle,
+            shutdown_rx,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_test_backend(
+        options: ConsumerOptions,
+        backend: Arc<dyn SqsBackend>,
+        handler: HandlerKind<H>,
+    ) -> Self {
+        Self::new(options, backend, handler)
+    }
+}
+
+async fn handle_one<H>(
+    handler: Arc<H>,
+    backend: Arc<dyn SqsBackend>,
+    listener: Arc<dyn ConsumerListener>,
+    options: ConsumerOptions,
+    message: Message,
+) -> Result<HandleOutcome, ConsumerError>
+where
+    H: MessageHandler,
+{
+    let heartbeats = if let Some(config) = &options.heartbeat {
+        let visibility_timeout = config
+            .visibility_timeout
+            .or(options.visibility_timeout)
+            .expect("heartbeat validation requires visibility_timeout");
+        spawn_heartbeat(
+            backend,
+            listener,
+            options.queue_url.clone(),
+            message.clone(),
+            config.interval,
+            visibility_timeout,
+        )
+        .into_iter()
+        .collect()
+    } else {
+        Vec::new()
+    };
+
+    let result = if let Some(timeout) = options.handle_message_timeout {
+        match tokio::time::timeout(timeout, handler.handle_message(message.clone())).await {
+            Ok(result) => result.map_err(|error| ConsumerError::Processing(Box::new(error))),
+            Err(_) => Err(ConsumerError::Timeout),
+        }
+    } else {
+        handler
+            .handle_message(message)
+            .await
+            .map_err(|error| ConsumerError::Processing(Box::new(error)))
+    };
+    stop_heartbeats(heartbeats).await;
+    result
+}
+
+async fn stop_heartbeats(
+    handles: Vec<(
+        tokio::sync::watch::Sender<bool>,
+        tokio::task::JoinHandle<()>,
+    )>,
+) {
+    let mut joins = JoinSet::new();
+    for (stop, handle) in handles {
+        let _ = stop.send(true);
+        joins.spawn(async move {
+            let _ = handle.await;
+        });
+    }
+    while joins.join_next().await.is_some() {}
+}
+
+fn map_receive_error(error: BackendError) -> ConsumerError {
+    ConsumerError::ReceiveMessage(Box::new(error))
+}
+
+fn map_delete_error(error: BackendError) -> ConsumerError {
+    ConsumerError::DeleteMessageBatch(Box::new(error))
+}
+
+fn map_visibility_error(error: BackendError) -> ConsumerError {
+    ConsumerError::ChangeMessageVisibility(Box::new(error))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::VecDeque, sync::Arc, time::Duration};
+
+    use async_trait::async_trait;
+    use tokio::sync::Mutex;
+
+    use super::*;
+    use crate::{options::ConsumerOptions, options::HeartbeatConfig};
+
+    #[derive(Default)]
+    struct MockBackend {
+        receives: Mutex<VecDeque<Result<Vec<Message>, BackendError>>>,
+        deleted: Mutex<Vec<Vec<String>>>,
+        visibility_changes: Mutex<Vec<(String, i32)>>,
+        fail_delete: bool,
+    }
+
+    #[async_trait]
+    impl SqsBackend for MockBackend {
+        async fn receive_messages(
+            &self,
+            _queue_url: &str,
+            _max_number_of_messages: i32,
+            _wait_time_seconds: i32,
+            _visibility_timeout: Option<i32>,
+        ) -> Result<Vec<Message>, BackendError> {
+            self.receives
+                .lock()
+                .await
+                .pop_front()
+                .unwrap_or_else(|| Ok(Vec::new()))
+        }
+
+        async fn delete_message_batch(
+            &self,
+            _queue_url: &str,
+            entries: Vec<DeleteMessageBatchRequestEntry>,
+        ) -> Result<(), BackendError> {
+            if self.fail_delete {
+                return Err(BackendError::Test("delete failed".into()));
+            }
+            self.deleted.lock().await.push(
+                entries
+                    .iter()
+                    .map(|entry| entry.receipt_handle().to_owned())
+                    .collect(),
+            );
+            Ok(())
+        }
+
+        async fn change_message_visibility(
+            &self,
+            _queue_url: &str,
+            receipt_handle: &str,
+            visibility_timeout: i32,
+        ) -> Result<(), BackendError> {
+            self.visibility_changes
+                .lock()
+                .await
+                .push((receipt_handle.to_owned(), visibility_timeout));
+            Ok(())
+        }
+    }
+
+    struct TestHandler {
+        batch_outcome: BatchOutcome,
+        message_outcome: HandleOutcome,
+        delay: Option<Duration>,
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("test handler error")]
+    struct TestHandlerError;
+
+    #[async_trait]
+    impl MessageHandler for TestHandler {
+        type Error = TestHandlerError;
+
+        async fn handle_message(&self, _message: Message) -> Result<HandleOutcome, Self::Error> {
+            if let Some(delay) = self.delay {
+                tokio::time::sleep(delay).await;
+            }
+            Ok(self.message_outcome.clone())
+        }
+    }
+
+    #[async_trait]
+    impl BatchMessageHandler for TestHandler {
+        type Error = TestHandlerError;
+
+        async fn handle_batch(&self, _messages: Vec<Message>) -> Result<BatchOutcome, Self::Error> {
+            if let Some(delay) = self.delay {
+                tokio::time::sleep(delay).await;
+            }
+            Ok(self.batch_outcome.clone())
+        }
+    }
+
+    fn message(id: &str, receipt: Option<&str>) -> Message {
+        let mut builder = Message::builder().message_id(id).body("{}");
+        if let Some(receipt) = receipt {
+            builder = builder.receipt_handle(receipt);
+        }
+        builder.build()
+    }
+
+    fn options() -> ConsumerOptions {
+        ConsumerOptions::builder()
+            .queue_url("queue")
+            .wait_time_seconds(0)
+            .build_for_backend()
+            .unwrap()
+    }
+
+    fn consumer(
+        backend: Arc<MockBackend>,
+        handler: TestHandler,
+        options: ConsumerOptions,
+    ) -> Consumer<TestHandler> {
+        Consumer::with_test_backend(options, backend, HandlerKind::Batch(Arc::new(handler)))
+    }
+
+    #[tokio::test]
+    async fn ack_all_deletes_all_receipt_handles() {
+        let backend = Arc::new(MockBackend::default());
+        backend
+            .receives
+            .lock()
+            .await
+            .push_back(Ok(vec![message("1", Some("r1")), message("2", Some("r2"))]));
+        let handler = TestHandler {
+            batch_outcome: BatchOutcome::AckAll,
+            message_outcome: HandleOutcome::Ack,
+            delay: None,
+        };
+
+        consumer(backend.clone(), handler, options())
+            .run_once()
+            .await
+            .unwrap();
+
+        assert_eq!(*backend.deleted.lock().await, vec![vec!["r1", "r2"]]);
+    }
+
+    #[tokio::test]
+    async fn partial_ack_deletes_only_selected_message_ids() {
+        let backend = Arc::new(MockBackend::default());
+        backend
+            .receives
+            .lock()
+            .await
+            .push_back(Ok(vec![message("1", Some("r1")), message("2", Some("r2"))]));
+        let handler = TestHandler {
+            batch_outcome: BatchOutcome::Partial {
+                ack_message_ids: vec!["2".into()],
+            },
+            message_outcome: HandleOutcome::Ack,
+            delay: None,
+        };
+
+        consumer(backend.clone(), handler, options())
+            .run_once()
+            .await
+            .unwrap();
+
+        assert_eq!(*backend.deleted.lock().await, vec![vec!["r2"]]);
+    }
+
+    #[tokio::test]
+    async fn missing_receipt_handle_surfaces_error() {
+        let backend = Arc::new(MockBackend::default());
+        backend
+            .receives
+            .lock()
+            .await
+            .push_back(Ok(vec![message("1", None)]));
+        let handler = TestHandler {
+            batch_outcome: BatchOutcome::AckAll,
+            message_outcome: HandleOutcome::Ack,
+            delay: None,
+        };
+
+        let error = consumer(backend, handler, options())
+            .run_once()
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, ConsumerError::MissingReceiptHandle { .. }));
+    }
+
+    #[tokio::test]
+    async fn delete_batch_failure_surfaces_error() {
+        let backend = Arc::new(MockBackend {
+            fail_delete: true,
+            ..MockBackend::default()
+        });
+        backend
+            .receives
+            .lock()
+            .await
+            .push_back(Ok(vec![message("1", Some("r1"))]));
+        let handler = TestHandler {
+            batch_outcome: BatchOutcome::AckAll,
+            message_outcome: HandleOutcome::Ack,
+            delay: None,
+        };
+
+        let error = consumer(backend, handler, options())
+            .run_once()
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, ConsumerError::DeleteMessageBatch(_)));
+    }
+
+    #[tokio::test]
+    async fn nack_terminates_visibility_when_configured() {
+        let backend = Arc::new(MockBackend::default());
+        backend
+            .receives
+            .lock()
+            .await
+            .push_back(Ok(vec![message("1", Some("r1"))]));
+        let handler = TestHandler {
+            batch_outcome: BatchOutcome::NackAll,
+            message_outcome: HandleOutcome::Ack,
+            delay: None,
+        };
+        let options = ConsumerOptions::builder()
+            .queue_url("queue")
+            .wait_time_seconds(0)
+            .terminate_visibility(TerminateVisibility::Reset)
+            .build_for_backend()
+            .unwrap();
+
+        consumer(backend.clone(), handler, options)
+            .run_once()
+            .await
+            .unwrap();
+
+        assert_eq!(
+            *backend.visibility_changes.lock().await,
+            vec![("r1".into(), 0)]
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn heartbeat_extends_visibility_while_batch_is_processing() {
+        let backend = Arc::new(MockBackend::default());
+        backend
+            .receives
+            .lock()
+            .await
+            .push_back(Ok(vec![message("1", Some("r1"))]));
+        let handler = TestHandler {
+            batch_outcome: BatchOutcome::AckAll,
+            message_outcome: HandleOutcome::Ack,
+            delay: Some(Duration::from_secs(3)),
+        };
+        let options = ConsumerOptions::builder()
+            .queue_url("queue")
+            .wait_time_seconds(0)
+            .visibility_timeout(10)
+            .heartbeat(HeartbeatConfig {
+                interval: Duration::from_secs(1),
+                visibility_timeout: None,
+            })
+            .build_for_backend()
+            .unwrap();
+
+        consumer(backend.clone(), handler, options)
+            .run_once()
+            .await
+            .unwrap();
+
+        assert!(!backend.visibility_changes.lock().await.is_empty());
+    }
+}

--- a/apps/api/sqs-consumer/src/consumer.rs
+++ b/apps/api/sqs-consumer/src/consumer.rs
@@ -418,7 +418,10 @@ impl Consumer {
                     graceful_timeout = None;
                 }
                 failed_message_id = heartbeats.recv_failure(), if heartbeats.has_failure_channel() => {
-                    let message_id = failed_message_id.expect("heartbeat failure channel should be open while tasks run");
+                    let Some(message_id) = failed_message_id else {
+                        heartbeats.clear_failure_channel();
+                        continue;
+                    };
                     handler_task.abort();
                     return Err(ConsumerError::HeartbeatFailed { message_id });
                 }
@@ -433,29 +436,30 @@ impl Consumer {
         let visibility_timeout =
             resolve_heartbeat_visibility_timeout(config, self.options.visibility_timeout)?;
         let (failure_tx, failure_rx) = mpsc::unbounded_channel();
-        Ok(HeartbeatGuard {
-            tasks: messages
-                .iter()
-                .filter_map(|message| {
-                    let receipt_handle = message.receipt_handle()?.to_owned();
-                    let message_id = message.message_id().unwrap_or(&receipt_handle).to_owned();
-                    let (stop_tx, stop_rx) = watch::channel(false);
-                    spawn_heartbeat_with_failure_channel(HeartbeatSpawn {
-                        backend: self.backend.clone(),
-                        listener: self.listener.clone(),
-                        queue_url: self.options.queue_url.clone(),
-                        message: message.clone(),
-                        receipt_handle,
-                        message_id,
-                        interval: config.interval,
-                        visibility_timeout,
-                        stop_tx,
-                        stop_rx,
-                        failure_tx: failure_tx.clone(),
-                    })
+        let tasks = messages
+            .iter()
+            .filter_map(|message| {
+                let receipt_handle = message.receipt_handle()?.to_owned();
+                let message_id = message.message_id().unwrap_or(&receipt_handle).to_owned();
+                let (stop_tx, stop_rx) = watch::channel(false);
+                spawn_heartbeat_with_failure_channel(HeartbeatSpawn {
+                    backend: self.backend.clone(),
+                    listener: self.listener.clone(),
+                    queue_url: self.options.queue_url.clone(),
+                    message: message.clone(),
+                    receipt_handle,
+                    message_id,
+                    interval: config.interval,
+                    visibility_timeout,
+                    stop_tx,
+                    stop_rx,
+                    failure_tx: failure_tx.clone(),
                 })
-                .collect(),
-            failure_rx: Some(failure_rx),
+            })
+            .collect::<Vec<_>>();
+        Ok(HeartbeatGuard {
+            failure_rx: (!tasks.is_empty()).then_some(failure_rx),
+            tasks,
         })
     }
 }
@@ -614,30 +618,55 @@ async fn handle_one(
     options: ConsumerOptions,
     message: Message,
 ) -> Result<HandleOutcome, ConsumerError> {
-    let heartbeats = if let Some(config) = &options.heartbeat {
+    let mut heartbeats = if let Some(config) = &options.heartbeat {
         let visibility_timeout =
             resolve_heartbeat_visibility_timeout(config, options.visibility_timeout)?;
-        spawn_heartbeat(
+        match spawn_heartbeat(
             backend,
             listener.clone(),
             options.queue_url.clone(),
             message.clone(),
             config.interval,
             visibility_timeout,
-        )
-        .into_iter()
-        .collect()
+        ) {
+            Some((task, failure_rx)) => HeartbeatGuard {
+                tasks: vec![task],
+                failure_rx: Some(failure_rx),
+            },
+            None => HeartbeatGuard::default(),
+        }
     } else {
         HeartbeatGuard::default()
     };
 
-    let result = if let Some(timeout) = options.handle_message_timeout {
-        match tokio::time::timeout(timeout, handler.handle_message(message.clone())).await {
-            Ok(result) => result,
-            Err(_) => Err(ConsumerError::Timeout),
+    let handler_message = message.clone();
+    let mut handler_task =
+        tokio::spawn(async move { handler.handle_message(handler_message).await });
+    let mut handler_timeout = options
+        .handle_message_timeout
+        .map(|duration| Box::pin(sleep(duration)));
+    let result = loop {
+        tokio::select! {
+            result = &mut handler_task => {
+                break result.map_err(ConsumerError::Join)?;
+            }
+            _ = async {
+                if let Some(timeout) = &mut handler_timeout {
+                    timeout.as_mut().await;
+                }
+            }, if handler_timeout.is_some() => {
+                handler_task.abort();
+                break Err(ConsumerError::Timeout);
+            }
+            failed_message_id = heartbeats.recv_failure(), if heartbeats.has_failure_channel() => {
+                let Some(message_id) = failed_message_id else {
+                    heartbeats.clear_failure_channel();
+                    continue;
+                };
+                handler_task.abort();
+                break Err(ConsumerError::HeartbeatFailed { message_id });
+            }
         }
-    } else {
-        handler.handle_message(message).await
     };
     stop_heartbeats(heartbeats, listener).await;
     result
@@ -668,6 +697,10 @@ impl HeartbeatGuard {
             Some(failure_rx) => failure_rx.recv().await,
             None => None,
         }
+    }
+
+    fn clear_failure_channel(&mut self) {
+        self.failure_rx = None;
     }
 }
 
@@ -891,6 +924,8 @@ mod tests {
         graceful_timeout_message_ids: Arc<std::sync::Mutex<Vec<Vec<String>>>>,
         error_message_ids: Arc<std::sync::Mutex<Vec<Vec<String>>>>,
         timeout_message_ids: Arc<std::sync::Mutex<Vec<String>>>,
+        processing_error_message_ids: Arc<std::sync::Mutex<Vec<String>>>,
+        heartbeat_failed_message_ids: Arc<std::sync::Mutex<Vec<String>>>,
         message_processed_ids: Arc<std::sync::Mutex<Vec<String>>>,
         response_processed_counts: Arc<std::sync::Mutex<Vec<usize>>>,
         polling_started_count: Arc<std::sync::Mutex<usize>>,
@@ -963,6 +998,27 @@ mod tests {
                     .lock()
                     .unwrap()
                     .push(message_id.to_owned());
+            }
+        }
+
+        fn on_processing_error(
+            &self,
+            message: &Message,
+            error: &(dyn std::error::Error + 'static),
+        ) {
+            if let Some(message_id) = message.message_id() {
+                self.processing_error_message_ids
+                    .lock()
+                    .unwrap()
+                    .push(message_id.to_owned());
+            }
+            if let Some(ConsumerError::HeartbeatFailed { message_id }) =
+                error.downcast_ref::<ConsumerError>()
+            {
+                self.heartbeat_failed_message_ids
+                    .lock()
+                    .unwrap()
+                    .push(message_id.clone());
             }
         }
     }
@@ -1328,6 +1384,75 @@ mod tests {
         assert!(
             matches!(error, ConsumerError::HeartbeatFailed { message_id } if message_id == "1")
         );
+        assert!(backend.deleted.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn heartbeat_guard_has_no_failure_channel_when_no_tasks_start() {
+        let backend = Arc::new(MockBackend::default());
+        let handler = TestHandler {
+            batch_outcome: BatchOutcome::AckAll,
+            message_outcome: HandleOutcome::Ack,
+            delay: None,
+        };
+        let options = ConsumerOptions::builder()
+            .queue_url("queue")
+            .wait_time_seconds(0)
+            .visibility_timeout(10)
+            .heartbeat(HeartbeatConfig::new(Duration::from_secs(1)))
+            .build_for_backend()
+            .unwrap();
+        let consumer = consumer(backend, handler, options);
+
+        let empty_guard = consumer.start_heartbeats(&[]).unwrap();
+        let no_receipt_guard = consumer.start_heartbeats(&[message("1", None)]).unwrap();
+
+        assert!(!empty_guard.has_failure_channel());
+        assert!(!no_receipt_guard.has_failure_channel());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn per_message_heartbeat_failure_aborts_handler() {
+        let backend = Arc::new(MockBackend {
+            fail_visibility: true,
+            ..MockBackend::default()
+        });
+        backend
+            .receives
+            .lock()
+            .await
+            .push_back(Ok(vec![message("1", Some("r1"))]));
+        let listener = RecordingListener::default();
+        let processing_error_message_ids = listener.processing_error_message_ids.clone();
+        let heartbeat_failed_message_ids = listener.heartbeat_failed_message_ids.clone();
+        let handler = TestHandler {
+            batch_outcome: BatchOutcome::AckAll,
+            message_outcome: HandleOutcome::Ack,
+            delay: Some(Duration::from_secs(60)),
+        };
+        let options = ConsumerOptions::builder()
+            .queue_url("queue")
+            .wait_time_seconds(0)
+            .visibility_timeout(10)
+            .heartbeat(HeartbeatConfig::new(Duration::from_secs(1)))
+            .build_for_backend()
+            .unwrap();
+        let consumer = Consumer::with_test_backend(
+            options,
+            backend.clone(),
+            HandlerKind::Message(Arc::new(handler)),
+        )
+        .listener(listener);
+
+        let task = tokio::spawn(async move { consumer.run_once().await });
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_secs(1)).await;
+        tokio::task::yield_now().await;
+
+        assert!(task.is_finished());
+        task.await.unwrap().unwrap();
+        assert_eq!(*processing_error_message_ids.lock().unwrap(), vec!["1"]);
+        assert_eq!(*heartbeat_failed_message_ids.lock().unwrap(), vec!["1"]);
         assert!(backend.deleted.lock().await.is_empty());
     }
 

--- a/apps/api/sqs-consumer/src/consumer.rs
+++ b/apps/api/sqs-consumer/src/consumer.rs
@@ -1,10 +1,9 @@
 use std::{collections::HashSet, pin::Pin, sync::Arc};
 
-use aws_sdk_sqs::types::{DeleteMessageBatchRequestEntry, Message};
+use aws_sdk_sqs::types::Message;
 use futures::{StreamExt, stream::FuturesUnordered};
 use tokio::{
-    sync::watch,
-    task::JoinHandle,
+    sync::{mpsc, watch},
     time::{Sleep, sleep},
 };
 
@@ -12,7 +11,7 @@ use crate::{
     backend::{AwsSqsBackend, BackendError, SqsBackend},
     error::ConsumerError,
     handler::{BatchMessageHandler, BatchOutcome, HandleOutcome, MessageHandler},
-    heartbeat::spawn_heartbeat,
+    heartbeat::{HeartbeatTask, spawn_heartbeat, spawn_heartbeat_with_failure_channel},
     listener::{ConsumerListener, NoopListener},
     options::{ConsumerOptions, TerminateVisibility, validate_visibility_timeout},
     shutdown::{ShutdownHandle, ShutdownState},
@@ -102,6 +101,7 @@ impl Consumer {
         if !self.options.should_delete_messages || messages.is_empty() {
             return Ok(());
         }
+        let message_ids = message_ids(messages);
         let entries = messages
             .iter()
             .enumerate()
@@ -111,18 +111,14 @@ impl Consumer {
                         message_id: message.message_id().map(ToOwned::to_owned),
                     });
                 };
-                DeleteMessageBatchRequestEntry::builder()
-                    .id(index.to_string())
-                    .receipt_handle(receipt_handle)
-                    .build()
-                    .map_err(|error| ConsumerError::InvalidOptions(error.to_string()))
+                Ok((index.to_string(), receipt_handle.to_owned()))
             })
             .collect::<Result<Vec<_>, _>>()?;
 
         self.backend
             .delete_message_batch(&self.options.queue_url, entries)
             .await
-            .map_err(map_delete_error)
+            .map_err(|error| map_delete_error(error, &message_ids))
     }
 
     async fn terminate_visibility(&self, messages: &[Message]) -> Result<(), ConsumerError> {
@@ -162,7 +158,7 @@ impl Consumer {
                 Some(result) => match result {
                     Ok(messages) => messages,
                     Err(error) => {
-                        self.listener.on_error(&error);
+                        self.listener.on_error(&error, None);
                         tokio::select! {
                             _ = tokio::time::sleep(self.options.receive_error_backoff) => {}
                             _ = self.shutdown_rx.changed() => {}
@@ -185,7 +181,7 @@ impl Consumer {
                     aborted_message_ids = message_ids.clone();
                     break 'running;
                 }
-                self.listener.on_error(&error);
+                self.listener.on_error(&error, None);
             }
             self.listener.on_response_processed();
             if *self.shutdown_rx.borrow() != ShutdownState::Running {
@@ -267,7 +263,13 @@ impl Consumer {
         handler: Arc<dyn DynBatchHandler>,
         messages: Vec<Message>,
     ) -> Result<(), ConsumerError> {
-        let early_ack_ids = handler.ack_before_batch(&messages).await?;
+        let early_ack_ids = match handler.ack_before_batch(&messages).await {
+            Ok(ack_ids) => ack_ids,
+            Err(error) => {
+                self.listener.on_error(&error, Some(&messages));
+                return Err(error);
+            }
+        };
         let early_ack_ids = validate_ack_ids(&messages, early_ack_ids)?;
         let (early_acked, messages) = partition_by_ack_ids(messages, &early_ack_ids);
         self.delete_acked(&early_acked).await?;
@@ -275,9 +277,13 @@ impl Consumer {
             return Ok(());
         }
 
-        let heartbeat_handles = self.start_heartbeats(&messages)?;
+        let mut heartbeat_handles = self.start_heartbeats(&messages)?;
         let result = self
-            .run_batch_handler_until_terminal_state(handler, messages.clone())
+            .run_batch_handler_until_terminal_state(
+                handler,
+                messages.clone(),
+                &mut heartbeat_handles,
+            )
             .await;
         stop_heartbeats(heartbeat_handles, self.listener.clone()).await;
 
@@ -313,6 +319,7 @@ impl Consumer {
         &self,
         handler: Arc<dyn DynBatchHandler>,
         messages: Vec<Message>,
+        heartbeats: &mut HeartbeatGuard,
     ) -> Result<BatchOutcome, ConsumerError> {
         let message_ids = message_ids(&messages);
         let handler_messages = messages.clone();
@@ -366,8 +373,13 @@ impl Consumer {
                     let error = ConsumerError::GracefulShutdownTimeout {
                         message_ids: message_ids.clone(),
                     };
-                    self.listener.on_error(&error);
+                    self.listener.on_error(&error, Some(&messages));
                     graceful_timeout = None;
+                }
+                failed_message_id = heartbeats.recv_failure(), if heartbeats.has_failure_channel() => {
+                    let message_id = failed_message_id.expect("heartbeat failure channel should be open while tasks run");
+                    handler_task.abort();
+                    return Err(ConsumerError::HeartbeatFailed { message_id });
                 }
             }
         }
@@ -385,19 +397,31 @@ impl Consumer {
                 "heartbeat requires visibility_timeout".into(),
             ));
         };
-        Ok(messages
-            .iter()
-            .filter_map(|message| {
-                spawn_heartbeat(
-                    self.backend.clone(),
-                    self.listener.clone(),
-                    self.options.queue_url.clone(),
-                    message.clone(),
-                    config.interval,
-                    visibility_timeout,
-                )
-            })
-            .collect())
+        let (failure_tx, failure_rx) = mpsc::unbounded_channel();
+        Ok(HeartbeatGuard {
+            tasks: messages
+                .iter()
+                .filter_map(|message| {
+                    let receipt_handle = message.receipt_handle()?.to_owned();
+                    let message_id = message.message_id().unwrap_or(&receipt_handle).to_owned();
+                    let (stop_tx, stop_rx) = watch::channel(false);
+                    spawn_heartbeat_with_failure_channel(
+                        self.backend.clone(),
+                        self.listener.clone(),
+                        self.options.queue_url.clone(),
+                        message.clone(),
+                        receipt_handle,
+                        message_id,
+                        config.interval,
+                        visibility_timeout,
+                        stop_tx,
+                        stop_rx,
+                        failure_tx.clone(),
+                    )
+                })
+                .collect(),
+            failure_rx: Some(failure_rx),
+        })
     }
 }
 
@@ -574,30 +598,49 @@ async fn handle_one(
 }
 
 #[derive(Default)]
-struct HeartbeatGuard(Vec<(watch::Sender<bool>, JoinHandle<()>)>);
+struct HeartbeatGuard {
+    tasks: Vec<HeartbeatTask>,
+    failure_rx: Option<mpsc::UnboundedReceiver<String>>,
+}
 
-impl FromIterator<(watch::Sender<bool>, JoinHandle<()>)> for HeartbeatGuard {
-    fn from_iter<T: IntoIterator<Item = (watch::Sender<bool>, JoinHandle<()>)>>(iter: T) -> Self {
-        Self(iter.into_iter().collect())
+impl FromIterator<HeartbeatTask> for HeartbeatGuard {
+    fn from_iter<T: IntoIterator<Item = HeartbeatTask>>(iter: T) -> Self {
+        Self {
+            tasks: iter.into_iter().collect(),
+            failure_rx: None,
+        }
+    }
+}
+
+impl HeartbeatGuard {
+    fn has_failure_channel(&self) -> bool {
+        self.failure_rx.is_some()
+    }
+
+    async fn recv_failure(&mut self) -> Option<String> {
+        match &mut self.failure_rx {
+            Some(failure_rx) => failure_rx.recv().await,
+            None => None,
+        }
     }
 }
 
 impl Drop for HeartbeatGuard {
     fn drop(&mut self) {
-        for (stop, handle) in &mut self.0 {
-            let _ = stop.send(true);
-            handle.abort();
+        for task in &mut self.tasks {
+            let _ = task.stop.send(true);
+            task.handle.abort();
         }
     }
 }
 
 async fn stop_heartbeats(mut handles: HeartbeatGuard, listener: Arc<dyn ConsumerListener>) {
-    let handles = std::mem::take(&mut handles.0);
-    for (stop, handle) in handles {
-        let _ = stop.send(true);
-        if let Err(error) = handle.await {
+    let handles = std::mem::take(&mut handles.tasks);
+    for task in handles {
+        let _ = task.stop.send(true);
+        if let Err(error) = task.handle.await {
             let error = ConsumerError::Join(error);
-            listener.on_error(&error);
+            listener.on_error(&error, None);
         }
     }
 }
@@ -606,8 +649,18 @@ fn map_receive_error(error: BackendError) -> ConsumerError {
     ConsumerError::ReceiveMessage(Box::new(error))
 }
 
-fn map_delete_error(error: BackendError) -> ConsumerError {
-    ConsumerError::DeleteMessageBatch(Box::new(error))
+fn map_delete_error(error: BackendError, message_ids: &[String]) -> ConsumerError {
+    let failed_message_ids = match &error {
+        BackendError::DeleteBatchFailed(indexes) => indexes
+            .iter()
+            .filter_map(|index| message_ids.get(*index).cloned())
+            .collect(),
+        _ => message_ids.to_vec(),
+    };
+    ConsumerError::DeleteMessageBatch {
+        failed_message_ids,
+        source: Box::new(error),
+    }
 }
 
 fn map_visibility_error(error: BackendError) -> ConsumerError {
@@ -647,6 +700,7 @@ mod tests {
         deleted: Mutex<Vec<Vec<String>>>,
         visibility_changes: Mutex<Vec<(String, i32)>>,
         fail_delete: bool,
+        fail_visibility: bool,
     }
 
     #[async_trait]
@@ -668,15 +722,15 @@ mod tests {
         async fn delete_message_batch(
             &self,
             _queue_url: &str,
-            entries: Vec<DeleteMessageBatchRequestEntry>,
+            entries: Vec<(String, String)>,
         ) -> Result<(), BackendError> {
             if self.fail_delete {
-                return Err(BackendError::Test("delete failed".into()));
+                return Err(BackendError::DeleteBatchFailed(vec![0]));
             }
             self.deleted.lock().await.push(
                 entries
                     .iter()
-                    .map(|entry| entry.receipt_handle().to_owned())
+                    .map(|(_, receipt_handle)| receipt_handle.to_owned())
                     .collect(),
             );
             Ok(())
@@ -688,6 +742,9 @@ mod tests {
             receipt_handle: &str,
             visibility_timeout: i32,
         ) -> Result<(), BackendError> {
+            if self.fail_visibility {
+                return Err(BackendError::Test("visibility failed".into()));
+            }
             self.visibility_changes
                 .lock()
                 .await
@@ -756,10 +813,29 @@ mod tests {
         }
     }
 
+    struct FailingEarlyAckHandler;
+
+    #[async_trait]
+    impl BatchMessageHandler for FailingEarlyAckHandler {
+        type Error = TestHandlerError;
+
+        async fn ack_before_batch(
+            &self,
+            _messages: &[Message],
+        ) -> Result<Vec<String>, Self::Error> {
+            Err(TestHandlerError)
+        }
+
+        async fn handle_batch(&self, _messages: Vec<Message>) -> Result<BatchOutcome, Self::Error> {
+            Ok(BatchOutcome::AckAll)
+        }
+    }
+
     #[derive(Default)]
     struct RecordingListener {
         aborted_message_ids: Arc<std::sync::Mutex<Vec<Vec<String>>>>,
         graceful_timeout_message_ids: Arc<std::sync::Mutex<Vec<Vec<String>>>>,
+        error_message_ids: Arc<std::sync::Mutex<Vec<Vec<String>>>>,
     }
 
     impl ConsumerListener for RecordingListener {
@@ -770,7 +846,11 @@ mod tests {
                 .push(aborted_message_ids.to_vec());
         }
 
-        fn on_error(&self, error: &(dyn std::error::Error + 'static)) {
+        fn on_error(
+            &self,
+            error: &(dyn std::error::Error + 'static),
+            messages: Option<&[Message]>,
+        ) {
             if let Some(ConsumerError::GracefulShutdownTimeout { message_ids }) =
                 error.downcast_ref::<ConsumerError>()
             {
@@ -778,6 +858,12 @@ mod tests {
                     .lock()
                     .unwrap()
                     .push(message_ids.clone());
+            }
+            if let Some(messages) = messages {
+                self.error_message_ids
+                    .lock()
+                    .unwrap()
+                    .push(message_ids(messages));
             }
         }
     }
@@ -924,7 +1010,72 @@ mod tests {
             .await
             .unwrap_err();
 
-        assert!(matches!(error, ConsumerError::DeleteMessageBatch(_)));
+        assert!(
+            matches!(error, ConsumerError::DeleteMessageBatch { failed_message_ids, .. } if failed_message_ids == vec!["1"])
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn heartbeat_failure_aborts_handler_and_surfaces_error() {
+        let backend = Arc::new(MockBackend {
+            fail_visibility: true,
+            ..MockBackend::default()
+        });
+        backend
+            .receives
+            .lock()
+            .await
+            .push_back(Ok(vec![message("1", Some("r1"))]));
+        let handler = TestHandler {
+            batch_outcome: BatchOutcome::AckAll,
+            message_outcome: HandleOutcome::Ack,
+            delay: Some(Duration::from_secs(60)),
+        };
+        let options = ConsumerOptions::builder()
+            .queue_url("queue")
+            .wait_time_seconds(0)
+            .visibility_timeout(10)
+            .heartbeat(HeartbeatConfig {
+                interval: Duration::from_secs(1),
+                visibility_timeout: None,
+            })
+            .build_for_backend()
+            .unwrap();
+
+        let consumer = consumer(backend.clone(), handler, options);
+        let task = tokio::spawn(async move { consumer.run_once().await });
+        tokio::time::advance(Duration::from_secs(1)).await;
+        let error = task.await.unwrap().unwrap_err();
+
+        assert!(
+            matches!(error, ConsumerError::HeartbeatFailed { message_id } if message_id == "1")
+        );
+        assert!(backend.deleted.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn ack_before_batch_error_notifies_listener_with_batch_messages() {
+        let backend = Arc::new(MockBackend::default());
+        backend
+            .receives
+            .lock()
+            .await
+            .push_back(Ok(vec![message("1", Some("r1"))]));
+        let listener = RecordingListener::default();
+        let error_message_ids = listener.error_message_ids.clone();
+
+        let error = Consumer::with_test_backend(
+            options(),
+            backend,
+            HandlerKind::Batch(Arc::new(FailingEarlyAckHandler)),
+        )
+        .listener(listener)
+        .run_once()
+        .await
+        .unwrap_err();
+
+        assert!(matches!(error, ConsumerError::Processing(_)));
+        assert_eq!(*error_message_ids.lock().unwrap(), vec![vec!["1"]]);
     }
 
     #[tokio::test]

--- a/apps/api/sqs-consumer/src/consumer.rs
+++ b/apps/api/sqs-consumer/src/consumer.rs
@@ -2,7 +2,7 @@ use std::{collections::HashSet, sync::Arc};
 
 use aws_sdk_sqs::types::{DeleteMessageBatchRequestEntry, Message};
 use futures::{StreamExt, stream::FuturesUnordered};
-use tokio::{sync::watch, task::JoinSet};
+use tokio::{sync::watch, task::JoinHandle};
 
 use crate::{
     backend::{AwsSqsBackend, BackendError, SqsBackend},
@@ -10,25 +10,66 @@ use crate::{
     handler::{BatchMessageHandler, BatchOutcome, HandleOutcome, MessageHandler},
     heartbeat::spawn_heartbeat,
     listener::{ConsumerListener, NoopListener},
-    options::{ConsumerOptions, TerminateVisibility},
+    options::{ConsumerOptions, TerminateVisibility, validate_visibility_timeout},
     shutdown::{ShutdownHandle, ShutdownState},
 };
 
-pub(crate) enum HandlerKind<H> {
-    Message(Arc<H>),
-    Batch(Arc<H>),
+#[async_trait::async_trait]
+trait DynMessageHandler: Send + Sync {
+    async fn handle_message(&self, message: Message) -> Result<HandleOutcome, ConsumerError>;
 }
 
-pub struct Consumer<H> {
+#[async_trait::async_trait]
+impl<H> DynMessageHandler for H
+where
+    H: MessageHandler,
+{
+    async fn handle_message(&self, message: Message) -> Result<HandleOutcome, ConsumerError> {
+        MessageHandler::handle_message(self, message)
+            .await
+            .map_err(|error| ConsumerError::Processing(Box::new(error)))
+    }
+}
+
+#[async_trait::async_trait]
+trait DynBatchHandler: Send + Sync {
+    async fn ack_before_batch(&self, messages: &[Message]) -> Result<Vec<String>, ConsumerError>;
+    async fn handle_batch(&self, messages: Vec<Message>) -> Result<BatchOutcome, ConsumerError>;
+}
+
+#[async_trait::async_trait]
+impl<H> DynBatchHandler for H
+where
+    H: BatchMessageHandler,
+{
+    async fn ack_before_batch(&self, messages: &[Message]) -> Result<Vec<String>, ConsumerError> {
+        BatchMessageHandler::ack_before_batch(self, messages)
+            .await
+            .map_err(|error| ConsumerError::Processing(Box::new(error)))
+    }
+
+    async fn handle_batch(&self, messages: Vec<Message>) -> Result<BatchOutcome, ConsumerError> {
+        BatchMessageHandler::handle_batch(self, messages)
+            .await
+            .map_err(|error| ConsumerError::Processing(Box::new(error)))
+    }
+}
+
+enum HandlerKind {
+    Message(Arc<dyn DynMessageHandler>),
+    Batch(Arc<dyn DynBatchHandler>),
+}
+
+pub struct Consumer {
     options: ConsumerOptions,
     backend: Arc<dyn SqsBackend>,
-    handler: HandlerKind<H>,
+    handler: HandlerKind,
     listener: Arc<dyn ConsumerListener>,
     shutdown_handle: ShutdownHandle,
     shutdown_rx: watch::Receiver<ShutdownState>,
 }
 
-impl<H> Consumer<H> {
+impl Consumer {
     pub fn listener<L>(mut self, listener: L) -> Self
     where
         L: ConsumerListener,
@@ -88,6 +129,7 @@ impl<H> Consumer<H> {
                 TerminateVisibility::Fixed(value) => *value,
                 TerminateVisibility::Dynamic(resolver) => resolver(message),
             };
+            validate_visibility_timeout("terminate_visibility", timeout)?;
             let Some(receipt_handle) = message.receipt_handle() else {
                 return Err(ConsumerError::MissingReceiptHandle {
                     message_id: message.message_id().map(ToOwned::to_owned),
@@ -105,25 +147,25 @@ impl<H> Consumer<H> {
         Ok(())
     }
 
-    async fn run_loop(mut self) -> Result<(), ConsumerError>
-    where
-        H: MessageHandler + BatchMessageHandler,
-    {
+    async fn run_loop(mut self) -> Result<(), ConsumerError> {
         self.listener.on_started();
-        loop {
+        'running: loop {
             if *self.shutdown_rx.borrow() != ShutdownState::Running {
                 break;
             }
-            let messages = match self.receive_once().await {
-                Ok(messages) => messages,
-                Err(error) => {
-                    self.listener.on_error(&error);
-                    tokio::select! {
-                        _ = tokio::time::sleep(self.options.receive_error_backoff) => {}
-                        _ = self.shutdown_rx.changed() => {}
+            let messages = match self.receive_until_shutdown().await {
+                Some(result) => match result {
+                    Ok(messages) => messages,
+                    Err(error) => {
+                        self.listener.on_error(&error);
+                        tokio::select! {
+                            _ = tokio::time::sleep(self.options.receive_error_backoff) => {}
+                            _ = self.shutdown_rx.changed() => {}
+                        }
+                        continue;
                     }
-                    continue;
-                }
+                },
+                None => break,
             };
             if messages.is_empty() {
                 self.listener.on_empty();
@@ -132,24 +174,67 @@ impl<H> Consumer<H> {
             for message in &messages {
                 self.listener.on_message_received(message);
             }
-            if let Err(error) = self.dispatch_and_ack(messages).await {
-                self.listener.on_error(&error);
+
+            let dispatch = self.dispatch_and_ack(messages);
+            let mut shutdown_rx = self.shutdown_rx.clone();
+            tokio::pin!(dispatch);
+            tokio::select! {
+                result = &mut dispatch => {
+                    if let Err(error) = result {
+                        self.listener.on_error(&error);
+                    }
+                }
+                changed = shutdown_rx.changed() => {
+                    if changed.is_err() {
+                        break 'running;
+                    }
+                    let shutdown_state = *shutdown_rx.borrow();
+                    match shutdown_state {
+                        ShutdownState::Abort => break 'running,
+                        ShutdownState::Graceful => {
+                            match tokio::time::timeout(
+                                self.options.polling_complete_wait_time,
+                                &mut dispatch,
+                            )
+                            .await
+                            {
+                                Ok(result) => {
+                                    if let Err(error) = result {
+                                        self.listener.on_error(&error);
+                                    }
+                                }
+                                Err(_) => {
+                                    self.listener.on_error(&ConsumerError::GracefulShutdownTimeout);
+                                }
+                            }
+                            break 'running;
+                        }
+                        ShutdownState::Running => {}
+                    }
+                }
             }
             self.listener.on_response_processed();
         }
         if *self.shutdown_rx.borrow() == ShutdownState::Abort {
             self.listener.on_aborted();
         } else {
-            let _polling_complete_wait_time = self.options.polling_complete_wait_time;
             self.listener.on_stopped();
         }
         Ok(())
     }
 
-    async fn dispatch_and_ack(&self, messages: Vec<Message>) -> Result<(), ConsumerError>
-    where
-        H: MessageHandler + BatchMessageHandler,
-    {
+    async fn receive_until_shutdown(&self) -> Option<Result<Vec<Message>, ConsumerError>> {
+        let mut shutdown_rx = self.shutdown_rx.clone();
+        tokio::select! {
+            result = self.receive_once() => Some(result),
+            changed = shutdown_rx.changed() => {
+                let _ = changed;
+                None
+            }
+        }
+    }
+
+    async fn dispatch_and_ack(&self, messages: Vec<Message>) -> Result<(), ConsumerError> {
         match &self.handler {
             HandlerKind::Message(handler) => {
                 self.dispatch_messages(handler.clone(), messages).await
@@ -160,12 +245,9 @@ impl<H> Consumer<H> {
 
     async fn dispatch_messages(
         &self,
-        handler: Arc<H>,
+        handler: Arc<dyn DynMessageHandler>,
         messages: Vec<Message>,
-    ) -> Result<(), ConsumerError>
-    where
-        H: MessageHandler,
-    {
+    ) -> Result<(), ConsumerError> {
         let mut futures = FuturesUnordered::new();
         for message in messages {
             let handler = handler.clone();
@@ -186,7 +268,11 @@ impl<H> Consumer<H> {
                 Ok(HandleOutcome::Ack) => acked.push(message),
                 Ok(HandleOutcome::Nack) => nacked.push(message),
                 Err(error) => {
-                    self.listener.on_processing_error(&message, &error);
+                    if matches!(error, ConsumerError::Timeout) {
+                        self.listener.on_timeout_error(&message);
+                    } else {
+                        self.listener.on_processing_error(&message, &error);
+                    }
                     nacked.push(message);
                 }
             }
@@ -201,16 +287,21 @@ impl<H> Consumer<H> {
 
     async fn dispatch_batch(
         &self,
-        handler: Arc<H>,
+        handler: Arc<dyn DynBatchHandler>,
         messages: Vec<Message>,
-    ) -> Result<(), ConsumerError>
-    where
-        H: BatchMessageHandler,
-    {
+    ) -> Result<(), ConsumerError> {
+        let early_ack_ids = handler.ack_before_batch(&messages).await?;
+        let early_ack_ids = validate_ack_ids(&messages, early_ack_ids)?;
+        let (early_acked, messages) = partition_by_ack_ids(messages, &early_ack_ids);
+        self.delete_acked(&early_acked).await?;
+        if messages.is_empty() {
+            return Ok(());
+        }
+
         let heartbeat_handles = self.start_heartbeats(&messages);
         let result = if let Some(timeout) = self.options.handle_message_timeout {
             match tokio::time::timeout(timeout, handler.handle_batch(messages.clone())).await {
-                Ok(result) => result.map_err(|error| ConsumerError::Processing(Box::new(error))),
+                Ok(result) => result,
                 Err(_) => {
                     for message in &messages {
                         self.listener.on_timeout_error(message);
@@ -219,10 +310,7 @@ impl<H> Consumer<H> {
                 }
             }
         } else {
-            handler
-                .handle_batch(messages.clone())
-                .await
-                .map_err(|error| ConsumerError::Processing(Box::new(error)))
+            handler.handle_batch(messages.clone()).await
         };
         stop_heartbeats(heartbeat_handles).await;
 
@@ -230,18 +318,8 @@ impl<H> Consumer<H> {
             Ok(BatchOutcome::AckAll) => (messages.clone(), Vec::new()),
             Ok(BatchOutcome::NackAll) => (Vec::new(), messages.clone()),
             Ok(BatchOutcome::Partial { ack_message_ids }) => {
-                let ids = ack_message_ids.into_iter().collect::<HashSet<_>>();
-                let acked = messages
-                    .iter()
-                    .filter(|message| message.message_id().is_some_and(|id| ids.contains(id)))
-                    .cloned()
-                    .collect::<Vec<_>>();
-                let nacked = messages
-                    .iter()
-                    .filter(|message| !message.message_id().is_some_and(|id| ids.contains(id)))
-                    .cloned()
-                    .collect::<Vec<_>>();
-                (acked, nacked)
+                let ids = validate_ack_ids(&messages, ack_message_ids)?;
+                partition_by_ack_ids(messages.clone(), &ids)
             }
             Err(error) => {
                 for message in &messages {
@@ -264,15 +342,9 @@ impl<H> Consumer<H> {
         self.delete_acked(&acked).await
     }
 
-    fn start_heartbeats(
-        &self,
-        messages: &[Message],
-    ) -> Vec<(
-        tokio::sync::watch::Sender<bool>,
-        tokio::task::JoinHandle<()>,
-    )> {
+    fn start_heartbeats(&self, messages: &[Message]) -> HeartbeatGuard {
         let Some(config) = &self.options.heartbeat else {
-            return Vec::new();
+            return HeartbeatGuard::default();
         };
         let visibility_timeout = config
             .visibility_timeout
@@ -294,22 +366,22 @@ impl<H> Consumer<H> {
     }
 }
 
-impl<H> Consumer<H>
-where
-    H: MessageHandler + BatchMessageHandler,
-{
+impl Consumer {
     pub async fn run(self) -> Result<(), ConsumerError> {
         self.run_loop().await
     }
 
     pub async fn run_until_ctrl_c(self) -> Result<(), ConsumerError> {
         let shutdown = self.shutdown_handle();
-        let task = tokio::spawn(async move { self.run().await });
-        tokio::signal::ctrl_c()
-            .await
-            .map_err(ConsumerError::ShutdownSignal)?;
-        shutdown.graceful();
-        task.await.map_err(ConsumerError::Join)?
+        let mut task = tokio::spawn(async move { self.run().await });
+        tokio::select! {
+            result = &mut task => result.map_err(ConsumerError::Join)?,
+            signal = tokio::signal::ctrl_c() => {
+                signal.map_err(ConsumerError::ShutdownSignal)?;
+                shutdown.graceful();
+                task.await.map_err(ConsumerError::Join)?
+            }
+        }
     }
 
     pub async fn run_once(&self) -> Result<(), ConsumerError> {
@@ -327,11 +399,11 @@ where
     }
 }
 
-impl<H> Consumer<H>
-where
-    H: MessageHandler + BatchMessageHandler,
-{
-    pub fn with_handler(options: ConsumerOptions, handler: H) -> Result<Self, ConsumerError> {
+impl Consumer {
+    pub fn with_handler<H>(options: ConsumerOptions, handler: H) -> Result<Self, ConsumerError>
+    where
+        H: MessageHandler,
+    {
         let client = options
             .sqs_client
             .clone()
@@ -343,7 +415,13 @@ where
         ))
     }
 
-    pub fn with_batch_handler(options: ConsumerOptions, handler: H) -> Result<Self, ConsumerError> {
+    pub fn with_batch_handler<H>(
+        options: ConsumerOptions,
+        handler: H,
+    ) -> Result<Self, ConsumerError>
+    where
+        H: BatchMessageHandler,
+    {
         let client = options
             .sqs_client
             .clone()
@@ -355,11 +433,7 @@ where
         ))
     }
 
-    fn new(
-        options: ConsumerOptions,
-        backend: Arc<dyn SqsBackend>,
-        handler: HandlerKind<H>,
-    ) -> Self {
+    fn new(options: ConsumerOptions, backend: Arc<dyn SqsBackend>, handler: HandlerKind) -> Self {
         let (shutdown_handle, shutdown_rx) = ShutdownHandle::new();
         Self {
             options,
@@ -372,25 +446,57 @@ where
     }
 
     #[cfg(test)]
-    pub(crate) fn with_test_backend(
+    fn with_test_backend(
         options: ConsumerOptions,
         backend: Arc<dyn SqsBackend>,
-        handler: HandlerKind<H>,
+        handler: HandlerKind,
     ) -> Self {
         Self::new(options, backend, handler)
     }
 }
 
-async fn handle_one<H>(
-    handler: Arc<H>,
+fn validate_ack_ids(
+    messages: &[Message],
+    ack_message_ids: Vec<String>,
+) -> Result<HashSet<String>, ConsumerError> {
+    let message_ids = messages
+        .iter()
+        .filter_map(|message| message.message_id().map(ToOwned::to_owned))
+        .collect::<HashSet<_>>();
+    let mut ack_ids = HashSet::new();
+    for ack_id in ack_message_ids {
+        if !ack_ids.insert(ack_id.clone()) {
+            return Err(ConsumerError::InvalidAck(format!(
+                "duplicate message id {ack_id}"
+            )));
+        }
+        if !message_ids.contains(&ack_id) {
+            return Err(ConsumerError::InvalidAck(format!(
+                "unknown message id {ack_id}"
+            )));
+        }
+    }
+    Ok(ack_ids)
+}
+
+fn partition_by_ack_ids(
+    messages: Vec<Message>,
+    ack_message_ids: &HashSet<String>,
+) -> (Vec<Message>, Vec<Message>) {
+    messages.into_iter().partition(|message| {
+        message
+            .message_id()
+            .is_some_and(|id| ack_message_ids.contains(id))
+    })
+}
+
+async fn handle_one(
+    handler: Arc<dyn DynMessageHandler>,
     backend: Arc<dyn SqsBackend>,
     listener: Arc<dyn ConsumerListener>,
     options: ConsumerOptions,
     message: Message,
-) -> Result<HandleOutcome, ConsumerError>
-where
-    H: MessageHandler,
-{
+) -> Result<HandleOutcome, ConsumerError> {
     let heartbeats = if let Some(config) = &options.heartbeat {
         let visibility_timeout = config
             .visibility_timeout
@@ -407,38 +513,45 @@ where
         .into_iter()
         .collect()
     } else {
-        Vec::new()
+        HeartbeatGuard::default()
     };
 
     let result = if let Some(timeout) = options.handle_message_timeout {
         match tokio::time::timeout(timeout, handler.handle_message(message.clone())).await {
-            Ok(result) => result.map_err(|error| ConsumerError::Processing(Box::new(error))),
+            Ok(result) => result,
             Err(_) => Err(ConsumerError::Timeout),
         }
     } else {
-        handler
-            .handle_message(message)
-            .await
-            .map_err(|error| ConsumerError::Processing(Box::new(error)))
+        handler.handle_message(message).await
     };
     stop_heartbeats(heartbeats).await;
     result
 }
 
-async fn stop_heartbeats(
-    handles: Vec<(
-        tokio::sync::watch::Sender<bool>,
-        tokio::task::JoinHandle<()>,
-    )>,
-) {
-    let mut joins = JoinSet::new();
+#[derive(Default)]
+struct HeartbeatGuard(Vec<(watch::Sender<bool>, JoinHandle<()>)>);
+
+impl FromIterator<(watch::Sender<bool>, JoinHandle<()>)> for HeartbeatGuard {
+    fn from_iter<T: IntoIterator<Item = (watch::Sender<bool>, JoinHandle<()>)>>(iter: T) -> Self {
+        Self(iter.into_iter().collect())
+    }
+}
+
+impl Drop for HeartbeatGuard {
+    fn drop(&mut self) {
+        for (stop, handle) in &mut self.0 {
+            let _ = stop.send(true);
+            handle.abort();
+        }
+    }
+}
+
+async fn stop_heartbeats(mut handles: HeartbeatGuard) {
+    let handles = std::mem::take(&mut handles.0);
     for (stop, handle) in handles {
         let _ = stop.send(true);
-        joins.spawn(async move {
-            let _ = handle.await;
-        });
+        let _ = handle.await;
     }
-    while joins.join_next().await.is_some() {}
 }
 
 fn map_receive_error(error: BackendError) -> ConsumerError {
@@ -552,6 +665,32 @@ mod tests {
         }
     }
 
+    struct EarlyAckHandler {
+        handled_message_ids: Arc<Mutex<Vec<Vec<String>>>>,
+    }
+
+    #[async_trait]
+    impl BatchMessageHandler for EarlyAckHandler {
+        type Error = TestHandlerError;
+
+        async fn ack_before_batch(
+            &self,
+            _messages: &[Message],
+        ) -> Result<Vec<String>, Self::Error> {
+            Ok(vec!["invalid".into()])
+        }
+
+        async fn handle_batch(&self, messages: Vec<Message>) -> Result<BatchOutcome, Self::Error> {
+            self.handled_message_ids.lock().await.push(
+                messages
+                    .iter()
+                    .filter_map(|message| message.message_id().map(ToOwned::to_owned))
+                    .collect(),
+            );
+            Ok(BatchOutcome::AckAll)
+        }
+    }
+
     fn message(id: &str, receipt: Option<&str>) -> Message {
         let mut builder = Message::builder().message_id(id).body("{}");
         if let Some(receipt) = receipt {
@@ -572,7 +711,7 @@ mod tests {
         backend: Arc<MockBackend>,
         handler: TestHandler,
         options: ConsumerOptions,
-    ) -> Consumer<TestHandler> {
+    ) -> Consumer {
         Consumer::with_test_backend(options, backend, HandlerKind::Batch(Arc::new(handler)))
     }
 
@@ -620,6 +759,34 @@ mod tests {
             .unwrap();
 
         assert_eq!(*backend.deleted.lock().await, vec![vec!["r2"]]);
+    }
+
+    #[tokio::test]
+    async fn pre_batch_ack_deletes_messages_before_handler_runs() {
+        let backend = Arc::new(MockBackend::default());
+        backend.receives.lock().await.push_back(Ok(vec![
+            message("invalid", Some("invalid-receipt")),
+            message("valid", Some("valid-receipt")),
+        ]));
+        let handled_message_ids = Arc::new(Mutex::new(Vec::new()));
+        let handler = EarlyAckHandler {
+            handled_message_ids: handled_message_ids.clone(),
+        };
+
+        Consumer::with_test_backend(
+            options(),
+            backend.clone(),
+            HandlerKind::Batch(Arc::new(handler)),
+        )
+        .run_once()
+        .await
+        .unwrap();
+
+        assert_eq!(
+            *backend.deleted.lock().await,
+            vec![vec!["invalid-receipt"], vec!["valid-receipt"]]
+        );
+        assert_eq!(*handled_message_ids.lock().await, vec![vec!["valid"]]);
     }
 
     #[tokio::test]
@@ -730,5 +897,33 @@ mod tests {
             .unwrap();
 
         assert!(!backend.visibility_changes.lock().await.is_empty());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn abort_shutdown_cancels_in_flight_batch() {
+        let backend = Arc::new(MockBackend::default());
+        backend
+            .receives
+            .lock()
+            .await
+            .push_back(Ok(vec![message("1", Some("r1"))]));
+        let handler = TestHandler {
+            batch_outcome: BatchOutcome::AckAll,
+            message_outcome: HandleOutcome::Ack,
+            delay: Some(Duration::from_secs(3_600)),
+        };
+        let consumer = consumer(backend.clone(), handler, options());
+        let shutdown = consumer.shutdown_handle();
+        let task = tokio::spawn(consumer.run());
+
+        tokio::task::yield_now().await;
+        shutdown.abort();
+
+        tokio::time::timeout(Duration::from_secs(1), task)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert!(backend.deleted.lock().await.is_empty());
     }
 }

--- a/apps/api/sqs-consumer/src/consumer.rs
+++ b/apps/api/sqs-consumer/src/consumer.rs
@@ -13,7 +13,10 @@ use crate::{
     handler::{BatchMessageHandler, BatchOutcome, HandleOutcome, MessageHandler},
     heartbeat::{HeartbeatTask, spawn_heartbeat, spawn_heartbeat_with_failure_channel},
     listener::{ConsumerListener, NoopListener},
-    options::{ConsumerOptions, TerminateVisibility, validate_visibility_timeout},
+    options::{
+        ConsumerOptions, TerminateVisibility, resolve_heartbeat_visibility_timeout,
+        validate_visibility_timeout,
+    },
     shutdown::{ShutdownHandle, ShutdownState},
 };
 
@@ -86,15 +89,21 @@ impl Consumer {
     }
 
     async fn receive_once(&self) -> Result<Vec<Message>, ConsumerError> {
-        self.backend
+        self.listener.on_polling_started();
+        let result = self
+            .backend
             .receive_messages(
                 &self.options.queue_url,
                 self.options.batch_size,
                 self.options.wait_time_seconds,
                 self.options.visibility_timeout,
+                &self.options.attribute_names,
+                &self.options.message_attribute_names,
             )
             .await
-            .map_err(map_receive_error)
+            .map_err(map_receive_error);
+        self.listener.on_polling_completed();
+        result
     }
 
     async fn delete_acked(&self, messages: &[Message]) -> Result<(), ConsumerError> {
@@ -170,20 +179,28 @@ impl Consumer {
             };
             if messages.is_empty() {
                 self.listener.on_empty();
+                if !self.wait_for_polling().await {
+                    break;
+                }
                 continue;
             }
+            let message_count = messages.len();
             for message in &messages {
                 self.listener.on_message_received(message);
             }
 
-            if let Err(error) = self.dispatch_and_ack(messages).await {
+            let result = self.dispatch_and_ack(messages.clone()).await;
+            if result.is_ok() {
+                self.notify_messages_processed(&messages);
+            }
+            if let Err(error) = result {
                 if let ConsumerError::Aborted { message_ids } = &error {
                     aborted_message_ids = message_ids.clone();
                     break 'running;
                 }
                 self.listener.on_error(&error, None);
             }
-            self.listener.on_response_processed();
+            self.listener.on_response_processed(message_count);
             if *self.shutdown_rx.borrow() != ShutdownState::Running {
                 break;
             }
@@ -194,6 +211,30 @@ impl Consumer {
             self.listener.on_stopped();
         }
         Ok(())
+    }
+
+    async fn wait_for_polling(&self) -> bool {
+        if self.options.polling_wait_time.is_zero() {
+            return true;
+        }
+        self.listener.on_waiting_for_polling();
+        let mut shutdown_rx = self.shutdown_rx.clone();
+        tokio::select! {
+            _ = sleep(self.options.polling_wait_time) => {
+                self.listener.on_polling_wait_exceeded();
+                true
+            }
+            changed = shutdown_rx.changed() => {
+                let _ = changed;
+                false
+            }
+        }
+    }
+
+    fn notify_messages_processed(&self, messages: &[Message]) {
+        for message in messages {
+            self.listener.on_message_processed(message);
+        }
     }
 
     async fn receive_until_shutdown(&self) -> Option<Result<Vec<Message>, ConsumerError>> {
@@ -389,14 +430,8 @@ impl Consumer {
         let Some(config) = &self.options.heartbeat else {
             return Ok(HeartbeatGuard::default());
         };
-        let Some(visibility_timeout) = config
-            .visibility_timeout
-            .or(self.options.visibility_timeout)
-        else {
-            return Err(ConsumerError::InvalidConfig(
-                "heartbeat requires visibility_timeout".into(),
-            ));
-        };
+        let visibility_timeout =
+            resolve_heartbeat_visibility_timeout(config, self.options.visibility_timeout)?;
         let (failure_tx, failure_rx) = mpsc::unbounded_channel();
         Ok(HeartbeatGuard {
             tasks: messages
@@ -450,11 +485,15 @@ impl Consumer {
             self.listener.on_empty();
             return Ok(());
         }
+        let message_count = messages.len();
         for message in &messages {
             self.listener.on_message_received(message);
         }
-        let result = self.dispatch_and_ack(messages).await;
-        self.listener.on_response_processed();
+        let result = self.dispatch_and_ack(messages.clone()).await;
+        if result.is_ok() {
+            self.notify_messages_processed(&messages);
+        }
+        self.listener.on_response_processed(message_count);
         result
     }
 }
@@ -468,6 +507,7 @@ impl Consumer {
             .sqs_client
             .clone()
             .ok_or_else(|| ConsumerError::InvalidOptions("sqs_client is required".into()))?;
+        warn_if_fifo_queue(&options);
         Ok(Self::new(
             options,
             Arc::new(AwsSqsBackend::new(client)),
@@ -486,6 +526,7 @@ impl Consumer {
             .sqs_client
             .clone()
             .ok_or_else(|| ConsumerError::InvalidOptions("sqs_client is required".into()))?;
+        warn_if_fifo_queue(&options);
         Ok(Self::new(
             options,
             Arc::new(AwsSqsBackend::new(client)),
@@ -512,6 +553,15 @@ impl Consumer {
         handler: HandlerKind,
     ) -> Self {
         Self::new(options, backend, handler)
+    }
+}
+
+fn warn_if_fifo_queue(options: &ConsumerOptions) {
+    if !options.suppress_fifo_warning && options.queue_url.ends_with(".fifo") {
+        tracing::warn!(
+            queue_url = %options.queue_url,
+            "sqs-consumer does not provide FIFO-specific ordering guarantees"
+        );
     }
 }
 
@@ -565,12 +615,8 @@ async fn handle_one(
     message: Message,
 ) -> Result<HandleOutcome, ConsumerError> {
     let heartbeats = if let Some(config) = &options.heartbeat {
-        let Some(visibility_timeout) = config.visibility_timeout.or(options.visibility_timeout)
-        else {
-            return Err(ConsumerError::InvalidConfig(
-                "heartbeat requires visibility_timeout".into(),
-            ));
-        };
+        let visibility_timeout =
+            resolve_heartbeat_visibility_timeout(config, options.visibility_timeout)?;
         spawn_heartbeat(
             backend,
             listener.clone(),
@@ -711,6 +757,8 @@ mod tests {
             _max_number_of_messages: i32,
             _wait_time_seconds: i32,
             _visibility_timeout: Option<i32>,
+            _attribute_names: &[aws_sdk_sqs::types::MessageSystemAttributeName],
+            _message_attribute_names: &[String],
         ) -> Result<Vec<Message>, BackendError> {
             self.receives
                 .lock()
@@ -836,9 +884,23 @@ mod tests {
         aborted_message_ids: Arc<std::sync::Mutex<Vec<Vec<String>>>>,
         graceful_timeout_message_ids: Arc<std::sync::Mutex<Vec<Vec<String>>>>,
         error_message_ids: Arc<std::sync::Mutex<Vec<Vec<String>>>>,
+        message_processed_ids: Arc<std::sync::Mutex<Vec<String>>>,
+        response_processed_counts: Arc<std::sync::Mutex<Vec<usize>>>,
+        polling_started_count: Arc<std::sync::Mutex<usize>>,
+        polling_completed_count: Arc<std::sync::Mutex<usize>>,
+        waiting_for_polling_count: Arc<std::sync::Mutex<usize>>,
+        polling_wait_exceeded_count: Arc<std::sync::Mutex<usize>>,
     }
 
     impl ConsumerListener for RecordingListener {
+        fn on_polling_started(&self) {
+            *self.polling_started_count.lock().unwrap() += 1;
+        }
+
+        fn on_polling_completed(&self) {
+            *self.polling_completed_count.lock().unwrap() += 1;
+        }
+
         fn on_aborted(&self, aborted_message_ids: &[String]) {
             self.aborted_message_ids
                 .lock()
@@ -865,6 +927,27 @@ mod tests {
                     .unwrap()
                     .push(message_ids(messages));
             }
+        }
+
+        fn on_message_processed(&self, message: &Message) {
+            if let Some(message_id) = message.message_id() {
+                self.message_processed_ids
+                    .lock()
+                    .unwrap()
+                    .push(message_id.to_owned());
+            }
+        }
+
+        fn on_response_processed(&self, count: usize) {
+            self.response_processed_counts.lock().unwrap().push(count);
+        }
+
+        fn on_waiting_for_polling(&self) {
+            *self.waiting_for_polling_count.lock().unwrap() += 1;
+        }
+
+        fn on_polling_wait_exceeded(&self) {
+            *self.polling_wait_exceeded_count.lock().unwrap() += 1;
         }
     }
 
@@ -1015,6 +1098,75 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn run_once_notifies_polling_lifecycle_and_processed_count() {
+        let backend = Arc::new(MockBackend::default());
+        backend
+            .receives
+            .lock()
+            .await
+            .push_back(Ok(vec![message("1", Some("r1"))]));
+        let listener = RecordingListener::default();
+        let message_processed_ids = listener.message_processed_ids.clone();
+        let response_processed_counts = listener.response_processed_counts.clone();
+        let polling_started_count = listener.polling_started_count.clone();
+        let polling_completed_count = listener.polling_completed_count.clone();
+        let handler = TestHandler {
+            batch_outcome: BatchOutcome::AckAll,
+            message_outcome: HandleOutcome::Ack,
+            delay: None,
+        };
+
+        consumer(backend, handler, options())
+            .listener(listener)
+            .run_once()
+            .await
+            .unwrap();
+
+        assert_eq!(*polling_started_count.lock().unwrap(), 1);
+        assert_eq!(*polling_completed_count.lock().unwrap(), 1);
+        assert_eq!(*message_processed_ids.lock().unwrap(), vec!["1"]);
+        assert_eq!(*response_processed_counts.lock().unwrap(), vec![1]);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn empty_response_waits_before_next_poll() {
+        let backend = Arc::new(MockBackend::default());
+        backend.receives.lock().await.push_back(Ok(Vec::new()));
+        backend
+            .receives
+            .lock()
+            .await
+            .push_back(Ok(vec![message("1", Some("r1"))]));
+        let listener = RecordingListener::default();
+        let waiting_for_polling_count = listener.waiting_for_polling_count.clone();
+        let polling_wait_exceeded_count = listener.polling_wait_exceeded_count.clone();
+        let handler = TestHandler {
+            batch_outcome: BatchOutcome::AckAll,
+            message_outcome: HandleOutcome::Ack,
+            delay: None,
+        };
+        let options = ConsumerOptions::builder()
+            .queue_url("queue")
+            .wait_time_seconds(0)
+            .polling_wait_time(Duration::from_secs(5))
+            .build_for_backend()
+            .unwrap();
+        let consumer = consumer(backend.clone(), handler, options).listener(listener);
+        let shutdown = consumer.shutdown_handle();
+
+        let task = tokio::spawn(async move { consumer.run().await });
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_secs(5)).await;
+        tokio::task::yield_now().await;
+        shutdown.graceful();
+        task.await.unwrap().unwrap();
+
+        assert_eq!(*backend.deleted.lock().await, vec![vec!["r1"]]);
+        assert!(*waiting_for_polling_count.lock().unwrap() >= 1);
+        assert!(*polling_wait_exceeded_count.lock().unwrap() >= 1);
+    }
+
     #[tokio::test(start_paused = true)]
     async fn heartbeat_failure_aborts_handler_and_surfaces_error() {
         let backend = Arc::new(MockBackend {
@@ -1035,10 +1187,7 @@ mod tests {
             .queue_url("queue")
             .wait_time_seconds(0)
             .visibility_timeout(10)
-            .heartbeat(HeartbeatConfig {
-                interval: Duration::from_secs(1),
-                visibility_timeout: None,
-            })
+            .heartbeat(HeartbeatConfig::new(Duration::from_secs(1)))
             .build_for_backend()
             .unwrap();
 
@@ -1126,10 +1275,7 @@ mod tests {
             .queue_url("queue")
             .wait_time_seconds(0)
             .visibility_timeout(10)
-            .heartbeat(HeartbeatConfig {
-                interval: Duration::from_secs(1),
-                visibility_timeout: None,
-            })
+            .heartbeat(HeartbeatConfig::new(Duration::from_secs(1)))
             .build_for_backend()
             .unwrap();
 

--- a/apps/api/sqs-consumer/src/consumer.rs
+++ b/apps/api/sqs-consumer/src/consumer.rs
@@ -1,8 +1,12 @@
-use std::{collections::HashSet, sync::Arc};
+use std::{collections::HashSet, pin::Pin, sync::Arc};
 
 use aws_sdk_sqs::types::{DeleteMessageBatchRequestEntry, Message};
 use futures::{StreamExt, stream::FuturesUnordered};
-use tokio::{sync::watch, task::JoinHandle};
+use tokio::{
+    sync::watch,
+    task::JoinHandle,
+    time::{Sleep, sleep},
+};
 
 use crate::{
     backend::{AwsSqsBackend, BackendError, SqsBackend},
@@ -149,6 +153,7 @@ impl Consumer {
 
     async fn run_loop(mut self) -> Result<(), ConsumerError> {
         self.listener.on_started();
+        let mut aborted_message_ids = Vec::new();
         'running: loop {
             if *self.shutdown_rx.borrow() != ShutdownState::Running {
                 break;
@@ -175,48 +180,20 @@ impl Consumer {
                 self.listener.on_message_received(message);
             }
 
-            let dispatch = self.dispatch_and_ack(messages);
-            let mut shutdown_rx = self.shutdown_rx.clone();
-            tokio::pin!(dispatch);
-            tokio::select! {
-                result = &mut dispatch => {
-                    if let Err(error) = result {
-                        self.listener.on_error(&error);
-                    }
+            if let Err(error) = self.dispatch_and_ack(messages).await {
+                if let ConsumerError::Aborted { message_ids } = &error {
+                    aborted_message_ids = message_ids.clone();
+                    break 'running;
                 }
-                changed = shutdown_rx.changed() => {
-                    if changed.is_err() {
-                        break 'running;
-                    }
-                    let shutdown_state = *shutdown_rx.borrow();
-                    match shutdown_state {
-                        ShutdownState::Abort => break 'running,
-                        ShutdownState::Graceful => {
-                            match tokio::time::timeout(
-                                self.options.polling_complete_wait_time,
-                                &mut dispatch,
-                            )
-                            .await
-                            {
-                                Ok(result) => {
-                                    if let Err(error) = result {
-                                        self.listener.on_error(&error);
-                                    }
-                                }
-                                Err(_) => {
-                                    self.listener.on_error(&ConsumerError::GracefulShutdownTimeout);
-                                }
-                            }
-                            break 'running;
-                        }
-                        ShutdownState::Running => {}
-                    }
-                }
+                self.listener.on_error(&error);
             }
             self.listener.on_response_processed();
+            if *self.shutdown_rx.borrow() != ShutdownState::Running {
+                break;
+            }
         }
         if *self.shutdown_rx.borrow() == ShutdownState::Abort {
-            self.listener.on_aborted();
+            self.listener.on_aborted(&aborted_message_ids);
         } else {
             self.listener.on_stopped();
         }
@@ -298,21 +275,11 @@ impl Consumer {
             return Ok(());
         }
 
-        let heartbeat_handles = self.start_heartbeats(&messages);
-        let result = if let Some(timeout) = self.options.handle_message_timeout {
-            match tokio::time::timeout(timeout, handler.handle_batch(messages.clone())).await {
-                Ok(result) => result,
-                Err(_) => {
-                    for message in &messages {
-                        self.listener.on_timeout_error(message);
-                    }
-                    Err(ConsumerError::Timeout)
-                }
-            }
-        } else {
-            handler.handle_batch(messages.clone()).await
-        };
-        stop_heartbeats(heartbeat_handles).await;
+        let heartbeat_handles = self.start_heartbeats(&messages)?;
+        let result = self
+            .run_batch_handler_until_terminal_state(handler, messages.clone())
+            .await;
+        stop_heartbeats(heartbeat_handles, self.listener.clone()).await;
 
         let (mut acked, nacked) = match result {
             Ok(BatchOutcome::AckAll) => (messages.clone(), Vec::new()),
@@ -342,15 +309,83 @@ impl Consumer {
         self.delete_acked(&acked).await
     }
 
-    fn start_heartbeats(&self, messages: &[Message]) -> HeartbeatGuard {
+    async fn run_batch_handler_until_terminal_state(
+        &self,
+        handler: Arc<dyn DynBatchHandler>,
+        messages: Vec<Message>,
+    ) -> Result<BatchOutcome, ConsumerError> {
+        let message_ids = message_ids(&messages);
+        let handler_messages = messages.clone();
+        let mut handler_task =
+            tokio::spawn(async move { handler.handle_batch(handler_messages).await });
+        let mut shutdown_rx = self.shutdown_rx.clone();
+        let mut handler_timeout = self
+            .options
+            .handle_message_timeout
+            .map(|duration| Box::pin(sleep(duration)));
+        let mut graceful_timeout: Option<Pin<Box<Sleep>>> = None;
+
+        loop {
+            tokio::select! {
+                result = &mut handler_task => {
+                    return result.map_err(ConsumerError::Join)?;
+                }
+                _ = async {
+                    if let Some(timeout) = &mut handler_timeout {
+                        timeout.as_mut().await;
+                    }
+                }, if handler_timeout.is_some() => {
+                    handler_task.abort();
+                    for message in &messages {
+                        self.listener.on_timeout_error(message);
+                    }
+                    return Err(ConsumerError::Timeout);
+                }
+                changed = shutdown_rx.changed() => {
+                    if changed.is_err() {
+                        continue;
+                    }
+                    match *shutdown_rx.borrow() {
+                        ShutdownState::Running => {}
+                        ShutdownState::Graceful => {
+                            if graceful_timeout.is_none() {
+                                graceful_timeout = Some(Box::pin(sleep(self.options.polling_complete_wait_time)));
+                            }
+                        }
+                        ShutdownState::Abort => {
+                            handler_task.abort();
+                            return Err(ConsumerError::Aborted { message_ids });
+                        }
+                    }
+                }
+                _ = async {
+                    if let Some(timeout) = &mut graceful_timeout {
+                        timeout.as_mut().await;
+                    }
+                }, if graceful_timeout.is_some() => {
+                    let error = ConsumerError::GracefulShutdownTimeout {
+                        message_ids: message_ids.clone(),
+                    };
+                    self.listener.on_error(&error);
+                    graceful_timeout = None;
+                }
+            }
+        }
+    }
+
+    fn start_heartbeats(&self, messages: &[Message]) -> Result<HeartbeatGuard, ConsumerError> {
         let Some(config) = &self.options.heartbeat else {
-            return HeartbeatGuard::default();
+            return Ok(HeartbeatGuard::default());
         };
-        let visibility_timeout = config
+        let Some(visibility_timeout) = config
             .visibility_timeout
             .or(self.options.visibility_timeout)
-            .expect("heartbeat validation requires visibility_timeout");
-        messages
+        else {
+            return Err(ConsumerError::InvalidConfig(
+                "heartbeat requires visibility_timeout".into(),
+            ));
+        };
+        Ok(messages
             .iter()
             .filter_map(|message| {
                 spawn_heartbeat(
@@ -362,7 +397,7 @@ impl Consumer {
                     visibility_timeout,
                 )
             })
-            .collect()
+            .collect())
     }
 }
 
@@ -480,6 +515,13 @@ fn validate_ack_ids(
     Ok(ack_ids)
 }
 
+fn message_ids(messages: &[Message]) -> Vec<String> {
+    messages
+        .iter()
+        .filter_map(|message| message.message_id().map(ToOwned::to_owned))
+        .collect()
+}
+
 fn partition_by_ack_ids(
     messages: Vec<Message>,
     ack_message_ids: &HashSet<String>,
@@ -499,13 +541,15 @@ async fn handle_one(
     message: Message,
 ) -> Result<HandleOutcome, ConsumerError> {
     let heartbeats = if let Some(config) = &options.heartbeat {
-        let visibility_timeout = config
-            .visibility_timeout
-            .or(options.visibility_timeout)
-            .expect("heartbeat validation requires visibility_timeout");
+        let Some(visibility_timeout) = config.visibility_timeout.or(options.visibility_timeout)
+        else {
+            return Err(ConsumerError::InvalidConfig(
+                "heartbeat requires visibility_timeout".into(),
+            ));
+        };
         spawn_heartbeat(
             backend,
-            listener,
+            listener.clone(),
             options.queue_url.clone(),
             message.clone(),
             config.interval,
@@ -525,7 +569,7 @@ async fn handle_one(
     } else {
         handler.handle_message(message).await
     };
-    stop_heartbeats(heartbeats).await;
+    stop_heartbeats(heartbeats, listener).await;
     result
 }
 
@@ -547,11 +591,14 @@ impl Drop for HeartbeatGuard {
     }
 }
 
-async fn stop_heartbeats(mut handles: HeartbeatGuard) {
+async fn stop_heartbeats(mut handles: HeartbeatGuard, listener: Arc<dyn ConsumerListener>) {
     let handles = std::mem::take(&mut handles.0);
     for (stop, handle) in handles {
         let _ = stop.send(true);
-        let _ = handle.await;
+        if let Err(error) = handle.await {
+            let error = ConsumerError::Join(error);
+            listener.on_error(&error);
+        }
     }
 }
 
@@ -706,6 +753,32 @@ mod tests {
                     .collect(),
             );
             Ok(BatchOutcome::AckAll)
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingListener {
+        aborted_message_ids: Arc<std::sync::Mutex<Vec<Vec<String>>>>,
+        graceful_timeout_message_ids: Arc<std::sync::Mutex<Vec<Vec<String>>>>,
+    }
+
+    impl ConsumerListener for RecordingListener {
+        fn on_aborted(&self, aborted_message_ids: &[String]) {
+            self.aborted_message_ids
+                .lock()
+                .unwrap()
+                .push(aborted_message_ids.to_vec());
+        }
+
+        fn on_error(&self, error: &(dyn std::error::Error + 'static)) {
+            if let Some(ConsumerError::GracefulShutdownTimeout { message_ids }) =
+                error.downcast_ref::<ConsumerError>()
+            {
+                self.graceful_timeout_message_ids
+                    .lock()
+                    .unwrap()
+                    .push(message_ids.clone());
+            }
         }
     }
 
@@ -930,7 +1003,9 @@ mod tests {
             message_outcome: HandleOutcome::Ack,
             delay: Some(Duration::from_secs(3_600)),
         };
-        let consumer = consumer(backend.clone(), handler, options());
+        let listener = RecordingListener::default();
+        let aborted_message_ids = listener.aborted_message_ids.clone();
+        let consumer = consumer(backend.clone(), handler, options()).listener(listener);
         let shutdown = consumer.shutdown_handle();
         let task = tokio::spawn(consumer.run());
 
@@ -943,5 +1018,42 @@ mod tests {
             .unwrap()
             .unwrap();
         assert!(backend.deleted.lock().await.is_empty());
+        assert_eq!(*aborted_message_ids.lock().unwrap(), vec![vec!["1"]]);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn graceful_shutdown_timeout_reports_ids_and_finishes_ack_state() {
+        let backend = Arc::new(MockBackend::default());
+        backend
+            .receives
+            .lock()
+            .await
+            .push_back(Ok(vec![message("1", Some("r1"))]));
+        let handler = TestHandler {
+            batch_outcome: BatchOutcome::AckAll,
+            message_outcome: HandleOutcome::Ack,
+            delay: Some(Duration::from_secs(5)),
+        };
+        let options = ConsumerOptions::builder()
+            .queue_url("queue")
+            .wait_time_seconds(0)
+            .polling_complete_wait_time(Duration::from_millis(100))
+            .build_for_backend()
+            .unwrap();
+        let listener = RecordingListener::default();
+        let timed_out_message_ids = listener.graceful_timeout_message_ids.clone();
+        let consumer = consumer(backend.clone(), handler, options).listener(listener);
+        let shutdown = consumer.shutdown_handle();
+        let task = tokio::spawn(consumer.run());
+
+        tokio::task::yield_now().await;
+        shutdown.graceful();
+        tokio::time::advance(Duration::from_millis(100)).await;
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_secs(5)).await;
+        task.await.unwrap().unwrap();
+
+        assert_eq!(*timed_out_message_ids.lock().unwrap(), vec![vec!["1"]]);
+        assert_eq!(*backend.deleted.lock().await, vec![vec!["r1"]]);
     }
 }

--- a/apps/api/sqs-consumer/src/consumer.rs
+++ b/apps/api/sqs-consumer/src/consumer.rs
@@ -11,7 +11,9 @@ use crate::{
     backend::{AwsSqsBackend, BackendError, SqsBackend},
     error::ConsumerError,
     handler::{BatchMessageHandler, BatchOutcome, HandleOutcome, MessageHandler},
-    heartbeat::{HeartbeatTask, spawn_heartbeat, spawn_heartbeat_with_failure_channel},
+    heartbeat::{
+        HeartbeatSpawn, HeartbeatTask, spawn_heartbeat, spawn_heartbeat_with_failure_channel,
+    },
     listener::{ConsumerListener, NoopListener},
     options::{
         ConsumerOptions, TerminateVisibility, resolve_heartbeat_visibility_timeout,
@@ -110,19 +112,17 @@ impl Consumer {
         if !self.options.should_delete_messages || messages.is_empty() {
             return Ok(());
         }
-        let message_ids = message_ids(messages);
-        let entries = messages
-            .iter()
-            .enumerate()
-            .map(|(index, message)| {
-                let Some(receipt_handle) = message.receipt_handle() else {
-                    return Err(ConsumerError::MissingReceiptHandle {
-                        message_id: message.message_id().map(ToOwned::to_owned),
-                    });
-                };
-                Ok((index.to_string(), receipt_handle.to_owned()))
-            })
-            .collect::<Result<Vec<_>, _>>()?;
+        let mut message_ids = Vec::with_capacity(messages.len());
+        let mut entries = Vec::with_capacity(messages.len());
+        for (index, message) in messages.iter().enumerate() {
+            let Some(receipt_handle) = message.receipt_handle() else {
+                return Err(ConsumerError::MissingReceiptHandle {
+                    message_id: message.message_id().map(ToOwned::to_owned),
+                });
+            };
+            message_ids.push(message.message_id().unwrap_or(receipt_handle).to_owned());
+            entries.push((index.to_string(), receipt_handle.to_owned()));
+        }
 
         self.backend
             .delete_message_batch(&self.options.queue_url, entries)
@@ -440,19 +440,19 @@ impl Consumer {
                     let receipt_handle = message.receipt_handle()?.to_owned();
                     let message_id = message.message_id().unwrap_or(&receipt_handle).to_owned();
                     let (stop_tx, stop_rx) = watch::channel(false);
-                    spawn_heartbeat_with_failure_channel(
-                        self.backend.clone(),
-                        self.listener.clone(),
-                        self.options.queue_url.clone(),
-                        message.clone(),
+                    spawn_heartbeat_with_failure_channel(HeartbeatSpawn {
+                        backend: self.backend.clone(),
+                        listener: self.listener.clone(),
+                        queue_url: self.options.queue_url.clone(),
+                        message: message.clone(),
                         receipt_handle,
                         message_id,
-                        config.interval,
+                        interval: config.interval,
                         visibility_timeout,
                         stop_tx,
                         stop_rx,
-                        failure_tx.clone(),
-                    )
+                        failure_tx: failure_tx.clone(),
+                    })
                 })
                 .collect(),
             failure_rx: Some(failure_rx),
@@ -743,8 +743,10 @@ mod tests {
     #[derive(Default)]
     struct MockBackend {
         receives: Mutex<VecDeque<Result<Vec<Message>, BackendError>>>,
+        receive_count: Mutex<usize>,
         deleted: Mutex<Vec<Vec<String>>>,
         visibility_changes: Mutex<Vec<(String, i32)>>,
+        delete_failure_indexes: Option<Vec<usize>>,
         fail_delete: bool,
         fail_visibility: bool,
     }
@@ -760,6 +762,7 @@ mod tests {
             _attribute_names: &[aws_sdk_sqs::types::MessageSystemAttributeName],
             _message_attribute_names: &[String],
         ) -> Result<Vec<Message>, BackendError> {
+            *self.receive_count.lock().await += 1;
             self.receives
                 .lock()
                 .await
@@ -772,6 +775,9 @@ mod tests {
             _queue_url: &str,
             entries: Vec<(String, String)>,
         ) -> Result<(), BackendError> {
+            if let Some(indexes) = &self.delete_failure_indexes {
+                return Err(BackendError::DeleteBatchFailed(indexes.clone()));
+            }
             if self.fail_delete {
                 return Err(BackendError::DeleteBatchFailed(vec![0]));
             }
@@ -884,6 +890,7 @@ mod tests {
         aborted_message_ids: Arc<std::sync::Mutex<Vec<Vec<String>>>>,
         graceful_timeout_message_ids: Arc<std::sync::Mutex<Vec<Vec<String>>>>,
         error_message_ids: Arc<std::sync::Mutex<Vec<Vec<String>>>>,
+        timeout_message_ids: Arc<std::sync::Mutex<Vec<String>>>,
         message_processed_ids: Arc<std::sync::Mutex<Vec<String>>>,
         response_processed_counts: Arc<std::sync::Mutex<Vec<usize>>>,
         polling_started_count: Arc<std::sync::Mutex<usize>>,
@@ -949,6 +956,15 @@ mod tests {
         fn on_polling_wait_exceeded(&self) {
             *self.polling_wait_exceeded_count.lock().unwrap() += 1;
         }
+
+        fn on_timeout_error(&self, message: &Message) {
+            if let Some(message_id) = message.message_id() {
+                self.timeout_message_ids
+                    .lock()
+                    .unwrap()
+                    .push(message_id.to_owned());
+            }
+        }
     }
 
     fn message(id: &str, receipt: Option<&str>) -> Message {
@@ -957,6 +973,13 @@ mod tests {
             builder = builder.receipt_handle(receipt);
         }
         builder.build()
+    }
+
+    fn message_without_id(receipt: &str) -> Message {
+        Message::builder()
+            .body("{}")
+            .receipt_handle(receipt)
+            .build()
     }
 
     fn options() -> ConsumerOptions {
@@ -1099,6 +1122,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn delete_batch_failure_preserves_failed_entry_index_without_message_id() {
+        let backend = Arc::new(MockBackend {
+            delete_failure_indexes: Some(vec![1]),
+            ..MockBackend::default()
+        });
+        backend
+            .receives
+            .lock()
+            .await
+            .push_back(Ok(vec![message("1", Some("r1")), message_without_id("r2")]));
+        let handler = TestHandler {
+            batch_outcome: BatchOutcome::AckAll,
+            message_outcome: HandleOutcome::Ack,
+            delay: None,
+        };
+
+        let error = consumer(backend, handler, options())
+            .run_once()
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(error, ConsumerError::DeleteMessageBatch { failed_message_ids, .. } if failed_message_ids == vec!["r2"])
+        );
+    }
+
+    #[tokio::test]
     async fn run_once_notifies_polling_lifecycle_and_processed_count() {
         let backend = Arc::new(MockBackend::default());
         backend
@@ -1165,6 +1215,85 @@ mod tests {
         assert_eq!(*backend.deleted.lock().await, vec![vec!["r1"]]);
         assert!(*waiting_for_polling_count.lock().unwrap() >= 1);
         assert!(*polling_wait_exceeded_count.lock().unwrap() >= 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn handle_message_timeout_notifies_and_nacks_message() {
+        let backend = Arc::new(MockBackend::default());
+        backend
+            .receives
+            .lock()
+            .await
+            .push_back(Ok(vec![message("1", Some("r1"))]));
+        let listener = RecordingListener::default();
+        let timeout_message_ids = listener.timeout_message_ids.clone();
+        let handler = TestHandler {
+            batch_outcome: BatchOutcome::AckAll,
+            message_outcome: HandleOutcome::Ack,
+            delay: Some(Duration::from_secs(1)),
+        };
+        let options = ConsumerOptions::builder()
+            .queue_url("queue")
+            .wait_time_seconds(0)
+            .handle_message_timeout(Duration::from_millis(100))
+            .terminate_visibility(TerminateVisibility::Reset)
+            .build_for_backend()
+            .unwrap();
+        let consumer = consumer(backend.clone(), handler, options).listener(listener);
+
+        let task = tokio::spawn(async move { consumer.run_once().await });
+        tokio::time::advance(Duration::from_millis(100)).await;
+        let error = task.await.unwrap().unwrap_err();
+
+        assert!(matches!(error, ConsumerError::Timeout));
+        assert_eq!(*timeout_message_ids.lock().unwrap(), vec!["1"]);
+        assert!(backend.deleted.lock().await.is_empty());
+        assert_eq!(
+            *backend.visibility_changes.lock().await,
+            vec![("r1".into(), 0)]
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn receive_error_backoff_delays_retry() {
+        let backend = Arc::new(MockBackend::default());
+        backend
+            .receives
+            .lock()
+            .await
+            .push_back(Err(BackendError::Test("receive failed".into())));
+        backend
+            .receives
+            .lock()
+            .await
+            .push_back(Ok(vec![message("1", Some("r1"))]));
+        let handler = TestHandler {
+            batch_outcome: BatchOutcome::AckAll,
+            message_outcome: HandleOutcome::Ack,
+            delay: None,
+        };
+        let options = ConsumerOptions::builder()
+            .queue_url("queue")
+            .wait_time_seconds(0)
+            .receive_error_backoff(Duration::from_secs(10))
+            .build_for_backend()
+            .unwrap();
+        let consumer = consumer(backend.clone(), handler, options);
+        let shutdown = consumer.shutdown_handle();
+
+        let task = tokio::spawn(async move { consumer.run().await });
+        tokio::task::yield_now().await;
+        assert_eq!(*backend.receive_count.lock().await, 1);
+        tokio::time::advance(Duration::from_secs(9)).await;
+        tokio::task::yield_now().await;
+        assert_eq!(*backend.receive_count.lock().await, 1);
+        tokio::time::advance(Duration::from_secs(1)).await;
+        tokio::task::yield_now().await;
+        shutdown.graceful();
+        task.await.unwrap().unwrap();
+
+        assert!(*backend.receive_count.lock().await >= 2);
+        assert_eq!(*backend.deleted.lock().await, vec![vec!["r1"]]);
     }
 
     #[tokio::test(start_paused = true)]
@@ -1255,6 +1384,68 @@ mod tests {
         assert_eq!(
             *backend.visibility_changes.lock().await,
             vec![("r1".into(), 0)]
+        );
+    }
+
+    #[tokio::test]
+    async fn fixed_terminate_visibility_uses_configured_timeout() {
+        let backend = Arc::new(MockBackend::default());
+        backend
+            .receives
+            .lock()
+            .await
+            .push_back(Ok(vec![message("1", Some("r1"))]));
+        let handler = TestHandler {
+            batch_outcome: BatchOutcome::NackAll,
+            message_outcome: HandleOutcome::Ack,
+            delay: None,
+        };
+        let options = ConsumerOptions::builder()
+            .queue_url("queue")
+            .wait_time_seconds(0)
+            .terminate_visibility(TerminateVisibility::Fixed(30))
+            .build_for_backend()
+            .unwrap();
+
+        consumer(backend.clone(), handler, options)
+            .run_once()
+            .await
+            .unwrap();
+
+        assert_eq!(
+            *backend.visibility_changes.lock().await,
+            vec![("r1".into(), 30)]
+        );
+    }
+
+    #[tokio::test]
+    async fn dynamic_terminate_visibility_uses_resolved_timeout() {
+        let backend = Arc::new(MockBackend::default());
+        backend
+            .receives
+            .lock()
+            .await
+            .push_back(Ok(vec![message("1", Some("r1"))]));
+        let handler = TestHandler {
+            batch_outcome: BatchOutcome::NackAll,
+            message_outcome: HandleOutcome::Ack,
+            delay: None,
+        };
+        let options = ConsumerOptions::builder()
+            .queue_url("queue")
+            .wait_time_seconds(0)
+            .terminate_visibility(TerminateVisibility::Dynamic(Arc::new(|_| 45)))
+            .build_for_backend()
+            .unwrap();
+
+        consumer(backend.clone(), handler, options)
+            .run_once()
+            .await
+            .unwrap();
+
+        assert_eq!(
+            *backend.visibility_changes.lock().await,
+            vec![("r1".into(), 45)]
         );
     }
 

--- a/apps/api/sqs-consumer/src/error.rs
+++ b/apps/api/sqs-consumer/src/error.rs
@@ -14,6 +14,12 @@ pub enum ConsumerError {
     Processing(#[source] Box<dyn std::error::Error + Send + Sync>),
     #[error("handler timed out")]
     Timeout,
+    #[error("handler returned invalid acknowledgement: {0}")]
+    InvalidAck(String),
+    #[error("invalid visibility timeout for {field}: {value}")]
+    InvalidVisibilityTimeout { field: &'static str, value: i32 },
+    #[error("graceful shutdown timed out while waiting for in-flight processing")]
+    GracefulShutdownTimeout,
     #[error("SQS message {message_id:?} has no receipt handle")]
     MissingReceiptHandle { message_id: Option<String> },
     #[error("shutdown signal error")]

--- a/apps/api/sqs-consumer/src/error.rs
+++ b/apps/api/sqs-consumer/src/error.rs
@@ -1,0 +1,23 @@
+use std::fmt::Debug;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ConsumerError {
+    #[error("invalid consumer options: {0}")]
+    InvalidOptions(String),
+    #[error("SQS receive message error")]
+    ReceiveMessage(#[source] Box<dyn std::error::Error + Send + Sync>),
+    #[error("SQS delete message batch error")]
+    DeleteMessageBatch(#[source] Box<dyn std::error::Error + Send + Sync>),
+    #[error("SQS change message visibility error")]
+    ChangeMessageVisibility(#[source] Box<dyn std::error::Error + Send + Sync>),
+    #[error("handler processing error")]
+    Processing(#[source] Box<dyn std::error::Error + Send + Sync>),
+    #[error("handler timed out")]
+    Timeout,
+    #[error("SQS message {message_id:?} has no receipt handle")]
+    MissingReceiptHandle { message_id: Option<String> },
+    #[error("shutdown signal error")]
+    ShutdownSignal(#[source] std::io::Error),
+    #[error("consumer task join error")]
+    Join(#[source] tokio::task::JoinError),
+}

--- a/apps/api/sqs-consumer/src/error.rs
+++ b/apps/api/sqs-consumer/src/error.rs
@@ -4,6 +4,8 @@ use std::fmt::Debug;
 pub enum ConsumerError {
     #[error("invalid consumer options: {0}")]
     InvalidOptions(String),
+    #[error("invalid consumer configuration: {0}")]
+    InvalidConfig(String),
     #[error("SQS receive message error")]
     ReceiveMessage(#[source] Box<dyn std::error::Error + Send + Sync>),
     #[error("SQS delete message batch error")]
@@ -18,8 +20,10 @@ pub enum ConsumerError {
     InvalidAck(String),
     #[error("invalid visibility timeout for {field}: {value}")]
     InvalidVisibilityTimeout { field: &'static str, value: i32 },
-    #[error("graceful shutdown timed out while waiting for in-flight processing")]
-    GracefulShutdownTimeout,
+    #[error("graceful shutdown timed out while waiting for in-flight processing: {message_ids:?}")]
+    GracefulShutdownTimeout { message_ids: Vec<String> },
+    #[error("in-flight processing aborted: {message_ids:?}")]
+    Aborted { message_ids: Vec<String> },
     #[error("SQS message {message_id:?} has no receipt handle")]
     MissingReceiptHandle { message_id: Option<String> },
     #[error("shutdown signal error")]

--- a/apps/api/sqs-consumer/src/error.rs
+++ b/apps/api/sqs-consumer/src/error.rs
@@ -8,14 +8,20 @@ pub enum ConsumerError {
     InvalidConfig(String),
     #[error("SQS receive message error")]
     ReceiveMessage(#[source] Box<dyn std::error::Error + Send + Sync>),
-    #[error("SQS delete message batch error")]
-    DeleteMessageBatch(#[source] Box<dyn std::error::Error + Send + Sync>),
+    #[error("SQS delete message batch error for messages {failed_message_ids:?}")]
+    DeleteMessageBatch {
+        failed_message_ids: Vec<String>,
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
     #[error("SQS change message visibility error")]
     ChangeMessageVisibility(#[source] Box<dyn std::error::Error + Send + Sync>),
     #[error("handler processing error")]
     Processing(#[source] Box<dyn std::error::Error + Send + Sync>),
     #[error("handler timed out")]
     Timeout,
+    #[error("heartbeat failed for message {message_id}")]
+    HeartbeatFailed { message_id: String },
     #[error("handler returned invalid acknowledgement: {0}")]
     InvalidAck(String),
     #[error("invalid visibility timeout for {field}: {value}")]

--- a/apps/api/sqs-consumer/src/error.rs
+++ b/apps/api/sqs-consumer/src/error.rs
@@ -21,7 +21,11 @@ pub enum ConsumerError {
     #[error("handler timed out")]
     Timeout,
     #[error("heartbeat failed for message {message_id}")]
-    HeartbeatFailed { message_id: String },
+    HeartbeatFailed {
+        message_id: String,
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
     #[error("handler returned invalid acknowledgement: {0}")]
     InvalidAck(String),
     #[error("invalid visibility timeout for {field}: {value}")]

--- a/apps/api/sqs-consumer/src/handler.rs
+++ b/apps/api/sqs-consumer/src/handler.rs
@@ -1,0 +1,29 @@
+use async_trait::async_trait;
+use aws_sdk_sqs::types::Message;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum HandleOutcome {
+    Ack,
+    Nack,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum BatchOutcome {
+    AckAll,
+    NackAll,
+    Partial { ack_message_ids: Vec<String> },
+}
+
+#[async_trait]
+pub trait MessageHandler: Send + Sync + 'static {
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    async fn handle_message(&self, message: Message) -> Result<HandleOutcome, Self::Error>;
+}
+
+#[async_trait]
+pub trait BatchMessageHandler: Send + Sync + 'static {
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    async fn handle_batch(&self, messages: Vec<Message>) -> Result<BatchOutcome, Self::Error>;
+}

--- a/apps/api/sqs-consumer/src/handler.rs
+++ b/apps/api/sqs-consumer/src/handler.rs
@@ -25,5 +25,9 @@ pub trait MessageHandler: Send + Sync + 'static {
 pub trait BatchMessageHandler: Send + Sync + 'static {
     type Error: std::error::Error + Send + Sync + 'static;
 
+    async fn ack_before_batch(&self, _messages: &[Message]) -> Result<Vec<String>, Self::Error> {
+        Ok(Vec::new())
+    }
+
     async fn handle_batch(&self, messages: Vec<Message>) -> Result<BatchOutcome, Self::Error>;
 }

--- a/apps/api/sqs-consumer/src/heartbeat.rs
+++ b/apps/api/sqs-consumer/src/heartbeat.rs
@@ -1,0 +1,38 @@
+use std::{sync::Arc, time::Duration};
+
+use aws_sdk_sqs::types::Message;
+use tokio::{sync::watch, task::JoinHandle};
+
+use crate::{backend::SqsBackend, listener::ConsumerListener};
+
+pub(crate) fn spawn_heartbeat(
+    backend: Arc<dyn SqsBackend>,
+    listener: Arc<dyn ConsumerListener>,
+    queue_url: String,
+    message: Message,
+    interval: Duration,
+    visibility_timeout: i32,
+) -> Option<(watch::Sender<bool>, JoinHandle<()>)> {
+    let receipt_handle = message.receipt_handle()?.to_owned();
+    let (stop_tx, mut stop_rx) = watch::channel(false);
+    let handle = tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                changed = stop_rx.changed() => {
+                    if changed.is_err() || *stop_rx.borrow() {
+                        break;
+                    }
+                }
+                _ = tokio::time::sleep(interval) => {
+                    if let Err(error) = backend
+                        .change_message_visibility(&queue_url, &receipt_handle, visibility_timeout)
+                        .await
+                    {
+                        listener.on_visibility_error(&message, &error);
+                    }
+                }
+            }
+        }
+    });
+    Some((stop_tx, handle))
+}

--- a/apps/api/sqs-consumer/src/heartbeat.rs
+++ b/apps/api/sqs-consumer/src/heartbeat.rs
@@ -1,7 +1,10 @@
 use std::{sync::Arc, time::Duration};
 
 use aws_sdk_sqs::types::Message;
-use tokio::{sync::watch, task::JoinHandle};
+use tokio::{
+    sync::{mpsc, watch},
+    task::JoinHandle,
+};
 
 use crate::{backend::SqsBackend, listener::ConsumerListener};
 
@@ -12,9 +15,44 @@ pub(crate) fn spawn_heartbeat(
     message: Message,
     interval: Duration,
     visibility_timeout: i32,
-) -> Option<(watch::Sender<bool>, JoinHandle<()>)> {
+) -> Option<HeartbeatTask> {
     let receipt_handle = message.receipt_handle()?.to_owned();
-    let (stop_tx, mut stop_rx) = watch::channel(false);
+    let message_id = message.message_id().unwrap_or(&receipt_handle).to_owned();
+    let (stop_tx, stop_rx) = watch::channel(false);
+    let (failure_tx, _failure_rx) = mpsc::unbounded_channel::<String>();
+    spawn_heartbeat_with_failure_channel(
+        backend,
+        listener,
+        queue_url,
+        message,
+        receipt_handle,
+        message_id,
+        interval,
+        visibility_timeout,
+        stop_tx,
+        stop_rx,
+        failure_tx,
+    )
+}
+
+pub(crate) struct HeartbeatTask {
+    pub(crate) stop: watch::Sender<bool>,
+    pub(crate) handle: JoinHandle<()>,
+}
+
+pub(crate) fn spawn_heartbeat_with_failure_channel(
+    backend: Arc<dyn SqsBackend>,
+    listener: Arc<dyn ConsumerListener>,
+    queue_url: String,
+    message: Message,
+    receipt_handle: String,
+    message_id: String,
+    interval: Duration,
+    visibility_timeout: i32,
+    stop_tx: watch::Sender<bool>,
+    mut stop_rx: watch::Receiver<bool>,
+    failure_tx: mpsc::UnboundedSender<String>,
+) -> Option<HeartbeatTask> {
     let handle = tokio::spawn(async move {
         loop {
             tokio::select! {
@@ -29,10 +67,15 @@ pub(crate) fn spawn_heartbeat(
                         .await
                     {
                         listener.on_visibility_error(&message, &error);
+                        let _ = failure_tx.send(message_id);
+                        break;
                     }
                 }
             }
         }
     });
-    Some((stop_tx, handle))
+    Some(HeartbeatTask {
+        stop: stop_tx,
+        handle,
+    })
 }

--- a/apps/api/sqs-consumer/src/heartbeat.rs
+++ b/apps/api/sqs-consumer/src/heartbeat.rs
@@ -6,7 +6,15 @@ use tokio::{
     task::JoinHandle,
 };
 
-use crate::{backend::SqsBackend, listener::ConsumerListener};
+use crate::{
+    backend::{BackendError, SqsBackend},
+    listener::ConsumerListener,
+};
+
+pub(crate) struct HeartbeatFailure {
+    pub(crate) message_id: String,
+    pub(crate) source: BackendError,
+}
 
 pub(crate) struct HeartbeatSpawn {
     pub(crate) backend: Arc<dyn SqsBackend>,
@@ -19,7 +27,7 @@ pub(crate) struct HeartbeatSpawn {
     pub(crate) visibility_timeout: i32,
     pub(crate) stop_tx: watch::Sender<bool>,
     pub(crate) stop_rx: watch::Receiver<bool>,
-    pub(crate) failure_tx: mpsc::UnboundedSender<String>,
+    pub(crate) failure_tx: mpsc::UnboundedSender<HeartbeatFailure>,
 }
 
 pub(crate) fn spawn_heartbeat(
@@ -29,11 +37,11 @@ pub(crate) fn spawn_heartbeat(
     message: Message,
     interval: Duration,
     visibility_timeout: i32,
-) -> Option<(HeartbeatTask, mpsc::UnboundedReceiver<String>)> {
+) -> Option<(HeartbeatTask, mpsc::UnboundedReceiver<HeartbeatFailure>)> {
     let receipt_handle = message.receipt_handle()?.to_owned();
     let message_id = message.message_id().unwrap_or(&receipt_handle).to_owned();
     let (stop_tx, stop_rx) = watch::channel(false);
-    let (failure_tx, failure_rx) = mpsc::unbounded_channel::<String>();
+    let (failure_tx, failure_rx) = mpsc::unbounded_channel::<HeartbeatFailure>();
     spawn_heartbeat_with_failure_channel(HeartbeatSpawn {
         backend,
         listener,
@@ -83,7 +91,10 @@ pub(crate) fn spawn_heartbeat_with_failure_channel(spawn: HeartbeatSpawn) -> Opt
                         .await
                     {
                         listener.on_visibility_error(&message, &error);
-                        let _ = failure_tx.send(message_id);
+                        let _ = failure_tx.send(HeartbeatFailure {
+                            message_id,
+                            source: error,
+                        });
                         break;
                     }
                 }

--- a/apps/api/sqs-consumer/src/heartbeat.rs
+++ b/apps/api/sqs-consumer/src/heartbeat.rs
@@ -8,6 +8,20 @@ use tokio::{
 
 use crate::{backend::SqsBackend, listener::ConsumerListener};
 
+pub(crate) struct HeartbeatSpawn {
+    pub(crate) backend: Arc<dyn SqsBackend>,
+    pub(crate) listener: Arc<dyn ConsumerListener>,
+    pub(crate) queue_url: String,
+    pub(crate) message: Message,
+    pub(crate) receipt_handle: String,
+    pub(crate) message_id: String,
+    pub(crate) interval: Duration,
+    pub(crate) visibility_timeout: i32,
+    pub(crate) stop_tx: watch::Sender<bool>,
+    pub(crate) stop_rx: watch::Receiver<bool>,
+    pub(crate) failure_tx: mpsc::UnboundedSender<String>,
+}
+
 pub(crate) fn spawn_heartbeat(
     backend: Arc<dyn SqsBackend>,
     listener: Arc<dyn ConsumerListener>,
@@ -20,7 +34,7 @@ pub(crate) fn spawn_heartbeat(
     let message_id = message.message_id().unwrap_or(&receipt_handle).to_owned();
     let (stop_tx, stop_rx) = watch::channel(false);
     let (failure_tx, _failure_rx) = mpsc::unbounded_channel::<String>();
-    spawn_heartbeat_with_failure_channel(
+    spawn_heartbeat_with_failure_channel(HeartbeatSpawn {
         backend,
         listener,
         queue_url,
@@ -32,7 +46,7 @@ pub(crate) fn spawn_heartbeat(
         stop_tx,
         stop_rx,
         failure_tx,
-    )
+    })
 }
 
 pub(crate) struct HeartbeatTask {
@@ -40,19 +54,20 @@ pub(crate) struct HeartbeatTask {
     pub(crate) handle: JoinHandle<()>,
 }
 
-pub(crate) fn spawn_heartbeat_with_failure_channel(
-    backend: Arc<dyn SqsBackend>,
-    listener: Arc<dyn ConsumerListener>,
-    queue_url: String,
-    message: Message,
-    receipt_handle: String,
-    message_id: String,
-    interval: Duration,
-    visibility_timeout: i32,
-    stop_tx: watch::Sender<bool>,
-    mut stop_rx: watch::Receiver<bool>,
-    failure_tx: mpsc::UnboundedSender<String>,
-) -> Option<HeartbeatTask> {
+pub(crate) fn spawn_heartbeat_with_failure_channel(spawn: HeartbeatSpawn) -> Option<HeartbeatTask> {
+    let HeartbeatSpawn {
+        backend,
+        listener,
+        queue_url,
+        message,
+        receipt_handle,
+        message_id,
+        interval,
+        visibility_timeout,
+        stop_tx,
+        mut stop_rx,
+        failure_tx,
+    } = spawn;
     let handle = tokio::spawn(async move {
         loop {
             tokio::select! {

--- a/apps/api/sqs-consumer/src/heartbeat.rs
+++ b/apps/api/sqs-consumer/src/heartbeat.rs
@@ -29,11 +29,11 @@ pub(crate) fn spawn_heartbeat(
     message: Message,
     interval: Duration,
     visibility_timeout: i32,
-) -> Option<HeartbeatTask> {
+) -> Option<(HeartbeatTask, mpsc::UnboundedReceiver<String>)> {
     let receipt_handle = message.receipt_handle()?.to_owned();
     let message_id = message.message_id().unwrap_or(&receipt_handle).to_owned();
     let (stop_tx, stop_rx) = watch::channel(false);
-    let (failure_tx, _failure_rx) = mpsc::unbounded_channel::<String>();
+    let (failure_tx, failure_rx) = mpsc::unbounded_channel::<String>();
     spawn_heartbeat_with_failure_channel(HeartbeatSpawn {
         backend,
         listener,
@@ -47,6 +47,7 @@ pub(crate) fn spawn_heartbeat(
         stop_rx,
         failure_tx,
     })
+    .map(|task| (task, failure_rx))
 }
 
 pub(crate) struct HeartbeatTask {

--- a/apps/api/sqs-consumer/src/lib.rs
+++ b/apps/api/sqs-consumer/src/lib.rs
@@ -8,7 +8,7 @@ pub mod shutdown;
 mod backend;
 mod heartbeat;
 
-pub use consumer::Consumer;
+pub use consumer::{Consumer, shutdown_signal};
 pub use error::ConsumerError;
 pub use handler::{BatchMessageHandler, BatchOutcome, HandleOutcome, MessageHandler};
 pub use listener::{ConsumerListener, TracingListener};

--- a/apps/api/sqs-consumer/src/lib.rs
+++ b/apps/api/sqs-consumer/src/lib.rs
@@ -1,0 +1,16 @@
+pub mod consumer;
+pub mod error;
+pub mod handler;
+pub mod listener;
+pub mod options;
+pub mod shutdown;
+
+mod backend;
+mod heartbeat;
+
+pub use consumer::Consumer;
+pub use error::ConsumerError;
+pub use handler::{BatchMessageHandler, BatchOutcome, HandleOutcome, MessageHandler};
+pub use listener::{ConsumerListener, TracingListener};
+pub use options::{ConsumerOptions, ConsumerOptionsBuilder, HeartbeatConfig, TerminateVisibility};
+pub use shutdown::ShutdownHandle;

--- a/apps/api/sqs-consumer/src/listener.rs
+++ b/apps/api/sqs-consumer/src/listener.rs
@@ -5,9 +5,14 @@ pub trait ConsumerListener: Send + Sync + 'static {
     fn on_started(&self) {}
     fn on_stopped(&self) {}
     fn on_aborted(&self, _aborted_message_ids: &[String]) {}
+    fn on_polling_started(&self) {}
+    fn on_polling_completed(&self) {}
     fn on_empty(&self) {}
     fn on_message_received(&self, _message: &Message) {}
-    fn on_response_processed(&self) {}
+    fn on_message_processed(&self, _message: &Message) {}
+    fn on_response_processed(&self, _count: usize) {}
+    fn on_waiting_for_polling(&self) {}
+    fn on_polling_wait_exceeded(&self) {}
     fn on_error(&self, _error: &(dyn std::error::Error + 'static), _messages: Option<&[Message]>) {}
     fn on_processing_error(&self, _message: &Message, _error: &(dyn std::error::Error + 'static)) {}
     fn on_timeout_error(&self, _message: &Message) {}
@@ -35,6 +40,14 @@ impl ConsumerListener for TracingListener {
         warn!(?aborted_message_ids, "sqs consumer aborted");
     }
 
+    fn on_polling_started(&self) {
+        debug!("sqs consumer polling started");
+    }
+
+    fn on_polling_completed(&self) {
+        debug!("sqs consumer polling completed");
+    }
+
     fn on_empty(&self) {
         debug!("sqs consumer received empty response");
     }
@@ -43,8 +56,20 @@ impl ConsumerListener for TracingListener {
         debug!(message_id = message.message_id(), "sqs message received");
     }
 
-    fn on_response_processed(&self) {
-        debug!("sqs response processed");
+    fn on_message_processed(&self, message: &Message) {
+        debug!(message_id = message.message_id(), "sqs message processed");
+    }
+
+    fn on_response_processed(&self, count: usize) {
+        debug!(message_count = count, "sqs response processed");
+    }
+
+    fn on_waiting_for_polling(&self) {
+        debug!("sqs consumer waiting before next poll");
+    }
+
+    fn on_polling_wait_exceeded(&self) {
+        debug!("sqs consumer polling wait elapsed");
     }
 
     fn on_error(&self, error: &(dyn std::error::Error + 'static), messages: Option<&[Message]>) {

--- a/apps/api/sqs-consumer/src/listener.rs
+++ b/apps/api/sqs-consumer/src/listener.rs
@@ -8,7 +8,7 @@ pub trait ConsumerListener: Send + Sync + 'static {
     fn on_empty(&self) {}
     fn on_message_received(&self, _message: &Message) {}
     fn on_response_processed(&self) {}
-    fn on_error(&self, _error: &(dyn std::error::Error + 'static)) {}
+    fn on_error(&self, _error: &(dyn std::error::Error + 'static), _messages: Option<&[Message]>) {}
     fn on_processing_error(&self, _message: &Message, _error: &(dyn std::error::Error + 'static)) {}
     fn on_timeout_error(&self, _message: &Message) {}
     fn on_visibility_error(&self, _message: &Message, _error: &(dyn std::error::Error + 'static)) {}
@@ -47,8 +47,12 @@ impl ConsumerListener for TracingListener {
         debug!("sqs response processed");
     }
 
-    fn on_error(&self, error: &(dyn std::error::Error + 'static)) {
-        error!(?error, "sqs consumer error");
+    fn on_error(&self, error: &(dyn std::error::Error + 'static), messages: Option<&[Message]>) {
+        error!(
+            ?error,
+            message_count = messages.map(|messages| messages.len()),
+            "sqs consumer error"
+        );
     }
 
     fn on_processing_error(&self, message: &Message, error: &(dyn std::error::Error + 'static)) {

--- a/apps/api/sqs-consumer/src/listener.rs
+++ b/apps/api/sqs-consumer/src/listener.rs
@@ -4,7 +4,7 @@ use tracing::{debug, error, info, warn};
 pub trait ConsumerListener: Send + Sync + 'static {
     fn on_started(&self) {}
     fn on_stopped(&self) {}
-    fn on_aborted(&self) {}
+    fn on_aborted(&self, _aborted_message_ids: &[String]) {}
     fn on_empty(&self) {}
     fn on_message_received(&self, _message: &Message) {}
     fn on_response_processed(&self) {}
@@ -31,8 +31,8 @@ impl ConsumerListener for TracingListener {
         info!("sqs consumer stopped");
     }
 
-    fn on_aborted(&self) {
-        warn!("sqs consumer aborted");
+    fn on_aborted(&self, aborted_message_ids: &[String]) {
+        warn!(?aborted_message_ids, "sqs consumer aborted");
     }
 
     fn on_empty(&self) {

--- a/apps/api/sqs-consumer/src/listener.rs
+++ b/apps/api/sqs-consumer/src/listener.rs
@@ -1,0 +1,76 @@
+use aws_sdk_sqs::types::Message;
+use tracing::{debug, error, info, warn};
+
+pub trait ConsumerListener: Send + Sync + 'static {
+    fn on_started(&self) {}
+    fn on_stopped(&self) {}
+    fn on_aborted(&self) {}
+    fn on_empty(&self) {}
+    fn on_message_received(&self, _message: &Message) {}
+    fn on_response_processed(&self) {}
+    fn on_error(&self, _error: &(dyn std::error::Error + 'static)) {}
+    fn on_processing_error(&self, _message: &Message, _error: &(dyn std::error::Error + 'static)) {}
+    fn on_timeout_error(&self, _message: &Message) {}
+    fn on_visibility_error(&self, _message: &Message, _error: &(dyn std::error::Error + 'static)) {}
+}
+
+#[derive(Default)]
+pub struct NoopListener;
+
+impl ConsumerListener for NoopListener {}
+
+#[derive(Default)]
+pub struct TracingListener;
+
+impl ConsumerListener for TracingListener {
+    fn on_started(&self) {
+        info!("sqs consumer started");
+    }
+
+    fn on_stopped(&self) {
+        info!("sqs consumer stopped");
+    }
+
+    fn on_aborted(&self) {
+        warn!("sqs consumer aborted");
+    }
+
+    fn on_empty(&self) {
+        debug!("sqs consumer received empty response");
+    }
+
+    fn on_message_received(&self, message: &Message) {
+        debug!(message_id = message.message_id(), "sqs message received");
+    }
+
+    fn on_response_processed(&self) {
+        debug!("sqs response processed");
+    }
+
+    fn on_error(&self, error: &(dyn std::error::Error + 'static)) {
+        error!(?error, "sqs consumer error");
+    }
+
+    fn on_processing_error(&self, message: &Message, error: &(dyn std::error::Error + 'static)) {
+        error!(
+            message_id = message.message_id(),
+            ?error,
+            "sqs message processing error"
+        );
+    }
+
+    fn on_timeout_error(&self, message: &Message) {
+        error!(
+            message_id = message.message_id(),
+            "sqs message processing timed out"
+        );
+    }
+
+    fn on_visibility_error(&self, message: &Message, error: &(dyn std::error::Error + 'static)) {
+        error!(
+            message_id = message.message_id(),
+            ?error,
+            "sqs message visibility change error"
+        );
+    }
+}

--- a/apps/api/sqs-consumer/src/options.rs
+++ b/apps/api/sqs-consumer/src/options.rs
@@ -6,6 +6,7 @@ use crate::error::ConsumerError;
 
 const DEFAULT_BATCH_SIZE: i32 = 10;
 const DEFAULT_WAIT_TIME_SECONDS: i32 = 20;
+const MAX_VISIBILITY_TIMEOUT_SECONDS: i32 = 43_200;
 
 #[derive(Clone)]
 pub struct ConsumerOptions {
@@ -167,12 +168,36 @@ impl ConsumerOptionsBuilder {
                 "wait_time_seconds must be between 0 and 20".into(),
             ));
         }
+        if let Some(visibility_timeout) = self.visibility_timeout {
+            validate_visibility_timeout("visibility_timeout", visibility_timeout)?;
+        }
+        if let TerminateVisibility::Fixed(visibility_timeout) = &self.terminate_visibility {
+            validate_visibility_timeout("terminate_visibility", *visibility_timeout)?;
+        }
         if let Some(heartbeat) = &self.heartbeat {
-            let Some(visibility_timeout) = self.visibility_timeout else {
+            if heartbeat.interval.is_zero() {
+                return Err(ConsumerError::InvalidOptions(
+                    "heartbeat interval must be greater than zero".into(),
+                ));
+            }
+            if let Some(heartbeat_visibility_timeout) = heartbeat.visibility_timeout {
+                validate_visibility_timeout(
+                    "heartbeat.visibility_timeout",
+                    heartbeat_visibility_timeout,
+                )?;
+            }
+            let Some(visibility_timeout) = heartbeat.visibility_timeout.or(self.visibility_timeout)
+            else {
                 return Err(ConsumerError::InvalidOptions(
                     "heartbeat requires visibility_timeout".into(),
                 ));
             };
+            if visibility_timeout == 0 {
+                return Err(ConsumerError::InvalidVisibilityTimeout {
+                    field: "heartbeat effective visibility_timeout",
+                    value: visibility_timeout,
+                });
+            }
             if heartbeat.interval >= Duration::from_secs(visibility_timeout as u64) {
                 return Err(ConsumerError::InvalidOptions(
                     "heartbeat interval must be less than visibility_timeout".into(),
@@ -200,4 +225,14 @@ impl ConsumerOptionsBuilder {
             polling_complete_wait_time: self.polling_complete_wait_time,
         })
     }
+}
+
+pub(crate) fn validate_visibility_timeout(
+    field: &'static str,
+    value: i32,
+) -> Result<(), ConsumerError> {
+    if !(0..=MAX_VISIBILITY_TIMEOUT_SECONDS).contains(&value) {
+        return Err(ConsumerError::InvalidVisibilityTimeout { field, value });
+    }
+    Ok(())
 }

--- a/apps/api/sqs-consumer/src/options.rs
+++ b/apps/api/sqs-consumer/src/options.rs
@@ -1,6 +1,6 @@
 use std::{sync::Arc, time::Duration};
 
-use aws_sdk_sqs::Client;
+use aws_sdk_sqs::{Client, types::MessageSystemAttributeName};
 
 use crate::error::ConsumerError;
 
@@ -18,6 +18,10 @@ pub struct ConsumerOptions {
     pub(crate) should_delete_messages: bool,
     pub(crate) always_acknowledge: bool,
     pub(crate) receive_error_backoff: Duration,
+    pub(crate) polling_wait_time: Duration,
+    pub(crate) attribute_names: Vec<MessageSystemAttributeName>,
+    pub(crate) message_attribute_names: Vec<String>,
+    pub(crate) suppress_fifo_warning: bool,
     pub(crate) handle_message_timeout: Option<Duration>,
     pub(crate) terminate_visibility: TerminateVisibility,
     pub(crate) heartbeat: Option<HeartbeatConfig>,
@@ -33,7 +37,21 @@ impl ConsumerOptions {
 #[derive(Clone)]
 pub struct HeartbeatConfig {
     pub interval: Duration,
-    pub visibility_timeout: Option<i32>,
+    pub extension: Option<Duration>,
+}
+
+impl HeartbeatConfig {
+    pub fn new(interval: Duration) -> Self {
+        Self {
+            interval,
+            extension: None,
+        }
+    }
+
+    pub fn extension(mut self, extension: Duration) -> Self {
+        self.extension = Some(extension);
+        self
+    }
 }
 
 #[derive(Clone, Default)]
@@ -54,6 +72,10 @@ pub struct ConsumerOptionsBuilder {
     should_delete_messages: bool,
     always_acknowledge: bool,
     receive_error_backoff: Duration,
+    polling_wait_time: Duration,
+    attribute_names: Vec<MessageSystemAttributeName>,
+    message_attribute_names: Vec<String>,
+    suppress_fifo_warning: bool,
     handle_message_timeout: Option<Duration>,
     terminate_visibility: TerminateVisibility,
     heartbeat: Option<HeartbeatConfig>,
@@ -70,7 +92,11 @@ impl Default for ConsumerOptionsBuilder {
             visibility_timeout: None,
             should_delete_messages: true,
             always_acknowledge: false,
-            receive_error_backoff: Duration::from_secs(1),
+            receive_error_backoff: Duration::from_secs(10),
+            polling_wait_time: Duration::ZERO,
+            attribute_names: Vec::new(),
+            message_attribute_names: Vec::new(),
+            suppress_fifo_warning: false,
             handle_message_timeout: None,
             terminate_visibility: TerminateVisibility::Off,
             heartbeat: None,
@@ -117,6 +143,26 @@ impl ConsumerOptionsBuilder {
 
     pub fn receive_error_backoff(mut self, receive_error_backoff: Duration) -> Self {
         self.receive_error_backoff = receive_error_backoff;
+        self
+    }
+
+    pub fn polling_wait_time(mut self, polling_wait_time: Duration) -> Self {
+        self.polling_wait_time = polling_wait_time;
+        self
+    }
+
+    pub fn attribute_names(mut self, attribute_names: Vec<MessageSystemAttributeName>) -> Self {
+        self.attribute_names = attribute_names;
+        self
+    }
+
+    pub fn message_attribute_names(mut self, message_attribute_names: Vec<String>) -> Self {
+        self.message_attribute_names = message_attribute_names;
+        self
+    }
+
+    pub fn suppress_fifo_warning(mut self, suppress_fifo_warning: bool) -> Self {
+        self.suppress_fifo_warning = suppress_fifo_warning;
         self
     }
 
@@ -180,29 +226,19 @@ impl ConsumerOptionsBuilder {
                     "heartbeat interval must be greater than zero".into(),
                 ));
             }
-            if let Some(heartbeat_visibility_timeout) = heartbeat.visibility_timeout {
-                validate_visibility_timeout(
-                    "heartbeat.visibility_timeout",
-                    heartbeat_visibility_timeout,
-                )?;
-            }
-            let Some(visibility_timeout) = heartbeat.visibility_timeout.or(self.visibility_timeout)
-            else {
-                return Err(ConsumerError::InvalidOptions(
-                    "heartbeat requires visibility_timeout".into(),
-                ));
-            };
-            if visibility_timeout == 0 {
+            let extension = heartbeat_extension_duration(heartbeat, self.visibility_timeout)?;
+            if extension.is_zero() {
                 return Err(ConsumerError::InvalidVisibilityTimeout {
-                    field: "heartbeat effective visibility_timeout",
-                    value: visibility_timeout,
+                    field: "heartbeat.extension",
+                    value: 0,
                 });
             }
-            if heartbeat.interval >= Duration::from_secs(visibility_timeout as u64) {
+            if heartbeat.interval >= extension {
                 return Err(ConsumerError::InvalidOptions(
-                    "heartbeat interval must be less than visibility_timeout".into(),
+                    "heartbeat interval must be less than heartbeat extension".into(),
                 ));
             }
+            let _ = duration_to_visibility_timeout("heartbeat.extension", extension)?;
         }
         if require_client && self.sqs_client.is_none() {
             return Err(ConsumerError::InvalidOptions(
@@ -219,6 +255,10 @@ impl ConsumerOptionsBuilder {
             should_delete_messages: self.should_delete_messages,
             always_acknowledge: self.always_acknowledge,
             receive_error_backoff: self.receive_error_backoff,
+            polling_wait_time: self.polling_wait_time,
+            attribute_names: self.attribute_names,
+            message_attribute_names: self.message_attribute_names,
+            suppress_fifo_warning: self.suppress_fifo_warning,
             handle_message_timeout: self.handle_message_timeout,
             terminate_visibility: self.terminate_visibility,
             heartbeat: self.heartbeat,
@@ -235,4 +275,59 @@ pub(crate) fn validate_visibility_timeout(
         return Err(ConsumerError::InvalidVisibilityTimeout { field, value });
     }
     Ok(())
+}
+
+pub(crate) fn resolve_heartbeat_visibility_timeout(
+    heartbeat: &HeartbeatConfig,
+    visibility_timeout: Option<i32>,
+) -> Result<i32, ConsumerError> {
+    let extension = heartbeat_extension_duration(heartbeat, visibility_timeout)?;
+    duration_to_visibility_timeout("heartbeat.extension", extension)
+}
+
+fn heartbeat_extension_duration(
+    heartbeat: &HeartbeatConfig,
+    visibility_timeout: Option<i32>,
+) -> Result<Duration, ConsumerError> {
+    if let Some(extension) = heartbeat.extension {
+        return Ok(extension);
+    }
+    let Some(visibility_timeout) = visibility_timeout else {
+        return Err(ConsumerError::InvalidOptions(
+            "heartbeat requires visibility_timeout".into(),
+        ));
+    };
+    Ok(Duration::from_secs(visibility_timeout as u64))
+}
+
+fn duration_to_visibility_timeout(
+    field: &'static str,
+    duration: Duration,
+) -> Result<i32, ConsumerError> {
+    let seconds = duration
+        .as_secs()
+        .checked_add(u64::from(duration.subsec_nanos() > 0))
+        .unwrap_or(u64::MAX);
+    let value = i32::try_from(seconds).unwrap_or(i32::MAX);
+    validate_visibility_timeout(field, value)?;
+    Ok(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_match_plan_aligned_options() {
+        let options = ConsumerOptions::builder()
+            .queue_url("queue")
+            .build_for_backend()
+            .unwrap();
+
+        assert_eq!(options.receive_error_backoff, Duration::from_secs(10));
+        assert_eq!(options.polling_wait_time, Duration::ZERO);
+        assert!(options.attribute_names.is_empty());
+        assert!(options.message_attribute_names.is_empty());
+        assert!(!options.suppress_fifo_warning);
+    }
 }

--- a/apps/api/sqs-consumer/src/options.rs
+++ b/apps/api/sqs-consumer/src/options.rs
@@ -1,0 +1,203 @@
+use std::{sync::Arc, time::Duration};
+
+use aws_sdk_sqs::Client;
+
+use crate::error::ConsumerError;
+
+const DEFAULT_BATCH_SIZE: i32 = 10;
+const DEFAULT_WAIT_TIME_SECONDS: i32 = 20;
+
+#[derive(Clone)]
+pub struct ConsumerOptions {
+    pub(crate) queue_url: String,
+    pub(crate) sqs_client: Option<Client>,
+    pub(crate) batch_size: i32,
+    pub(crate) wait_time_seconds: i32,
+    pub(crate) visibility_timeout: Option<i32>,
+    pub(crate) should_delete_messages: bool,
+    pub(crate) always_acknowledge: bool,
+    pub(crate) receive_error_backoff: Duration,
+    pub(crate) handle_message_timeout: Option<Duration>,
+    pub(crate) terminate_visibility: TerminateVisibility,
+    pub(crate) heartbeat: Option<HeartbeatConfig>,
+    pub(crate) polling_complete_wait_time: Duration,
+}
+
+impl ConsumerOptions {
+    pub fn builder() -> ConsumerOptionsBuilder {
+        ConsumerOptionsBuilder::default()
+    }
+}
+
+#[derive(Clone)]
+pub struct HeartbeatConfig {
+    pub interval: Duration,
+    pub visibility_timeout: Option<i32>,
+}
+
+#[derive(Clone, Default)]
+pub enum TerminateVisibility {
+    #[default]
+    Off,
+    Reset,
+    Fixed(i32),
+    Dynamic(Arc<dyn Fn(&aws_sdk_sqs::types::Message) -> i32 + Send + Sync>),
+}
+
+pub struct ConsumerOptionsBuilder {
+    queue_url: Option<String>,
+    sqs_client: Option<Client>,
+    batch_size: i32,
+    wait_time_seconds: i32,
+    visibility_timeout: Option<i32>,
+    should_delete_messages: bool,
+    always_acknowledge: bool,
+    receive_error_backoff: Duration,
+    handle_message_timeout: Option<Duration>,
+    terminate_visibility: TerminateVisibility,
+    heartbeat: Option<HeartbeatConfig>,
+    polling_complete_wait_time: Duration,
+}
+
+impl Default for ConsumerOptionsBuilder {
+    fn default() -> Self {
+        Self {
+            queue_url: None,
+            sqs_client: None,
+            batch_size: DEFAULT_BATCH_SIZE,
+            wait_time_seconds: DEFAULT_WAIT_TIME_SECONDS,
+            visibility_timeout: None,
+            should_delete_messages: true,
+            always_acknowledge: false,
+            receive_error_backoff: Duration::from_secs(1),
+            handle_message_timeout: None,
+            terminate_visibility: TerminateVisibility::Off,
+            heartbeat: None,
+            polling_complete_wait_time: Duration::from_secs(30),
+        }
+    }
+}
+
+impl ConsumerOptionsBuilder {
+    pub fn queue_url(mut self, queue_url: impl Into<String>) -> Self {
+        self.queue_url = Some(queue_url.into());
+        self
+    }
+
+    pub fn sqs_client(mut self, sqs_client: Client) -> Self {
+        self.sqs_client = Some(sqs_client);
+        self
+    }
+
+    pub fn batch_size(mut self, batch_size: i32) -> Self {
+        self.batch_size = batch_size;
+        self
+    }
+
+    pub fn wait_time_seconds(mut self, wait_time_seconds: i32) -> Self {
+        self.wait_time_seconds = wait_time_seconds;
+        self
+    }
+
+    pub fn visibility_timeout(mut self, visibility_timeout: i32) -> Self {
+        self.visibility_timeout = Some(visibility_timeout);
+        self
+    }
+
+    pub fn should_delete_messages(mut self, should_delete_messages: bool) -> Self {
+        self.should_delete_messages = should_delete_messages;
+        self
+    }
+
+    pub fn always_acknowledge(mut self, always_acknowledge: bool) -> Self {
+        self.always_acknowledge = always_acknowledge;
+        self
+    }
+
+    pub fn receive_error_backoff(mut self, receive_error_backoff: Duration) -> Self {
+        self.receive_error_backoff = receive_error_backoff;
+        self
+    }
+
+    pub fn handle_message_timeout(mut self, handle_message_timeout: Duration) -> Self {
+        self.handle_message_timeout = Some(handle_message_timeout);
+        self
+    }
+
+    pub fn terminate_visibility(mut self, terminate_visibility: TerminateVisibility) -> Self {
+        self.terminate_visibility = terminate_visibility;
+        self
+    }
+
+    pub fn heartbeat(mut self, heartbeat: HeartbeatConfig) -> Self {
+        self.heartbeat = Some(heartbeat);
+        self
+    }
+
+    pub fn polling_complete_wait_time(mut self, polling_complete_wait_time: Duration) -> Self {
+        self.polling_complete_wait_time = polling_complete_wait_time;
+        self
+    }
+
+    pub fn build(self) -> Result<ConsumerOptions, ConsumerError> {
+        self.build_with_client_requirement(true)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn build_for_backend(self) -> Result<ConsumerOptions, ConsumerError> {
+        self.build_with_client_requirement(false)
+    }
+
+    fn build_with_client_requirement(
+        self,
+        require_client: bool,
+    ) -> Result<ConsumerOptions, ConsumerError> {
+        let Some(queue_url) = self.queue_url.filter(|value| !value.is_empty()) else {
+            return Err(ConsumerError::InvalidOptions(
+                "queue_url is required".into(),
+            ));
+        };
+        if !(1..=10).contains(&self.batch_size) {
+            return Err(ConsumerError::InvalidOptions(
+                "batch_size must be between 1 and 10".into(),
+            ));
+        }
+        if !(0..=20).contains(&self.wait_time_seconds) {
+            return Err(ConsumerError::InvalidOptions(
+                "wait_time_seconds must be between 0 and 20".into(),
+            ));
+        }
+        if let Some(heartbeat) = &self.heartbeat {
+            let Some(visibility_timeout) = self.visibility_timeout else {
+                return Err(ConsumerError::InvalidOptions(
+                    "heartbeat requires visibility_timeout".into(),
+                ));
+            };
+            if heartbeat.interval >= Duration::from_secs(visibility_timeout as u64) {
+                return Err(ConsumerError::InvalidOptions(
+                    "heartbeat interval must be less than visibility_timeout".into(),
+                ));
+            }
+        }
+        if require_client && self.sqs_client.is_none() {
+            return Err(ConsumerError::InvalidOptions(
+                "sqs_client is required".into(),
+            ));
+        }
+
+        Ok(ConsumerOptions {
+            queue_url,
+            sqs_client: self.sqs_client,
+            batch_size: self.batch_size,
+            wait_time_seconds: self.wait_time_seconds,
+            visibility_timeout: self.visibility_timeout,
+            should_delete_messages: self.should_delete_messages,
+            always_acknowledge: self.always_acknowledge,
+            receive_error_backoff: self.receive_error_backoff,
+            handle_message_timeout: self.handle_message_timeout,
+            terminate_visibility: self.terminate_visibility,
+            heartbeat: self.heartbeat,
+            polling_complete_wait_time: self.polling_complete_wait_time,
+        })
+    }
+}

--- a/apps/api/sqs-consumer/src/options.rs
+++ b/apps/api/sqs-consumer/src/options.rs
@@ -306,8 +306,7 @@ fn duration_to_visibility_timeout(
 ) -> Result<i32, ConsumerError> {
     let seconds = duration
         .as_secs()
-        .checked_add(u64::from(duration.subsec_nanos() > 0))
-        .unwrap_or(u64::MAX);
+        .saturating_add(u64::from(duration.subsec_nanos() > 0));
     let value = i32::try_from(seconds).unwrap_or(i32::MAX);
     validate_visibility_timeout(field, value)?;
     Ok(value)

--- a/apps/api/sqs-consumer/src/shutdown.rs
+++ b/apps/api/sqs-consumer/src/shutdown.rs
@@ -1,0 +1,28 @@
+use tokio::sync::watch;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ShutdownState {
+    Running,
+    Graceful,
+    Abort,
+}
+
+#[derive(Clone)]
+pub struct ShutdownHandle {
+    sender: watch::Sender<ShutdownState>,
+}
+
+impl ShutdownHandle {
+    pub(crate) fn new() -> (Self, watch::Receiver<ShutdownState>) {
+        let (sender, receiver) = watch::channel(ShutdownState::Running);
+        (Self { sender }, receiver)
+    }
+
+    pub fn graceful(&self) {
+        let _ = self.sender.send(ShutdownState::Graceful);
+    }
+
+    pub fn abort(&self) {
+        let _ = self.sender.send(ShutdownState::Abort);
+    }
+}

--- a/apps/api/sqs-consumer/tests/integration_elasticmq.rs
+++ b/apps/api/sqs-consumer/tests/integration_elasticmq.rs
@@ -1,0 +1,92 @@
+use async_trait::async_trait;
+use aws_sdk_sqs::types::Message;
+use sqs_consumer::{
+    BatchMessageHandler, BatchOutcome, Consumer, ConsumerOptions, HandleOutcome, MessageHandler,
+};
+
+struct AckAllHandler;
+
+#[derive(Debug, thiserror::Error)]
+#[error("integration handler error")]
+struct HandlerError;
+
+#[async_trait]
+impl MessageHandler for AckAllHandler {
+    type Error = HandlerError;
+
+    async fn handle_message(&self, _message: Message) -> Result<HandleOutcome, Self::Error> {
+        Ok(HandleOutcome::Ack)
+    }
+}
+
+#[async_trait]
+impl BatchMessageHandler for AckAllHandler {
+    type Error = HandlerError;
+
+    async fn handle_batch(&self, _messages: Vec<Message>) -> Result<BatchOutcome, Self::Error> {
+        Ok(BatchOutcome::AckAll)
+    }
+}
+
+#[tokio::test]
+async fn acked_messages_leave_elasticmq_queue() {
+    let endpoint =
+        std::env::var("AWS_SQS_ENDPOINT").unwrap_or_else(|_| "http://elasticmq:9324".to_owned());
+    let config = aws_config::from_env().endpoint_url(endpoint).load().await;
+    let client = aws_sdk_sqs::Client::new(&config);
+    let queue_name = format!(
+        "sqs-consumer-integration-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis()
+    );
+    let queue_url = client
+        .create_queue()
+        .queue_name(queue_name)
+        .send()
+        .await
+        .unwrap()
+        .queue_url()
+        .unwrap()
+        .to_owned();
+
+    client
+        .send_message()
+        .queue_url(&queue_url)
+        .message_body("one")
+        .send()
+        .await
+        .unwrap();
+    client
+        .send_message()
+        .queue_url(&queue_url)
+        .message_body("two")
+        .send()
+        .await
+        .unwrap();
+
+    let options = ConsumerOptions::builder()
+        .queue_url(queue_url.clone())
+        .sqs_client(client.clone())
+        .batch_size(10)
+        .wait_time_seconds(0)
+        .build()
+        .unwrap();
+
+    Consumer::with_batch_handler(options, AckAllHandler)
+        .unwrap()
+        .run_once()
+        .await
+        .unwrap();
+
+    let remaining = client
+        .receive_message()
+        .queue_url(&queue_url)
+        .max_number_of_messages(1)
+        .wait_time_seconds(0)
+        .send()
+        .await
+        .unwrap();
+    assert!(remaining.messages().is_empty());
+}

--- a/apps/api/sqs-consumer/tests/integration_elasticmq.rs
+++ b/apps/api/sqs-consumer/tests/integration_elasticmq.rs
@@ -1,23 +1,12 @@
 use async_trait::async_trait;
 use aws_sdk_sqs::types::Message;
-use sqs_consumer::{
-    BatchMessageHandler, BatchOutcome, Consumer, ConsumerOptions, HandleOutcome, MessageHandler,
-};
+use sqs_consumer::{BatchMessageHandler, BatchOutcome, Consumer, ConsumerOptions};
 
 struct AckAllHandler;
 
 #[derive(Debug, thiserror::Error)]
 #[error("integration handler error")]
 struct HandlerError;
-
-#[async_trait]
-impl MessageHandler for AckAllHandler {
-    type Error = HandlerError;
-
-    async fn handle_message(&self, _message: Message) -> Result<HandleOutcome, Self::Error> {
-        Ok(HandleOutcome::Ack)
-    }
-}
 
 #[async_trait]
 impl BatchMessageHandler for AckAllHandler {

--- a/apps/api/sqs-consumer/tests/unit_options.rs
+++ b/apps/api/sqs-consumer/tests/unit_options.rs
@@ -1,6 +1,14 @@
 use std::time::Duration;
 
+use aws_sdk_sqs::types::MessageSystemAttributeName;
 use sqs_consumer::{ConsumerError, ConsumerOptions, HeartbeatConfig};
+
+fn sqs_client() -> aws_sdk_sqs::Client {
+    let config = aws_sdk_sqs::Config::builder()
+        .behavior_version_latest()
+        .build();
+    aws_sdk_sqs::Client::from_conf(config)
+}
 
 fn build_error(builder: sqs_consumer::ConsumerOptionsBuilder) -> ConsumerError {
     match builder.build() {
@@ -50,14 +58,33 @@ fn validates_wait_time_range() {
 }
 
 #[test]
+fn heartbeat_config_uses_interval_and_extension_durations() {
+    let heartbeat = HeartbeatConfig::new(Duration::from_secs(1)).extension(Duration::from_secs(5));
+
+    assert_eq!(heartbeat.interval, Duration::from_secs(1));
+    assert_eq!(heartbeat.extension, Some(Duration::from_secs(5)));
+}
+
+#[test]
+fn builder_accepts_plan_aligned_polling_and_attribute_options() {
+    ConsumerOptions::builder()
+        .queue_url("http://localhost/queue")
+        .sqs_client(sqs_client())
+        .polling_wait_time(Duration::from_millis(50))
+        .attribute_names(vec![MessageSystemAttributeName::ApproximateReceiveCount])
+        .message_attribute_names(vec!["trace-id".to_string()])
+        .suppress_fifo_warning(true)
+        .heartbeat(HeartbeatConfig::new(Duration::from_secs(1)).extension(Duration::from_secs(5)))
+        .build()
+        .unwrap();
+}
+
+#[test]
 fn heartbeat_requires_visibility_timeout() {
     let error = build_error(
         ConsumerOptions::builder()
             .queue_url("http://localhost/queue")
-            .heartbeat(HeartbeatConfig {
-                interval: Duration::from_secs(1),
-                visibility_timeout: None,
-            }),
+            .heartbeat(HeartbeatConfig::new(Duration::from_secs(1))),
     );
     assert!(
         matches!(error, ConsumerError::InvalidOptions(message) if message.contains("heartbeat requires"))
@@ -70,10 +97,7 @@ fn heartbeat_interval_must_be_less_than_visibility_timeout() {
         ConsumerOptions::builder()
             .queue_url("http://localhost/queue")
             .visibility_timeout(10)
-            .heartbeat(HeartbeatConfig {
-                interval: Duration::from_secs(10),
-                visibility_timeout: None,
-            }),
+            .heartbeat(HeartbeatConfig::new(Duration::from_secs(10))),
     );
     assert!(
         matches!(error, ConsumerError::InvalidOptions(message) if message.contains("interval"))

--- a/apps/api/sqs-consumer/tests/unit_options.rs
+++ b/apps/api/sqs-consumer/tests/unit_options.rs
@@ -1,0 +1,81 @@
+use std::time::Duration;
+
+use sqs_consumer::{ConsumerError, ConsumerOptions, HeartbeatConfig};
+
+fn build_error(builder: sqs_consumer::ConsumerOptionsBuilder) -> ConsumerError {
+    match builder.build() {
+        Ok(_) => panic!("expected options build to fail"),
+        Err(error) => error,
+    }
+}
+
+#[test]
+fn requires_queue_url() {
+    let error = build_error(ConsumerOptions::builder());
+    assert!(
+        matches!(error, ConsumerError::InvalidOptions(message) if message.contains("queue_url"))
+    );
+}
+
+#[test]
+fn requires_sqs_client_for_public_build() {
+    let error = build_error(ConsumerOptions::builder().queue_url("http://localhost/queue"));
+    assert!(
+        matches!(error, ConsumerError::InvalidOptions(message) if message.contains("sqs_client"))
+    );
+}
+
+#[test]
+fn validates_batch_size_range() {
+    let error = build_error(
+        ConsumerOptions::builder()
+            .queue_url("http://localhost/queue")
+            .batch_size(11),
+    );
+    assert!(
+        matches!(error, ConsumerError::InvalidOptions(message) if message.contains("batch_size"))
+    );
+}
+
+#[test]
+fn validates_wait_time_range() {
+    let error = build_error(
+        ConsumerOptions::builder()
+            .queue_url("http://localhost/queue")
+            .wait_time_seconds(21),
+    );
+    assert!(
+        matches!(error, ConsumerError::InvalidOptions(message) if message.contains("wait_time_seconds"))
+    );
+}
+
+#[test]
+fn heartbeat_requires_visibility_timeout() {
+    let error = build_error(
+        ConsumerOptions::builder()
+            .queue_url("http://localhost/queue")
+            .heartbeat(HeartbeatConfig {
+                interval: Duration::from_secs(1),
+                visibility_timeout: None,
+            }),
+    );
+    assert!(
+        matches!(error, ConsumerError::InvalidOptions(message) if message.contains("heartbeat requires"))
+    );
+}
+
+#[test]
+fn heartbeat_interval_must_be_less_than_visibility_timeout() {
+    let error = build_error(
+        ConsumerOptions::builder()
+            .queue_url("http://localhost/queue")
+            .visibility_timeout(10)
+            .heartbeat(HeartbeatConfig {
+                interval: Duration::from_secs(10),
+                visibility_timeout: None,
+            }),
+    );
+    assert!(
+        matches!(error, ConsumerError::InvalidOptions(message) if message.contains("interval"))
+    );
+}

--- a/apps/api/src/bin/track_point_worker.rs
+++ b/apps/api/src/bin/track_point_worker.rs
@@ -9,7 +9,6 @@ use walking_dog::queue::track_point::{
 
 const DEFAULT_WORKER_CONCURRENCY: usize = 10;
 const DEFAULT_BATCH_SIZE: i32 = 10;
-const RECEIVE_WAIT_SECONDS: i32 = 20;
 const DEFAULT_VISIBILITY_TIMEOUT_SECONDS: i32 = 60;
 const DEFAULT_HEARTBEAT_INTERVAL_SECONDS: u64 = 30;
 const DEFAULT_HANDLER_TIMEOUT_SECONDS: u64 = 50;
@@ -35,7 +34,7 @@ async fn main() -> Result<()> {
         .queue_url(queue_url)
         .sqs_client(sqs_client)
         .batch_size(batch_size)
-        .wait_time_seconds(RECEIVE_WAIT_SECONDS)
+        .wait_time_seconds(20)
         .visibility_timeout(DEFAULT_VISIBILITY_TIMEOUT_SECONDS)
         .handle_message_timeout(Duration::from_secs(handler_timeout_seconds))
         .heartbeat(sqs_consumer::HeartbeatConfig::new(Duration::from_secs(

--- a/apps/api/src/bin/track_point_worker.rs
+++ b/apps/api/src/bin/track_point_worker.rs
@@ -1,4 +1,4 @@
-use std::{env, time::Duration};
+use std::{env, fmt, time::Duration};
 
 use anyhow::Result;
 use sqs_consumer::{Consumer, ConsumerOptions, TracingListener};
@@ -112,27 +112,69 @@ where
 }
 
 fn positive_usize_env(name: &str, default: usize) -> usize {
-    env::var(name)
-        .ok()
-        .and_then(|value| value.parse::<usize>().ok())
-        .filter(|value| *value > 0)
-        .unwrap_or(default)
+    let value = env::var(name).ok();
+    positive_usize_env_value(name, value.as_deref(), default)
+}
+
+fn positive_usize_env_value(name: &str, value: Option<&str>, default: usize) -> usize {
+    let Some(value) = value else {
+        return default;
+    };
+    match value.parse::<usize>() {
+        Ok(parsed) if parsed > 0 => parsed,
+        _ => {
+            warn_invalid_env_value(name, value, default);
+            default
+        }
+    }
 }
 
 fn positive_u64_env(name: &str, default: u64) -> u64 {
-    env::var(name)
-        .ok()
-        .and_then(|value| value.parse::<u64>().ok())
-        .filter(|value| *value > 0)
-        .unwrap_or(default)
+    let value = env::var(name).ok();
+    positive_u64_env_value(name, value.as_deref(), default)
+}
+
+fn positive_u64_env_value(name: &str, value: Option<&str>, default: u64) -> u64 {
+    let Some(value) = value else {
+        return default;
+    };
+    match value.parse::<u64>() {
+        Ok(parsed) if parsed > 0 => parsed,
+        _ => {
+            warn_invalid_env_value(name, value, default);
+            default
+        }
+    }
 }
 
 fn sqs_batch_size_env(name: &str, default: i32) -> i32 {
-    env::var(name)
-        .ok()
-        .and_then(|value| value.parse::<i32>().ok())
-        .filter(|value| (1..=10).contains(value))
-        .unwrap_or(default)
+    let value = env::var(name).ok();
+    sqs_batch_size_env_value(name, value.as_deref(), default)
+}
+
+fn sqs_batch_size_env_value(name: &str, value: Option<&str>, default: i32) -> i32 {
+    let Some(value) = value else {
+        return default;
+    };
+    match value.parse::<i32>() {
+        Ok(parsed) if (1..=10).contains(&parsed) => parsed,
+        _ => {
+            warn_invalid_env_value(name, value, default);
+            default
+        }
+    }
+}
+
+fn warn_invalid_env_value<T>(name: &str, value: &str, default: T)
+where
+    T: fmt::Display,
+{
+    tracing::warn!(
+        env_var = name,
+        value,
+        default = %default,
+        "invalid environment variable, using default"
+    );
 }
 
 async fn build_dynamodb_client() -> aws_sdk_dynamodb::Client {
@@ -151,4 +193,73 @@ async fn build_sqs_client() -> aws_sdk_sqs::Client {
         Err(_) => config_loader.load().await,
     };
     aws_sdk_sqs::Client::new(&config)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        io::{Result as IoResult, Write},
+        sync::{Arc, Mutex},
+    };
+
+    use tracing_subscriber::fmt::MakeWriter;
+
+    use super::*;
+
+    #[test]
+    fn positive_env_helpers_read_valid_values() {
+        assert_eq!(positive_usize_env_value("TEST_USIZE", Some("5"), 10), 5);
+        assert_eq!(positive_u64_env_value("TEST_U64", Some("6"), 10), 6);
+        assert_eq!(sqs_batch_size_env_value("TEST_BATCH", Some("7"), 10), 7);
+    }
+
+    #[test]
+    fn invalid_env_helpers_use_defaults_and_warn() {
+        let output = capture_warnings(|| {
+            assert_eq!(positive_usize_env_value("TEST_USIZE", Some("foo"), 10), 10);
+            assert_eq!(positive_u64_env_value("TEST_U64", Some("0"), 10), 10);
+            assert_eq!(sqs_batch_size_env_value("TEST_BATCH", Some("11"), 10), 10);
+        });
+
+        assert!(output.contains("TEST_USIZE"));
+        assert!(output.contains("TEST_U64"));
+        assert!(output.contains("TEST_BATCH"));
+    }
+
+    fn capture_warnings(run: impl FnOnce()) -> String {
+        let output = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::WARN)
+            .with_writer(BufferMakeWriter(output.clone()))
+            .without_time()
+            .finish();
+
+        tracing::subscriber::with_default(subscriber, run);
+
+        String::from_utf8(output.lock().unwrap().clone()).unwrap()
+    }
+
+    #[derive(Clone)]
+    struct BufferMakeWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl<'a> MakeWriter<'a> for BufferMakeWriter {
+        type Writer = BufferWriter;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            BufferWriter(self.0.clone())
+        }
+    }
+
+    struct BufferWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for BufferWriter {
+        fn write(&mut self, buf: &[u8]) -> IoResult<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> IoResult<()> {
+            Ok(())
+        }
+    }
 }

--- a/apps/api/src/bin/track_point_worker.rs
+++ b/apps/api/src/bin/track_point_worker.rs
@@ -38,10 +38,9 @@ async fn main() -> Result<()> {
         .wait_time_seconds(RECEIVE_WAIT_SECONDS)
         .visibility_timeout(DEFAULT_VISIBILITY_TIMEOUT_SECONDS)
         .handle_message_timeout(Duration::from_secs(handler_timeout_seconds))
-        .heartbeat(sqs_consumer::HeartbeatConfig {
-            interval: Duration::from_secs(DEFAULT_HEARTBEAT_INTERVAL_SECONDS),
-            visibility_timeout: None,
-        })
+        .heartbeat(sqs_consumer::HeartbeatConfig::new(Duration::from_secs(
+            DEFAULT_HEARTBEAT_INTERVAL_SECONDS,
+        )))
         .build()?;
     let handler = TrackPointBatchHandler::new(DynamoDbTrackPointBatchWriter::new(dynamodb_client));
 

--- a/apps/api/src/bin/track_point_worker.rs
+++ b/apps/api/src/bin/track_point_worker.rs
@@ -1,15 +1,13 @@
-use std::{env, sync::Arc};
+use std::{env, time::Duration};
 
 use anyhow::Result;
-use aws_sdk_sqs::types::Message;
-use tokio::{sync::Semaphore, task::JoinSet, time::Duration};
-use tracing::{error, info, warn};
-use walking_dog::entity::track_point;
-use walking_dog::queue::track_point::{TrackPointMessage, TrackPointQueueError};
+use sqs_consumer::{Consumer, ConsumerOptions, TracingListener};
+use walking_dog::queue::track_point::{DynamoDbTrackPointBatchWriter, TrackPointBatchHandler};
 
-const DEFAULT_WORKER_CONCURRENCY: usize = 10;
+const DEFAULT_WORKER_CONCURRENCY: i32 = 10;
 const RECEIVE_WAIT_SECONDS: i32 = 20;
-const RECEIVE_MAX_MESSAGES: i32 = 10;
+const DEFAULT_VISIBILITY_TIMEOUT_SECONDS: i32 = 60;
+const DEFAULT_HEARTBEAT_INTERVAL_SECONDS: u64 = 30;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -19,176 +17,30 @@ async fn main() -> Result<()> {
 
     let sqs_client = build_sqs_client().await;
     let dynamodb_client = build_dynamodb_client().await;
-    let worker_concurrency = env::var("TRACK_POINT_WORKER_CONCURRENCY")
+    let queue_url = env::var("AWS_SQS_QUEUE_URL_TRACK_POINT")?;
+    let batch_size = env::var("TRACK_POINT_WORKER_CONCURRENCY")
         .ok()
-        .and_then(|value| value.parse::<usize>().ok())
-        .filter(|value| *value > 0)
+        .and_then(|value| value.parse::<i32>().ok())
+        .filter(|value| (1..=10).contains(value))
         .unwrap_or(DEFAULT_WORKER_CONCURRENCY);
 
-    run_worker(sqs_client, dynamodb_client, worker_concurrency).await
-}
-
-async fn run_worker(
-    sqs_client: aws_sdk_sqs::Client,
-    dynamodb_client: aws_sdk_dynamodb::Client,
-    worker_concurrency: usize,
-) -> Result<()> {
-    let semaphore = Arc::new(Semaphore::new(worker_concurrency));
-    let mut tasks = JoinSet::new();
-
-    info!(worker_concurrency, "track point worker started");
-
-    loop {
-        while let Some(result) = tasks.try_join_next() {
-            if let Err(error) = result {
-                error!(?error, "track point worker task panicked");
-            }
-        }
-
-        let messages = match receive_messages(&sqs_client).await {
-            Ok(messages) => messages,
-            Err(error) => {
-                error!(?error, "failed to receive track point messages");
-                tokio::time::sleep(Duration::from_secs(1)).await;
-                continue;
-            }
-        };
-        if messages.is_empty() {
-            continue;
-        }
-
-        let permit = Arc::clone(&semaphore).acquire_owned().await?;
-        let sqs_client = sqs_client.clone();
-        let dynamodb_client = dynamodb_client.clone();
-
-        tasks.spawn(async move {
-            let _permit = permit;
-            if let Err(error) = process_batch(&sqs_client, &dynamodb_client, messages).await {
-                error!(?error, "failed to process track point batch");
-            }
-        });
-    }
-}
-
-async fn receive_messages(
-    sqs_client: &aws_sdk_sqs::Client,
-) -> Result<Vec<Message>, TrackPointQueueError> {
-    let queue_url = std::env::var("AWS_SQS_QUEUE_URL_TRACK_POINT").unwrap();
-    let output = sqs_client
-        .receive_message()
-        .queue_url(&queue_url)
-        .max_number_of_messages(RECEIVE_MAX_MESSAGES)
-        .wait_time_seconds(RECEIVE_WAIT_SECONDS)
-        .send()
-        .await
-        .map_err(|error| TrackPointQueueError::ReceiveMessage(error.into_service_error()))?;
-
-    Ok(output.messages().to_vec())
-}
-
-async fn process_batch(
-    sqs_client: &aws_sdk_sqs::Client,
-    dynamodb_client: &aws_sdk_dynamodb::Client,
-    messages: Vec<Message>,
-) -> Result<()> {
-    let queue_url = std::env::var("AWS_SQS_QUEUE_URL_TRACK_POINT").unwrap();
-
-    let mut models = Vec::with_capacity(messages.len());
-    let mut successful_messages: Vec<&Message> = Vec::with_capacity(messages.len());
-
-    for message in &messages {
-        let body = match message.body() {
-            Some(b) => b,
-            None => {
-                warn!(message_id = message.message_id(), "message has no body, skipping");
-                delete_message(sqs_client, &queue_url, message).await;
-                continue;
-            }
-        };
-
-        match TrackPointMessage::from_json(body) {
-            Ok(track_point_message) => {
-                models.push(track_point::Model::from(track_point_message));
-                successful_messages.push(message);
-            }
-            Err(error) => {
-                warn!(
-                    message_id = message.message_id(),
-                    ?error,
-                    "failed to deserialize message, skipping"
-                );
-                delete_message(sqs_client, &queue_url, message).await;
-            }
-        }
-    }
-
-    if models.is_empty() {
-        return Ok(());
-    }
-
-    let batch_size = models.len();
-    track_point::Model::batch_put_write(dynamodb_client, &models).await?;
-
-    delete_message_batch(sqs_client, &queue_url, &successful_messages).await?;
-
-    info!(batch_size, "processed track point batch");
-
-    Ok(())
-}
-
-async fn delete_message(sqs_client: &aws_sdk_sqs::Client, queue_url: &str, message: &Message) {
-    if let Some(receipt_handle) = message.receipt_handle()
-        && let Err(error) = sqs_client
-            .delete_message()
-            .queue_url(queue_url)
-            .receipt_handle(receipt_handle)
-            .send()
-            .await
-        {
-            error!(?error, "failed to delete message from queue");
-        }
-}
-
-async fn delete_message_batch(
-    sqs_client: &aws_sdk_sqs::Client,
-    queue_url: &str,
-    messages: &[&Message],
-) -> Result<()> {
-    use aws_sdk_sqs::types::DeleteMessageBatchRequestEntry;
-
-    let entries: Vec<DeleteMessageBatchRequestEntry> = messages
-        .iter()
-        .enumerate()
-        .filter_map(|(i, msg)| {
-            msg.receipt_handle().map(|handle| {
-                DeleteMessageBatchRequestEntry::builder()
-                    .id(i.to_string())
-                    .receipt_handle(handle)
-                    .build()
-                    .expect("DeleteMessageBatchRequestEntry build should not fail")
-            })
-        })
-        .collect();
-
-    if entries.is_empty() {
-        return Ok(());
-    }
-
-    let output = sqs_client
-        .delete_message_batch()
+    let options = ConsumerOptions::builder()
         .queue_url(queue_url)
-        .set_entries(Some(entries))
-        .send()
-        .await
-        .map_err(|e| TrackPointQueueError::DeleteMessageBatch(e.into_service_error()))?;
+        .sqs_client(sqs_client)
+        .batch_size(batch_size)
+        .wait_time_seconds(RECEIVE_WAIT_SECONDS)
+        .visibility_timeout(DEFAULT_VISIBILITY_TIMEOUT_SECONDS)
+        .heartbeat(sqs_consumer::HeartbeatConfig {
+            interval: Duration::from_secs(DEFAULT_HEARTBEAT_INTERVAL_SECONDS),
+            visibility_timeout: None,
+        })
+        .build()?;
+    let handler = TrackPointBatchHandler::new(DynamoDbTrackPointBatchWriter::new(dynamodb_client));
 
-    let failed = output.failed();
-    if !failed.is_empty() {
-        warn!(
-            failed_count = failed.len(),
-            "some messages failed to delete from queue"
-        );
-    }
+    Consumer::with_batch_handler(options, handler)?
+        .listener(TracingListener)
+        .run_until_ctrl_c()
+        .await?;
 
     Ok(())
 }

--- a/apps/api/src/bin/track_point_worker.rs
+++ b/apps/api/src/bin/track_point_worker.rs
@@ -73,8 +73,9 @@ where
 
     loop {
         tokio::select! {
-            signal = tokio::signal::ctrl_c() => {
+            signal = sqs_consumer::shutdown_signal() => {
                 signal?;
+                tracing::info!("graceful shutdown triggered");
                 for shutdown in &shutdown_handles {
                     shutdown.graceful();
                 }

--- a/apps/api/src/bin/track_point_worker.rs
+++ b/apps/api/src/bin/track_point_worker.rs
@@ -2,12 +2,17 @@ use std::{env, time::Duration};
 
 use anyhow::Result;
 use sqs_consumer::{Consumer, ConsumerOptions, TracingListener};
-use walking_dog::queue::track_point::{DynamoDbTrackPointBatchWriter, TrackPointBatchHandler};
+use tokio::task::JoinSet;
+use walking_dog::queue::track_point::{
+    DynamoDbTrackPointBatchWriter, TrackPointBatchHandler, TrackPointBatchWriter,
+};
 
-const DEFAULT_WORKER_CONCURRENCY: i32 = 10;
+const DEFAULT_WORKER_CONCURRENCY: usize = 10;
+const DEFAULT_BATCH_SIZE: i32 = 10;
 const RECEIVE_WAIT_SECONDS: i32 = 20;
 const DEFAULT_VISIBILITY_TIMEOUT_SECONDS: i32 = 60;
 const DEFAULT_HEARTBEAT_INTERVAL_SECONDS: u64 = 30;
+const DEFAULT_HANDLER_TIMEOUT_SECONDS: u64 = 50;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -18,11 +23,13 @@ async fn main() -> Result<()> {
     let sqs_client = build_sqs_client().await;
     let dynamodb_client = build_dynamodb_client().await;
     let queue_url = env::var("AWS_SQS_QUEUE_URL_TRACK_POINT")?;
-    let batch_size = env::var("TRACK_POINT_WORKER_CONCURRENCY")
-        .ok()
-        .and_then(|value| value.parse::<i32>().ok())
-        .filter(|value| (1..=10).contains(value))
-        .unwrap_or(DEFAULT_WORKER_CONCURRENCY);
+    let worker_concurrency =
+        positive_usize_env("TRACK_POINT_WORKER_CONCURRENCY", DEFAULT_WORKER_CONCURRENCY);
+    let batch_size = sqs_batch_size_env("TRACK_POINT_WORKER_BATCH_SIZE", DEFAULT_BATCH_SIZE);
+    let handler_timeout_seconds = positive_u64_env(
+        "TRACK_POINT_HANDLER_TIMEOUT_SECONDS",
+        DEFAULT_HANDLER_TIMEOUT_SECONDS,
+    );
 
     let options = ConsumerOptions::builder()
         .queue_url(queue_url)
@@ -30,6 +37,7 @@ async fn main() -> Result<()> {
         .batch_size(batch_size)
         .wait_time_seconds(RECEIVE_WAIT_SECONDS)
         .visibility_timeout(DEFAULT_VISIBILITY_TIMEOUT_SECONDS)
+        .handle_message_timeout(Duration::from_secs(handler_timeout_seconds))
         .heartbeat(sqs_consumer::HeartbeatConfig {
             interval: Duration::from_secs(DEFAULT_HEARTBEAT_INTERVAL_SECONDS),
             visibility_timeout: None,
@@ -37,12 +45,95 @@ async fn main() -> Result<()> {
         .build()?;
     let handler = TrackPointBatchHandler::new(DynamoDbTrackPointBatchWriter::new(dynamodb_client));
 
-    Consumer::with_batch_handler(options, handler)?
-        .listener(TracingListener)
-        .run_until_ctrl_c()
-        .await?;
+    run_consumers(options, handler, worker_concurrency).await?;
 
     Ok(())
+}
+
+async fn run_consumers<W>(
+    options: ConsumerOptions,
+    handler: TrackPointBatchHandler<W>,
+    worker_concurrency: usize,
+) -> Result<()>
+where
+    W: TrackPointBatchWriter + Clone,
+{
+    let mut tasks = JoinSet::new();
+    let mut shutdown_handles = Vec::with_capacity(worker_concurrency);
+
+    for worker_index in 0..worker_concurrency {
+        let consumer = Consumer::with_batch_handler(options.clone(), handler.clone())?
+            .listener(TracingListener);
+        shutdown_handles.push(consumer.shutdown_handle());
+        tasks.spawn(async move {
+            tracing::info!(worker_index, "track point consumer started");
+            consumer.run().await
+        });
+    }
+
+    loop {
+        tokio::select! {
+            signal = tokio::signal::ctrl_c() => {
+                signal?;
+                for shutdown in &shutdown_handles {
+                    shutdown.graceful();
+                }
+                break;
+            }
+            result = tasks.join_next(), if !tasks.is_empty() => {
+                match result {
+                    Some(Ok(Ok(()))) => {
+                        if tasks.is_empty() {
+                            return Ok(());
+                        }
+                    }
+                    Some(Ok(Err(error))) => {
+                        for shutdown in &shutdown_handles {
+                            shutdown.abort();
+                        }
+                        return Err(error.into());
+                    }
+                    Some(Err(error)) => {
+                        for shutdown in &shutdown_handles {
+                            shutdown.abort();
+                        }
+                        return Err(error.into());
+                    }
+                    None => return Ok(()),
+                }
+            }
+        }
+    }
+
+    while let Some(result) = tasks.join_next().await {
+        result??;
+    }
+
+    Ok(())
+}
+
+fn positive_usize_env(name: &str, default: usize) -> usize {
+    env::var(name)
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(default)
+}
+
+fn positive_u64_env(name: &str, default: u64) -> u64 {
+    env::var(name)
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(default)
+}
+
+fn sqs_batch_size_env(name: &str, default: i32) -> i32 {
+    env::var(name)
+        .ok()
+        .and_then(|value| value.parse::<i32>().ok())
+        .filter(|value| (1..=10).contains(value))
+        .unwrap_or(default)
 }
 
 async fn build_dynamodb_client() -> aws_sdk_dynamodb::Client {

--- a/apps/api/src/entity/track_point.rs
+++ b/apps/api/src/entity/track_point.rs
@@ -252,10 +252,10 @@ impl TryFrom<&HashMap<String, AttributeValue>> for Model {
 
 #[derive(Debug, thiserror::Error)]
 pub enum TrackPointError {
-    #[error("Put item error: {0}")]
-    PutItemError(PutItemError),
-    #[error("Batch write item error: {0}")]
-    BatchWriteItemError(BatchWriteItemError),
-    #[error("Query error: {0}")]
-    QueryError(QueryError),
+    #[error("Put item error")]
+    PutItemError(#[source] PutItemError),
+    #[error("Batch write item error")]
+    BatchWriteItemError(#[source] BatchWriteItemError),
+    #[error("Query error")]
+    QueryError(#[source] QueryError),
 }

--- a/apps/api/src/entity/track_point.rs
+++ b/apps/api/src/entity/track_point.rs
@@ -1,10 +1,6 @@
 use anyhow::{Result, anyhow};
 use aws_sdk_dynamodb::{
-    operation::{
-        batch_write_item::BatchWriteItemError,
-        put_item::PutItemError,
-        query::QueryError,
-    },
+    operation::{batch_write_item::BatchWriteItemError, put_item::PutItemError, query::QueryError},
     types::{AttributeValue, PutRequest, WriteRequest},
 };
 use std::collections::HashMap;
@@ -79,14 +75,8 @@ impl Model {
                                         model.tracked_at.timestamp_micros().to_string(),
                                     ),
                                 )
-                                .item(
-                                    "latitude",
-                                    AttributeValue::N(model.latitude.to_string()),
-                                )
-                                .item(
-                                    "longitude",
-                                    AttributeValue::N(model.longitude.to_string()),
-                                )
+                                .item("latitude", AttributeValue::N(model.latitude.to_string()))
+                                .item("longitude", AttributeValue::N(model.longitude.to_string()))
                                 .build()
                                 .expect("PutRequest build should not fail"),
                         )
@@ -107,9 +97,7 @@ impl Model {
                     .request_items(&table_name, requests)
                     .send()
                     .await
-                    .map_err(|e| {
-                        TrackPointError::BatchWriteItemError(e.into_service_error())
-                    })?;
+                    .map_err(|e| TrackPointError::BatchWriteItemError(e.into_service_error()))?;
 
                 let remaining = output
                     .unprocessed_items()

--- a/apps/api/src/entity/track_point.rs
+++ b/apps/api/src/entity/track_point.rs
@@ -259,3 +259,51 @@ pub enum TrackPointError {
     #[error("Query error")]
     QueryError(#[source] QueryError),
 }
+
+#[cfg(test)]
+mod tests {
+    use std::error::Error as _;
+
+    use aws_sdk_dynamodb::operation::query::QueryError;
+
+    use super::*;
+    use crate::util::error::format_error_chain;
+
+    #[test]
+    fn track_point_error_preserves_dynamodb_query_source_chain() {
+        #[derive(Debug)]
+        struct ThrottlingException;
+
+        impl std::fmt::Display for ThrottlingException {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "ThrottlingException")
+            }
+        }
+
+        impl std::error::Error for ThrottlingException {}
+
+        #[derive(Debug)]
+        struct QueryFailure(ThrottlingException);
+
+        impl std::fmt::Display for QueryFailure {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "DynamoDB Query failed")
+            }
+        }
+
+        impl std::error::Error for QueryFailure {
+            fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+                Some(&self.0)
+            }
+        }
+
+        let error =
+            TrackPointError::QueryError(QueryError::unhandled(QueryFailure(ThrottlingException)));
+        assert!(error.source().is_some());
+
+        let chain = format_error_chain(&error);
+        assert!(chain.contains("Query error"), "{chain}");
+        assert!(chain.contains("DynamoDB Query failed"), "{chain}");
+        assert!(chain.contains("ThrottlingException"), "{chain}");
+    }
+}

--- a/apps/api/src/graphql/error.rs
+++ b/apps/api/src/graphql/error.rs
@@ -46,6 +46,7 @@ impl ErrorExtensions for AppError {
     }
 }
 
+#[allow(clippy::enum_variant_names)]
 #[derive(Debug, thiserror::Error)]
 pub enum AuthError {
     #[error("Sign up error: {0}")]

--- a/apps/api/src/graphql/mod.rs
+++ b/apps/api/src/graphql/mod.rs
@@ -5,13 +5,23 @@ pub mod mutation;
 pub mod object;
 pub mod query;
 
-use std::env;
+use std::{env, sync::Arc};
 
 use crate::graphql::query::Query;
+use crate::queue::track_point::TrackPointEnqueuer;
 use async_graphql::{EmptySubscription, extensions::Tracing};
 
-pub async fn build_schema() -> async_graphql::Schema<Query, mutation::Mutation, EmptySubscription> {
-    async_graphql::Schema::build(
+pub async fn build_schema()
+-> anyhow::Result<async_graphql::Schema<Query, mutation::Mutation, EmptySubscription>> {
+    let sqs_client = build_sqs_client().await;
+    let track_point_queue_url = match env::var("AWS_SQS_QUEUE_URL_TRACK_POINT") {
+        Ok(value) if !value.is_empty() => value,
+        _ => anyhow::bail!("AWS_SQS_QUEUE_URL_TRACK_POINT is not set"),
+    };
+    let track_point_enqueuer =
+        Arc::new(TrackPointEnqueuer::new(sqs_client, track_point_queue_url)?);
+
+    Ok(async_graphql::Schema::build(
         Query::default(),
         mutation::Mutation::default(),
         EmptySubscription,
@@ -19,10 +29,10 @@ pub async fn build_schema() -> async_graphql::Schema<Query, mutation::Mutation, 
     .data(build_database_connection().await)
     .data(build_cognitoidentityprovider_client().await)
     .data(build_dynamodb_client().await)
-    .data(build_sqs_client().await)
+    .data(track_point_enqueuer)
     .data(build_s3_client().await)
     .extension(Tracing)
-    .finish()
+    .finish())
 }
 
 async fn build_database_connection() -> sea_orm::DatabaseConnection {

--- a/apps/api/src/graphql/mutation/dog.rs
+++ b/apps/api/src/graphql/mutation/dog.rs
@@ -141,6 +141,7 @@ struct AddDogInput {
 }
 
 impl AddDogInput {
+    #[allow(clippy::wrong_self_convention)]
     fn into_active_model(&self) -> dog::ActiveModel {
         dog::ActiveModel {
             name: Set(self.name.clone()),
@@ -169,6 +170,7 @@ struct UpdateDogInput {
 }
 
 impl UpdateDogInput {
+    #[allow(clippy::wrong_self_convention)]
     fn into_active_model(&self) -> dog::ActiveModel {
         dog::ActiveModel {
             id: Set(self.id),

--- a/apps/api/src/graphql/mutation/track_point.rs
+++ b/apps/api/src/graphql/mutation/track_point.rs
@@ -11,7 +11,7 @@ use crate::graphql::{
         track_point::TrackPointReceipt,
     },
 };
-use crate::queue::track_point::{TrackPointEnqueuer, TrackPointMessage};
+use crate::queue::track_point::{TrackPointEnqueuer, TrackPointMessage, TrackPointQueueError};
 use crate::util::error::format_error_chain;
 use crate::{entity::user, graphql::guard::AuthGuard};
 
@@ -56,15 +56,7 @@ impl TrackPointMutation {
         track_point_enqueuer
             .enqueue(&message)
             .await
-            .map_err(|error| {
-                let error_chain = format_error_chain(&error);
-                tracing::error!(
-                    error = ?error,
-                    %error_chain,
-                    "enqueue_track_point error"
-                );
-                AppError::InternalServerError(format!("enqueue_track_point error: {error_chain}"))
-            })?;
+            .map_err(map_track_point_enqueue_error)?;
 
         Ok(TrackPointReceipt {
             walk_id: input.walk_id,
@@ -80,4 +72,67 @@ struct TrackPointInput {
     tracked_at: chrono::DateTime<chrono::Utc>,
     latitude: Latitude,
     longitude: Longitude,
+}
+
+fn map_track_point_enqueue_error(error: TrackPointQueueError) -> AppError {
+    let error_chain = format_error_chain(&error);
+    tracing::error!(
+        error = ?error,
+        %error_chain,
+        "enqueue_track_point error"
+    );
+    AppError::InternalServerError(format!("enqueue_track_point error: {error_chain}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::error::Error as _;
+
+    use aws_sdk_sqs::operation::send_message::SendMessageError;
+
+    use super::*;
+    use crate::queue::track_point::TrackPointQueueError;
+
+    #[test]
+    fn enqueue_error_mapping_preserves_send_message_source_chain() {
+        #[derive(Debug)]
+        struct ThrottlingException;
+
+        impl std::fmt::Display for ThrottlingException {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "ThrottlingException")
+            }
+        }
+
+        impl std::error::Error for ThrottlingException {}
+
+        #[derive(Debug)]
+        struct SendMessageFailure(ThrottlingException);
+
+        impl std::fmt::Display for SendMessageFailure {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "SendMessage failed")
+            }
+        }
+
+        impl std::error::Error for SendMessageFailure {
+            fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+                Some(&self.0)
+            }
+        }
+
+        let error = TrackPointQueueError::SendMessage(Box::new(SendMessageError::unhandled(
+            SendMessageFailure(ThrottlingException),
+        )));
+        assert!(error.source().is_some());
+
+        let AppError::InternalServerError(reason) = map_track_point_enqueue_error(error) else {
+            panic!("enqueue failures must map to internal server errors");
+        };
+
+        assert!(reason.contains("enqueue_track_point error"), "{reason}");
+        assert!(reason.contains("SQS send message error"), "{reason}");
+        assert!(reason.contains("SendMessage failed"), "{reason}");
+        assert!(reason.contains("ThrottlingException"), "{reason}");
+    }
 }

--- a/apps/api/src/graphql/mutation/track_point.rs
+++ b/apps/api/src/graphql/mutation/track_point.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use async_graphql::{Context, InputObject, Object};
 use sea_orm::{ColumnTrait, DatabaseConnection, EntityTrait};
+use std::sync::Arc;
 use uuid::Uuid;
 
 use crate::graphql::{
@@ -10,7 +11,7 @@ use crate::graphql::{
         track_point::TrackPointReceipt,
     },
 };
-use crate::queue::track_point::{TrackPointMessage, enqueue_track_point};
+use crate::queue::track_point::{TrackPointEnqueuer, TrackPointMessage};
 use crate::{entity::user, graphql::guard::AuthGuard};
 
 #[derive(Default, Debug)]
@@ -48,7 +49,11 @@ impl TrackPointMutation {
             input.longitude.value(),
             accepted_at,
         );
-        enqueue_track_point(ctx.data::<aws_sdk_sqs::Client>().unwrap(), &message)
+        let track_point_enqueuer = ctx.data::<Arc<TrackPointEnqueuer>>().map_err(|_| {
+            AppError::InternalServerError("Track point enqueuer is not configured".to_string())
+        })?;
+        track_point_enqueuer
+            .enqueue(&message)
             .await
             .map_err(|e| AppError::InternalServerError(e.to_string()))?;
 

--- a/apps/api/src/graphql/mutation/track_point.rs
+++ b/apps/api/src/graphql/mutation/track_point.rs
@@ -12,6 +12,7 @@ use crate::graphql::{
     },
 };
 use crate::queue::track_point::{TrackPointEnqueuer, TrackPointMessage};
+use crate::util::error::format_error_chain;
 use crate::{entity::user, graphql::guard::AuthGuard};
 
 #[derive(Default, Debug)]
@@ -55,7 +56,15 @@ impl TrackPointMutation {
         track_point_enqueuer
             .enqueue(&message)
             .await
-            .map_err(|e| AppError::InternalServerError(e.to_string()))?;
+            .map_err(|error| {
+                let error_chain = format_error_chain(&error);
+                tracing::error!(
+                    error = ?error,
+                    %error_chain,
+                    "enqueue_track_point error"
+                );
+                AppError::InternalServerError(format!("enqueue_track_point error: {error_chain}"))
+            })?;
 
         Ok(TrackPointReceipt {
             walk_id: input.walk_id,

--- a/apps/api/src/graphql/mutation/user.rs
+++ b/apps/api/src/graphql/mutation/user.rs
@@ -17,9 +17,10 @@ impl UserMutation {
         let user = ctx.data::<user::Model>().unwrap();
         let mut active_model = input.into_active_model(user.id);
         if let Some(file) = input.avatar
-            && let Ok(file) = upload_avatar(ctx, file).await {
-                active_model.avatar = Set(Some(file));
-            }
+            && let Ok(file) = upload_avatar(ctx, file).await
+        {
+            active_model.avatar = Set(Some(file));
+        }
         let db = ctx.data::<sea_orm::DatabaseConnection>().unwrap();
         let updated_user = active_model.update(db).await?;
         Ok(User::from(updated_user))
@@ -33,6 +34,7 @@ struct UpdateUserInput {
 }
 
 impl UpdateUserInput {
+    #[allow(clippy::wrong_self_convention)]
     fn into_active_model(&self, id: uuid::Uuid) -> user::ActiveModel {
         user::ActiveModel {
             id: Set(id),

--- a/apps/api/src/graphql/object/dog.rs
+++ b/apps/api/src/graphql/object/dog.rs
@@ -189,51 +189,84 @@ mod tests {
     #[test]
     fn year_unknown_is_none() {
         assert_eq!(calculate_age(&birthday(None, None, None), today()), None);
-        assert_eq!(calculate_age(&birthday(None, Some(3), Some(4)), today()), None);
+        assert_eq!(
+            calculate_age(&birthday(None, Some(3), Some(4)), today()),
+            None
+        );
     }
 
     #[test]
     fn year_only_treats_missing_parts_as_january_first() {
         // 2020-01-01 → 2026-05-10 は満 6 歳。
-        assert_eq!(calculate_age(&birthday(Some(2020), None, None), today()), Some(6));
+        assert_eq!(
+            calculate_age(&birthday(Some(2020), None, None), today()),
+            Some(6)
+        );
     }
 
     #[test]
     fn birthday_month_not_yet_reached_this_year() {
         // 2020-08-01: 2026 年 5 月の時点で 8 月はまだ来ていない → 満 5 歳。
-        assert_eq!(calculate_age(&birthday(Some(2020), Some(8), None), today()), Some(5));
+        assert_eq!(
+            calculate_age(&birthday(Some(2020), Some(8), None), today()),
+            Some(5)
+        );
     }
 
     #[test]
     fn boundary_on_and_before_birthday() {
         // 2020-05-10 生まれ → 2026-05-10 にちょうど満 6 歳。
-        assert_eq!(calculate_age(&birthday(Some(2020), Some(5), Some(10)), today()), Some(6));
+        assert_eq!(
+            calculate_age(&birthday(Some(2020), Some(5), Some(10)), today()),
+            Some(6)
+        );
         // 2020-05-11 生まれ → 2026-05-10 はまだ満 5 歳（誕生日前日）。
-        assert_eq!(calculate_age(&birthday(Some(2020), Some(5), Some(11)), today()), Some(5));
+        assert_eq!(
+            calculate_age(&birthday(Some(2020), Some(5), Some(11)), today()),
+            Some(5)
+        );
     }
 
     #[test]
     fn newborn_is_zero() {
-        assert_eq!(calculate_age(&birthday(Some(2026), Some(1), Some(1)), today()), Some(0));
+        assert_eq!(
+            calculate_age(&birthday(Some(2026), Some(1), Some(1)), today()),
+            Some(0)
+        );
     }
 
     #[test]
     fn future_birthday_is_none() {
-        assert_eq!(calculate_age(&birthday(Some(2030), Some(1), Some(1)), today()), None);
+        assert_eq!(
+            calculate_age(&birthday(Some(2030), Some(1), Some(1)), today()),
+            None
+        );
         // 同じ年でも基準日より後 → まだ生まれていない → None。
-        assert_eq!(calculate_age(&birthday(Some(2026), Some(12), Some(31)), today()), None);
+        assert_eq!(
+            calculate_age(&birthday(Some(2026), Some(12), Some(31)), today()),
+            None
+        );
     }
 
     #[test]
     fn out_of_range_month_or_day_treated_as_january_first() {
         // month 13 / 0、day 40 / 0 はいずれも {2020, None, None} と同じ扱い → 満 6 歳。
-        assert_eq!(calculate_age(&birthday(Some(2020), Some(13), Some(40)), today()), Some(6));
-        assert_eq!(calculate_age(&birthday(Some(2020), Some(0), Some(0)), today()), Some(6));
+        assert_eq!(
+            calculate_age(&birthday(Some(2020), Some(13), Some(40)), today()),
+            Some(6)
+        );
+        assert_eq!(
+            calculate_age(&birthday(Some(2020), Some(0), Some(0)), today()),
+            Some(6)
+        );
     }
 
     #[test]
     fn day_not_valid_for_month_falls_back_to_first_of_month() {
         // 2024-02-30 は存在しない → 2024-02-01 として扱う → 2026-05-10 で満 2 歳。
-        assert_eq!(calculate_age(&birthday(Some(2024), Some(2), Some(30)), today()), Some(2));
+        assert_eq!(
+            calculate_age(&birthday(Some(2024), Some(2), Some(30)), today()),
+            Some(2)
+        );
     }
 }

--- a/apps/api/src/graphql/object/walk.rs
+++ b/apps/api/src/graphql/object/walk.rs
@@ -8,6 +8,7 @@ use crate::graphql::{
     error::AppError,
     object::{dog::Dog, track_point::TrackPoint, walk_dog::WalkDog, walk_photo::WalkPhoto},
 };
+use crate::util::error::format_error_chain;
 
 #[derive(SimpleObject, Clone, Debug)]
 #[graphql(complex)]
@@ -34,7 +35,17 @@ impl Walk {
         // DynamoDB Query は range key (tracked_at) で昇順ソート済みで返るため、再ソートは不要。
         let points = track_point::Model::find_all_by_walk_id(client, self.id)
             .await
-            .map_err(|e| AppError::InternalServerError(e.to_string()))?;
+            .map_err(|error| {
+                let error_ref: &(dyn std::error::Error + Send + Sync + 'static) = error.as_ref();
+                let error_chain = format_error_chain(error_ref);
+                tracing::error!(
+                    walk_id = %self.id,
+                    error = ?error,
+                    %error_chain,
+                    "failed to load track points for live distance"
+                );
+                AppError::InternalServerError(error_chain)
+            })?;
         let distance_m = crate::util::distance::cumulative_distance_meters(&points);
         Ok(Some(distance_m.round() as i64))
     }
@@ -76,7 +87,17 @@ impl Walk {
         let client = ctx.data::<aws_sdk_dynamodb::Client>().unwrap();
         let track_points = track_point::Model::find_all_by_walk_id(client, self.id)
             .await
-            .map_err(|e| AppError::InternalServerError(e.to_string()))?;
+            .map_err(|error| {
+                let error_ref: &(dyn std::error::Error + Send + Sync + 'static) = error.as_ref();
+                let error_chain = format_error_chain(error_ref);
+                tracing::error!(
+                    walk_id = %self.id,
+                    error = ?error,
+                    %error_chain,
+                    "failed to load track points"
+                );
+                AppError::InternalServerError(error_chain)
+            })?;
         Ok(track_points.into_iter().map(TrackPoint::from).collect())
     }
 }

--- a/apps/api/src/main.rs
+++ b/apps/api/src/main.rs
@@ -21,12 +21,12 @@ use walking_dog::{
 };
 
 #[tokio::main]
-async fn main() {
+async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
         .with_max_level(tracing::Level::INFO)
         .init();
-    run_migrations().await;
-    let schema = graphql::build_schema().await;
+    run_migrations().await?;
+    let schema = graphql::build_schema().await?;
     let app = Router::new()
         .route("/graphql", get(graphql_playground).post(graphql_handler))
         .route_layer(middleware::from_fn_with_state(
@@ -36,9 +36,8 @@ async fn main() {
         .route("/health", get(|| async { StatusCode::OK }))
         .with_state(schema);
     let addr = SocketAddr::from(([0, 0, 0, 0], 3000));
-    axum::serve(TcpListener::bind(addr).await.unwrap(), app)
-        .await
-        .unwrap();
+    axum::serve(TcpListener::bind(addr).await.unwrap(), app).await?;
+    Ok(())
 }
 
 async fn graphql_handler(
@@ -57,14 +56,11 @@ async fn graphql_playground() -> impl IntoResponse {
     Html(GraphiQLSource::build().finish())
 }
 
-async fn run_migrations() {
-    let database_url = std::env::var("DATABASE_URL").expect("DATABASE_URL is not set");
-    let db = Database::connect(&database_url)
-        .await
-        .expect("Failed to connect to the database for migrations");
+async fn run_migrations() -> anyhow::Result<()> {
+    let database_url = std::env::var("DATABASE_URL")?;
+    let db = Database::connect(&database_url).await?;
     info!("Running database migrations");
-    Migrator::up(&db, None)
-        .await
-        .expect("Failed to run database migrations");
+    Migrator::up(&db, None).await?;
     info!("Database migrations applied");
+    Ok(())
 }

--- a/apps/api/src/queue/track_point.rs
+++ b/apps/api/src/queue/track_point.rs
@@ -66,20 +66,41 @@ impl From<TrackPointMessage> for track_point::Model {
     }
 }
 
-pub async fn enqueue_track_point(
-    client: &aws_sdk_sqs::Client,
-    message: &TrackPointMessage,
-) -> Result<(), TrackPointQueueError> {
-    let queue_url = std::env::var("AWS_SQS_QUEUE_URL_TRACK_POINT").unwrap();
-    client
-        .send_message()
-        .queue_url(&queue_url)
-        .message_body(message.to_json()?)
-        .send()
-        .await
-        .map_err(|e| TrackPointQueueError::SendMessage(Box::new(e.into_service_error())))?;
+#[derive(Clone)]
+pub struct TrackPointEnqueuer {
+    client: aws_sdk_sqs::Client,
+    queue_url: String,
+}
 
-    Ok(())
+impl TrackPointEnqueuer {
+    pub fn new(
+        client: aws_sdk_sqs::Client,
+        queue_url: impl Into<String>,
+    ) -> Result<Self, TrackPointQueueError> {
+        let queue_url = queue_url.into();
+        if queue_url.is_empty() {
+            return Err(TrackPointQueueError::MissingQueueUrl);
+        }
+        Ok(Self { client, queue_url })
+    }
+
+    pub fn from_env(client: aws_sdk_sqs::Client) -> Result<Self, TrackPointQueueError> {
+        let queue_url = std::env::var("AWS_SQS_QUEUE_URL_TRACK_POINT")
+            .map_err(|_| TrackPointQueueError::MissingQueueUrl)?;
+        Self::new(client, queue_url)
+    }
+
+    pub async fn enqueue(&self, message: &TrackPointMessage) -> Result<(), TrackPointQueueError> {
+        self.client
+            .send_message()
+            .queue_url(&self.queue_url)
+            .message_body(message.to_json()?)
+            .send()
+            .await
+            .map_err(|e| TrackPointQueueError::SendMessage(Box::new(e.into_service_error())))?;
+
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -244,6 +265,8 @@ pub enum TrackPointQueueError {
     UnsupportedVersion(u16),
     #[error("SQS send message error: {0}")]
     SendMessage(Box<SendMessageError>),
+    #[error("AWS_SQS_QUEUE_URL_TRACK_POINT is not set")]
+    MissingQueueUrl,
     #[error("SQS receive message error: {0}")]
     ReceiveMessage(Box<ReceiveMessageError>),
     #[error("SQS delete message error: {0}")]
@@ -296,6 +319,21 @@ mod tests {
 
         let error = TrackPointMessage::from_json(body).unwrap_err();
         assert!(matches!(error, TrackPointQueueError::UnsupportedVersion(2)));
+    }
+
+    #[test]
+    fn track_point_enqueuer_requires_queue_url_at_construction() {
+        let config = aws_sdk_sqs::Config::builder()
+            .behavior_version_latest()
+            .build();
+        let client = aws_sdk_sqs::Client::from_conf(config);
+
+        let error = match TrackPointEnqueuer::new(client, "") {
+            Ok(_) => panic!("empty queue URL should be rejected"),
+            Err(error) => error,
+        };
+
+        assert!(matches!(error, TrackPointQueueError::MissingQueueUrl));
     }
 
     #[derive(Clone, Default)]

--- a/apps/api/src/queue/track_point.rs
+++ b/apps/api/src/queue/track_point.rs
@@ -201,13 +201,9 @@ where
         messages: Vec<aws_sdk_sqs::types::Message>,
     ) -> Result<BatchOutcome, Self::Error> {
         let mut models = Vec::with_capacity(messages.len());
-        let mut invalid_message_ids = Vec::new();
 
         for message in &messages {
             let Some(body) = message.body() else {
-                if let Some(message_id) = message.message_id() {
-                    invalid_message_ids.push(message_id.to_owned());
-                }
                 tracing::warn!(
                     message_id = message.message_id(),
                     "message has no body, acking"
@@ -220,9 +216,6 @@ where
                     models.push(track_point::Model::from(track_point_message));
                 }
                 Err(error) => {
-                    if let Some(message_id) = message.message_id() {
-                        invalid_message_ids.push(message_id.to_owned());
-                    }
                     tracing::warn!(
                         message_id = message.message_id(),
                         ?error,
@@ -236,22 +229,11 @@ where
             return Ok(BatchOutcome::AckAll);
         }
 
-        match self.writer.batch_put_write(&models).await {
-            Ok(()) => Ok(BatchOutcome::AckAll),
-            Err(error) if invalid_message_ids.is_empty() => {
-                Err(TrackPointBatchHandlerError::BatchWrite(Box::new(error)))
-            }
-            Err(error) => {
-                tracing::error!(
-                    ?error,
-                    invalid_count = invalid_message_ids.len(),
-                    "DynamoDB write failed after invalid track point messages were identified"
-                );
-                Ok(BatchOutcome::Partial {
-                    ack_message_ids: invalid_message_ids,
-                })
-            }
-        }
+        self.writer
+            .batch_put_write(&models)
+            .await
+            .map_err(|error| TrackPointBatchHandlerError::BatchWrite(Box::new(error)))?;
+        Ok(BatchOutcome::AckAll)
     }
 }
 
@@ -449,24 +431,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn track_point_batch_handler_acks_only_invalid_messages_when_write_fails() {
+    async fn track_point_batch_handler_nacks_all_when_write_fails_after_pre_ack() {
         let writer = FakeWriter::default();
         writer.fail.store(true, Ordering::SeqCst);
         let handler = TrackPointBatchHandler::new(writer);
 
-        let outcome = handler
+        let error = handler
             .handle_batch(vec![
                 sqs_message("invalid", Some("{".into())),
                 sqs_message("valid", Some(valid_body())),
             ])
             .await
-            .unwrap();
+            .unwrap_err();
 
-        assert_eq!(
-            outcome,
-            BatchOutcome::Partial {
-                ack_message_ids: vec!["invalid".into()]
-            }
-        );
+        assert!(error.to_string().contains("DynamoDB batch write failed"));
     }
 }

--- a/apps/api/src/queue/track_point.rs
+++ b/apps/api/src/queue/track_point.rs
@@ -5,7 +5,8 @@ use aws_sdk_sqs::operation::{
 };
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use sqs_consumer::{BatchMessageHandler, BatchOutcome, HandleOutcome, MessageHandler};
+use sqs_consumer::{BatchMessageHandler, BatchOutcome};
+use std::fmt;
 use uuid::Uuid;
 
 use crate::entity::track_point;
@@ -83,10 +84,10 @@ pub async fn enqueue_track_point(
 
 #[async_trait]
 pub trait TrackPointBatchWriter: Send + Sync + 'static {
-    async fn batch_put_write(
-        &self,
-        models: &[track_point::Model],
-    ) -> Result<(), TrackPointBatchHandlerError>;
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    /// Failed writes are retried by SQS, so implementations must be idempotent.
+    async fn batch_put_write(&self, models: &[track_point::Model]) -> Result<(), Self::Error>;
 }
 
 #[derive(Clone)]
@@ -102,22 +103,33 @@ impl DynamoDbTrackPointBatchWriter {
 
 #[async_trait]
 impl TrackPointBatchWriter for DynamoDbTrackPointBatchWriter {
-    async fn batch_put_write(
-        &self,
-        models: &[track_point::Model],
-    ) -> Result<(), TrackPointBatchHandlerError> {
+    type Error = DynamoDbTrackPointBatchWriteError;
+
+    async fn batch_put_write(&self, models: &[track_point::Model]) -> Result<(), Self::Error> {
         track_point::Model::batch_put_write(&self.client, models)
             .await
-            .map_err(TrackPointBatchHandlerError::BatchWrite)
+            .map_err(DynamoDbTrackPointBatchWriteError)
     }
 }
+
+#[derive(Debug)]
+pub struct DynamoDbTrackPointBatchWriteError(anyhow::Error);
+
+impl fmt::Display for DynamoDbTrackPointBatchWriteError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for DynamoDbTrackPointBatchWriteError {}
 
 #[derive(Debug, thiserror::Error)]
 pub enum TrackPointBatchHandlerError {
     #[error("DynamoDB batch write failed")]
-    BatchWrite(#[source] anyhow::Error),
+    BatchWrite(#[source] Box<dyn std::error::Error + Send + Sync>),
 }
 
+#[derive(Clone)]
 pub struct TrackPointBatchHandler<W> {
     writer: W,
 }
@@ -131,12 +143,37 @@ where
     }
 }
 
+fn invalid_track_point_message_ids(messages: &[aws_sdk_sqs::types::Message]) -> Vec<String> {
+    messages
+        .iter()
+        .filter_map(|message| {
+            let invalid_reason = match message.body() {
+                Some(body) => TrackPointMessage::from_json(body).err(),
+                None => Some(TrackPointQueueError::MissingBody),
+            }?;
+            tracing::warn!(
+                message_id = message.message_id(),
+                ?invalid_reason,
+                "invalid track point message, acking before batch write"
+            );
+            message.message_id().map(ToOwned::to_owned)
+        })
+        .collect()
+}
+
 #[async_trait]
 impl<W> BatchMessageHandler for TrackPointBatchHandler<W>
 where
     W: TrackPointBatchWriter,
 {
     type Error = TrackPointBatchHandlerError;
+
+    async fn ack_before_batch(
+        &self,
+        messages: &[aws_sdk_sqs::types::Message],
+    ) -> Result<Vec<String>, Self::Error> {
+        Ok(invalid_track_point_message_ids(messages))
+    }
 
     async fn handle_batch(
         &self,
@@ -180,35 +217,18 @@ where
 
         match self.writer.batch_put_write(&models).await {
             Ok(()) => Ok(BatchOutcome::AckAll),
-            Err(error) if invalid_message_ids.is_empty() => Err(error),
-            Err(_) => Ok(BatchOutcome::Partial {
-                ack_message_ids: invalid_message_ids,
-            }),
-        }
-    }
-}
-
-#[async_trait]
-impl<W> MessageHandler for TrackPointBatchHandler<W>
-where
-    W: TrackPointBatchWriter,
-{
-    type Error = TrackPointBatchHandlerError;
-
-    async fn handle_message(
-        &self,
-        message: aws_sdk_sqs::types::Message,
-    ) -> Result<HandleOutcome, Self::Error> {
-        let message_id = message.message_id().map(ToOwned::to_owned);
-        match self.handle_batch(vec![message]).await? {
-            BatchOutcome::AckAll => Ok(HandleOutcome::Ack),
-            BatchOutcome::NackAll => Ok(HandleOutcome::Nack),
-            BatchOutcome::Partial { ack_message_ids } => {
-                if message_id.is_some_and(|id| ack_message_ids.contains(&id)) {
-                    Ok(HandleOutcome::Ack)
-                } else {
-                    Ok(HandleOutcome::Nack)
-                }
+            Err(error) if invalid_message_ids.is_empty() => {
+                Err(TrackPointBatchHandlerError::BatchWrite(Box::new(error)))
+            }
+            Err(error) => {
+                tracing::error!(
+                    ?error,
+                    invalid_count = invalid_message_ids.len(),
+                    "DynamoDB write failed after invalid track point messages were identified"
+                );
+                Ok(BatchOutcome::Partial {
+                    ack_message_ids: invalid_message_ids,
+                })
             }
         }
     }
@@ -284,17 +304,18 @@ mod tests {
         written_count: Arc<std::sync::Mutex<usize>>,
     }
 
+    #[derive(Debug, thiserror::Error)]
+    #[error("dynamodb batch write failed")]
+    struct FakeWriterError;
+
     #[async_trait]
     impl TrackPointBatchWriter for FakeWriter {
-        async fn batch_put_write(
-            &self,
-            models: &[track_point::Model],
-        ) -> Result<(), TrackPointBatchHandlerError> {
+        type Error = FakeWriterError;
+
+        async fn batch_put_write(&self, models: &[track_point::Model]) -> Result<(), Self::Error> {
             *self.written_count.lock().unwrap() += models.len();
             if self.fail.load(Ordering::SeqCst) {
-                return Err(TrackPointBatchHandlerError::BatchWrite(anyhow::anyhow!(
-                    "dynamodb batch write failed"
-                )));
+                return Err(FakeWriterError);
             }
             Ok(())
         }
@@ -354,6 +375,25 @@ mod tests {
             .unwrap();
 
         assert_eq!(outcome, BatchOutcome::AckAll);
+    }
+
+    #[tokio::test]
+    async fn track_point_batch_handler_reports_invalid_ids_for_pre_write_ack() {
+        let writer = FakeWriter::default();
+        let written_count = writer.written_count.clone();
+        let handler = TrackPointBatchHandler::new(writer);
+
+        let ack_ids = handler
+            .ack_before_batch(&[
+                sqs_message("malformed", Some("{".into())),
+                sqs_message("missing", None),
+                sqs_message("valid", Some(valid_body())),
+            ])
+            .await
+            .unwrap();
+
+        assert_eq!(ack_ids, vec!["malformed", "missing"]);
+        assert_eq!(*written_count.lock().unwrap(), 0);
     }
 
     #[tokio::test]

--- a/apps/api/src/queue/track_point.rs
+++ b/apps/api/src/queue/track_point.rs
@@ -1,9 +1,11 @@
+use async_trait::async_trait;
 use aws_sdk_sqs::operation::{
     delete_message::DeleteMessageError, delete_message_batch::DeleteMessageBatchError,
     receive_message::ReceiveMessageError, send_message::SendMessageError,
 };
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use sqs_consumer::{BatchMessageHandler, BatchOutcome, HandleOutcome, MessageHandler};
 use uuid::Uuid;
 
 use crate::entity::track_point;
@@ -74,9 +76,142 @@ pub async fn enqueue_track_point(
         .message_body(message.to_json()?)
         .send()
         .await
-        .map_err(|e| TrackPointQueueError::SendMessage(e.into_service_error()))?;
+        .map_err(|e| TrackPointQueueError::SendMessage(Box::new(e.into_service_error())))?;
 
     Ok(())
+}
+
+#[async_trait]
+pub trait TrackPointBatchWriter: Send + Sync + 'static {
+    async fn batch_put_write(
+        &self,
+        models: &[track_point::Model],
+    ) -> Result<(), TrackPointBatchHandlerError>;
+}
+
+#[derive(Clone)]
+pub struct DynamoDbTrackPointBatchWriter {
+    client: aws_sdk_dynamodb::Client,
+}
+
+impl DynamoDbTrackPointBatchWriter {
+    pub fn new(client: aws_sdk_dynamodb::Client) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait]
+impl TrackPointBatchWriter for DynamoDbTrackPointBatchWriter {
+    async fn batch_put_write(
+        &self,
+        models: &[track_point::Model],
+    ) -> Result<(), TrackPointBatchHandlerError> {
+        track_point::Model::batch_put_write(&self.client, models)
+            .await
+            .map_err(TrackPointBatchHandlerError::BatchWrite)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum TrackPointBatchHandlerError {
+    #[error("DynamoDB batch write failed")]
+    BatchWrite(#[source] anyhow::Error),
+}
+
+pub struct TrackPointBatchHandler<W> {
+    writer: W,
+}
+
+impl<W> TrackPointBatchHandler<W>
+where
+    W: TrackPointBatchWriter,
+{
+    pub fn new(writer: W) -> Self {
+        Self { writer }
+    }
+}
+
+#[async_trait]
+impl<W> BatchMessageHandler for TrackPointBatchHandler<W>
+where
+    W: TrackPointBatchWriter,
+{
+    type Error = TrackPointBatchHandlerError;
+
+    async fn handle_batch(
+        &self,
+        messages: Vec<aws_sdk_sqs::types::Message>,
+    ) -> Result<BatchOutcome, Self::Error> {
+        let mut models = Vec::with_capacity(messages.len());
+        let mut invalid_message_ids = Vec::new();
+
+        for message in &messages {
+            let Some(body) = message.body() else {
+                if let Some(message_id) = message.message_id() {
+                    invalid_message_ids.push(message_id.to_owned());
+                }
+                tracing::warn!(
+                    message_id = message.message_id(),
+                    "message has no body, acking"
+                );
+                continue;
+            };
+
+            match TrackPointMessage::from_json(body) {
+                Ok(track_point_message) => {
+                    models.push(track_point::Model::from(track_point_message));
+                }
+                Err(error) => {
+                    if let Some(message_id) = message.message_id() {
+                        invalid_message_ids.push(message_id.to_owned());
+                    }
+                    tracing::warn!(
+                        message_id = message.message_id(),
+                        ?error,
+                        "failed to deserialize message, acking"
+                    );
+                }
+            }
+        }
+
+        if models.is_empty() {
+            return Ok(BatchOutcome::AckAll);
+        }
+
+        match self.writer.batch_put_write(&models).await {
+            Ok(()) => Ok(BatchOutcome::AckAll),
+            Err(error) if invalid_message_ids.is_empty() => Err(error),
+            Err(_) => Ok(BatchOutcome::Partial {
+                ack_message_ids: invalid_message_ids,
+            }),
+        }
+    }
+}
+
+#[async_trait]
+impl<W> MessageHandler for TrackPointBatchHandler<W>
+where
+    W: TrackPointBatchWriter,
+{
+    type Error = TrackPointBatchHandlerError;
+
+    async fn handle_message(
+        &self,
+        message: aws_sdk_sqs::types::Message,
+    ) -> Result<HandleOutcome, Self::Error> {
+        let message_id = message.message_id().map(ToOwned::to_owned);
+        match self.handle_batch(vec![message]).await? {
+            BatchOutcome::AckAll => Ok(HandleOutcome::Ack),
+            BatchOutcome::NackAll => Ok(HandleOutcome::Nack),
+            BatchOutcome::Partial { ack_message_ids } => {
+                if message_id.is_some_and(|id| ack_message_ids.contains(&id)) {
+                    Ok(HandleOutcome::Ack)
+                } else {
+                    Ok(HandleOutcome::Nack)
+                }
+            }
+        }
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -88,13 +223,13 @@ pub enum TrackPointQueueError {
     #[error("Unsupported track point message version: {0}")]
     UnsupportedVersion(u16),
     #[error("SQS send message error: {0}")]
-    SendMessage(SendMessageError),
+    SendMessage(Box<SendMessageError>),
     #[error("SQS receive message error: {0}")]
-    ReceiveMessage(ReceiveMessageError),
+    ReceiveMessage(Box<ReceiveMessageError>),
     #[error("SQS delete message error: {0}")]
-    DeleteMessage(DeleteMessageError),
+    DeleteMessage(Box<DeleteMessageError>),
     #[error("SQS delete message batch error: {0}")]
-    DeleteMessageBatch(DeleteMessageBatchError),
+    DeleteMessageBatch(Box<DeleteMessageBatchError>),
     #[error("SQS message has no body")]
     MissingBody,
     #[error("SQS message has no receipt handle")]
@@ -104,6 +239,11 @@ pub enum TrackPointQueueError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aws_sdk_sqs::types::Message;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    };
 
     #[test]
     fn serializes_and_deserializes_track_point_message() {
@@ -136,5 +276,119 @@ mod tests {
 
         let error = TrackPointMessage::from_json(body).unwrap_err();
         assert!(matches!(error, TrackPointQueueError::UnsupportedVersion(2)));
+    }
+
+    #[derive(Clone, Default)]
+    struct FakeWriter {
+        fail: Arc<AtomicBool>,
+        written_count: Arc<std::sync::Mutex<usize>>,
+    }
+
+    #[async_trait]
+    impl TrackPointBatchWriter for FakeWriter {
+        async fn batch_put_write(
+            &self,
+            models: &[track_point::Model],
+        ) -> Result<(), TrackPointBatchHandlerError> {
+            *self.written_count.lock().unwrap() += models.len();
+            if self.fail.load(Ordering::SeqCst) {
+                return Err(TrackPointBatchHandlerError::BatchWrite(anyhow::anyhow!(
+                    "dynamodb batch write failed"
+                )));
+            }
+            Ok(())
+        }
+    }
+
+    fn sqs_message(id: &str, body: Option<String>) -> Message {
+        let mut builder = Message::builder()
+            .message_id(id)
+            .receipt_handle(format!("receipt-{id}"));
+        if let Some(body) = body {
+            builder = builder.body(body);
+        }
+        builder.build()
+    }
+
+    fn valid_body() -> String {
+        TrackPointMessage::new(
+            Uuid::parse_str("018f6a72-3f7a-7a8b-9c0d-111111111111").unwrap(),
+            DateTime::parse_from_rfc3339("2026-05-09T10:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+            35.6812,
+            139.7671,
+            DateTime::parse_from_rfc3339("2026-05-09T10:00:01Z")
+                .unwrap()
+                .with_timezone(&Utc),
+        )
+        .to_json()
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn track_point_batch_handler_acks_all_after_successful_write() {
+        let writer = FakeWriter::default();
+        let written_count = writer.written_count.clone();
+        let handler = TrackPointBatchHandler::new(writer);
+
+        let outcome = handler
+            .handle_batch(vec![sqs_message("valid", Some(valid_body()))])
+            .await
+            .unwrap();
+
+        assert_eq!(outcome, BatchOutcome::AckAll);
+        assert_eq!(*written_count.lock().unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn track_point_batch_handler_acks_malformed_and_missing_body_messages() {
+        let handler = TrackPointBatchHandler::new(FakeWriter::default());
+
+        let outcome = handler
+            .handle_batch(vec![
+                sqs_message("malformed", Some("{".into())),
+                sqs_message("missing", None),
+            ])
+            .await
+            .unwrap();
+
+        assert_eq!(outcome, BatchOutcome::AckAll);
+    }
+
+    #[tokio::test]
+    async fn track_point_batch_handler_keeps_valid_messages_unacked_when_write_fails() {
+        let writer = FakeWriter::default();
+        writer.fail.store(true, Ordering::SeqCst);
+        let handler = TrackPointBatchHandler::new(writer);
+
+        let error = handler
+            .handle_batch(vec![sqs_message("valid", Some(valid_body()))])
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("DynamoDB batch write failed"));
+    }
+
+    #[tokio::test]
+    async fn track_point_batch_handler_acks_only_invalid_messages_when_write_fails() {
+        let writer = FakeWriter::default();
+        writer.fail.store(true, Ordering::SeqCst);
+        let handler = TrackPointBatchHandler::new(writer);
+
+        let outcome = handler
+            .handle_batch(vec![
+                sqs_message("invalid", Some("{".into())),
+                sqs_message("valid", Some(valid_body())),
+            ])
+            .await
+            .unwrap();
+
+        assert_eq!(
+            outcome,
+            BatchOutcome::Partial {
+                ack_message_ids: vec!["invalid".into()]
+            }
+        );
     }
 }

--- a/apps/api/src/queue/track_point.rs
+++ b/apps/api/src/queue/track_point.rs
@@ -1,8 +1,5 @@
 use async_trait::async_trait;
-use aws_sdk_sqs::operation::{
-    delete_message::DeleteMessageError, delete_message_batch::DeleteMessageBatchError,
-    receive_message::ReceiveMessageError, send_message::SendMessageError,
-};
+use aws_sdk_sqs::operation::send_message::SendMessageError;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use sqs_consumer::{BatchMessageHandler, BatchOutcome};
@@ -249,12 +246,6 @@ pub enum TrackPointQueueError {
     SendMessage(Box<SendMessageError>),
     #[error("AWS_SQS_QUEUE_URL_TRACK_POINT is not set")]
     MissingQueueUrl,
-    #[error("SQS receive message error: {0}")]
-    ReceiveMessage(Box<ReceiveMessageError>),
-    #[error("SQS delete message error: {0}")]
-    DeleteMessage(Box<DeleteMessageError>),
-    #[error("SQS delete message batch error: {0}")]
-    DeleteMessageBatch(Box<DeleteMessageBatchError>),
     #[error("SQS message has no body")]
     MissingBody,
     #[error("SQS message has no receipt handle")]

--- a/apps/api/src/queue/track_point.rs
+++ b/apps/api/src/queue/track_point.rs
@@ -139,7 +139,12 @@ impl fmt::Display for DynamoDbTrackPointBatchWriteError {
     }
 }
 
-impl std::error::Error for DynamoDbTrackPointBatchWriteError {}
+impl std::error::Error for DynamoDbTrackPointBatchWriteError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        let error: &(dyn std::error::Error + Send + Sync + 'static) = self.0.as_ref();
+        error.source()
+    }
+}
 
 #[derive(Debug, thiserror::Error)]
 pub enum TrackPointBatchHandlerError {
@@ -255,6 +260,7 @@ pub enum TrackPointQueueError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::util::error::format_error_chain;
     use aws_sdk_sqs::types::Message;
     use std::sync::{
         Arc,
@@ -307,6 +313,45 @@ mod tests {
         };
 
         assert!(matches!(error, TrackPointQueueError::MissingQueueUrl));
+    }
+
+    #[test]
+    fn batch_handler_error_preserves_dynamodb_writer_source_chain() {
+        #[derive(Debug)]
+        struct ThrottlingException;
+
+        impl std::fmt::Display for ThrottlingException {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "ThrottlingException")
+            }
+        }
+
+        impl std::error::Error for ThrottlingException {}
+
+        #[derive(Debug)]
+        struct BatchWriteFailure(ThrottlingException);
+
+        impl std::fmt::Display for BatchWriteFailure {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "DynamoDB BatchWriteItem failed")
+            }
+        }
+
+        impl std::error::Error for BatchWriteFailure {
+            fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+                Some(&self.0)
+            }
+        }
+
+        let error =
+            TrackPointBatchHandlerError::BatchWrite(Box::new(DynamoDbTrackPointBatchWriteError(
+                anyhow::Error::new(BatchWriteFailure(ThrottlingException)),
+            )));
+
+        let chain = format_error_chain(&error);
+        assert!(chain.contains("DynamoDB batch write failed"), "{chain}");
+        assert!(chain.contains("DynamoDB BatchWriteItem failed"), "{chain}");
+        assert!(chain.contains("ThrottlingException"), "{chain}");
     }
 
     #[derive(Clone, Default)]

--- a/apps/api/src/queue/track_point.rs
+++ b/apps/api/src/queue/track_point.rs
@@ -242,8 +242,8 @@ pub enum TrackPointQueueError {
     Deserialize(serde_json::Error),
     #[error("Unsupported track point message version: {0}")]
     UnsupportedVersion(u16),
-    #[error("SQS send message error: {0}")]
-    SendMessage(Box<SendMessageError>),
+    #[error("SQS send message error")]
+    SendMessage(#[source] Box<SendMessageError>),
     #[error("AWS_SQS_QUEUE_URL_TRACK_POINT is not set")]
     MissingQueueUrl,
     #[error("SQS message has no body")]

--- a/apps/api/src/storage.rs
+++ b/apps/api/src/storage.rs
@@ -4,6 +4,8 @@ use std::{ffi::OsStr, io::Read, path::Path};
 use tracing::error;
 use url::Url;
 
+use crate::util::error::format_error_chain;
+
 const DEFAULT_MAX_UPLOAD_BYTES: u64 = 20 * 1024 * 1024;
 const MAX_UPLOAD_BYTES_ENV: &str = "MAX_UPLOAD_BYTES";
 
@@ -45,8 +47,14 @@ async fn upload_file(ctx: &Context<'_>, file: Upload, bucket: &str) -> Result<St
         .send()
         .await
         .map_err(|e| {
-            error!("Failed to upload file: {:?} to bucket: {}", e, bucket);
-            StorageError::InternalError(e.to_string())
+            let error_chain = format_error_chain(&e);
+            error!(
+                error = ?e,
+                %error_chain,
+                bucket,
+                "Failed to upload file"
+            );
+            StorageError::InternalError(error_chain)
         })?;
     Ok(key)
 }

--- a/apps/api/src/util/distance.rs
+++ b/apps/api/src/util/distance.rs
@@ -7,8 +7,7 @@ pub fn haversine_meters(lat1: f64, lng1: f64, lat2: f64, lng2: f64) -> f64 {
     let phi2 = lat2.to_radians();
     let dphi = (lat2 - lat1).to_radians();
     let dlambda = (lng2 - lng1).to_radians();
-    let a = (dphi / 2.0).sin().powi(2)
-        + phi1.cos() * phi2.cos() * (dlambda / 2.0).sin().powi(2);
+    let a = (dphi / 2.0).sin().powi(2) + phi1.cos() * phi2.cos() * (dlambda / 2.0).sin().powi(2);
     let c = 2.0 * a.sqrt().atan2((1.0 - a).sqrt());
     EARTH_RADIUS_M * c
 }
@@ -67,6 +66,9 @@ mod tests {
         let p2 = point(35.6812, 139.7671, 120);
         let total = cumulative_distance_meters(&[p0, p1, p2]);
         // round-trip Tokyo → Shinjuku → Tokyo ≈ 12.2km.
-        assert!((total - 12_200.0).abs() < 200.0, "expected ~12200m, got {total}");
+        assert!(
+            (total - 12_200.0).abs() < 200.0,
+            "expected ~12200m, got {total}"
+        );
     }
 }

--- a/apps/api/src/util/error.rs
+++ b/apps/api/src/util/error.rs
@@ -1,0 +1,65 @@
+pub fn format_error_chain<E>(error: &E) -> String
+where
+    E: std::error::Error + ?Sized,
+{
+    let mut chain = error.to_string();
+    let mut source = error.source();
+    while let Some(error) = source {
+        chain.push_str(": ");
+        chain.push_str(&error.to_string());
+        source = error.source();
+    }
+    chain
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn format_error_chain_walks_full_source_chain() {
+        #[derive(Debug)]
+        struct Inner;
+
+        impl std::fmt::Display for Inner {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "ThrottlingException")
+            }
+        }
+
+        impl std::error::Error for Inner {}
+
+        #[derive(Debug)]
+        struct Middle(Inner);
+
+        impl std::fmt::Display for Middle {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "SendMessage failed")
+            }
+        }
+
+        impl std::error::Error for Middle {
+            fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+                Some(&self.0)
+            }
+        }
+
+        #[derive(Debug)]
+        struct Outer(Middle);
+
+        impl std::fmt::Display for Outer {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "enqueue_track_point error")
+            }
+        }
+
+        impl std::error::Error for Outer {
+            fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+                Some(&self.0)
+            }
+        }
+
+        assert_eq!(
+            super::format_error_chain(&Outer(Middle(Inner))),
+            "enqueue_track_point error: SendMessage failed: ThrottlingException"
+        );
+    }
+}

--- a/apps/api/src/util/mod.rs
+++ b/apps/api/src/util/mod.rs
@@ -1,1 +1,2 @@
 pub mod distance;
+pub mod error;


### PR DESCRIPTION
## Summary
- Add reusable Rust sqs-consumer workspace crate with ack semantics, heartbeat visibility extension, timeout, listener hooks, and shutdown handling
- Migrate track_point_worker to the generic consumer while preserving invalid-message deletion and valid-message retry behavior
- Add ElasticMQ/unit coverage and harden shutdown, pre-write ack, and worker concurrency behavior

## Test plan
- docker compose -f apps/compose.yml run --rm api cargo test -p sqs-consumer --tests -- --test-threads=1
- docker compose -f apps/compose.yml run --rm api cargo test --features test-utils -- --test-threads=1
- docker compose -f apps/compose.yml run --rm api cargo fmt --check
- docker compose -f apps/compose.yml run --rm api cargo clippy -p sqs-consumer --all-targets -- -D warnings
- docker compose -f apps/compose.yml run --rm api cargo clippy --features test-utils --all-targets -- -D warnings