### PR TITLE
[codex] Add opt-in SQL bind value logging

### DIFF
--- a/apps/api/Cargo.toml
+++ b/apps/api/Cargo.toml
@@ -20,7 +20,7 @@ async-graphql-axum = { version = "7.2.1" }
 async-trait = "0.1.89"
 tokio = { version = "1.52.3", features = ["macros", "rt-multi-thread", "sync", "time"] }
 tracing = { version = "0.1.44" }
-tracing-subscriber = { version = "0.3.23" }
+tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 aws-config = { version = "1.8.16", features = ["behavior-version-latest"] }
 aws-sdk-dynamodb = "1.111.0"
 aws-sdk-s3 = { version = "1.132.0", features = ["behavior-version-latest"] }

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -12,3 +12,21 @@ curl -sS http://localhost:3000 \
 ```
 cargo run --bin walking-dog & cargo run --bin track_point_worker
 ```
+
+## SQL bind value logs
+
+By default the API logs at `INFO` and does not print SQL bind values.
+
+For local debugging only, enable SeaORM SQL logs with bind values injected:
+
+```
+API_SQL_BIND_LOG=1 cargo run --bin walking-dog
+```
+
+When `API_SQL_BIND_LOG=1` is set, the API uses `info,sea_orm=debug,sqlx::query=off`
+unless `RUST_LOG` is also set. `RUST_LOG` is ignored for the HTTP API unless
+`API_SQL_BIND_LOG=1` is set, so `RUST_LOG=sea_orm=debug` alone will not expose
+bind values.
+
+Bind values can include user IDs, email addresses, tokens, or other user data.
+Do not enable this in shared, staging, or production environments.

