### PR TITLE
feat(mobile): dog avatar upload via update_dog (graphql multipart)

### DIFF
--- a/apps/mobile/__tests__/app/dogs/edit.test.tsx
+++ b/apps/mobile/__tests__/app/dogs/edit.test.tsx
@@ -1,5 +1,6 @@
 import { Alert } from 'react-native';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import * as ImagePicker from 'expo-image-picker';
 import EditDogScreen from '../../../app/dogs/[id]/edit';
 import type { DogWithStats } from '@/types/graphql';
 
@@ -17,13 +18,33 @@ jest.mock('expo-router', () => ({
   useRouter: () => ({ back: mockBack, replace: mockReplace }),
 }));
 
+jest.mock('expo-image', () => ({
+  Image: 'Image',
+}));
+
+jest.mock('expo-image-picker', () => ({
+  PermissionStatus: { GRANTED: 'granted' },
+  requestMediaLibraryPermissionsAsync: jest.fn(),
+  launchImageLibraryAsync: jest.fn(),
+}));
+
+const mockRequestMediaLibraryPermissionsAsync =
+  ImagePicker.requestMediaLibraryPermissionsAsync as jest.MockedFunction<
+    typeof ImagePicker.requestMediaLibraryPermissionsAsync
+  >;
+const mockLaunchImageLibraryAsync =
+  ImagePicker.launchImageLibraryAsync as jest.MockedFunction<
+    typeof ImagePicker.launchImageLibraryAsync
+  >;
+
 const mockDog = {
   id: 'dog-1',
   name: 'Buddy',
   breed: 'Golden Retriever',
   gender: 'MALE',
+  avatar: 'https://example.com/buddy.jpg',
   birthday: null,
-  photoUrl: null,
+  photoUrl: 'https://example.com/buddy.jpg',
   createdAt: '2026-01-01',
   walkStats: null,
 } satisfies DogWithStats;
@@ -47,6 +68,16 @@ describe('EditDogScreen', () => {
     mockUpdateDog.mockResolvedValue(mockDog);
     mockDeleteDog.mockResolvedValue(mockDog);
     jest.spyOn(Alert, 'alert').mockImplementation(jest.fn());
+    mockRequestMediaLibraryPermissionsAsync.mockResolvedValue({
+      granted: true,
+      status: ImagePicker.PermissionStatus.GRANTED,
+      canAskAgain: true,
+      expires: 'never',
+    });
+    mockLaunchImageLibraryAsync.mockResolvedValue({
+      canceled: true,
+      assets: null,
+    });
   });
 
   it('renders the inline ScreenHeader title and common actions', () => {
@@ -116,5 +147,44 @@ describe('EditDogScreen', () => {
       expect(mockDeleteDog).toHaveBeenCalledWith('dog-1');
     });
     expect(mockReplace).toHaveBeenCalledWith('/(tabs)/dogs');
+  });
+
+  it('saves the selected avatar file with the form values', async () => {
+    mockLaunchImageLibraryAsync.mockResolvedValue({
+      canceled: false,
+      assets: [
+        {
+          uri: 'file:///buddy.png',
+          width: 100,
+          height: 100,
+          fileName: 'buddy.png',
+          mimeType: 'image/png',
+        },
+      ],
+    });
+    render(<EditDogScreen />);
+
+    fireEvent.press(screen.getByRole('button', { name: 'Change photo' }));
+    await waitFor(() => {
+      expect(mockLaunchImageLibraryAsync).toHaveBeenCalled();
+    });
+    fireEvent.press(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(mockUpdateDog).toHaveBeenCalledWith({
+        id: 'dog-1',
+        input: {
+          name: 'Buddy',
+          breed: 'Golden Retriever',
+          gender: 'MALE',
+          birthday: null,
+          avatarFile: {
+            uri: 'file:///buddy.png',
+            name: 'buddy.png',
+            type: 'image/png',
+          },
+        },
+      });
+    });
   });
 });

--- a/apps/mobile/app/dogs/[id]/edit.tsx
+++ b/apps/mobile/app/dogs/[id]/edit.tsx
@@ -13,10 +13,12 @@ import {
   isDogFormValid,
   type DogFormValues,
 } from '@/components/dogs/DogForm';
+import { DogAvatarEditor } from '@/components/dogs/DogAvatarEditor';
 import { LoadingScreen } from '@/components/ui/LoadingScreen';
 import { ScreenHeader } from '@/components/ui/ScreenHeader';
 import { useColors } from '@/hooks/use-colors';
 import { components, spacing } from '@/theme/tokens';
+import type { UploadFile } from '@/lib/graphql/client';
 
 // 犬編集画面 — inline ScreenHeader でフォームの Cancel/Save を提供します。
 // dog データのロード待ちは外側、form state 初期化は内側コンポーネントに分離して
@@ -37,6 +39,7 @@ export default function EditDogScreen() {
         gender: dog.gender ?? '',
         ...dogBirthdayToFormValues(dog.birthday),
       }}
+      currentAvatar={dog.avatar ?? dog.photoUrl ?? null}
     />
   );
 }
