### PR TITLE
Add refresh token support

### DIFF
--- a/apps/api/schema.graphql
+++ b/apps/api/schema.graphql
@@ -33,9 +33,25 @@ input BirthdayInput {
 	day: Int
 }
 
+input ChangeEmailInput {
+	newEmail: String!
+}
+
+type ChangeEmailOutput {
+	success: Boolean!
+}
+
 input ChangePasswordInput {
 	oldPassword: String!
 	newPassword: String!
+}
+
+input ConfirmEmailChangeInput {
+	code: String!
+}
+
+type ConfirmEmailChangeOutput {
+	success: Boolean!
 }
 
 input ConfirmSignUpInput {
@@ -73,7 +89,23 @@ type Dog {
 	基準日は UTC の今日。
 	"""
 	age: Int
+	walkGoal: DogWalkGoal
 	walks(after: String, before: String, first: Int, last: Int): WalkConnection!
+}
+
+type DogWalkGoal {
+	id: UUID!
+	dogId: UUID!
+	walkAmount: WalkAmount!
+	effectiveFrom: NaiveDate!
+	effectiveTo: NaiveDate
+	createdAt: DateTime!
+	updatedAt: DateTime!
+}
+
+input EditGoalInput {
+	dogId: UUID!
+	walkAmount: WalkAmountInput!
 }
 
 input EndWalkInput {
@@ -101,11 +133,16 @@ type Mutation {
 	signUp(input: SignUpInput!): SignUpOutput!
 	confirmSignUp(input: ConfirmSignUpInput!): ConfirmSignUpOutput!
 	signIn(input: SignInInput!): SignInOutput!
+	refreshToken(input: RefreshTokenInput!): SignInOutput!
 	signOut: SignOutOutput!
+	changeEmail(input: ChangeEmailInput!): ChangeEmailOutput!
+	confirmEmailChange(input: ConfirmEmailChangeInput!): ConfirmEmailChangeOutput!
 	changePassword(input: ChangePasswordInput!): SignOutOutput!
 	addDog(input: AddDogInput!): Dog!
 	updateDog(input: UpdateDogInput!): Dog!
 	removeDog(input: RemoveDogInput!): Dog!
+	setGoal(input: SetGoalInput!): DogWalkGoal!
+	editGoal(input: EditGoalInput!): DogWalkGoal!
 	trackPoint(input: TrackPointInput!): TrackPointReceipt!
 	updateUser(input: UpdateUserInput!): User!
 	startWalk(input: StartWalkInput!): Walk!
@@ -113,6 +150,17 @@ type Mutation {
 	addEvent(input: AddEventInput!): WalkDogEvent!
 	takePhoto(input: TakePhotoInput!): WalkPhoto!
 }
+
+"""
+ISO 8601 calendar date without timezone.
+Format: %Y-%m-%d
+
+# Examples
+
+* `1994-11-13`
+* `2000-02-24`
+"""
+scalar NaiveDate
 
 """
 Information about pagination in a connection
@@ -137,13 +185,24 @@ type PageInfo {
 }
 
 type Query {
+	dog(id: UUID!): Dog!
 	dogs: [Dog!]!
 	user: User!
 	walk(id: UUID!): Walk!
 }
 
+input RefreshTokenInput {
+	refreshToken: String!
+}
+
 input RemoveDogInput {
 	id: UUID!
+}
+
+input SetGoalInput {
+	dogId: UUID!
+	walkAmount: WalkAmountInput!
+	effectiveFrom: NaiveDate!
 }
 
 input SignInInput {
@@ -262,6 +321,16 @@ type Walk {
 	dogs: [Dog!]!
 	photos: [WalkPhoto!]!
 	trackPoints: [TrackPoint!]!
+}
+
+type WalkAmount {
+	minutes: Int!
+	cycleDays: Int!
+}
+
+input WalkAmountInput {
+	minutes: Int!
+	cycleDays: Int!
 }
 
 type WalkConnection {

--- a/apps/api/src/graphql/error.rs
+++ b/apps/api/src/graphql/error.rs
@@ -57,6 +57,8 @@ pub enum AuthError {
     ConfirmSignUpError(ConfirmSignUpError),
     #[error("Sign in error: {0}")]
     SignInError(InitiateAuthError),
+    #[error("Refresh token error: {0}")]
+    RefreshTokenError(InitiateAuthError),
     #[error("Sign out error: {0}")]
     SignOutError(GlobalSignOutError),
     #[error("Update user attributes error: {0}")]
@@ -65,6 +67,16 @@ pub enum AuthError {
     VerifyUserAttributeError(VerifyUserAttributeError),
     #[error("Change password error: {0}")]
     ChangePasswordError(ChangePasswordError),
+}
+
+fn refresh_token_error_status_code(error: &InitiateAuthError) -> i32 {
+    match error.code() {
+        Some(
+            "InternalErrorException" | "TooManyRequestsException" | "UnexpectedLambdaException",
+        )
+        | None => 503,
+        _ => 422,
+    }
 }
 
 impl ErrorExtensions for AuthError {
@@ -84,6 +96,11 @@ impl ErrorExtensions for AuthError {
                 error!("Sign in error: {:?}", sign_in_error);
                 e.set("code", 422);
                 e.set("message", sign_in_error.message());
+            }
+            AuthError::RefreshTokenError(refresh_token_error) => {
+                error!("Refresh token error: {:?}", refresh_token_error);
+                e.set("code", refresh_token_error_status_code(refresh_token_error));
+                e.set("message", refresh_token_error.message());
             }
             AuthError::SignOutError(sign_out_error) => {
                 error!("Sign out error: {:?}", sign_out_error);

--- a/apps/api/src/graphql/error.rs
+++ b/apps/api/src/graphql/error.rs
@@ -1,6 +1,7 @@
 use async_graphql::{Error, ErrorExtensions};
 use aws_sdk_cognitoidentityprovider::operation::{
     change_password::ChangePasswordError, confirm_sign_up::ConfirmSignUpError,
+    get_tokens_from_refresh_token::GetTokensFromRefreshTokenError,
     global_sign_out::GlobalSignOutError, initiate_auth::InitiateAuthError, sign_up::SignUpError,
     update_user_attributes::UpdateUserAttributesError,
     verify_user_attribute::VerifyUserAttributeError,
@@ -58,7 +59,7 @@ pub enum AuthError {
     #[error("Sign in error: {0}")]
     SignInError(InitiateAuthError),
     #[error("Refresh token error: {0}")]
-    RefreshTokenError(InitiateAuthError),
+    RefreshTokenError(GetTokensFromRefreshTokenError),
     #[error("Sign out error: {0}")]
     SignOutError(GlobalSignOutError),
     #[error("Update user attributes error: {0}")]
@@ -67,16 +68,6 @@ pub enum AuthError {
     VerifyUserAttributeError(VerifyUserAttributeError),
     #[error("Change password error: {0}")]
     ChangePasswordError(ChangePasswordError),
-}
-
-fn refresh_token_error_status_code(error: &InitiateAuthError) -> i32 {
-    match error.code() {
-        Some(
-            "InternalErrorException" | "TooManyRequestsException" | "UnexpectedLambdaException",
-        )
-        | None => 503,
-        _ => 422,
-    }
 }
 
 impl ErrorExtensions for AuthError {
@@ -99,7 +90,7 @@ impl ErrorExtensions for AuthError {
             }
             AuthError::RefreshTokenError(refresh_token_error) => {
                 error!("Refresh token error: {:?}", refresh_token_error);
-                e.set("code", refresh_token_error_status_code(refresh_token_error));
+                e.set("code", 401);
                 e.set("message", refresh_token_error.message());
             }
             AuthError::SignOutError(sign_out_error) => {

--- a/apps/api/src/graphql/mutation/auth.rs
+++ b/apps/api/src/graphql/mutation/auth.rs
@@ -70,6 +70,29 @@ impl AuthMutation {
         Ok(output.into())
     }
 
+    async fn refresh_token(
+        &self,
+        ctx: &Context<'_>,
+        input: RefreshTokenInput,
+    ) -> Result<SignInOutput> {
+        let cognitoidentityprovider_client = ctx
+            .data::<aws_sdk_cognitoidentityprovider::Client>()
+            .unwrap();
+        let refresh_token = input.refresh_token;
+        let output = cognitoidentityprovider_client
+            .initiate_auth()
+            .client_id(std::env::var("AWS_COGNITO_CLIENT_ID").unwrap())
+            .auth_flow(aws_sdk_cognitoidentityprovider::types::AuthFlowType::RefreshTokenAuth)
+            .auth_parameters("REFRESH_TOKEN", refresh_token.clone())
+            .send()
+            .await
+            .map_err(|e| AuthError::RefreshTokenError(e.into_service_error()))?;
+        Ok(SignInOutput::from_refresh_token_auth_output(
+            output,
+            refresh_token,
+        ))
+    }
+
     #[graphql(guard = "AuthGuard")]
     async fn sign_out(&self, ctx: &Context<'_>) -> Result<SignOutOutput> {
         let cognitoidentityprovider_client = ctx
@@ -193,6 +216,11 @@ pub struct SignInInput {
     password: String,
 }
 
+#[derive(Clone, Debug, InputObject)]
+pub struct RefreshTokenInput {
+    refresh_token: String,
+}
+
 #[derive(SimpleObject)]
 pub struct SignInOutput {
     access_token: String,
@@ -227,10 +255,26 @@ pub struct ChangePasswordInput {
 
 impl From<InitiateAuthOutput> for SignInOutput {
     fn from(output: InitiateAuthOutput) -> Self {
+        SignInOutput::from_auth_output(output, None)
+    }
+}
+
+impl SignInOutput {
+    fn from_refresh_token_auth_output(output: InitiateAuthOutput, refresh_token: String) -> Self {
+        SignInOutput::from_auth_output(output, Some(refresh_token))
+    }
+
+    fn from_auth_output(
+        output: InitiateAuthOutput,
+        fallback_refresh_token: Option<String>,
+    ) -> Self {
         let result = output.authentication_result.unwrap();
         SignInOutput {
             access_token: result.access_token.unwrap_or_default(),
-            refresh_token: result.refresh_token.unwrap_or_default(),
+            refresh_token: result
+                .refresh_token
+                .or(fallback_refresh_token)
+                .unwrap_or_default(),
         }
     }
 }

--- a/apps/api/src/graphql/mutation/auth.rs
+++ b/apps/api/src/graphql/mutation/auth.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use async_graphql::{Context, InputObject, Object, SimpleObject};
+use aws_sdk_cognitoidentityprovider::operation::get_tokens_from_refresh_token::GetTokensFromRefreshTokenOutput;
 use aws_sdk_cognitoidentityprovider::operation::initiate_auth::InitiateAuthOutput;
 use aws_sdk_cognitoidentityprovider::types::AttributeType;
 use axum_extra::headers::authorization;
@@ -74,23 +75,19 @@ impl AuthMutation {
         &self,
         ctx: &Context<'_>,
         input: RefreshTokenInput,
-    ) -> Result<SignInOutput> {
+    ) -> Result<RefreshTokenOutput> {
         let cognitoidentityprovider_client = ctx
             .data::<aws_sdk_cognitoidentityprovider::Client>()
             .unwrap();
-        let refresh_token = input.refresh_token;
+        // let output = cognitoidentityprovi))
         let output = cognitoidentityprovider_client
-            .initiate_auth()
+            .get_tokens_from_refresh_token()
             .client_id(std::env::var("AWS_COGNITO_CLIENT_ID").unwrap())
-            .auth_flow(aws_sdk_cognitoidentityprovider::types::AuthFlowType::RefreshTokenAuth)
-            .auth_parameters("REFRESH_TOKEN", refresh_token.clone())
+            .refresh_token(input.refresh_token)
             .send()
             .await
             .map_err(|e| AuthError::RefreshTokenError(e.into_service_error()))?;
-        Ok(SignInOutput::from_refresh_token_auth_output(
-            output,
-            refresh_token,
-        ))
+        Ok(RefreshTokenOutput::from(output))
     }
 
     #[graphql(guard = "AuthGuard")]
@@ -216,15 +213,55 @@ pub struct SignInInput {
     password: String,
 }
 
+#[derive(SimpleObject)]
+pub struct SignInOutput {
+    access_token: String,
+    refresh_token: String,
+}
+
+impl From<InitiateAuthOutput> for SignInOutput {
+    fn from(output: InitiateAuthOutput) -> Self {
+        SignInOutput {
+            access_token: output
+                .authentication_result
+                .as_ref()
+                .and_then(|result| result.access_token.clone())
+                .unwrap_or_default(),
+            refresh_token: output
+                .authentication_result
+                .as_ref()
+                .and_then(|result| result.refresh_token.clone())
+                .unwrap_or_default(),
+        }
+    }
+}
+
 #[derive(Clone, Debug, InputObject)]
 pub struct RefreshTokenInput {
     refresh_token: String,
 }
 
 #[derive(SimpleObject)]
-pub struct SignInOutput {
+pub struct RefreshTokenOutput {
     access_token: String,
     refresh_token: String,
+}
+
+impl From<GetTokensFromRefreshTokenOutput> for RefreshTokenOutput {
+    fn from(output: GetTokensFromRefreshTokenOutput) -> Self {
+        RefreshTokenOutput {
+            access_token: output
+                .authentication_result
+                .as_ref()
+                .and_then(|result| result.access_token.clone())
+                .unwrap_or_default(),
+            refresh_token: output
+                .authentication_result
+                .as_ref()
+                .and_then(|result| result.refresh_token.clone())
+                .unwrap_or_default(),
+        }
+    }
 }
 
 #[derive(Clone, Debug, InputObject)]
@@ -253,28 +290,22 @@ pub struct ChangePasswordInput {
     new_password: String,
 }
 
-impl From<InitiateAuthOutput> for SignInOutput {
-    fn from(output: InitiateAuthOutput) -> Self {
-        SignInOutput::from_auth_output(output, None)
-    }
-}
+// impl SignInOutput {
+//     fn from_refresh_token_auth_output(output: InitiateAuthOutput, refresh_token: String) -> Self {
+//         SignInOutput::from_auth_output(output, Some(refresh_token))
+//     }
 
-impl SignInOutput {
-    fn from_refresh_token_auth_output(output: InitiateAuthOutput, refresh_token: String) -> Self {
-        SignInOutput::from_auth_output(output, Some(refresh_token))
-    }
-
-    fn from_auth_output(
-        output: InitiateAuthOutput,
-        fallback_refresh_token: Option<String>,
-    ) -> Self {
-        let result = output.authentication_result.unwrap();
-        SignInOutput {
-            access_token: result.access_token.unwrap_or_default(),
-            refresh_token: result
-                .refresh_token
-                .or(fallback_refresh_token)
-                .unwrap_or_default(),
-        }
-    }
-}
+//     fn from_auth_output(
+//         output: InitiateAuthOutput,
+//         fallback_refresh_token: Option<String>,
+//     ) -> Self {
+//         let result = output.authentication_result.unwrap();
+//         SignInOutput {
+//             access_token: result.access_token.unwrap_or_default(),
+//             refresh_token: result
+//                 .refresh_token
+//                 .or(fallback_refresh_token)
+//                 .unwrap_or_default(),
+//         }
+//     }
+// }

--- a/apps/mobile/lib/auth/api.test.ts
+++ b/apps/mobile/lib/auth/api.test.ts
@@ -1,7 +1,7 @@
 import { GraphQLError } from 'graphql';
 import { graphqlClient } from '../graphql/client';
 import { ClientError } from '../graphql/client-error';
-import { confirmSignUp, signIn, signUp } from './api';
+import { confirmSignUp, refreshToken, signIn, signUp } from './api';
 
 jest.mock('../graphql/client', () => ({
   graphqlClient: {
@@ -75,5 +75,38 @@ describe('auth api', () => {
       kind: 'code-mismatch',
       reason: 'expired',
     });
+  });
+
+  it('refreshToken returns refreshed tokens on success', async () => {
+    mockRequest.mockResolvedValue({
+      refreshToken: { accessToken: 'new-access-token', refreshToken: 'old-refresh-token' },
+    });
+
+    await expect(refreshToken('old-refresh-token')).resolves.toEqual({
+      accessToken: 'new-access-token',
+      refreshToken: 'old-refresh-token',
+    });
+    expect(mockRequest).toHaveBeenCalledWith(
+      expect.any(String),
+      {
+        input: { refreshToken: 'old-refresh-token' },
+      },
+      { includeAuth: false },
+    );
+  });
+
+  it('refreshToken maps backend auth failures to invalid-credentials', async () => {
+    mockRequest.mockRejectedValue(makeClientError('NotAuthorizedException'));
+
+    await expect(refreshToken('expired-refresh-token')).rejects.toMatchObject({
+      kind: 'invalid-credentials',
+    });
+  });
+
+  it('refreshToken preserves network failures so auth refresh can retry them', async () => {
+    const networkError = new TypeError('Failed to fetch');
+    mockRequest.mockRejectedValue(networkError);
+
+    await expect(refreshToken('old-refresh-token')).rejects.toBe(networkError);
   });
 });

--- a/apps/mobile/lib/auth/api.test.ts
+++ b/apps/mobile/lib/auth/api.test.ts
@@ -91,7 +91,6 @@ describe('auth api', () => {
       {
         input: { refreshToken: 'old-refresh-token' },
       },
-      { includeAuth: false },
     );
   });
 

--- a/apps/mobile/lib/auth/api.ts
+++ b/apps/mobile/lib/auth/api.ts
@@ -3,6 +3,7 @@ import {
   SIGN_UP_MUTATION,
   CONFIRM_SIGN_UP_MUTATION,
   SIGN_IN_MUTATION,
+  REFRESH_TOKEN_MUTATION,
 } from '../graphql/mutations/auth';
 import { toAuthError } from './errors';
 
@@ -28,11 +29,27 @@ interface SignInResponse {
   signIn: SignInResult;
 }
 
+interface RefreshTokenResponse {
+  refreshToken: SignInResult;
+}
+
 async function mapAuthRequestError<T>(request: () => Promise<T>): Promise<T> {
   try {
     return await request();
   } catch (error) {
     throw toAuthError(error);
+  }
+}
+
+async function mapRefreshTokenRequestError<T>(request: () => Promise<T>): Promise<T> {
+  try {
+    return await request();
+  } catch (error) {
+    const authError = toAuthError(error);
+    if (authError.kind === 'network') {
+      throw error;
+    }
+    throw authError;
   }
 }
 
@@ -71,6 +88,15 @@ export async function signOut(_accessToken: string): Promise<boolean> {
   return true;
 }
 
-export async function refreshToken(_refreshTokenValue: string): Promise<SignInResult> {
-  throw new Error('Refresh token is not supported by the current GraphQL schema.');
+export async function refreshToken(refreshTokenValue: string): Promise<SignInResult> {
+  const data = await mapRefreshTokenRequestError(() =>
+    graphqlClient.request<RefreshTokenResponse>(
+      REFRESH_TOKEN_MUTATION,
+      {
+        input: { refreshToken: refreshTokenValue },
+      },
+      { includeAuth: false },
+    )
+  );
+  return data.refreshToken;
 }

--- a/apps/mobile/lib/auth/api.ts
+++ b/apps/mobile/lib/auth/api.ts
@@ -17,6 +17,11 @@ export interface SignInResult {
   refreshToken: string;
 }
 
+export interface RefreshTokenResult {
+  accessToken: string;
+  refreshToken: string;
+}
+
 interface SignUpResponse {
   signUp: SignUpResult;
 }
@@ -30,7 +35,7 @@ interface SignInResponse {
 }
 
 interface RefreshTokenResponse {
-  refreshToken: SignInResult;
+  refreshToken: RefreshTokenResult;
 }
 
 async function mapAuthRequestError<T>(request: () => Promise<T>): Promise<T> {
@@ -88,14 +93,13 @@ export async function signOut(_accessToken: string): Promise<boolean> {
   return true;
 }
 
-export async function refreshToken(refreshTokenValue: string): Promise<SignInResult> {
+export async function refreshToken(refreshTokenValue: string): Promise<RefreshTokenResult> {
   const data = await mapRefreshTokenRequestError(() =>
     graphqlClient.request<RefreshTokenResponse>(
       REFRESH_TOKEN_MUTATION,
       {
         input: { refreshToken: refreshTokenValue },
       },
-      { includeAuth: false },
     )
   );
   return data.refreshToken;

--- a/apps/mobile/lib/graphql/client.test.ts
+++ b/apps/mobile/lib/graphql/client.test.ts
@@ -70,19 +70,6 @@ describe('graphql client auth header', () => {
     );
   });
 
-  it('omits the Authorization header when auth is disabled for a request', async () => {
-    setAuthToken('expired-access-token');
-
-    await graphqlClient.request(query, undefined, { includeAuth: false });
-
-    expect(mockFetch).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.objectContaining({
-        headers: { 'Content-Type': 'application/json' },
-      }),
-    );
-  });
-
   it('sends variables with the GraphQL request body', async () => {
     await graphqlClient.request(query, { id: 'user-id' });
 

--- a/apps/mobile/lib/graphql/client.test.ts
+++ b/apps/mobile/lib/graphql/client.test.ts
@@ -70,6 +70,19 @@ describe('graphql client auth header', () => {
     );
   });
 
+  it('omits the Authorization header when auth is disabled for a request', async () => {
+    setAuthToken('expired-access-token');
+
+    await graphqlClient.request(query, undefined, { includeAuth: false });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+  });
+
   it('sends variables with the GraphQL request body', async () => {
     await graphqlClient.request(query, { id: 'user-id' });
 

--- a/apps/mobile/lib/graphql/client.ts
+++ b/apps/mobile/lib/graphql/client.ts
@@ -7,9 +7,6 @@ import {
 import { logReproducibleRequest } from './request-log';
 
 export type Variables = Record<string, unknown>;
-export type RequestOptions = {
-  includeAuth?: boolean;
-};
 export type UploadFile = {
   uri: string;
   name: string;
@@ -261,7 +258,6 @@ export const graphqlClient = {
   async request<T>(
     document: string,
     variables?: Variables,
-    options: RequestOptions = {},
   ): Promise<T> {
     const op = parseOperation(document);
     const startedAt = Date.now();
@@ -277,10 +273,9 @@ export const graphqlClient = {
       operationName: op.name,
     });
 
-    const includeAuth = options.includeAuth ?? true;
     const headers: HeadersInit = {
       'Content-Type': 'application/json',
-      ...(includeAuth && authToken ? { Authorization: `Bearer ${authToken}` } : {}),
+      ...(authToken ? { Authorization: `Bearer ${authToken}` } : {}),
     };
 
     let response: Response;

--- a/apps/mobile/lib/graphql/client.ts
+++ b/apps/mobile/lib/graphql/client.ts
@@ -7,6 +7,9 @@ import {
 import { logReproducibleRequest } from './request-log';
 
 export type Variables = Record<string, unknown>;
+export type RequestOptions = {
+  includeAuth?: boolean;
+};
 export type UploadFile = {
   uri: string;
   name: string;
@@ -255,7 +258,11 @@ export async function authenticatedMultipartRequest<T>(
 }
 
 export const graphqlClient = {
-  async request<T>(document: string, variables?: Variables): Promise<T> {
+  async request<T>(
+    document: string,
+    variables?: Variables,
+    options: RequestOptions = {},
+  ): Promise<T> {
     const op = parseOperation(document);
     const startedAt = Date.now();
     console.log(
@@ -270,9 +277,10 @@ export const graphqlClient = {
       operationName: op.name,
     });
 
+    const includeAuth = options.includeAuth ?? true;
     const headers: HeadersInit = {
       'Content-Type': 'application/json',
-      ...(authToken ? { Authorization: `Bearer ${authToken}` } : {}),
+      ...(includeAuth && authToken ? { Authorization: `Bearer ${authToken}` } : {}),
     };
 
     let response: Response;

--- a/apps/mobile/lib/graphql/errors.test.ts
+++ b/apps/mobile/lib/graphql/errors.test.ts
@@ -1,6 +1,10 @@
 import { GraphQLError } from 'graphql';
 import { ClientError } from './client-error';
-import { isNetworkError, extractGraphQLErrorMessage } from './errors';
+import {
+  isNetworkError,
+  extractGraphQLErrorMessage,
+  isUnauthorizedError,
+} from './errors';
 
 function makeClientError(status: number): ClientError {
   return new ClientError(
@@ -16,6 +20,18 @@ function makeClientErrorWithMessage(message: string): ClientError {
   );
 }
 
+function makeClientErrorWithExtensionCode(code: string | number): ClientError {
+  return new ClientError(
+    {
+      status: 200,
+      headers: new Headers(),
+      errors: [new GraphQLError('Access denied', { extensions: { code } })],
+      body: '',
+    },
+    { query: '' },
+  );
+}
+
 describe('isNetworkError', () => {
   it('returns true for TypeError (DNS/connection failure)', () => {
     expect(isNetworkError(new TypeError('Failed to fetch'))).toBe(true);
@@ -27,6 +43,10 @@ describe('isNetworkError', () => {
 
   it('returns true for ClientError with 503 status', () => {
     expect(isNetworkError(makeClientError(503))).toBe(true);
+  });
+
+  it('returns true for GraphQL errors with 5xx extension code', () => {
+    expect(isNetworkError(makeClientErrorWithExtensionCode(503))).toBe(true);
   });
 
   it('returns false for ClientError with 401 status', () => {
@@ -68,5 +88,30 @@ describe('extractGraphQLErrorMessage', () => {
     expect(extractGraphQLErrorMessage('string')).toBeNull();
     expect(extractGraphQLErrorMessage(null)).toBeNull();
     expect(extractGraphQLErrorMessage(undefined)).toBeNull();
+  });
+});
+
+describe('isUnauthorizedError', () => {
+  it('returns true for ClientError with HTTP 401 status', () => {
+    expect(isUnauthorizedError(makeClientError(401))).toBe(true);
+  });
+
+  it('returns true for GraphQL Unauthorized errors in HTTP 200 responses', () => {
+    expect(isUnauthorizedError(makeClientErrorWithMessage('Unauthorized'))).toBe(true);
+  });
+
+  it('returns true for GraphQL errors with numeric 401 extension code', () => {
+    expect(isUnauthorizedError(makeClientErrorWithExtensionCode(401))).toBe(true);
+  });
+
+  it('returns true for GraphQL errors with string 401 extension code', () => {
+    expect(isUnauthorizedError(makeClientErrorWithExtensionCode('401'))).toBe(true);
+  });
+
+  it('returns false for unrelated client and network errors', () => {
+    expect(isUnauthorizedError(makeClientError(400))).toBe(false);
+    expect(isUnauthorizedError(makeClientError(500))).toBe(false);
+    expect(isUnauthorizedError(makeClientErrorWithMessage('Forbidden'))).toBe(false);
+    expect(isUnauthorizedError(new TypeError('Failed to fetch'))).toBe(false);
   });
 });

--- a/apps/mobile/lib/graphql/errors.ts
+++ b/apps/mobile/lib/graphql/errors.ts
@@ -3,7 +3,23 @@ import { ClientError } from './client-error';
 export function isNetworkError(error: unknown): boolean {
   if (error instanceof TypeError) return true;
   if (error instanceof ClientError && error.response.status >= 500) return true;
+  if (error instanceof ClientError) {
+    const code = error.response.errors?.[0]?.extensions?.code;
+    if (typeof code === 'number' && code >= 500) return true;
+    if (typeof code === 'string' && Number(code) >= 500) return true;
+  }
   return false;
+}
+
+export function isUnauthorizedError(error: unknown): boolean {
+  if (!(error instanceof ClientError)) return false;
+  if (error.response.status === 401) return true;
+
+  const firstError = error.response.errors?.[0];
+  if (firstError?.message.trim().toLowerCase() === 'unauthorized') return true;
+
+  const code = firstError?.extensions?.code;
+  return code === 401 || code === '401';
 }
 
 export function extractGraphQLErrorMessage(error: unknown): string | null {

--- a/apps/mobile/lib/graphql/middleware/refresh-on-401.test.ts
+++ b/apps/mobile/lib/graphql/middleware/refresh-on-401.test.ts
@@ -1,9 +1,17 @@
+import { GraphQLError } from 'graphql';
 import { ClientError } from '../client-error';
 import { createRefreshMiddleware } from './refresh-on-401';
 
 function makeClientError(status: number): ClientError {
   return new ClientError(
     { status, headers: new Headers(), errors: [], body: '' },
+    { query: '' },
+  );
+}
+
+function makeUnauthorizedGraphQLError(): ClientError {
+  return new ClientError(
+    { status: 200, headers: new Headers(), errors: [new GraphQLError('Unauthorized')], body: '' },
     { query: '' },
   );
 }
@@ -41,6 +49,20 @@ describe('createRefreshMiddleware', () => {
 
   it('refreshes and retries on 401', async () => {
     const error = makeClientError(401);
+    const request = jest
+      .fn()
+      .mockRejectedValueOnce(error)
+      .mockResolvedValueOnce('retry-ok');
+    const refresh = jest.fn().mockResolvedValue(true);
+    const wrap = createRefreshMiddleware(refresh);
+
+    await expect(wrap(request)).resolves.toBe('retry-ok');
+    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+
+  it('refreshes and retries on GraphQL Unauthorized errors returned with HTTP 200', async () => {
+    const error = makeUnauthorizedGraphQLError();
     const request = jest
       .fn()
       .mockRejectedValueOnce(error)

--- a/apps/mobile/lib/graphql/middleware/refresh-on-401.ts
+++ b/apps/mobile/lib/graphql/middleware/refresh-on-401.ts
@@ -1,4 +1,4 @@
-import { ClientError } from '../client-error';
+import { isUnauthorizedError } from '../errors';
 
 export type RefreshHandler = () => Promise<boolean>;
 
@@ -9,7 +9,7 @@ export function createRefreshMiddleware(refresh: RefreshHandler) {
     try {
       return await request();
     } catch (error) {
-      if (!(error instanceof ClientError) || error.response.status !== 401) {
+      if (!isUnauthorizedError(error)) {
         throw error;
       }
       if (!refreshPromise) {

--- a/apps/mobile/lib/graphql/mutations/auth.ts
+++ b/apps/mobile/lib/graphql/mutations/auth.ts
@@ -24,3 +24,12 @@ export const SIGN_IN_MUTATION = gql`
     }
   }
 `;
+
+export const REFRESH_TOKEN_MUTATION = gql`
+  mutation RefreshToken($input: RefreshTokenInput!) {
+    refreshToken(input: $input) {
+      accessToken
+      refreshToken
+    }
+  }
+`;

--- a/apps/mobile/lib/graphql/request-log.test.ts
+++ b/apps/mobile/lib/graphql/request-log.test.ts
@@ -94,4 +94,37 @@ describe('logReproducibleRequest', () => {
     expect(output).toContain(`'\\''`);
     expect(output).not.toContain(`"name":"O'Brien"`);
   });
+
+  it('redacts sensitive auth variables in the variable block and curl body', () => {
+    logReproducibleRequest({
+      endpoint,
+      document: 'mutation RefreshToken($input: RefreshTokenInput!) { refreshToken(input: $input) { accessToken } }',
+      variables: {
+        input: {
+          refreshToken: 'refresh-secret',
+          refresh_token: 'snake-refresh-secret',
+          accessToken: 'access-secret',
+          'access-token': 'kebab-access-secret',
+          password: 'password-secret',
+          oldPassword: 'old-password-secret',
+        },
+      },
+      operationKind: 'mutation',
+      operationName: 'RefreshToken',
+    });
+
+    const output = logSpy.mock.calls[0][0] as string;
+    expect(output).not.toContain('refresh-secret');
+    expect(output).not.toContain('snake-refresh-secret');
+    expect(output).not.toContain('access-secret');
+    expect(output).not.toContain('kebab-access-secret');
+    expect(output).not.toContain('password-secret');
+    expect(output).not.toContain('old-password-secret');
+    expect(output).toContain('"refreshToken": "[REDACTED]"');
+    expect(output).toContain('"refresh_token": "[REDACTED]"');
+    expect(output).toContain('"accessToken": "[REDACTED]"');
+    expect(output).toContain('"access-token": "[REDACTED]"');
+    expect(output).toContain('"password": "[REDACTED]"');
+    expect(output).toContain('"oldPassword": "[REDACTED]"');
+  });
 });

--- a/apps/mobile/lib/graphql/request-log.ts
+++ b/apps/mobile/lib/graphql/request-log.ts
@@ -12,13 +12,44 @@ type ReproducibleRequest = {
 // developer knows to add the header themselves when reproducing an authenticated request.
 const AUTH_HEADER_COMMENT = '# Authorization: Bearer $TOKEN  (add manually if auth is required)';
 const AUTH_CURL_COMMENT = '# add when auth is required: -H "Authorization: Bearer $TOKEN"';
+const REDACTED_VALUE = '[REDACTED]';
 
 /** Wrap a value in single quotes for a POSIX shell, escaping embedded single quotes as '\''. */
 function shellSingleQuote(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`;
 }
 
-/** Build the exact JSON body that `graphqlClient.request` sends, so the curl reproduces it byte-for-byte. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isSensitiveVariableKey(key: string): boolean {
+  const normalizedKey = key.toLowerCase().replace(/[^a-z0-9]/g, '');
+  return (
+    normalizedKey.includes('password') ||
+    normalizedKey === 'accesstoken' ||
+    normalizedKey === 'refreshtoken'
+  );
+}
+
+function redactSensitiveVariables(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(redactSensitiveVariables);
+  }
+
+  if (isRecord(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, child]) => [
+        key,
+        isSensitiveVariableKey(key) ? REDACTED_VALUE : redactSensitiveVariables(child),
+      ]),
+    );
+  }
+
+  return value;
+}
+
+/** Build the JSON body shown in reproduction logs. Sensitive variables may be redacted. */
 function buildRequestBody(document: string, variables?: Variables): string {
   return JSON.stringify({
     query: document,
@@ -48,7 +79,7 @@ function indent(text: string, spaces: number): string {
  * request so a developer can reproduce it in a GraphQL client (GraphiQL / Insomnia / curl).
  *
  * Emits the endpoint, headers (Authorization intentionally omitted — only a placeholder
- * comment), the full query document, the full variables, and a ready-to-run curl command.
+ * comment), the query document, redacted variables, and a ready-to-run curl command.
  * Does nothing in production builds, since variables may contain PII (e.g. location track points).
  */
 export function logReproducibleRequest({
@@ -62,9 +93,12 @@ export function logReproducibleRequest({
     return;
   }
 
-  const body = buildRequestBody(document, variables);
+  const redactedVariables = variables
+    ? (redactSensitiveVariables(variables) as Variables)
+    : undefined;
+  const body = buildRequestBody(document, redactedVariables);
   const curl = buildCurl(endpoint, body);
-  const variablesText = variables ? JSON.stringify(variables, null, 2) : '(none)';
+  const variablesText = redactedVariables ? JSON.stringify(redactedVariables, null, 2) : '(none)';
 
   const block = [
     `[graphql] ⟲ reproduce ${operationKind} ${operationName}`,

--- a/apps/mobile/lib/providers.tsx
+++ b/apps/mobile/lib/providers.tsx
@@ -1,26 +1,20 @@
 import { MutationCache, QueryCache, QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { PropsWithChildren } from 'react';
-import { ClientError } from '@/lib/graphql/client-error';
+import { isUnauthorizedError } from '@/lib/graphql/errors';
 import { useAuthStore } from '@/stores/auth-store';
 
-function isUnauthorized(error: unknown): boolean {
-  return error instanceof ClientError && error.response.status === 401;
+function clearAuthOnUnauthorized(error: unknown): void {
+  if (isUnauthorizedError(error)) {
+    useAuthStore.getState().clearAuth();
+  }
 }
 
 const queryCache = new QueryCache({
-  onError: (error) => {
-    if (isUnauthorized(error)) {
-      useAuthStore.getState().clearAuth();
-    }
-  },
+  onError: clearAuthOnUnauthorized,
 });
 
 const mutationCache = new MutationCache({
-  onError: (error) => {
-    if (isUnauthorized(error)) {
-      useAuthStore.getState().clearAuth();
-    }
-  },
+  onError: clearAuthOnUnauthorized,
 });
 
 const queryClient = new QueryClient({
@@ -30,7 +24,7 @@ const queryClient = new QueryClient({
     queries: {
       staleTime: 5 * 60 * 1000,
       retry: (failureCount, error) => {
-        if (isUnauthorized(error)) {
+        if (isUnauthorizedError(error)) {
           return false;
         }
         return failureCount < 2;


### PR DESCRIPTION
## Summary
 - Add API refreshToken mutation backed by Cognito refresh auth
 - Implement mobile refreshToken request without Authorization header
 - Refresh/retry GraphQL 200 Unauthorized responses and clear auth on invalid refresh
 - Redact sensitive auth values in GraphQL request logs
 
 ## Validation
 - Mobile targeted Jest tests passed
 - Mobile typecheck passed
 - API cargo check passed
 - iOS Simulator manual verification passed