### PR TITLE
[codex] Fix stale dog IDs when starting walks

### DIFF
--- a/apps/api/Cargo.toml
+++ b/apps/api/Cargo.toml
@@ -56,5 +56,9 @@ features = [
 [dev-dependencies]
 serde_json = { version = "1.0.103" }
 
+[dev-dependencies.sea-orm]
+version = "~2.0.0-rc"
+features = ["mock"]
+
 [workspace]
 members = [".", "migration", "sqs-consumer"]

--- a/apps/api/src/graphql/mutation/walk.rs
+++ b/apps/api/src/graphql/mutation/walk.rs
@@ -1,7 +1,8 @@
 use anyhow::Result;
 use async_graphql::{Context, InputObject, Object};
 use sea_orm::{
-    ActiveModelTrait, ActiveValue::Set, ColumnTrait, EntityTrait, QueryFilter, TransactionTrait,
+    ActiveModelTrait, ActiveValue::Set, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter,
+    QuerySelect, TransactionError, TransactionTrait,
 };
 use uuid::Uuid;
 
@@ -11,37 +12,58 @@ use crate::graphql::{error::AppError, guard::AuthGuard, object::walk::Walk};
 #[derive(Default, Debug)]
 pub struct WalkMutation;
 
+async fn start_walk_for_user(
+    db: &DatabaseConnection,
+    user_id: Uuid,
+    dog_ids: &[Uuid],
+) -> Result<crate::entity::walk::Model> {
+    let dog_ids = dog_ids.to_vec();
+    db.transaction::<_, crate::entity::walk::Model, anyhow::Error>(|txn| {
+        Box::pin(async move {
+            let walk = crate::entity::walk::ActiveModel {
+                user_id: Set(user_id),
+                started_at: Set(chrono::Utc::now().into()),
+                ..Default::default()
+            }
+            .insert(txn)
+            .await?;
+
+            for dog_id in dog_ids.iter() {
+                let dog: Option<Uuid> = dog::Entity::find_by_id(*dog_id)
+                    .has_related(user_dog::Entity, user_dog::Column::UserId.eq(user_id))
+                    .select_only()
+                    .column(dog::Column::Id)
+                    .into_tuple()
+                    .one(txn)
+                    .await?;
+                if dog.is_none() {
+                    return Err(AppError::NotFound.into());
+                }
+                let active_model = crate::entity::walk_dog::ActiveModel {
+                    walk_id: Set(walk.id),
+                    dog_id: Set(*dog_id),
+                    ..Default::default()
+                };
+                active_model.insert(txn).await?;
+            }
+
+            Ok(walk)
+        })
+    })
+    .await
+    .map_err(|error| match error {
+        TransactionError::Connection(error) => error.into(),
+        TransactionError::Transaction(error) => error,
+    })
+}
+
 #[Object]
 impl WalkMutation {
     #[graphql(guard = "AuthGuard")]
     async fn start_walk(&self, ctx: &Context<'_>, input: StartWalkInput) -> Result<Walk> {
         let user = ctx.data::<user::Model>().unwrap();
         let db = ctx.data::<sea_orm::DatabaseConnection>().unwrap();
-        let txn = db.begin().await?;
-        let walk = crate::entity::walk::ActiveModel {
-            user_id: Set(user.id),
-            started_at: Set(chrono::Utc::now().into()),
-            ..Default::default()
-        }
-        .insert(db)
-        .await?;
-
-        for dog_id in input.dog_ids.iter() {
-            let dog: Option<dog::Model> = dog::Entity::find_by_id(*dog_id)
-                .has_related(user_dog::Entity, user_dog::Column::UserId.eq(user.id))
-                .one(db)
-                .await?;
-            if dog.is_none() {
-                return Err(AppError::NotFound.into());
-            }
-            let active_model = crate::entity::walk_dog::ActiveModel {
-                walk_id: Set(walk.id),
-                dog_id: Set(*dog_id),
-                ..Default::default()
-            };
-            active_model.insert(db).await?;
-        }
-        txn.commit().await?;
+        let walk = start_walk_for_user(db, user.id, &input.dog_ids).await?;
         Ok(Walk::from(walk))
     }
 
@@ -80,4 +102,87 @@ struct StartWalkInput {
 #[derive(Clone, Debug, InputObject)]
 struct EndWalkInput {
     id: Uuid,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use chrono::TimeZone;
+    use sea_orm::{DatabaseBackend, MockDatabase, Value};
+
+    use super::*;
+    use crate::entity::walk_dog;
+
+    fn fixed_time() -> sea_orm::prelude::DateTimeWithTimeZone {
+        chrono::Utc
+            .with_ymd_and_hms(2026, 5, 23, 9, 15, 11)
+            .single()
+            .unwrap()
+            .into()
+    }
+
+    fn walk_model(id: Uuid, user_id: Uuid) -> crate::entity::walk::Model {
+        crate::entity::walk::Model {
+            id,
+            user_id,
+            started_at: fixed_time(),
+            ended_at: None,
+            distance: None,
+            created_at: fixed_time(),
+            updated_at: fixed_time(),
+        }
+    }
+
+    fn walk_dog_model(id: Uuid, walk_id: Uuid, dog_id: Uuid) -> walk_dog::Model {
+        walk_dog::Model {
+            id,
+            walk_id,
+            dog_id,
+            created_at: fixed_time(),
+            updated_at: fixed_time(),
+        }
+    }
+
+    fn dog_id_row(id: Uuid) -> BTreeMap<&'static str, Value> {
+        BTreeMap::from([("id", id.into())])
+    }
+
+    #[tokio::test]
+    async fn start_walk_rolls_back_when_a_dog_is_not_owned_by_user() {
+        let user_id = Uuid::parse_str("019e0dc4-066b-7a22-b755-969ee6beb5e9").unwrap();
+        let walk_id = Uuid::parse_str("019e541d-f9ff-7e33-9db6-71b08c717a28").unwrap();
+        let stale_dog_id = Uuid::parse_str("019e0c14-2b36-73b3-8db2-01bbf64d0af9").unwrap();
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([[walk_model(walk_id, user_id)]])
+            .append_query_results([Vec::<dog::Model>::new()])
+            .into_connection();
+
+        let result = start_walk_for_user(&db, user_id, &[stale_dog_id]).await;
+
+        assert!(result.is_err());
+        let log = db.into_transaction_log();
+        assert_eq!(log.len(), 1);
+        assert!(log[0].statements().last().is_some_and(|statement| statement.sql == "ROLLBACK"));
+    }
+
+    #[tokio::test]
+    async fn start_walk_commits_walk_and_walk_dogs_for_owned_dogs() {
+        let user_id = Uuid::parse_str("019e0dc4-066b-7a22-b755-969ee6beb5e9").unwrap();
+        let walk_id = Uuid::parse_str("019e541d-f9ff-7e33-9db6-71b08c717a28").unwrap();
+        let dog_id = Uuid::parse_str("019e0dc4-d1d6-77e0-be4f-f688025006e6").unwrap();
+        let walk_dog_id = Uuid::parse_str("019e541e-81bb-7f16-bc34-d44a6d08fba1").unwrap();
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([[walk_model(walk_id, user_id)]])
+            .append_query_results([[dog_id_row(dog_id)]])
+            .append_query_results([[walk_dog_model(walk_dog_id, walk_id, dog_id)]])
+            .into_connection();
+
+        let walk = start_walk_for_user(&db, user_id, &[dog_id]).await.unwrap();
+
+        assert_eq!(walk.id, walk_id);
+        let log = db.into_transaction_log();
+        assert_eq!(log.len(), 1);
+        assert!(log[0].statements().last().is_some_and(|statement| statement.sql == "COMMIT"));
+    }
 }

--- a/apps/mobile/components/walk/WalkReadyView.test.tsx
+++ b/apps/mobile/components/walk/WalkReadyView.test.tsx
@@ -146,6 +146,19 @@ describe('WalkReadyView', () => {
     expect(btn.props.accessibilityState.disabled).toBe(true);
   });
 
+  it('drops selected dog ids that are not in the current user dog list', () => {
+    mockStore = buildStore(['dog-1', 'stale-dog']);
+    render(<WalkReadyView onStart={jest.fn()} isStarting={false} />);
+    expect(mockStore.setSelectedDogs).toHaveBeenCalledWith(['dog-1']);
+  });
+
+  it('disables START WALK when only stale dog ids are selected', () => {
+    mockStore = buildStore(['stale-dog']);
+    render(<WalkReadyView onStart={jest.fn()} isStarting={false} />);
+    const btn = screen.getByRole('button', { name: 'START WALK' });
+    expect(btn.props.accessibilityState.disabled).toBe(true);
+  });
+
   it('enables START WALK when at least one dog is selected and calls onStart', () => {
     mockStore = buildStore(['dog-1']);
     const onStart = jest.fn();

--- a/apps/mobile/components/walk/WalkReadyView.tsx
+++ b/apps/mobile/components/walk/WalkReadyView.tsx
@@ -20,6 +20,10 @@ interface WalkReadyViewProps {
   isStarting: boolean;
 }
 
+function sameIds(left: string[], right: string[]): boolean {
+  return left.length === right.length && left.every((id, index) => id === right[index]);
+}
+
 // 散歩開始前の画面です。犬の選択、統計、開始ボタンをマップ上の下部カードにまとめます。
 export function WalkReadyView({ onStart, isStarting }: WalkReadyViewProps) {
   const { t } = useTranslation();
@@ -31,16 +35,28 @@ export function WalkReadyView({ onStart, isStarting }: WalkReadyViewProps) {
   const setSelectedDogs = useWalkStore((s) => s.setSelectedDogs);
 
   const isSingleDog = dogs.length === 1;
+  const dogIds = useMemo(() => dogs.map((dog) => dog.id), [dogs]);
+  const validSelectedDogIds = useMemo(
+    () => selectedDogIds.filter((id) => dogIds.includes(id)),
+    [dogIds, selectedDogIds],
+  );
+  const selectedDogs = useMemo(
+    () => dogs.filter((dog) => validSelectedDogIds.includes(dog.id)),
+    [dogs, validSelectedDogIds],
+  );
 
-  // 犬が 1 匹だけのときは選択 UI を出さないため、開始できるよう選択状態を同期します。
+  // 認証切替や犬削除後に残った stale ID を落とし、単頭では開始できるよう自動選択します。
   useEffect(() => {
-    if (isSingleDog && selectedDogIds.length === 0) {
-      setSelectedDogs([dogs[0].id]);
+    const nextSelectedDogIds =
+      isSingleDog && validSelectedDogIds.length === 0 ? [dogs[0].id] : validSelectedDogIds;
+
+    if (!sameIds(selectedDogIds, nextSelectedDogIds)) {
+      setSelectedDogs(nextSelectedDogIds);
     }
-  }, [isSingleDog, dogs, selectedDogIds.length, setSelectedDogs]);
+  }, [dogs, isSingleDog, selectedDogIds, setSelectedDogs, validSelectedDogIds]);
 
   const allSelected =
-    dogs.length > 0 && dogs.every((d) => selectedDogIds.includes(d.id));
+    dogs.length > 0 && dogs.every((d) => validSelectedDogIds.includes(d.id));
 
   // 複数犬の選択をまとめて切り替え、全選択済みなら解除にします。
   const handleSelectAll = useCallback(() => {
@@ -51,11 +67,10 @@ export function WalkReadyView({ onStart, isStarting }: WalkReadyViewProps) {
     }
   }, [allSelected, dogs, setSelectedDogs]);
 
-  const canStart = selectedDogIds.length > 0 && !isStarting;
+  const canStart = selectedDogs.length > 0 && !isStarting;
   const selectAllLabel = allSelected
     ? t('walk.ready.deselectAll')
     : t('walk.ready.selectAll');
-  const selectedDogs = dogs.filter((dog) => selectedDogIds.includes(dog.id));
 
   return (
     <View style={styles.container}>
@@ -79,7 +94,7 @@ export function WalkReadyView({ onStart, isStarting }: WalkReadyViewProps) {
               <View style={styles.bodyColumn}>
                 <DogPickerCard
                   dogs={[dogs[0]]}
-                  selectedIds={selectedDogIds}
+                  selectedIds={validSelectedDogIds}
                   onToggle={() => undefined}
                   variant="single"
                 />
@@ -105,7 +120,7 @@ export function WalkReadyView({ onStart, isStarting }: WalkReadyViewProps) {
                 </View>
                 <DogPickerCard
                   dogs={dogs}
-                  selectedIds={selectedDogIds}
+                  selectedIds={validSelectedDogIds}
                   onToggle={selectDog}
                   variant="multi"
                 />

--- a/apps/mobile/lib/providers.tsx
+++ b/apps/mobile/lib/providers.tsx
@@ -1,42 +1,10 @@
-import { MutationCache, QueryCache, QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { PropsWithChildren } from 'react';
-import { ClientError } from '@/lib/graphql/client-error';
+import { queryClient, setUnauthorizedHandler } from '@/lib/query-client';
 import { useAuthStore } from '@/stores/auth-store';
 
-function isUnauthorized(error: unknown): boolean {
-  return error instanceof ClientError && error.response.status === 401;
-}
-
-const queryCache = new QueryCache({
-  onError: (error) => {
-    if (isUnauthorized(error)) {
-      useAuthStore.getState().clearAuth();
-    }
-  },
-});
-
-const mutationCache = new MutationCache({
-  onError: (error) => {
-    if (isUnauthorized(error)) {
-      useAuthStore.getState().clearAuth();
-    }
-  },
-});
-
-const queryClient = new QueryClient({
-  queryCache,
-  mutationCache,
-  defaultOptions: {
-    queries: {
-      staleTime: 5 * 60 * 1000,
-      retry: (failureCount, error) => {
-        if (isUnauthorized(error)) {
-          return false;
-        }
-        return failureCount < 2;
-      },
-    },
-  },
+setUnauthorizedHandler(() => {
+  useAuthStore.getState().clearAuth();
 });
 
 export function AppProviders({ children }: PropsWithChildren) {

--- a/apps/mobile/lib/query-client.ts
+++ b/apps/mobile/lib/query-client.ts
@@ -1,0 +1,44 @@
+import { MutationCache, QueryCache, QueryClient } from '@tanstack/react-query';
+import { ClientError } from '@/lib/graphql/client-error';
+
+let onUnauthorized: (() => void) | null = null;
+
+function isUnauthorized(error: unknown): boolean {
+  return error instanceof ClientError && error.response.status === 401;
+}
+
+export function setUnauthorizedHandler(handler: () => void): void {
+  onUnauthorized = handler;
+}
+
+const queryCache = new QueryCache({
+  onError: (error) => {
+    if (isUnauthorized(error)) {
+      onUnauthorized?.();
+    }
+  },
+});
+
+const mutationCache = new MutationCache({
+  onError: (error) => {
+    if (isUnauthorized(error)) {
+      onUnauthorized?.();
+    }
+  },
+});
+
+export const queryClient = new QueryClient({
+  queryCache,
+  mutationCache,
+  defaultOptions: {
+    queries: {
+      staleTime: 5 * 60 * 1000,
+      retry: (failureCount, error) => {
+        if (isUnauthorized(error)) {
+          return false;
+        }
+        return failureCount < 2;
+      },
+    },
+  },
+});

--- a/apps/mobile/stores/auth-store.test.ts
+++ b/apps/mobile/stores/auth-store.test.ts
@@ -9,6 +9,16 @@ jest.mock('@/lib/auth/secure-storage');
 jest.mock('@/lib/graphql/client', () => ({
   setAuthToken: jest.fn(),
 }));
+jest.mock('@/lib/query-client', () => ({
+  queryClient: {
+    clear: jest.fn(),
+  },
+}));
+jest.mock('@/stores/walk-store', () => ({
+  useWalkStore: {
+    getState: jest.fn(),
+  },
+}));
 jest.mock('@/lib/auth/api', () => ({
   refreshToken: jest.fn(),
 }));
@@ -18,17 +28,24 @@ jest.mock('@/lib/auth/bootstrap', () => ({
 
 const { useAuthStore } = require('./auth-store') as typeof AuthStoreModule;
 const { setAuthToken } = require('@/lib/graphql/client') as typeof GraphQLClientModule;
+const { queryClient } = require('@/lib/query-client') as typeof import('@/lib/query-client');
+const { useWalkStore } = require('@/stores/walk-store') as typeof import('@/stores/walk-store');
 const authApi = require('@/lib/auth/api') as typeof AuthApiModule;
 const authBootstrap = require('@/lib/auth/bootstrap') as typeof AuthBootstrapModule;
 
 const mockSecureStorage = secureStorage as jest.Mocked<typeof secureStorage>;
 const mockSetAuthToken = setAuthToken as jest.Mock;
+const mockQueryClient = queryClient as unknown as { clear: jest.Mock };
+const mockWalkStore = useWalkStore as unknown as { getState: jest.Mock };
 const mockAuthApi = authApi as jest.Mocked<typeof authApi>;
 const mockBootstrap = authBootstrap as jest.Mocked<typeof authBootstrap>;
 
 describe('auth-store', () => {
+  const mockResetWalkStore = jest.fn();
+
   beforeEach(() => {
     jest.clearAllMocks();
+    mockWalkStore.getState.mockReturnValue({ reset: mockResetWalkStore });
     useAuthStore.setState({
       accessToken: null,
       isAuthenticated: false,
@@ -86,6 +103,8 @@ describe('auth-store', () => {
       accessToken: 'access-token',
       isAuthenticated: true,
     });
+    expect(mockQueryClient.clear).toHaveBeenCalledTimes(1);
+    expect(mockResetWalkStore).toHaveBeenCalledTimes(1);
   });
 
   it('clearAuth removes tokens and resets state', async () => {
@@ -98,6 +117,8 @@ describe('auth-store', () => {
       isAuthenticated: false,
       networkError: false,
     });
+    expect(mockQueryClient.clear).toHaveBeenCalledTimes(1);
+    expect(mockResetWalkStore).toHaveBeenCalledTimes(1);
   });
 
   describe('refreshAuth', () => {

--- a/apps/mobile/stores/auth-store.ts
+++ b/apps/mobile/stores/auth-store.ts
@@ -8,12 +8,15 @@ import { refreshToken } from '@/lib/auth/api';
 import { setAuthToken } from '@/lib/graphql/client';
 import { isNetworkError } from '@/lib/graphql/errors';
 import { bootstrapAuth } from '@/lib/auth/bootstrap';
+import { queryClient } from '@/lib/query-client';
+import { useWalkStore } from '@/stores/walk-store';
 
 interface AuthState {
   accessToken: string | null;
   isAuthenticated: boolean;
   isLoading: boolean;
   networkError: boolean;
+  resetSessionState: () => void;
   initialize: () => Promise<void>;
   setAuth: (accessToken: string, refreshToken: string) => Promise<void>;
   clearAuth: () => Promise<void>;
@@ -25,6 +28,11 @@ export const useAuthStore = create<AuthState>((set, get) => ({
   isAuthenticated: false,
   isLoading: true,
   networkError: false,
+
+  resetSessionState: () => {
+    queryClient.clear();
+    useWalkStore.getState().reset();
+  },
 
   initialize: async () => {
     set({ isLoading: true, networkError: false });
@@ -45,12 +53,14 @@ export const useAuthStore = create<AuthState>((set, get) => ({
   },
 
   setAuth: async (accessToken, refreshToken) => {
+    get().resetSessionState();
     await setToken(accessToken, refreshToken);
     setAuthToken(accessToken);
     set({ accessToken, isAuthenticated: true });
   },
 
   clearAuth: async () => {
+    get().resetSessionState();
     await deleteToken();
     setAuthToken(null);
     set({ accessToken: null, isAuthenticated: false, networkError: false });


### PR DESCRIPTION
## Summary
- Filter stale selected dog IDs against the current user's dog list before enabling START WALK.
- Clear React Query user data and walk session state across auth boundaries.
- Run API startWalk creation and dog association writes inside a single transaction so failed ownership checks roll back cleanly.

## Root Cause
START WALK could send dog IDs left over from a previous user/session. The API correctly rejected dogs not linked to the authenticated user, but the mutation also inserted the walk outside the transaction, leaving orphan walk rows when ownership validation failed.

## Test Plan
- `npm test -- WalkReadyView.test.tsx --runInBand`
- `npm test -- auth-store.test.ts --runInBand`
- `npm run typecheck`
- `docker compose -f apps/compose.yml run --rm --no-deps api cargo test --lib`
- `npm test -- --runInBand --forceExit`