@@ -45,9 +48,10 @@ interface EditDogContentProps {
   id: string;
   dogName: string;
   initialValues: DogFormValues;
+  currentAvatar: string | null;
 }
 
-function EditDogContent({ id, dogName, initialValues }: EditDogContentProps) {
+function EditDogContent({ id, dogName, initialValues, currentAvatar }: EditDogContentProps) {
   const { t } = useTranslation();
   const router = useRouter();
   const theme = useColors();
@@ -56,6 +60,7 @@ function EditDogContent({ id, dogName, initialValues }: EditDogContentProps) {
   const runWithAlert = useMutationWithAlert();
 
   const [values, setValues] = useState<DogFormValues>(initialValues);
+  const [avatarFile, setAvatarFile] = useState<UploadFile | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
   const canSave = isDogFormValid(values) && !submitting;
@@ -72,6 +77,7 @@ function EditDogContent({ id, dogName, initialValues }: EditDogContentProps) {
           breed: values.breed.trim() || undefined,
           gender: values.gender.trim() || undefined,
           birthday: birthdayValuesToInput(values),
+          ...(avatarFile ? { avatarFile } : {}),
         },
       });
       router.back();
@@ -121,6 +127,7 @@ function EditDogContent({ id, dogName, initialValues }: EditDogContentProps) {
         contentContainerStyle={styles.scrollContent}
         keyboardShouldPersistTaps="handled"
       >
+        <DogAvatarEditor value={currentAvatar} onChange={setAvatarFile} dogName={dogName} />
         <DogForm values={values} onChange={setValues} />
         <Pressable
           accessibilityRole="button"

--- a/apps/mobile/components/dogs/DogAvatarEditor.test.tsx
+++ b/apps/mobile/components/dogs/DogAvatarEditor.test.tsx
@@ -1,0 +1,142 @@
+import { Alert } from 'react-native';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import * as ImagePicker from 'expo-image-picker';
+import { DogAvatarEditor } from './DogAvatarEditor';
+
+jest.mock('@/hooks/use-color-scheme', () => ({
+  useColorScheme: () => 'light',
+}));
+
+jest.mock('expo-image', () => ({
+  Image: 'Image',
+}));
+
+jest.mock('expo-image-picker', () => ({
+  PermissionStatus: { GRANTED: 'granted', DENIED: 'denied' },
+  requestMediaLibraryPermissionsAsync: jest.fn(),
+  launchImageLibraryAsync: jest.fn(),
+}));
+
+const mockRequestMediaLibraryPermissionsAsync =
+  ImagePicker.requestMediaLibraryPermissionsAsync as jest.MockedFunction<
+    typeof ImagePicker.requestMediaLibraryPermissionsAsync
+  >;
+const mockLaunchImageLibraryAsync =
+  ImagePicker.launchImageLibraryAsync as jest.MockedFunction<
+    typeof ImagePicker.launchImageLibraryAsync
+  >;
+
+describe('DogAvatarEditor', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+    mockRequestMediaLibraryPermissionsAsync.mockResolvedValue({
+      granted: true,
+      status: ImagePicker.PermissionStatus.GRANTED,
+      canAskAgain: true,
+      expires: 'never',
+    });
+    mockLaunchImageLibraryAsync.mockResolvedValue({
+      canceled: true,
+      assets: null,
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('passes an existing avatar URL to the image source', () => {
+    render(
+      <DogAvatarEditor
+        value="https://example.com/buddy.jpg"
+        onChange={jest.fn()}
+        dogName="Buddy"
+      />,
+    );
+
+    expect(screen.getByTestId('dog-avatar-editor-image').props.source).toEqual({
+      uri: 'https://example.com/buddy.jpg',
+    });
+  });
+
+  it('renders the dog fallback when no avatar URL is present', () => {
+    render(<DogAvatarEditor value={null} onChange={jest.fn()} dogName="Buddy" />);
+
+    expect(screen.getByText('🐩')).toBeTruthy();
+  });
+
+  it('launches the image library when Change photo is pressed', async () => {
+    render(<DogAvatarEditor value={null} onChange={jest.fn()} dogName="Buddy" />);
+
+    fireEvent.press(screen.getByRole('button', { name: 'Change photo' }));
+
+    await waitFor(() => {
+      expect(mockLaunchImageLibraryAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mediaTypes: 'images',
+          allowsEditing: true,
+        }),
+      );
+    });
+  });
+
+  it('emits an UploadFile from the selected image asset', async () => {
+    const onChange = jest.fn();
+    mockLaunchImageLibraryAsync.mockResolvedValue({
+      canceled: false,
+      assets: [
+        {
+          uri: 'file:///selected.png',
+          width: 100,
+          height: 100,
+          fileName: 'selected.png',
+          mimeType: 'image/x-png',
+        },
+      ],
+    });
+    render(<DogAvatarEditor value={null} onChange={onChange} dogName="Buddy" />);
+
+    fireEvent.press(screen.getByRole('button', { name: 'Change photo' }));
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith({
+        uri: 'file:///selected.png',
+        name: 'selected.png',
+        type: 'image/png',
+      });
+    });
+  });
+
+  it('does not emit a file when image picking is canceled', async () => {
+    const onChange = jest.fn();
+    render(<DogAvatarEditor value={null} onChange={onChange} dogName="Buddy" />);
+
+    fireEvent.press(screen.getByRole('button', { name: 'Change photo' }));
+
+    await waitFor(() => {
+      expect(mockLaunchImageLibraryAsync).toHaveBeenCalled();
+    });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('shows a localized alert when photo permission is denied', async () => {
+    mockRequestMediaLibraryPermissionsAsync.mockResolvedValue({
+      granted: false,
+      status: ImagePicker.PermissionStatus.DENIED,
+      canAskAgain: false,
+      expires: 'never',
+    });
+    render(<DogAvatarEditor value={null} onChange={jest.fn()} dogName="Buddy" />);
+
+    fireEvent.press(screen.getByRole('button', { name: 'Change photo' }));
+
+    await waitFor(() => {
+      expect(Alert.alert).toHaveBeenCalledWith(
+        'Photo access denied',
+        'Please allow photo library access in Settings.',
+      );
+    });
+    expect(mockLaunchImageLibraryAsync).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/components/dogs/DogAvatarEditor.tsx
+++ b/apps/mobile/components/dogs/DogAvatarEditor.tsx
@@ -1,0 +1,109 @@
+import { useState } from 'react';
+import { Alert, Pressable, StyleSheet, Text, View } from 'react-native';
+import { Image } from 'expo-image';
+import * as ImagePicker from 'expo-image-picker';
+import { useTranslation } from 'react-i18next';
+import { useColors } from '@/hooks/use-colors';
+import { normalizeImageContentType } from '@/lib/upload';
+import { components, spacing, typography } from '@/theme/tokens';
+import type { UploadFile } from '@/lib/graphql/client';
+
+interface DogAvatarEditorProps {
+  value: string | null;
+  onChange: (file: UploadFile | null) => void;
+  dogName?: string;
+}
+
+export function DogAvatarEditor({ value, onChange, dogName }: DogAvatarEditorProps) {
+  const { t } = useTranslation();
+  const theme = useColors();
+  const [selectedFile, setSelectedFile] = useState<UploadFile | null>(null);
+  const previewUri = selectedFile?.uri ?? value;
+
+  async function handleChangePhoto() {
+    const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (!permission.granted) {
+      Alert.alert(
+        t('dogs.form.photoPermissionDenied'),
+        t('dogs.form.photoPermissionMessage'),
+      );
+      return;
+    }
+
+    const aspect: [number, number] = [...components.dogAvatarEditor.pickerAspect];
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: 'images',
+      quality: components.dogAvatarEditor.pickerQuality,
+      allowsEditing: true,
+      aspect,
+    });
+    if (result.canceled || !result.assets[0]) return;
+
+    const asset = result.assets[0];
+    const file = {
+      uri: asset.uri,
+      name: asset.fileName ?? 'avatar.jpg',
+      type: normalizeImageContentType(asset.mimeType),
+    };
+    setSelectedFile(file);
+    onChange(file);
+  }
+
+  return (
+    <View style={styles.container}>
+      <View style={[styles.avatar, { backgroundColor: theme.surfaceContainer }]}>
+        {previewUri ? (
+          <Image
+            testID="dog-avatar-editor-image"
+            source={{ uri: previewUri }}
+            style={styles.image}
+            contentFit="cover"
+            cachePolicy="memory-disk"
+            accessibilityLabel={dogName}
+            accessibilityIgnoresInvertColors
+          />
+        ) : (
+          <Text style={styles.placeholder} accessibilityLabel={dogName}>
+            🐩
+          </Text>
+        )}
+      </View>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={t('dogs.form.changePhoto')}
+        onPress={handleChangePhoto}
+        hitSlop={spacing.sm}
+      >
+        <Text style={[styles.changePhoto, { color: theme.interactive }]}>
+          {t('dogs.form.changePhoto')}
+        </Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    gap: spacing.sm,
+    marginBottom: spacing.lg,
+  },
+  avatar: {
+    width: components.dogAvatarEditor.size,
+    height: components.dogAvatarEditor.size,
+    borderRadius: components.dogAvatarEditor.radius,
+    alignItems: 'center',
+    justifyContent: 'center',
+    overflow: 'hidden',
+  },
+  image: {
+    width: '100%',
+    height: '100%',
+  },
+  placeholder: {
+    fontSize: components.dogAvatarEditor.placeholderFontSize,
+  },
+  changePhoto: {
+    ...typography.subheadline,
+  },
+});

--- a/apps/mobile/hooks/use-dog-mutations.test.ts
+++ b/apps/mobile/hooks/use-dog-mutations.test.ts
@@ -1,0 +1,133 @@
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement, type ReactNode } from 'react';
+import type * as ClientModule from '@/lib/graphql/client';
+import { useUpdateDog } from './use-dog-mutations';
+
+jest.mock('@/lib/graphql/client', () => ({
+  authenticatedRequest: jest.fn(),
+  authenticatedMultipartRequest: jest.fn(),
+}));
+
+const {
+  authenticatedRequest,
+  authenticatedMultipartRequest,
+} = require('@/lib/graphql/client') as typeof ClientModule;
+const mockAuthenticatedRequest = authenticatedRequest as jest.MockedFunction<
+  typeof authenticatedRequest
+>;
+const mockAuthenticatedMultipartRequest =
+  authenticatedMultipartRequest as jest.MockedFunction<
+    typeof authenticatedMultipartRequest
+  >;
+const mockInvalidateUserQueries = jest.fn();
+
+jest.mock('./use-invalidate-user-queries', () => ({
+  useInvalidateUserQueries: () => mockInvalidateUserQueries,
+}));
+
+const apiDog = {
+  id: 'dog-1',
+  name: 'Buddy',
+  breed: 'Golden Retriever',
+  gender: 'MALE' as const,
+  avatar: 'https://example.com/avatar.jpg',
+  birthday: null,
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-02T00:00:00Z',
+};
+
+function createWrapper(): ({ children }: { children: ReactNode }) => ReactNode {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: Infinity },
+      mutations: { retry: false, gcTime: Infinity },
+    },
+  });
+
+  return function Wrapper({ children }: { children: ReactNode }): ReactNode {
+    return createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+}
+
+describe('useUpdateDog', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAuthenticatedRequest.mockResolvedValue({ updateDog: apiDog });
+    mockAuthenticatedMultipartRequest.mockResolvedValue({ updateDog: apiDog });
+    mockInvalidateUserQueries.mockResolvedValue(undefined);
+  });
+
+  it('uses the JSON GraphQL request path when avatarFile is omitted', async () => {
+    const { result, unmount } = renderHook(() => useUpdateDog(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        id: 'dog-1',
+        input: {
+          name: 'Buddy',
+          breed: 'Golden Retriever',
+          gender: 'male',
+          birthday: null,
+        },
+      });
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockAuthenticatedRequest).toHaveBeenCalledWith(expect.any(String), {
+      input: {
+        id: 'dog-1',
+        name: 'Buddy',
+        breed: 'Golden Retriever',
+        gender: 'MALE',
+        birthday: null,
+      },
+    });
+    expect(mockAuthenticatedMultipartRequest).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it('uses the multipart GraphQL request path when avatarFile is provided', async () => {
+    const avatarFile = {
+      uri: 'file:///avatar.png',
+      name: 'avatar.png',
+      type: 'image/png',
+    };
+    const { result, unmount } = renderHook(() => useUpdateDog(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        id: 'dog-1',
+        input: {
+          name: 'Buddy',
+          breed: 'Golden Retriever',
+          gender: 'female',
+          birthday: null,
+          avatarFile,
+        },
+      });
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockAuthenticatedMultipartRequest).toHaveBeenCalledWith(
+      expect.any(String),
+      {
+        input: {
+          id: 'dog-1',
+          name: 'Buddy',
+          breed: 'Golden Retriever',
+          gender: 'FEMALE',
+          birthday: null,
+          avatar: null,
+        },
+      },
+      { 'variables.input.avatar': avatarFile },
+    );
+    expect(mockAuthenticatedRequest).not.toHaveBeenCalled();
+    unmount();
+  });
+});

