### PR TITLE
[codex] Use popup gender picker on Edit dog

### DIFF
--- a/apps/mobile/CLAUDE.md
+++ b/apps/mobile/CLAUDE.md
@@ -32,6 +32,7 @@
 - Use secure storage for tokens — avoid AsyncStorage for sensitive data
 - Conventional Commits: feat:, fix:, refactor:, test:, docs:, chore:
 - UI 実装は **Expo 公式ライブラリを最優先で検討する**（`expo-router/unstable-native-tabs` の `NativeTabs`、`presentation: 'formSheet'`、`expo-glass-effect`、`@expo/ui`、`expo-blur` など）。カスタム実装・community 製パッケージはネイティブ API が足りないことを確認してから採用する。
+- grouped row 形式の設定・フォーム選択 UI は、Me 画面の Units と同じ `ActionSheetIOS` ベースのポップアップ選択を第一候補にする。
 - スタイルは **必ず `apps/mobile/theme/tokens.ts` のトークンを使う**。`StyleSheet.create` で `fontSize` / `fontWeight` / `letterSpacing` / `lineHeight` / `padding*` / `margin*` / `borderRadius` / `color` / 影 などを直書きしてはならない。`typography.*` / `spacing.*` / `radius.*` / `colors[scheme].*` / `elevation.*` を spread か参照で利用する。**設計仕様の値が既存トークンに無い場合は、`tokens.ts` に新しいトークンを追加してから使う**（インラインで magic number を書かない）。例外は overlay-on-photo のように意図的にテーマ非依存にしたい色のみで、その場合もファイル内の名前付き定数にしてコメントで根拠を残す。
 
 ## Available Commands

