### PR TITLE
feat(api): add changeEmail/confirmEmailChange mutations and harden auth guards

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,1 +1,2 @@
 plans
+worktrees

--- a/apps/api/src/graphql/error.rs
+++ b/apps/api/src/graphql/error.rs
@@ -2,6 +2,8 @@ use async_graphql::{Error, ErrorExtensions};
 use aws_sdk_cognitoidentityprovider::operation::{
     change_password::ChangePasswordError, confirm_sign_up::ConfirmSignUpError,
     global_sign_out::GlobalSignOutError, initiate_auth::InitiateAuthError, sign_up::SignUpError,
+    update_user_attributes::UpdateUserAttributesError,
+    verify_user_attribute::VerifyUserAttributeError,
 };
 use aws_sdk_s3::error::ProvideErrorMetadata;
 use tracing::error;
@@ -57,6 +59,10 @@ pub enum AuthError {
     SignInError(InitiateAuthError),
     #[error("Sign out error: {0}")]
     SignOutError(GlobalSignOutError),
+    #[error("Update user attributes error: {0}")]
+    UpdateUserAttributesError(UpdateUserAttributesError),
+    #[error("Verify user attribute error: {0}")]
+    VerifyUserAttributeError(VerifyUserAttributeError),
     #[error("Change password error: {0}")]
     ChangePasswordError(ChangePasswordError),
 }