--- a/apps/mobile/hooks/use-dog-mutations.ts
+++ b/apps/mobile/hooks/use-dog-mutations.ts
@@ -1,5 +1,9 @@
 import { useMutation } from '@tanstack/react-query';
-import { authenticatedRequest } from '@/lib/graphql/client';
+import {
+  authenticatedMultipartRequest,
+  authenticatedRequest,
+  type UploadFile,
+} from '@/lib/graphql/client';
 import {
   ADD_DOG_MUTATION,
   UPDATE_DOG_MUTATION,
@@ -24,6 +28,34 @@ function toApiGender(gender: string | undefined): 'MALE' | 'FEMALE' | 'OTHER' {
   return 'OTHER';
 }
 
+type UpdateDogMutationInput = UpdateDogInput & {
+  avatarFile?: UploadFile;
+};
+
+type UpdateDogMutationVariables = {
+  id: string;
+  input: UpdateDogMutationInput;
+};
+
+function toUpdateDogRequestInput(
+  id: string,
+  input: UpdateDogMutationInput,
+): {
+  id: string;
+  name: string | undefined;
+  breed: string | undefined;
+  gender: 'MALE' | 'FEMALE' | 'OTHER' | undefined;
+  birthday: UpdateDogInput['birthday'];
+} {
+  return {
+    id,
+    name: input.name,
+    breed: input.breed,
+    gender: input.gender ? toApiGender(input.gender) : undefined,
+    birthday: input.birthday,
+  };
+}
+
 // 犬の作成後、ユーザー関連キャッシュを更新して一覧へ反映します。
 export function useCreateDog() {
   const invalidateUserQueries = useInvalidateUserQueries();
@@ -46,17 +78,23 @@ export function useCreateDog() {
 // 犬のプロフィール更新後、詳細と一覧で使うユーザー関連キャッシュを更新します。
 export function useUpdateDog() {
   const invalidateUserQueries = useInvalidateUserQueries();
-  return useMutation<Dog, Error, { id: string; input: UpdateDogInput }>({
+  return useMutation<Dog, Error, UpdateDogMutationVariables>({
     mutationFn: async ({ id, input }) => {
-      const data = await authenticatedRequest<UpdateDogResponse>(UPDATE_DOG_MUTATION, {
-        input: {
-          id,
-          name: input.name,
-          breed: input.breed,
-          gender: input.gender ? toApiGender(input.gender) : undefined,
-          birthday: input.birthday,
-        },
-      });
+      const requestInput = toUpdateDogRequestInput(id, input);
+      const data = input.avatarFile
+        ? await authenticatedMultipartRequest<UpdateDogResponse>(
+            UPDATE_DOG_MUTATION,
+            {
+              input: {
+                ...requestInput,
+                avatar: null,
+              },
+            },
+            { 'variables.input.avatar': input.avatarFile },
+          )
+        : await authenticatedRequest<UpdateDogResponse>(UPDATE_DOG_MUTATION, {
+            input: requestInput,
+          });
       return mapApiDog(data.updateDog);
     },
     onSuccess: invalidateUserQueries,

--- a/apps/mobile/lib/graphql/client.multipart.test.ts
+++ b/apps/mobile/lib/graphql/client.multipart.test.ts
@@ -1,0 +1,201 @@
+import type * as ClientModule from './client';
+import { ClientError } from './client-error';
+
+const mutation = 'mutation UpdateDog($input: UpdateDogInput!) { updateDog(input: $input) { id } }';
+const successfulResponse = { data: { updateDog: { id: 'dog-1' } } };
+const uploadFile = {
+  uri: 'file:///avatar.jpg',
+  name: 'avatar.jpg',
+  type: 'image/jpeg',
+};
+
+const mockFetch = jest.fn();
+const originalFetch = global.fetch;
+const originalFormData = global.FormData;
+
+beforeAll(() => {
+  global.fetch = mockFetch;
+  global.FormData = class TestFormData {
+    _parts: MultipartPart[] = [];
+
+    append(name: string, value: unknown) {
+      this._parts.push([name, value]);
+    }
+  } as unknown as typeof FormData;
+  jest.spyOn(console, 'log').mockImplementation(() => {});
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+const {
+  authenticatedMultipartRequest,
+  setAuthToken,
+  setRefreshHandler,
+} = require('./client') as typeof ClientModule;
+
+type MultipartPart = [string, unknown];
+
+function createJsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function getFetchOptions(): RequestInit {
+  return mockFetch.mock.calls[0][1] as RequestInit;
+}
+
+function getFormDataPart(body: BodyInit | null | undefined, name: string): unknown {
+  const formData = body as FormData & {
+    _parts?: MultipartPart[];
+    get?: (key: string) => FormDataEntryValue | null;
+  };
+
+  if (Array.isArray(formData._parts)) {
+    return formData._parts.find(([partName]) => partName === name)?.[1];
+  }
+
+  return formData.get?.(name);
+}
+
+afterEach(() => {
+  setAuthToken(null);
+  setRefreshHandler(() => Promise.resolve(false));
+  mockFetch.mockReset();
+});
+
+afterAll(() => {
+  global.fetch = originalFetch;
+  global.FormData = originalFormData;
+  jest.restoreAllMocks();
+});
+
+describe('authenticatedMultipartRequest', () => {
+  beforeEach(() => {
+    mockFetch.mockResolvedValue(createJsonResponse(successfulResponse));
+  });
+
+  it('builds graphql-multipart-request-spec FormData with null-injected operations and map', async () => {
+    await authenticatedMultipartRequest(
+      mutation,
+      {
+        input: {
+          id: 'dog-1',
+          name: 'Buddy',
+          avatar: uploadFile,
+        },
+      },
+      { 'variables.input.avatar': uploadFile },
+    );
+
+    const body = getFetchOptions().body;
+    expect(getFormDataPart(body, 'operations')).toBe(
+      JSON.stringify({
+        query: mutation,
+        variables: {
+          input: {
+            id: 'dog-1',
+            name: 'Buddy',
+            avatar: null,
+          },
+        },
+      }),
+    );
+    expect(getFormDataPart(body, 'map')).toBe(
+      JSON.stringify({ '0': ['variables.input.avatar'] }),
+    );
+    expect(getFormDataPart(body, '0')).toEqual(uploadFile);
+  });
+
+  it('does not set Content-Type manually and keeps Authorization when authenticated', async () => {
+    setAuthToken('access-token');
+
+    await authenticatedMultipartRequest(
+      mutation,
+      { input: { id: 'dog-1', avatar: uploadFile } },
+      { 'variables.input.avatar': uploadFile },
+    );
+
+    expect(getFetchOptions().headers).toEqual({
+      Authorization: 'Bearer access-token',
+    });
+  });
+
+  it('returns response data', async () => {
+    await expect(
+      authenticatedMultipartRequest(
+        mutation,
+        { input: { id: 'dog-1', avatar: uploadFile } },
+        { 'variables.input.avatar': uploadFile },
+      ),
+    ).resolves.toEqual(successfulResponse.data);
+  });
+
+  it('keeps GraphQL error details from a successful HTTP response body', async () => {
+    const result = { errors: [{ message: 'Invalid avatar' }] };
+    mockFetch.mockResolvedValue(createJsonResponse(result));
+
+    const errorPromise = authenticatedMultipartRequest(
+      mutation,
+      { input: { id: 'dog-1', avatar: uploadFile } },
+      { 'variables.input.avatar': uploadFile },
+    );
+
+    await expect(errorPromise).rejects.toBeInstanceOf(ClientError);
+    await expect(errorPromise).rejects.toMatchObject({
+      response: {
+        status: 200,
+        body: JSON.stringify(result),
+        errors: [expect.objectContaining({ message: 'Invalid avatar' })],
+      },
+      request: {
+        query: mutation,
+        variables: { input: { id: 'dog-1', avatar: uploadFile } },
+      },
+    });
+  });
+
+  it('keeps GraphQL error details from a failed HTTP response body', async () => {
+    const result = { errors: [{ message: 'Unauthorized' }] };
+    mockFetch.mockResolvedValue(createJsonResponse(result, 401));
+
+    const errorPromise = authenticatedMultipartRequest(
+      mutation,
+      { input: { id: 'dog-1', avatar: uploadFile } },
+      { 'variables.input.avatar': uploadFile },
+    );
+
+    await expect(errorPromise).rejects.toBeInstanceOf(ClientError);
+    await expect(errorPromise).rejects.toMatchObject({
+      response: {
+        status: 401,
+        body: JSON.stringify(result),
+        errors: [expect.objectContaining({ message: 'Unauthorized' })],
+      },
+      request: {
+        query: mutation,
+        variables: { input: { id: 'dog-1', avatar: uploadFile } },
+      },
+    });
+  });
+
+  it('retries through the refresh middleware after a 401 refresh succeeds', async () => {
+    const refresh = jest.fn().mockResolvedValue(true);
+    setRefreshHandler(refresh);
+    mockFetch
+      .mockResolvedValueOnce(createJsonResponse({ errors: [{ message: 'Unauthorized' }] }, 401))
+      .mockResolvedValueOnce(createJsonResponse(successfulResponse));
+
+    await expect(
+      authenticatedMultipartRequest(
+        mutation,
+        { input: { id: 'dog-1', avatar: uploadFile } },
+        { 'variables.input.avatar': uploadFile },
+      ),
+    ).resolves.toEqual(successfulResponse.data);
+
+    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/mobile/lib/graphql/client.ts
+++ b/apps/mobile/lib/graphql/client.ts
@@ -6,11 +6,21 @@ import {
 } from './middleware/refresh-on-401';
 import { logReproducibleRequest } from './request-log';
 
-type Variables = Record<string, unknown>;
+export type Variables = Record<string, unknown>;
+export type UploadFile = {
+  uri: string;
+  name: string;
+  type: string;
+};
+
 type GraphQLResult = {
   data?: unknown;
   errors?: readonly unknown[];
   extensions?: unknown;
+};
+type MultipartOperations = {
+  query: string;
+  variables?: Variables;
 };
 
 const endpoint = `${process.env.EXPO_PUBLIC_API_URL}/graphql`;
@@ -54,6 +64,95 @@ function parseResponseBodySafely(body: string): Partial<GraphQLResponse> {
   }
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function cloneGraphQLValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(cloneGraphQLValue);
+  }
+
+  if (isRecord(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, child]) => [key, cloneGraphQLValue(child)]),
+    );
+  }
+
+  return value;
+}
+
+function setPathValue(root: Record<string, unknown>, path: string, value: unknown): void {
+  const parts = path.split('.');
+  if (parts.some((part) => part.length === 0)) {
+    throw new Error(`Invalid upload variable path: ${path}`);
+  }
+
+  let current = root;
+  parts.forEach((part, index) => {
+    if (index === parts.length - 1) {
+      current[part] = value;
+      return;
+    }
+
+    const next = current[part];
+    if (next === undefined) {
+      const child: Record<string, unknown> = {};
+      current[part] = child;
+      current = child;
+      return;
+    }
+
+    if (!isRecord(next)) {
+      throw new Error(`Cannot inject upload variable at ${path}`);
+    }
+
+    current = next;
+  });
+}
+
+function createMultipartOperations(
+  document: string,
+  variables: Variables | undefined,
+  fileMap: Record<string, UploadFile>,
+): MultipartOperations {
+  const operations: MultipartOperations = {
+    query: document,
+    ...(variables ? { variables: cloneGraphQLValue(variables) as Variables } : {}),
+  };
+
+  for (const variablePath of Object.keys(fileMap)) {
+    setPathValue(operations as Record<string, unknown>, variablePath, null);
+  }
+
+  return operations;
+}
+
+function createMultipartBody(
+  document: string,
+  variables: Variables | undefined,
+  fileMap: Record<string, UploadFile>,
+): FormData {
+  const body = new FormData();
+  const operations = createMultipartOperations(document, variables, fileMap);
+  const map: Record<string, string[]> = {};
+
+  body.append('operations', JSON.stringify(operations));
+
+  Object.entries(fileMap).forEach(([variablePath], index) => {
+    const key = String(index);
+    map[key] = [variablePath];
+  });
+
+  body.append('map', JSON.stringify(map));
+
+  Object.values(fileMap).forEach((file, index) => {
+    body.append(String(index), file as unknown as Blob);
+  });
+
+  return body;
+}
+
 function createClientErrorFromBody(
   response: Response,
   query: string,
@@ -85,6 +184,38 @@ async function createClientErrorFromResponse(
   return createClientErrorFromBody(response, query, body, variables);
 }
 
+async function readGraphQLResponse<T>(
+  response: Response,
+  query: string,
+  variables: Variables | undefined,
+  operation: { kind: string; name: string },
+  startedAt: number,
+): Promise<T> {
+  const elapsedMs = Date.now() - startedAt;
+
+  if (!response.ok) {
+    console.warn(
+      `[graphql] ← ${operation.kind} ${operation.name} ${response.status} (${elapsedMs}ms)`,
+    );
+    throw await createClientErrorFromResponse(response, query, variables);
+  }
+
+  const body = await response.text();
+  const parsedBody = parseResponseBodySafely(body);
+
+  if (parsedBody.errors?.length) {
+    console.warn(
+      `[graphql] ← ${operation.kind} ${operation.name} ${response.status} with ${parsedBody.errors.length} errors (${elapsedMs}ms)`,
+    );
+    throw createClientErrorFromBody(response, query, body, variables);
+  }
+
+  console.log(
+    `[graphql] ← ${operation.kind} ${operation.name} ${response.status} ok (${elapsedMs}ms)`,
+  );
+  return parsedBody.data as T;
+}
+
 function parseOperation(document: string): { kind: string; name: string } {
   const m = document.match(/(query|mutation|subscription)\s+(\w+)/);
   return m ? { kind: m[1], name: m[2] } : { kind: 'query', name: 'anonymous' };
@@ -106,6 +237,18 @@ export async function authenticatedRequest<T>(
 ): Promise<T> {
   function request(): Promise<T> {
     return graphqlClient.request<T>(document, variables);
+  }
+
+  return wrap ? wrap(request) : request();
+}
+
+export async function authenticatedMultipartRequest<T>(
+  document: string,
+  variables: Variables,
+  fileMap: Record<string, UploadFile>,
+): Promise<T> {
+  function request(): Promise<T> {
+    return multipartGraphqlClient.request<T>(document, variables, fileMap);
   }
 
   return wrap ? wrap(request) : request();
@@ -150,24 +293,41 @@ export const graphqlClient = {
       throw err;
     }
 
-    const elapsedMs = Date.now() - startedAt;
+    return readGraphQLResponse<T>(response, document, variables, op, startedAt);
+  },
+};
 
-    if (!response.ok) {
-      console.warn(`[graphql] ← ${op.kind} ${op.name} ${response.status} (${elapsedMs}ms)`);
-      throw await createClientErrorFromResponse(response, document, variables);
-    }
+export const multipartGraphqlClient = {
+  async request<T>(
+    document: string,
+    variables: Variables,
+    fileMap: Record<string, UploadFile>,
+  ): Promise<T> {
+    const op = parseOperation(document);
+    const startedAt = Date.now();
+    console.log(`[graphql] → ${op.kind} ${op.name} ${endpoint}`, {
+      variableKeys: Object.keys(variables),
+    });
 
-    const body = await response.text();
-    const parsedBody = parseResponseBodySafely(body);
+    const headers: HeadersInit = {
+      ...(authToken ? { Authorization: `Bearer ${authToken}` } : {}),
+    };
 
-    if (parsedBody.errors?.length) {
-      console.warn(
-        `[graphql] ← ${op.kind} ${op.name} ${response.status} with ${parsedBody.errors.length} errors (${elapsedMs}ms)`,
+    let response: Response;
+    try {
+      response = await fetch(endpoint, {
+        method: 'POST',
+        headers,
+        body: createMultipartBody(document, variables, fileMap),
+      });
+    } catch (err) {
+      console.error(
+        `[graphql] ✗ ${op.kind} ${op.name} network failure after ${Date.now() - startedAt}ms`,
+        err,
       );
-      throw createClientErrorFromBody(response, document, body, variables);
+      throw err;
     }
 
-    console.log(`[graphql] ← ${op.kind} ${op.name} ${response.status} ok (${elapsedMs}ms)`);
-    return parsedBody.data as T;
+    return readGraphQLResponse<T>(response, document, variables, op, startedAt);
   },
 };

--- a/apps/mobile/lib/i18n/locales/en.json
+++ b/apps/mobile/lib/i18n/locales/en.json
@@ -130,7 +130,10 @@
       "birthdayMonth": "Month",
       "birthdayMonthPlaceholder": "e.g. 6",
       "birthdayDay": "Day",
-      "birthdayDayPlaceholder": "e.g. 15"
+      "birthdayDayPlaceholder": "e.g. 15",
+      "changePhoto": "Change photo",
+      "photoPermissionDenied": "Photo access denied",
+      "photoPermissionMessage": "Please allow photo library access in Settings."
     },
     "stats": {
       "walks": "Walks",

--- a/apps/mobile/lib/i18n/locales/ja.json
+++ b/apps/mobile/lib/i18n/locales/ja.json
@@ -130,7 +130,10 @@
       "birthdayMonth": "月",
       "birthdayMonthPlaceholder": "例: 6",
       "birthdayDay": "日",
-      "birthdayDayPlaceholder": "例: 15"
+      "birthdayDayPlaceholder": "例: 15",
+      "changePhoto": "写真を変更",
+      "photoPermissionDenied": "写真へのアクセスが拒否されました",
+      "photoPermissionMessage": "設定で写真ライブラリへのアクセスを許可してください。"
     },
     "stats": {
       "walks": "散歩",

--- a/apps/mobile/theme/tokens.ts
+++ b/apps/mobile/theme/tokens.ts
@@ -291,6 +291,13 @@ export const components = {
     segmentRadius: 6,
     segmentPaddingH: 10,
   },
+  dogAvatarEditor: {
+    size: 100,
+    radius: 50,
+    placeholderFontSize: 40,
+    pickerQuality: 0.8,
+    pickerAspect: [1, 1] as const,
+  },
 } as const;
 
 export type ComponentTokens = typeof components;


### PR DESCRIPTION
## Summary

Edit dog screen に犬の写真 (avatar) アップロード機能を追加。アップロード手段は **既存の \`update_dog\` mutation 経由**で、[graphql-multipart-request-spec](https://github.com/jaydenseric/graphql-multipart-request-spec) に基づく multipart/form-data 送信をモバイル client に実装。

3 つの commit に分離:

1. **`feat(mobile): add graphql multipart upload to client`** — `apps/mobile/lib/graphql/client.ts` に `authenticatedMultipartRequest` を追加。`operations` / `map` / file parts を spec 通りに構築。既存リフレッシュミドルウェアも適用。Content-Type ヘッダーは手動設定せず boundary 自動付与に任せる
2. **`feat(mobile): extend useUpdateDog to accept avatar file`** — `useUpdateDog` を `avatarFile?: UploadFile` 拡張、ありで multipart / なしで JSON に分岐
3. **`feat(mobile): add Photo section to Edit dog screen`** — 新規 `DogAvatarEditor` コンポーネント (100×100 円形 avatar + Change photo ボタン)。`expo-image-picker` で画像選択、権限拒否時は Alert、`normalizeImageContentType` (既存) で MIME 正規化

## API 変更

なし。`async_graphql_axum::GraphQLRequest` が JSON / multipart を自動判別するため、サーバー側コードは無変更で動作する (既存 `UpdateDogInput { avatar: Option<Upload> }` をそのまま使用)。

## Scope

✅ 含む / Included:
- graphql multipart spec のモバイル client 実装
- Dog avatar upload UI

❌ 含まない / Out of scope:
- User avatar (\`me\` クエリ経由) アップロード — 同じ multipart client が使い回せるはずだが本 PR では着手しない
- Avatar クリア機能 (\`avatar: null\` 明示送信) — 仕様未定

## Implementation notes

- **TDD**: 全 3 commits とも RED → GREEN → REFACTOR
- **Tokens**: 新規 `components.dogAvatarEditor.{size,radius,placeholderFontSize,pickerQuality,pickerAspect}` を `theme/tokens.ts` に追加
- **i18n**: `dogs.form.{changePhoto,photoPermissionDenied,photoPermissionMessage}` を en/ja 両方に追加
- **\`DogForm.tsx\` には触れていない** — Photo セクションは \`<DogForm>\` の前に挿入するだけ
- **依存追加なし** — 既存 \`expo-image\` / \`expo-image-picker\` / \`expo-file-system\` を使用

## 関連 PR / Related

#244 (Remove btn + Birthday picker + Gender segmented control) と並列開発。両 PR が同じ \`edit.tsx\` の異なる箇所を編集するため、後にマージされる側で rebase + コンフリクト解決が必要 (Photo は \`<DogForm>\` 上、Remove btn は \`<DogForm>\` 下、お互いに非対称な追加なので機械的に解決可能)。

## Test plan

- [x] \`npm test -- --runInBand\` — 100 suites / 643 tests pass
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run lint\` — clean
- [ ] iOS Simulator で目視確認:
  - Edit 画面で Avatar が表示される (既存 dog の場合)
  - Avatar 無し dog で 🐩 fallback 表示
  - Change photo → 画像選択 → preview 更新 → Save → サーバーに反映
  - 権限拒否時に Alert
- [ ] バックエンドの S3 アップロードログを確認

## Commits

| SHA | Subject |
|---|---|
| f0d2c2a | feat(mobile): add graphql multipart upload to client |
| 10db349 | feat(mobile): extend useUpdateDog to accept avatar file |
| 76341bb | feat(mobile): add Photo section to Edit dog screen |

🤖 Generated with [Claude Code](https://claude.com/claude-code), implemented via [GitHub Copilot CLI](https://github.com/github/copilot) delegation