### PR TITLE
docs(skill): tighten copilot-delegate flow based on first real run

### DIFF
--- a/.claude/skills/copilot-delegate/SKILL.md
+++ b/.claude/skills/copilot-delegate/SKILL.md
@@ -42,7 +42,7 @@ GitHub Copilot CLI に実装タスクを委譲する。Claude が「監督者」
 | Mode | 用途 | Worktree |
 |---|---|---|
 | `parallel` | 独立タスクの同時実装 | タスクごとに 1 つ作成 |
-| `single` | 重い単発タスクを丸投げ | 現在の worktree を流用 |
+| `single` | 重い単発タスクを丸投げ | 1 つ新規作成（main の作業ツリーに直接書かせない） |
 | `second-opinion` | 代替実装を比較取得 | 1 つ新規作成 |
 
 ユーザーが mode を指定しなかった場合は、タスク数・内容から推測して提案する：
@@ -79,58 +79,127 @@ tasks:
 `references/worktree.md` の手順に従い、各 task について：
 
 ```bash
-git worktree add ".claude/worktrees/copilot-${TASK_ID}" -b "copilot/${TASK_ID}"
+git worktree add ".claude/worktrees/copilot-${TASK_ID}" -b "copilot/${TASK_ID}" main
 ```
 
-`single` モードは既存 worktree を流用するので作成不要。
+**全モードで worktree を作成する**（`single` でも main の作業ツリーに直接書かせると、main の uncommitted な変更との衝突や誤 push のリスクが高い）。
+
+**JS/TS タスクは Copilot 起動前に依存をインストールしておく**。新規 worktree の `node_modules` は空で、これを Copilot が走行中に `npm ci` で埋めると 1〜2 分余計にかかる：
+
+```bash
+(cd ".claude/worktrees/copilot-${TASK_ID}/apps/mobile" && npm ci --no-audit --prefer-offline)
+```
+
+Rust タスクは Cargo の `target/` が共有されないので `docker compose build` も同様に先に走らせると速い。
 
 ### 3. Copilot CLI の起動
 
 `references/permissions.md` の言語別テンプレを使って組み立てる。骨格：
 
 ```bash
-copilot -p "${TASK_DESCRIPTION}" \
+copilot \
+  -p "${TASK_DESCRIPTION}" \
   -C "${WORKTREE_PATH}" \
   --add-dir "${PROJECT_ROOT}" \
-  ${ALLOW_TOOLS} \
-  ${DENY_TOOLS} \
+  --allow-all-tools \                           # ★ 非インタラクティブ (-p) には必須
+  --no-ask-user \                               # ★ 自走モード（ユーザーに問い返さない）
+  --effort high --no-color \                    # 出力を読みやすく、ログ汚染を避ける
+  ${DENY_TOOLS} \                               # 危険操作だけ denylist で締める
   > "tasks/copilot/${SESSION}/logs/${TASK_ID}.log" 2>&1
 ```
 
-**parallel モードでは Bash の `run_in_background: true` で全タスクを同時起動する。** Bash tool は完了通知を返すので、各通知が来たら次の処理に進める（poll しない）。
+`--allow-all-tools` を付けないと `-p` モードは止まる、または各ツールで permission prompt を出してハング → ログには何も流れず "なぜ動かないのか" がわからない、というのが一番のハマりどころ。`--no-ask-user` は Copilot がユーザーへの質問ツール (`ask_user`) を呼ばないようにする。
 
-**common allow/deny（全モード共通）**：
-- `--allow-tool='write'` — ファイル編集を許可
-- `--allow-tool='shell(git:*)'` — `git add`/`commit`/`diff` などローカル git は許可
+`--add-dir "${PROJECT_ROOT}"` の意義は **worktree の外にある指示書ファイル (`tasks/copilot/<session>/instruction.md`) と参照ドキュメント (`docs/`, `.claude/plans/`) を Copilot に読ませるため**。worktree の中身は `-C` で見える。
+
+**parallel モードでは Bash の `run_in_background: true` で全タスクを同時起動する。** Bash tool は完了通知を返すので、各通知が来たら次の処理に進める（`sleep` で poll しないこと）。ただし**ユーザーから「進捗は？」と聞かれた場合や、長時間 (>5 min) 応答がない場合は `Read tasks/copilot/<session>/logs/<task-id>.log` でログを覗いてよい** — 完了通知ベースでドライブしつつ、安全弁としての覗き見は許容。
+
+**common deny（全モード共通）** — allow は `--allow-all-tools` で済むので、denylist だけ書く：
 - `--deny-tool='shell(git push)'` — push は禁止（worktree 隔離のため）
 - `--deny-tool='shell(rm -rf)'` — 危険な削除は禁止
 - `--deny-tool='shell(sudo)'` — 権限昇格は禁止