@@ -83,6 +89,22 @@ impl ErrorExtensions for AuthError {
                 error!("Sign out error: {:?}", sign_out_error);
                 e.set("code", 422);
                 e.set("message", sign_out_error.message());
+            }
+            AuthError::UpdateUserAttributesError(update_user_attributes_error) => {
+                error!(
+                    "Update user attributes error: {:?}",
+                    update_user_attributes_error
+                );
+                e.set("code", 422);
+                e.set("message", update_user_attributes_error.message());
+            }
+            AuthError::VerifyUserAttributeError(verify_user_attribute_error) => {
+                error!(
+                    "Verify user attribute error: {:?}",
+                    verify_user_attribute_error
+                );
+                e.set("code", 422);
+                e.set("message", verify_user_attribute_error.message());
             }
             AuthError::ChangePasswordError(change_password_error) => {
                 error!("Change password error: {:?}", change_password_error);

--- a/apps/api/src/graphql/mutation/auth.rs
+++ b/apps/api/src/graphql/mutation/auth.rs
@@ -1,11 +1,13 @@
 use anyhow::Result;
 use async_graphql::{Context, InputObject, Object, SimpleObject};
 use aws_sdk_cognitoidentityprovider::operation::initiate_auth::InitiateAuthOutput;
+use aws_sdk_cognitoidentityprovider::types::AttributeType;
 use axum_extra::headers::authorization;
 use sea_orm::{ActiveModelTrait, ActiveValue::Set, DatabaseConnection};
 
 use crate::entity::user;
-use crate::graphql::error::AuthError;
+use crate::graphql::error::AppError;
+use crate::graphql::{error::AuthError, guard::AuthGuard};
 
 #[derive(Default, Debug)]
 pub struct AuthMutation;
@@ -68,6 +70,7 @@ impl AuthMutation {
         Ok(output.into())
     }
 
+    #[graphql(guard = "AuthGuard")]
     async fn sign_out(&self, ctx: &Context<'_>) -> Result<SignOutOutput> {
         let cognitoidentityprovider_client = ctx
             .data::<aws_sdk_cognitoidentityprovider::Client>()
@@ -82,6 +85,58 @@ impl AuthMutation {
         Ok(SignOutOutput { success: true })
     }
 
+    #[graphql(guard = "AuthGuard")]
+    async fn change_email(
+        &self,
+        ctx: &Context<'_>,
+        input: ChangeEmailInput,
+    ) -> Result<ChangeEmailOutput> {
+        let cognitoidentityprovider_client = ctx
+            .data::<aws_sdk_cognitoidentityprovider::Client>()
+            .unwrap();
+        let authorization = ctx
+            .data::<authorization::Bearer>()
+            .map_err(|_| AppError::Unauthorized)?;
+        cognitoidentityprovider_client
+            .update_user_attributes()
+            .access_token(authorization.token())
+            .user_attributes(
+                AttributeType::builder()
+                    .name("email")
+                    .value(input.new_email)
+                    .build()
+                    .unwrap(),
+            )
+            .send()
+            .await
+            .map_err(|e| AuthError::UpdateUserAttributesError(e.into_service_error()))?;
+        Ok(ChangeEmailOutput { success: true })
+    }
+
+    #[graphql(guard = "AuthGuard")]
+    async fn confirm_email_change(
+        &self,
+        ctx: &Context<'_>,
+        input: ConfirmEmailChangeInput,
+    ) -> Result<ConfirmEmailChangeOutput> {
+        let cognitoidentityprovider_client = ctx
+            .data::<aws_sdk_cognitoidentityprovider::Client>()
+            .unwrap();
+        let authorization = ctx
+            .data::<authorization::Bearer>()
+            .map_err(|_| AppError::Unauthorized)?;
+        cognitoidentityprovider_client
+            .verify_user_attribute()
+            .access_token(authorization.token())
+            .attribute_name("email")
+            .code(input.code)
+            .send()
+            .await
+            .map_err(|e| AuthError::VerifyUserAttributeError(e.into_service_error()))?;
+        Ok(ConfirmEmailChangeOutput { success: true })
+    }
+
+    #[graphql(guard = "AuthGuard")]
     async fn change_password(
         &self,
         ctx: &Context<'_>,
@@ -90,7 +145,9 @@ impl AuthMutation {
         let cognitoidentityprovider_client = ctx
             .data::<aws_sdk_cognitoidentityprovider::Client>()
             .unwrap();
-        let authorization = ctx.data::<authorization::Bearer>().unwrap();
+        let authorization = ctx
+            .data::<authorization::Bearer>()
+            .map_err(|_| AppError::Unauthorized)?;
         cognitoidentityprovider_client
             .change_password()
             .previous_password(input.old_password)
@@ -140,6 +197,26 @@ pub struct SignInInput {
 pub struct SignInOutput {
     access_token: String,
     refresh_token: String,
+}
+
+#[derive(Clone, Debug, InputObject)]
+pub struct ChangeEmailInput {
+    new_email: String,
+}
+
+#[derive(SimpleObject)]
+pub struct ChangeEmailOutput {
+    success: bool,
+}
+
+#[derive(Clone, Debug, InputObject)]
+pub struct ConfirmEmailChangeInput {
+    code: String,
+}
+
+#[derive(SimpleObject)]
+pub struct ConfirmEmailChangeOutput {
+    success: bool,
 }
 
 #[derive(Clone, Debug, InputObject)]

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -6,7 +6,7 @@
     "start": "expo start --host lan",
     "metro:kill": "sh ./scripts/kill-metro.sh",
     "ios:clean": "npx expo prebuild --platform ios --clean",
-    "ios:sim:local": "EXPO_PUBLIC_API_URL=http://localhost:3000 expo run:ios",
+    "ios:sim:local": "EXPO_PUBLIC_API_URL=http://localhost:3000 expo run:ios --device",
     "ios:sim:dev": "EXPO_PUBLIC_API_URL=https://walkingdogdev.dpdns.org expo run:ios",
     "ios:sim:prod": "EXPO_PUBLIC_API_URL=https://walkingdogdev.dpdns.org expo run:ios --configuration Release",
     "ios:dev:local": "EXPO_PUBLIC_API_URL=http://localhost:3000 expo run:ios --device",


### PR DESCRIPTION
## Summary
- Cognito の `UpdateUserAttributes` / `VerifyUserAttribute` を呼び出す `changeEmail` / `confirmEmailChange` mutation を追加
- `sign_out` / `change_password` / `changeEmail` / `confirmEmailChange` に `AuthGuard` を適用し、`change_password` の `unwrap()` を `AppError::Unauthorized` に置換
- mobile: `ios:sim:local` に `--device` を付与、`.claude/.gitignore` に `worktrees` を追加
- Added `changeEmail` / `confirmEmailChange` mutations backed by Cognito `UpdateUserAttributes` / `VerifyUserAttribute`.
- Applied `AuthGuard` to `sign_out` / `change_password` / `changeEmail` / `confirmEmailChange` and replaced `change_password`'s `unwrap()` with `AppError::Unauthorized`.
- mobile: added `--device` to `ios:sim:local`; ignored `worktrees/` under `.claude/`.

## Test plan
- [ ] \`docker compose -f apps/api/compose.yml run --rm api cargo build\` が通る
- [ ] GraphQL Playground から \`changeEmail\` → メール受信 → \`confirmEmailChange\` の一連が成功する
- [ ] 認証なしで \`sign_out\` / \`change_password\` / \`changeEmail\` / \`confirmEmailChange\` を叩くと \`Unauthorized\` が返る

🤖 Generated with [Claude Code](https://claude.com/claude-code)