--- a/apps/api/src/config.rs
+++ b/apps/api/src/config.rs
@@ -1,0 +1,150 @@
+use std::{collections::HashMap, env};
+
+use tracing_subscriber::EnvFilter;
+
+const SQL_BIND_LOG_ENV: &str = "API_SQL_BIND_LOG";
+const RUST_LOG_ENV: &str = "RUST_LOG";
+const DEFAULT_FILTER_DIRECTIVES: &str = "info";
+const SQL_BIND_FILTER_DIRECTIVES: &str = "info,sea_orm=debug,sqlx::query=off";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DatabaseLogConfig {
+    SqlxDefault,
+    SqlBindValues,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ApiLogConfig {
+    sql_bind_logging_enabled: bool,
+    filter_directives: String,
+}
+
+impl ApiLogConfig {
+    pub fn from_env() -> Self {
+        Self::from_env_vars(env::vars().collect::<HashMap<_, _>>())
+    }
+
+    pub fn from_env_vars(vars: HashMap<String, String>) -> Self {
+        let sql_bind_logging_enabled = vars.get(SQL_BIND_LOG_ENV).is_some_and(|value| value == "1");
+        let filter_directives = if sql_bind_logging_enabled {
+            vars.get(RUST_LOG_ENV)
+                .filter(|value| !value.is_empty())
+                .cloned()
+                .unwrap_or_else(|| SQL_BIND_FILTER_DIRECTIVES.to_owned())
+        } else {
+            DEFAULT_FILTER_DIRECTIVES.to_owned()
+        };
+
+        Self {
+            sql_bind_logging_enabled,
+            filter_directives,
+        }
+    }
+
+    pub fn sql_bind_logging_enabled(&self) -> bool {
+        self.sql_bind_logging_enabled
+    }
+
+    pub fn database_log_config(&self) -> DatabaseLogConfig {
+        if self.sql_bind_logging_enabled {
+            DatabaseLogConfig::SqlBindValues
+        } else {
+            DatabaseLogConfig::SqlxDefault
+        }
+    }
+
+    pub fn filter_directives(&self) -> &str {
+        &self.filter_directives
+    }
+
+    fn env_filter(&self) -> anyhow::Result<EnvFilter> {
+        Ok(EnvFilter::try_new(self.filter_directives())?)
+    }
+}
+
+pub fn init_tracing(config: &ApiLogConfig) -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(config.env_filter()?)
+        .try_init()
+        .map_err(|error| anyhow::anyhow!("failed to initialize tracing subscriber: {error}"))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+
+    #[test]
+    fn default_log_config_keeps_bind_sql_logging_disabled() {
+        let config = ApiLogConfig::from_env_vars(HashMap::<String, String>::new());
+
+        assert!(!config.sql_bind_logging_enabled());
+        assert_eq!(config.database_log_config(), DatabaseLogConfig::SqlxDefault);
+        assert_eq!(config.filter_directives(), "info");
+    }
+
+    #[test]
+    fn dedicated_opt_in_enables_sea_orm_bind_sql_and_disables_sqlx_query_logs() {
+        let config = ApiLogConfig::from_env_vars(HashMap::from([(
+            "API_SQL_BIND_LOG".to_owned(),
+            "1".to_owned(),
+        )]));
+
+        assert!(config.sql_bind_logging_enabled());
+        assert_eq!(
+            config.database_log_config(),
+            DatabaseLogConfig::SqlBindValues
+        );
+        assert_eq!(
+            config.filter_directives(),
+            "info,sea_orm=debug,sqlx::query=off"
+        );
+    }
+
+    #[test]
+    fn rust_log_cannot_enable_bind_sql_without_dedicated_opt_in() {
+        let config = ApiLogConfig::from_env_vars(HashMap::from([(
+            "RUST_LOG".to_owned(),
+            "sea_orm=debug".to_owned(),
+        )]));
+
+        assert!(!config.sql_bind_logging_enabled());
+        assert_eq!(config.database_log_config(), DatabaseLogConfig::SqlxDefault);
+        assert_eq!(config.filter_directives(), "info");
+    }
+
+    #[test]
+    fn rust_log_is_respected_after_dedicated_opt_in() {
+        let config = ApiLogConfig::from_env_vars(HashMap::from([
+            ("API_SQL_BIND_LOG".to_owned(), "1".to_owned()),
+            (
+                "RUST_LOG".to_owned(),
+                "info,walking_dog=debug,sea_orm=debug,sqlx::query=off".to_owned(),
+            ),
+        ]));
+
+        assert!(config.sql_bind_logging_enabled());
+        assert_eq!(
+            config.filter_directives(),
+            "info,walking_dog=debug,sea_orm=debug,sqlx::query=off"
+        );
+    }
+
+    #[test]
+    fn invalid_or_empty_bind_log_values_are_disabled() {
+        for value in ["", "true", "0", "yes", "debug"] {
+            let config = ApiLogConfig::from_env_vars(HashMap::from([(
+                "API_SQL_BIND_LOG".to_owned(),
+                value.to_owned(),
+            )]));
+
+            assert!(
+                !config.sql_bind_logging_enabled(),
+                "value {value:?} should not enable bind SQL logging"
+            );
+            assert_eq!(config.filter_directives(), "info");
+        }
+    }
+}

--- a/apps/api/src/db.rs
+++ b/apps/api/src/db.rs
@@ -1,0 +1,54 @@
+use sea_orm::{ConnectOptions, Database, DatabaseConnection};
+
+use crate::config::DatabaseLogConfig;
+
+pub async fn connect_database_from_env(
+    config: DatabaseLogConfig,
+) -> anyhow::Result<DatabaseConnection> {
+    let database_url = std::env::var("DATABASE_URL")?;
+    connect_database(database_url, config).await
+}
+
+pub async fn connect_database(
+    database_url: impl Into<String>,
+    config: DatabaseLogConfig,
+) -> anyhow::Result<DatabaseConnection> {
+    Ok(Database::connect(build_connect_options(database_url, config)).await?)
+}
+
+pub(crate) fn build_connect_options(
+    database_url: impl Into<String>,
+    config: DatabaseLogConfig,
+) -> ConnectOptions {
+    let mut options = ConnectOptions::new(database_url.into());
+    if config == DatabaseLogConfig::SqlBindValues {
+        options.sqlx_logging(false);
+    }
+    options
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::DatabaseLogConfig;
+
+    #[test]
+    fn connect_options_keep_sqlx_logging_by_default() {
+        let options = build_connect_options(
+            "postgres://postgres:postgres@localhost/walking_dog",
+            DatabaseLogConfig::SqlxDefault,
+        );
+
+        assert!(options.get_sqlx_logging());
+    }
+
+    #[test]
+    fn connect_options_disable_sqlx_logging_for_bind_value_logs() {
+        let options = build_connect_options(
+            "postgres://postgres:postgres@localhost/walking_dog",
+            DatabaseLogConfig::SqlBindValues,
+        );
+
+        assert!(!options.get_sqlx_logging());
+    }
+}