+- `--deny-tool='shell(docker)'` — 本番資源への接続を防ぐ（プロジェクトの Rust ローカル開発は `docker compose run --rm` を別途許可するなら個別調整）
 
-言語別の追加は `references/permissions.md`。
+言語別の追加 deny は `references/permissions.md`。
 
 ### 4. 進捗監視 & 結果収集
 
 各 task の完了通知を受けたら：
 
 1. 終了コードと最後の数行をログから読む
-2. `git -C <worktree> diff --stat` で変更サマリを取得
-3. `tasks/copilot/<session>/results.md` に下記フォーマットで追記：
+2. worktree に入って `git log --oneline main..HEAD && git diff --stat main..HEAD` で commit と変更サマリを取得
+3. `tasks/copilot/<session>/results.md` に下記の **3 ブロック構成** で追記する
+
+スケルトンよりも実用性を優先したテンプレ：
 
 ```markdown
-## ${TASK_ID}
-- status: success | failed
-- duration: 4m23s
-- diff:
-  - apps/mobile/src/screens/DogForm.tsx (+12 -8)
-  - apps/mobile/src/validators/dog.ts (new, +34)
-- notes: テスト1件失敗、Copilot ログ末尾参照
+# Copilot delegation results — `${SESSION}`
+
+**Task:** （指示書のスコープを 1〜2 行で要約）
+**Mode:** parallel | single | second-opinion
+**Worktree:** .claude/worktrees/copilot-${TASK_ID}
+**Branch:** copilot/${TASK_ID}
+**Commits:**
+- `<sha>` <subject>
+
+## Acceptance criteria check
+| # | Criterion | Status |
+|---|---|---|
+| 1 | （instruction.md §6 から逐条転記） | ✅ / ⚠ / ❌ + 根拠（ファイル:行 or テスト名）|
+| 2 | ... | ... |
+
+## Tests
+- `npx jest <targeted>` — N/N pass
+- `npx tsc --noEmit` — clean
+- ⚠ 不可解な失敗があれば、原因が本 PR 内か外かを明示
+
+## Code review notes (Claude)
+- 仕様への忠実度、トークン使用、accessibility、box-none 等の細部レビュー
+- 仕様逸脱や follow-up 候補
+- Blockers (NOTES.md があればここに転記)
+
+## Recommended next steps
+1. Visual verification (Mobile タスクなら §5b)
+2. Merge / PR (§5c)
+3. Worktree cleanup (§6)
 ```
+
+スケッチ的な 5 行テンプレでは実用にならない（受け入れ基準チェックが落ちる）。**最低でも "受け入れ基準表 + テスト結果 + Claude のレビュー所見" の 3 ブロックを残すこと**。
 
 ### 5. レビューと結合判断
 
 `parallel` の場合、各 worktree の diff を Claude が読み、矛盾や品質を判定。問題なければユーザーに結合方針を提示（cherry-pick / merge / rebase）。
 
 `second-opinion` の場合、元実装と Copilot の代替案を side-by-side で比較し、長所短所をまとめてユーザーに返す。