--- a/apps/mobile/components/dogs/DogForm.test.tsx
+++ b/apps/mobile/components/dogs/DogForm.test.tsx
@@ -1,3 +1,4 @@
+import { ActionSheetIOS } from 'react-native';
 import { render, screen, fireEvent } from '@testing-library/react-native';
 import {
   DogForm,
@@ -20,20 +21,25 @@ function makeValues(overrides: Partial<DogFormValues> = {}): DogFormValues {
 }
 
 describe('DogForm', () => {
+  beforeEach(() => {
+    jest.spyOn(ActionSheetIOS, 'showActionSheetWithOptions').mockImplementation(
+      (_config, cb) => cb(1),
+    );
+  });
+
   function setup(initial: DogFormValues = makeValues()) {
     const onChange = jest.fn();
     const utils = render(<DogForm values={initial} onChange={onChange} />);
     return { onChange, ...utils };
   }
 
-  it('renders name/breed fields and gender options', () => {
+  it('renders name/breed fields and the selected gender value', () => {
     setup();
     expect(screen.getByLabelText('Name')).toBeTruthy();
     expect(screen.getByLabelText('Breed')).toBeTruthy();
     expect(screen.getByText('Gender')).toBeTruthy();
-    expect(screen.getByRole('button', { name: 'Male' })).toBeTruthy();
-    expect(screen.getByRole('button', { name: 'Female' })).toBeTruthy();
-    expect(screen.getByRole('button', { name: 'Other' })).toBeTruthy();
+    expect(screen.getByText('Select gender')).toBeTruthy();
+    expect(screen.queryByTestId('dog-gender-segmented-control')).toBeNull();
   });
 
   it('renders the birthday placeholder when no birthday is set', () => {
@@ -59,9 +65,16 @@ describe('DogForm', () => {
     expect(onChange).toHaveBeenCalledWith(makeValues({ name: 'Hana', breed: 'Poodle', gender: 'male' }));
   });
 
-  it('calls onChange with patched values when gender changes', () => {
+  it('opens the gender ActionSheet and calls onChange with patched values', () => {
     const { onChange } = setup(makeValues({ name: 'Hana', breed: 'Poodle' }));
-    fireEvent.press(screen.getByRole('button', { name: 'Female' }));
+    fireEvent.press(screen.getByRole('button', { name: 'Gender' }));
+    expect(ActionSheetIOS.showActionSheetWithOptions).toHaveBeenCalledWith(
+      {
+        options: ['Male', 'Female', 'Other', 'Cancel'],
+        cancelButtonIndex: 3,
+      },
+      expect.any(Function),
+    );
     expect(onChange).toHaveBeenCalledWith(makeValues({ name: 'Hana', breed: 'Poodle', gender: 'FEMALE' }));
   });
 
@@ -92,7 +105,7 @@ describe('DogForm', () => {
     setup(makeValues({ name: 'Kuro', breed: 'Labrador', gender: 'male', birthdayYear: '2021', birthdayMonth: '6' }));
     expect(screen.getByDisplayValue('Kuro')).toBeTruthy();
     expect(screen.getByDisplayValue('Labrador')).toBeTruthy();
-    expect(screen.getByRole('button', { name: 'Male' }).props.accessibilityState?.selected).toBe(true);
+    expect(screen.getByText('Male')).toBeTruthy();
     expect(screen.getByText('Jun 2021')).toBeTruthy();
   });
 });

--- a/apps/mobile/components/dogs/DogForm.tsx
+++ b/apps/mobile/components/dogs/DogForm.tsx
@@ -1,8 +1,16 @@
 import { useMemo, useState } from 'react';
-import { Modal, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import {
+  ActionSheetIOS,
+  Modal,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { GroupedCard } from '@/components/ui/GroupedCard';
-import { SegmentedControl } from '@/components/ui/SegmentedControl';
 import { TextInput } from '@/components/ui/TextInput';
 import { useColors } from '@/hooks/use-colors';
 import { components, radius, spacing, typography } from '@/theme/tokens';
@@ -46,7 +54,10 @@ export function DogForm({ values, onChange }: DogFormProps) {
     { value: 'MALE', label: t('dogs.form.genderMale') },
     { value: 'FEMALE', label: t('dogs.form.genderFemale') },
     { value: 'OTHER', label: t('dogs.form.genderOther') },
-  ];
+  ] as const;
+  const genderLabel =
+    genderOptions.find((option) => option.value === genderValue)?.label ??
+    t('dogs.form.genderSelect');
   const selectedYear = toPositiveInt(values.birthdayYear);
   const selectedMonth = toBoundedInt(values.birthdayMonth, MONTH_COUNT);
   const selectedDay = toBoundedInt(values.birthdayDay, DEFAULT_DAY_COUNT);
@@ -85,6 +96,27 @@ export function DogForm({ values, onChange }: DogFormProps) {
     set({ birthdayMonth: month, birthdayDay });
   }
 
+  function presentGenderSheet() {
+    const apply = (index: number) => {
+      const option = genderOptions[index];
+      if (option) set({ gender: option.value });
+    };
+
+    if (Platform.OS === 'ios') {
+      ActionSheetIOS.showActionSheetWithOptions(
+        {
+          options: [...genderOptions.map((option) => option.label), t('common.action.cancel')],
+          cancelButtonIndex: genderOptions.length,
+        },
+        apply,
+      );
+      return;
+    }
+
+    const currentIndex = genderOptions.findIndex((option) => option.value === genderValue);
+    apply((currentIndex + 1) % genderOptions.length);
+  }
+
   return (
     <View style={styles.container}>
       <GroupedCard>
@@ -108,14 +140,22 @@ export function DogForm({ values, onChange }: DogFormProps) {
           <Text style={[styles.inlineLabel, { color: theme.onSurfaceVariant }]}>
             {t('dogs.form.gender')}
           </Text>
-          <View style={styles.genderControlWrap}>
-            <SegmentedControl
-              options={genderOptions}
-              value={genderValue}
-              onChange={(gender) => set({ gender })}
-              testID="dog-gender-segmented-control"
-            />
-          </View>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={t('dogs.form.gender')}
+            onPress={presentGenderSheet}
+            style={styles.genderValueWrap}
+          >
+            <Text
+              style={[
+                styles.genderValue,
+                { color: genderValue ? theme.onSurface : theme.onSurfaceVariant },
+              ]}
+              numberOfLines={1}
+            >
+              {genderLabel}
+            </Text>
+          </Pressable>
         </View>
       </GroupedCard>
 
@@ -421,8 +461,14 @@ const styles = StyleSheet.create({
   chevron: {
     ...typography.body,
   },
-  genderControlWrap: {
+  genderValueWrap: {
     flex: 1,
+    minHeight: components.row.minHeight,
+    justifyContent: 'center',
+  },
+  genderValue: {
+    ...typography.body,
+    textAlign: 'left',
   },
   modalBackdrop: {
     flex: 1,

--- a/apps/mobile/lib/i18n/locales/en.json
+++ b/apps/mobile/lib/i18n/locales/en.json
@@ -119,6 +119,7 @@
       "genderMale": "Male",
       "genderFemale": "Female",
       "genderOther": "Other",
+      "genderSelect": "Select gender",
       "genderPlaceholder": "e.g. Male",
       "birthday": "Birthday (whatever you know)",
       "birthdayPlaceholder": "Add birthday",

--- a/apps/mobile/lib/i18n/locales/ja.json
+++ b/apps/mobile/lib/i18n/locales/ja.json
@@ -119,6 +119,7 @@
       "genderMale": "オス",
       "genderFemale": "メス",
       "genderOther": "その他",
+      "genderSelect": "性別を選択",
       "genderPlaceholder": "例: オス",
       "birthday": "誕生日（わかる範囲でOK）",
       "birthdayPlaceholder": "誕生日を追加",


### PR DESCRIPTION
## Summary
- Replace the Edit dog Gender segmented control with a popup picker matching the Me screen Units interaction.
- Keep the existing inline row label/value styling, remove the chevron, and left-align the selected text.
- Add tests and translation keys for the new gender selector display.

## Validation
- `npm test -- DogForm.test.tsx --runInBand`
- `npm test -- lib/i18n/__tests__/translations.test.ts --runInBand`
- `npm run typecheck`