--- a/apps/api/src/graphql/mod.rs
+++ b/apps/api/src/graphql/mod.rs
@@ -7,6 +7,8 @@ pub mod query;
 
 use std::{env, sync::Arc};
 
+use crate::config::ApiLogConfig;
+use crate::db;
 use crate::graphql::query::Query;
 use crate::queue::track_point::TrackPointEnqueuer;
 use anyhow::Result;
@@ -19,7 +21,7 @@ pub async fn build_schema()
         mutation::Mutation::default(),
         EmptySubscription,
     )
-    .data(build_database_connection().await)
+    .data(build_database_connection().await?)
     .data(build_cognitoidentityprovider_client().await)
     .data(build_dynamodb_client().await)
     .data(build_track_point_enqueuer().await?)
@@ -28,10 +30,9 @@ pub async fn build_schema()
     .finish())
 }
 
-async fn build_database_connection() -> sea_orm::DatabaseConnection {
-    sea_orm::Database::connect(std::env::var("DATABASE_URL").unwrap())
-        .await
-        .unwrap()
+async fn build_database_connection() -> anyhow::Result<sea_orm::DatabaseConnection> {
+    let log_config = ApiLogConfig::from_env();
+    db::connect_database_from_env(log_config.database_log_config()).await
 }
 
 async fn build_cognitoidentityprovider_client() -> aws_sdk_cognitoidentityprovider::Client {

--- a/apps/api/src/lib.rs
+++ b/apps/api/src/lib.rs
@@ -1,4 +1,6 @@
 pub mod auth;
+pub mod config;
+pub mod db;
 pub mod entity;
 pub mod graphql;
 pub mod queue;

--- a/apps/api/src/main.rs
+++ b/apps/api/src/main.rs
@@ -11,21 +11,21 @@ use axum::{
     routing::get,
 };
 use migration::{Migrator, MigratorTrait};
-use sea_orm::Database;
 use tokio::net::TcpListener;
 use tracing::info;
 use walking_dog::{
     auth,
+    config::{self, DatabaseLogConfig},
+    db,
     entity::user,
     graphql::{self, mutation, query::Query},
 };
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::INFO)
-        .init();
-    run_migrations().await?;
+    let log_config = config::ApiLogConfig::from_env();
+    config::init_tracing(&log_config)?;
+    run_migrations(log_config.database_log_config()).await?;
     let schema = graphql::build_schema().await?;
     let app = Router::new()
         .route("/graphql", get(graphql_playground).post(graphql_handler))
@@ -56,9 +56,8 @@ async fn graphql_playground() -> impl IntoResponse {
     Html(GraphiQLSource::build().finish())
 }
 
-async fn run_migrations() -> anyhow::Result<()> {
-    let database_url = std::env::var("DATABASE_URL")?;
-    let db = Database::connect(&database_url).await?;
+async fn run_migrations(database_log_config: DatabaseLogConfig) -> anyhow::Result<()> {
+    let db = db::connect_database_from_env(database_log_config).await?;
     info!("Running database migrations");
     Migrator::up(&db, None).await?;
     info!("Database migrations applied");


### PR DESCRIPTION
## Summary

- add an explicit `API_SQL_BIND_LOG=1` gate for SeaORM SQL bind-value logging
- centralize API database connection options and disable duplicate SQLx query logs in bind logging mode
- wire the HTTP API migrations and GraphQL schema DB connection through the shared helpers
- document local-only usage and sensitive-data risk

## Validation

- `docker compose -f apps/compose.yml run --rm api cargo test --features test-utils -- --test-threads=1`

## Notes

`docker compose -f apps/compose.yml run --rm api cargo fmt --check` still reports pre-existing formatting drift in `apps/api/migration/src/m20260517_000000_create_dog_walk_goal.rs` and `apps/api/src/graphql/mutation/walk.rs`; those unrelated files were left untouched.