+
+**`NOTES.md` の事後処理** — Copilot が worktree のルートに `NOTES.md` を残していた場合（受け入れ基準を満たせなかったときや、スコープ外の既存 fail を見つけたときに使う）：
+
+1. 内容を `results.md` の "Code review notes" → "Blockers" サブセクションに転記する
+2. worktree で `git rm NOTES.md && git commit -m "chore: drop delegation notes from tracked tree"` で除去
+3. `NOTES.md` は PR / マージ対象に含めない（リポジトリを delegation プロセスの痕跡で汚さない）
+
+### 5b. Visual verification (Mobile only)
+
+`apps/mobile/` 配下の編集を含むタスクは Jest + tsc に加え、**iOS Simulator での目視確認** が必須。手順:
+
+1. main の Metro を一旦停止 (`kill $(lsof -t -i :8081)`)
+2. worktree の `apps/mobile` から Metro を立ち上げ（`APP_ENV=local EXPO_PUBLIC_API_URL=http://localhost:3000 nohup npx expo start --port 8081 &`）
+3. シミュレータのアプリを `xcrun simctl terminate && launch com.walkingdog.app` でリロードして worktree のバンドルを読み込ませる
+4. 該当画面までナビゲートして before/after のスクリーンショットを `tasks/copilot/<session>/{before,after}.png` に保存
+5. `results.md` の "Visual verification" セクションに添付し、A1/A2/... のような diff item ごとに ✅/⚠ を付ける
+6. 最後に main の Metro を復元（worktree Metro を停止 → main で再起動）
+
+詳細スクリプトは `ios-sim-test` skill を呼ぶ。`apps/api/` 単独タスクには不要（cargo test で十分）。
+
+### 5c. マージ判断後の流れ
+
+ユーザーが結合方針を返したら：
+
+- **squash merge**: `git checkout main && git merge --squash copilot/${TASK_ID} && git commit -m "..."` でローカル merge。push は別途ユーザー指示で。
+- **PR**: `commit-push-pr` skill か直接 `gh pr create` で別途実行。PR 本文には instruction.md のスコープ表、テスト結果、視覚確認結果、スコープ外の追跡項目を入れる。`NOTES.md` が §5 で除去済みであることを再確認。
+- **cherry-pick**: 既存ブランチに `git cherry-pick <sha>`。
+
+PR を作るときは、delegation の `tasks/copilot/<session>/` ディレクトリを PR の差分に含めるかは判断もの — 通常は **含めない**（セッション metadata であり、コードベースの一部ではない）。`.gitignore` に `tasks/copilot/` を追加しておくか、push 前に未追跡のままにする運用が望ましい。
 
 ### 6. クリーンアップ
 

--- a/.claude/skills/copilot-delegate/SKILL.md
+++ b/.claude/skills/copilot-delegate/SKILL.md
@@ -114,13 +114,15 @@ copilot \
 
 **parallel モードでは Bash の `run_in_background: true` で全タスクを同時起動する。** Bash tool は完了通知を返すので、各通知が来たら次の処理に進める（`sleep` で poll しないこと）。ただし**ユーザーから「進捗は？」と聞かれた場合や、長時間 (>5 min) 応答がない場合は `Read tasks/copilot/<session>/logs/<task-id>.log` でログを覗いてよい** — 完了通知ベースでドライブしつつ、安全弁としての覗き見は許容。
 
-**common deny（全モード共通）** — allow は `--allow-all-tools` で済むので、denylist だけ書く：
-- `--deny-tool='shell(git push)'` — push は禁止（worktree 隔離のため）
-- `--deny-tool='shell(rm -rf)'` — 危険な削除は禁止
-- `--deny-tool='shell(sudo)'` — 権限昇格は禁止
-- `--deny-tool='shell(docker)'` — 本番資源への接続を防ぐ（プロジェクトの Rust ローカル開発は `docker compose run --rm` を別途許可するなら個別調整）
+**common deny（全モード共通）** — allow は `--allow-all-tools` で済むので、denylist だけ書く。Copilot の `--deny-tool` は `--allow-all-tools` より優先される（help 記載の precedence）ので、両者を同時指定して問題ない：
 
-言語別の追加 deny は `references/permissions.md`。
+- `--deny-tool='shell(git push)'` — push は禁止（worktree 隔離のため）
+- `--deny-tool='shell(rm:*)'` — `rm` 全般を禁止。`shell(rm -rf)` は exact-match で literal `rm -rf` しかブロックせず、引数付き `rm -rf /foo` がすり抜ける。`:*` の prefix match で確実に止める
+- `--deny-tool='shell(sudo)'` — 権限昇格は禁止
+
+**`docker` は本プロジェクトでは deny しない** — Rust / Terraform / npm の開発はすべて Docker Compose 経由が必須 (`feedback_rust_docker.md` ほか)。`references/permissions.md` 側で言語別に `shell(docker:*)` を allow する運用に合わせる。
+
+言語別の追加 deny / allow は `references/permissions.md`。
 
 ### 4. 進捗監視 & 結果収集
 
@@ -180,14 +182,34 @@ copilot \
 
 ### 5b. Visual verification (Mobile only)
 
-`apps/mobile/` 配下の編集を含むタスクは Jest + tsc に加え、**iOS Simulator での目視確認** が必須。手順:
+`apps/mobile/` 配下の編集を含むタスクは Jest + tsc に加え、**iOS Simulator での目視確認** が必須。
 
-1. main の Metro を一旦停止 (`kill $(lsof -t -i :8081)`)
-2. worktree の `apps/mobile` から Metro を立ち上げ（`APP_ENV=local EXPO_PUBLIC_API_URL=http://localhost:3000 nohup npx expo start --port 8081 &`）
-3. シミュレータのアプリを `xcrun simctl terminate && launch com.walkingdog.app` でリロードして worktree のバンドルを読み込ませる
-4. 該当画面までナビゲートして before/after のスクリーンショットを `tasks/copilot/<session>/{before,after}.png` に保存
-5. `results.md` の "Visual verification" セクションに添付し、A1/A2/... のような diff item ごとに ✅/⚠ を付ける
-6. 最後に main の Metro を復元（worktree Metro を停止 → main で再起動）
+Metro 切り替え方針は **`main の Metro はそのまま、worktree Metro を別ポートで立てる`** を default にする。main を一旦停止する旧フローは、途中で Jest 失敗 / シミュレータクラッシュ等が起きると main の Metro が復元されず "main Metro が落ちたまま" の状態をユーザーに残してしまう。別ポート方式なら main 側は終始無傷。
+
+手順:
+
+1. main の Metro はそのまま稼働させる。worktree の `apps/mobile` から **port 8082** で Metro を立ち上げる:
+
+   ```bash
+   (cd <worktree>/apps/mobile && \
+     EXPO_PUBLIC_API_URL=http://localhost:3000 \
+     nohup npx expo start --port 8082 > /tmp/metro-worktree.log 2>&1 &)
+   ```
+
+   `APP_ENV` は **設定しない** — `apps/mobile/app.config.*` から `APP_ENV` 参照は撤去済み (2026-04-26) で no-op。
+2. シミュレータのアプリを `--env RCT_METRO_PORT=8082` 付きで relaunch して worktree のバンドルに繋ぐ:
+
+   ```bash
+   xcrun simctl terminate $UDID com.walkingdog.app
+   xcrun simctl launch --terminate-running-process \
+     --env RCT_METRO_PORT=8082 \
+     $UDID com.walkingdog.app
+   ```
+
+   `RCT_METRO_PORT` が効かない Expo バージョンでは fallback として、いったん main の Metro (8081) を停止 → 1 の Metro を `--port 8081` で起動し直し → 検証後に main を `cd <main>/apps/mobile && nohup npx expo start --port 8081 &` で復元する。**この fallback を使う場合は、検証手順の頭で main Metro の起動コマンドを `ps -o args= -p $(lsof -t -i :8081)` で記録してから kill すること**。
+3. 該当画面までナビゲートして before/after のスクリーンショットを `tasks/copilot/<session>/{before,after}.png` に保存
+4. `results.md` の "Visual verification" セクションに添付し、A1/A2/... のような diff item ごとに ✅/⚠ を付ける
+5. 後片付け: `kill $(lsof -t -i :8082)` で worktree Metro を落とすだけ。fallback フローを使った場合のみ main Metro を 1 で記録したコマンドで restart する
 
 詳細スクリプトは `ios-sim-test` skill を呼ぶ。`apps/api/` 単独タスクには不要（cargo test で十分）。
 
@@ -196,7 +218,7 @@ copilot \
 ユーザーが結合方針を返したら：
 
 - **squash merge**: `git checkout main && git merge --squash copilot/${TASK_ID} && git commit -m "..."` でローカル merge。push は別途ユーザー指示で。
-- **PR**: `commit-push-pr` skill か直接 `gh pr create` で別途実行。PR 本文には instruction.md のスコープ表、テスト結果、視覚確認結果、スコープ外の追跡項目を入れる。`NOTES.md` が §5 で除去済みであることを再確認。
+- **PR**: `/commit-push-pr` slash command (`.claude/commands/commit-push-pr.md`)、または `commit-commands:commit-push-pr` plugin skill、または直接 `gh pr create`。**`commit-push-pr` という名前の skill は存在しない** ので `Skill(name="commit-push-pr")` 呼び出しはしない。PR 本文には instruction.md のスコープ表、テスト結果、視覚確認結果、スコープ外の追跡項目を入れる。`NOTES.md` が §5 で除去済みであることを再確認。
 - **cherry-pick**: 既存ブランチに `git cherry-pick <sha>`。
 
 PR を作るときは、delegation の `tasks/copilot/<session>/` ディレクトリを PR の差分に含めるかは判断もの — 通常は **含めない**（セッション metadata であり、コードベースの一部ではない）。`.gitignore` に `tasks/copilot/` を追加しておくか、push 前に未追跡のままにする運用が望ましい。


### PR DESCRIPTION
## Summary

`copilot-delegate` skill を実運用 (#236 の Dog detail chrome リファクタ) で初めて回したときに「あれが書かれていなかった」「ここが詰まった」の摩擦点が複数出たので、その学びを skill 本体に反映する。`SKILL.md` のみの変更 (+89 −20)。

## 反映した 8 項目

| § | 改善 | 痛みポイントだった理由 |
|---|---|---|
| Modes 表 + §2 | `single` モードも **新規 worktree を作る** をデフォルトに | 旧記述は "main の作業ツリーを流用" だったが、main の uncommitted 変更との衝突 / 誤 push リスクが高い |
| §2 | JS/TS タスクは Copilot 起動前に `npm ci` を済ませる手順を追加 | 新規 worktree の `node_modules` は空。Copilot が実行中に `npm ci` で 1〜2 分余計に食う |
| §3 | `--allow-all-tools` と `--no-ask-user` を骨格テンプレに必須として明記 | これが無いと `-p` の非インタラクティブモードは permission prompt で無言ハング。ログには何も出ず原因不明 |
| §3 | allow を `--allow-all-tools` で済ませて、許容/拒否は **denylist 中心** に再構成 | enumerate していくと漏れる。default permissive + minimal deny の方が現実的 |
| §3 | "完了通知ベースだが、ユーザー要求や長時間無応答時はログを覗いてよい" を明記 | 旧記述は "poll しない" のみ。実際にはユーザーから「進捗は？」が来る |
| §4 | `results.md` テンプレを 5 行スケッチ → **3 ブロック構成** (受け入れ基準表 / テスト結果 / Claude review notes) に拡張 | スケッチでは受け入れ基準のチェックが落ちる。実用に出てきた形をテンプレ昇格 |
| §5 | `NOTES.md` の事後処理（results.md に転記 → `git rm`）を追加 | Copilot は受け入れ基準未達 / スコープ外失敗のとき worktree ルートに `NOTES.md` を残すが、それを PR / マージに含めない手順が無かった |
| §5b 新設 | Mobile タスクは **iOS Simulator での目視確認** を必須に。`ios-sim-test` skill にクロスリンク | apps/mobile タスクで Jest + tsc を通しただけでは見落としあり (例: A1〜C1 の chrome リファクタは目視で初めて確認) |
| §5c 新設 | レビュー後のマージ / PR への接続を `commit-push-pr` skill 経由で明示 | 旧 skill はレビューで終わっており、その後 PR にどう持っていくかが書かれていなかった |

## 検証

- `SKILL.md` のセクション構造を読み返して論理一貫性確認済み
- 既存の §6 (cleanup)、§Error Handling、§Project-Specific Constraints は無変更
- `references/{modes,permissions,worktree}.md` は今回触らず（別途必要なら追って）

## Test plan

- [ ] 次回 `copilot-delegate` を呼ぶときに §3 のテンプレで一発で `-p` モードが動くこと
- [ ] §4 のテンプレに沿った `results.md` を生成して、受け入れ基準表が自然に書けること
- [ ] Mobile タスクで §5b を踏んで目視確認まで完走できること
- [ ] §5c の `commit-push-pr` 連携で PR まで継ぎ目なくつなげること

🤖 Generated with [Claude Code](https://claude.com/claude-code)