### PR TITLE
[codex] Fix walk Live Activity state and background tracking

### DIFF
--- a/apps/mobile/CLAUDE.md
+++ b/apps/mobile/CLAUDE.md
@@ -37,6 +37,7 @@
 - Expo SDK 56 以降では `@react-navigation/*` を直接依存・直接 import しない。`ThemeProvider` / `DarkTheme` / `DefaultTheme` など必要な API は `expo-router` から import する。
 - `expo-widgets` / `@expo/ui` の Live Activity UI は native module を module load 時に読むため、通常の hook / store / controller からは静的 import しない。テスト可能な純粋ロジックと controller を分け、controller 側では widget UI module を遅延 require して Jest が `ExpoWidgets` native module を要求しない構造にする。
 - `expo-widgets` で Widget extension を追加した後に Xcode の dependency cycle が出た場合は、生成済み `ios/` だけを手で直さず config plugin で再生成後も安定する修正にする。App extension の embed は `[CP] Embed Pods Frameworks` の後、Dev Launcher の Info.plist 変更 script は不要な `Info.plist` input dependency を持たせない。
+- Live Activity と散歩記録をまたぐ修正では、ActivityKit 側だけを更新せず、前景 GPS・背景 GPS・永続化した active walk session・復帰時 navigation が同じ点列と `walkId` を参照する設計にする。Dynamic Island の tap は iOS がアプリ起動に予約しているため、tap URL は履歴詳細ではなく active recording route を指す。
 
 ## iOS Simulator 起動手順
 

--- a/apps/mobile/__tests__/app/walks/[id].test.tsx
+++ b/apps/mobile/__tests__/app/walks/[id].test.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react-native';
+import { router } from 'expo-router';
+import { useWalkStore } from '@/stores/walk-store';
 
 jest.mock('expo-router', () => ({
   useLocalSearchParams: () => ({ id: 'walk-1' }),
+  router: {
+    replace: jest.fn(),
+  },
 }));
 
 jest.mock('react-native-maps', () => {
@@ -31,6 +36,8 @@ jest.mock('@/hooks/use-walks', () => ({
 // eslint-disable-next-line import/first
 import WalkDetailScreen from '../../../app/walks/[id]';
 
+const mockReplace = router.replace as jest.Mock;
+
 const baseWalk = {
   id: 'walk-1',
   dogs: [{ id: 'dog-1', name: 'Buddy', breed: null, gender: null, birthday: null, photoUrl: null, createdAt: '2026-01-01' }],
@@ -45,6 +52,7 @@ const baseWalk = {
 describe('WalkDetailScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    useWalkStore.getState().reset();
   });
 
   it('displays both start and end time when endedAt is present', () => {
@@ -89,6 +97,22 @@ describe('WalkDetailScreen', () => {
     render(<WalkDetailScreen />);
 
     expect(screen.queryByTestId('walk-time')).toBeNull();
+  });
+
+  it('redirects stale detail links back to the active recording route', () => {
+    mockUseWalk.mockReturnValue({ data: baseWalk, isLoading: false });
+    useWalkStore.getState().startRecording('active-walk', {
+      startedAt: new Date('2026-04-04T09:00:00Z'),
+      dogs: baseWalk.dogs,
+      selectedDogIds: ['dog-1'],
+    });
+
+    render(<WalkDetailScreen />);
+
+    expect(mockReplace).toHaveBeenCalledWith({
+      pathname: '/walk-recording',
+      params: { walkId: 'active-walk' },
+    });
   });
 
   it('displays walk-time element in dark mode', () => {

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -53,6 +53,9 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
       {
         locationWhenInUsePermission:
           'Walking Dog uses your location to record walk routes.',
+        locationAlwaysAndWhenInUsePermission:
+          'Walking Dog uses your location in the background to keep recording active walks.',
+        isIosBackgroundLocationEnabled: true,
       },
     ],
     [
@@ -67,6 +70,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
       {
         bundleIdentifier: 'com.walkingdog.app.widgets',
         groupIdentifier: 'group.com.walkingdog.app',
+        frequentUpdates: true,
         widgets: [],
       },
     ],

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -3,6 +3,7 @@ import { StatusBar } from 'expo-status-bar';
 import { useEffect } from 'react';
 import 'react-native-reanimated';
 import '@/lib/i18n';
+import '@/lib/walk/background-location-task';
 import { useTranslation } from 'react-i18next';
 
 import { useColorScheme } from '@/hooks/use-color-scheme';

--- a/apps/mobile/app/walk-recording.tsx
+++ b/apps/mobile/app/walk-recording.tsx
@@ -19,24 +19,44 @@ export default function WalkRecordingScreen() {
   const theme = useColors();
   const phase = useWalkStore((s) => s.phase);
   const selectedDogIds = useWalkStore((s) => s.selectedDogIds);
+  const storedDogs = useWalkStore((s) => s.dogs);
   const walkId = useWalkStore((s) => s.walkId);
   const setTotalDistanceM = useWalkStore((s) => s.setTotalDistanceM);
-  const params = useLocalSearchParams<{ action?: string }>();
+  const hydrateRecordingSession = useWalkStore((s) => s.hydrateRecordingSession);
+  const params = useLocalSearchParams<{ action?: string; walkId?: string }>();
 
   const { data: me } = useMe();
 
   // サーバ側 (track_point → Haversine 累積) で計算した distance を定期取得し、
   // ストアの totalDistanceM へ反映します。
   const isRecording = phase === 'recording';
-  const { data: walkSnapshot } = useWalk(walkId ?? '', {
+  const routeWalkId = typeof params.walkId === 'string' ? params.walkId : undefined;
+  const effectiveWalkId = walkId ?? routeWalkId ?? '';
+  const { data: walkSnapshot } = useWalk(effectiveWalkId, {
     refetchIntervalMs: isRecording ? WALK_DISTANCE_POLL_INTERVAL_MS : undefined,
   });
 
   useEffect(() => {
-    const distance = walkSnapshot?.distance;
+    const distance = walkSnapshot?.distanceM ?? walkSnapshot?.distance;
     if (typeof distance !== 'number') return;
     setTotalDistanceM(distance);
-  }, [walkSnapshot?.distance, setTotalDistanceM]);
+  }, [walkSnapshot?.distance, walkSnapshot?.distanceM, setTotalDistanceM]);
+
+  useEffect(() => {
+    if (!routeWalkId || !walkSnapshot || walkSnapshot.status !== 'ACTIVE') return;
+    if (phase === 'recording' && walkId === walkSnapshot.id) return;
+
+    hydrateRecordingSession({
+      walkId: walkSnapshot.id,
+      startedAt: walkSnapshot.startedAt,
+      selectedDogIds: walkSnapshot.dogs.map((dog) => dog.id),
+      dogs: walkSnapshot.dogs,
+      points: walkSnapshot.points ?? [],
+      flushedPointCount: walkSnapshot.points?.length ?? 0,
+      totalDistanceM: walkSnapshot.distanceM ?? walkSnapshot.distance ?? 0,
+      events: walkSnapshot.events ?? [],
+    });
+  }, [hydrateRecordingSession, phase, routeWalkId, walkId, walkSnapshot]);
 
   const hasPushedRef = useRef(false);
   useEffect(() => {
@@ -52,8 +72,11 @@ export default function WalkRecordingScreen() {
 
   // 選択済み犬 ID から表示用の犬情報を引き直し、上部チップの単一情報源にします。
   const selectedDogs = useMemo<Dog[]>(
-    () => (me?.dogs ?? []).filter((d) => selectedDogIds.includes(d.id)),
-    [me?.dogs, selectedDogIds],
+    () => {
+      const dogs = (me?.dogs ?? []).filter((d) => selectedDogIds.includes(d.id));
+      return dogs.length > 0 ? dogs : storedDogs;
+    },
+    [me?.dogs, selectedDogIds, storedDogs],
   );
   useWalkLiveActivitySync(selectedDogs);
 

--- a/apps/mobile/app/walks/[id].tsx
+++ b/apps/mobile/app/walks/[id].tsx
@@ -1,7 +1,8 @@
+import { useEffect } from 'react';
 import { ActivityIndicator, ScrollView, StyleSheet, Text, View } from 'react-native';
 import MapView, { Polyline, Marker } from 'react-native-maps';
 import { Image } from 'expo-image';
-import { useLocalSearchParams } from 'expo-router';
+import { router, useLocalSearchParams } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { GroupedCard } from '@/components/ui/GroupedCard';
 import { useColors } from '@/hooks/use-colors';
@@ -10,14 +11,26 @@ import { useWalk } from '@/hooks/use-walks';
 import { useWalkDetailViewModel } from '@/hooks/use-walk-detail-view-model';
 import { WalkEventTimeline } from '@/components/walk/WalkEventTimeline';
 import { MAP_EVENT_EMOJIS } from '@/lib/walk/events';
+import { useWalkStore } from '@/stores/walk-store';
 
 // 散歩詳細画面は保存済み散歩のルート、メトリクス、担当者、イベント履歴を表示します。
 export default function WalkDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
+  const phase = useWalkStore((s) => s.phase);
+  const activeWalkId = useWalkStore((s) => s.walkId);
   const { t } = useTranslation();
   const theme = useColors();
   const { data: walk, isLoading } = useWalk(id ?? '');
   const vm = useWalkDetailViewModel(walk);
+
+  useEffect(() => {
+    if (phase !== 'recording' || !activeWalkId) return;
+
+    router.replace({
+      pathname: '/walk-recording',
+      params: { walkId: activeWalkId },
+    });
+  }, [activeWalkId, phase]);
 
   if (isLoading || !walk || !vm) {
     // 詳細データまたは表示用モデルが揃うまでは、地図を描画せずローディングに留めます。

--- a/apps/mobile/hooks/use-active-walk-session-hydration.ts
+++ b/apps/mobile/hooks/use-active-walk-session-hydration.ts
@@ -1,0 +1,32 @@
+import { useCallback, useEffect } from 'react';
+import { AppState } from 'react-native';
+import { loadActiveWalkSession } from '@/lib/walk/active-walk-session';
+import { useWalkStore } from '@/stores/walk-store';
+
+export function useActiveWalkSessionHydration() {
+  const hydrate = useCallback(async () => {
+    try {
+      const session = await loadActiveWalkSession();
+      if (!session) return;
+
+      const state = useWalkStore.getState();
+      if (state.phase === 'recording' && state.walkId !== session.walkId) return;
+
+      state.hydrateRecordingSession(session);
+    } catch (error) {
+      console.error('[walk.activeSession.hydrate] failed', error);
+    }
+  }, []);
+
+  useEffect(() => {
+    void hydrate();
+
+    const subscription = AppState.addEventListener('change', (status) => {
+      if (status === 'active') {
+        void hydrate();
+      }
+    });
+
+    return () => subscription.remove();
+  }, [hydrate]);
+}

--- a/apps/mobile/hooks/use-walk-session.test.ts
+++ b/apps/mobile/hooks/use-walk-session.test.ts
@@ -5,6 +5,7 @@ import {
 } from './use-walk-session';
 import * as walkMutations from './use-walk-mutations';
 import * as gpsTracker from '@/lib/walk/gps-tracker';
+import * as backgroundLocationTask from '@/lib/walk/background-location-task';
 import * as liveActivityController from '@/lib/walk/live-activity-controller';
 import { MAX_POINTS_PER_BATCH } from '@/lib/walk/tracking-manager';
 import type { Dog, WalkPoint } from '@/types/graphql';
@@ -17,6 +18,10 @@ jest.mock('./use-walk-mutations', () => ({
 
 jest.mock('@/lib/walk/gps-tracker', () => ({
   startTracking: jest.fn(),
+}));
+
+jest.mock('@/lib/walk/background-location-task', () => ({
+  stopWalkBackgroundLocationUpdates: jest.fn(),
 }));
 
 jest.mock('@/lib/walk/live-activity-controller', () => ({
@@ -157,6 +162,9 @@ beforeEach(() => {
     mutateAsync: mockAddPointsMutateAsync,
   });
   (gpsTracker.startTracking as jest.Mock).mockResolvedValue(mockStopTracking);
+  (backgroundLocationTask.stopWalkBackgroundLocationUpdates as jest.Mock).mockResolvedValue(
+    undefined,
+  );
 });
 
 describe('useWalkSession.start', () => {
@@ -183,7 +191,14 @@ describe('useWalkSession.start', () => {
       await result.current.start({ selectedDogIds: ['dog-1'] });
     });
 
-    expect(mockStoreStartRecording).toHaveBeenCalledWith('walk-1');
+    expect(mockStoreStartRecording).toHaveBeenCalledWith('walk-1', {
+      startedAt: new Date(startedAtIso),
+      selectedDogIds: ['dog-1'],
+      dogs: [dog],
+      totalDistanceM: 0,
+      events: [],
+      points: [],
+    });
   });
 
   it('starts the lock screen live activity with current walk data', async () => {
@@ -273,6 +288,18 @@ describe('useWalkSession.stop', () => {
     });
 
     expect(mockStopTracking).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops restored background location updates even without a foreground subscription', async () => {
+    mockStorePhase = 'recording';
+    (backgroundLocationTask.stopWalkBackgroundLocationUpdates as jest.Mock).mockClear();
+
+    const { result } = renderHook(() => useWalkSession());
+    await act(async () => {
+      await result.current.stop('walk-1');
+    });
+
+    expect(backgroundLocationTask.stopWalkBackgroundLocationUpdates).toHaveBeenCalledTimes(1);
   });
 
   it('ignores late GPS callbacks after stop begins', async () => {

--- a/apps/mobile/hooks/use-walk-session.ts
+++ b/apps/mobile/hooks/use-walk-session.ts
@@ -39,13 +39,20 @@ export function useWalkSession() {
   const start = useCallback(
     async ({ selectedDogIds }: WalkSessionStartOptions): Promise<string> => {
       // 既存の GPS 監視を止めてから、新しい散歩と端末側の記録状態を開始します。
-      stopWalkTracking();
+      await stopWalkTracking();
 
       const walk = await startWalkMutation.mutateAsync(selectedDogIds);
-      startRecording(walk.id);
-      const startedAt = useWalkStore.getState().startedAt ?? new Date(walk.startedAt);
+      const startedAt = new Date(walk.startedAt);
+      startRecording(walk.id, {
+        startedAt,
+        selectedDogIds,
+        dogs: walk.dogs,
+        points: walk.points ?? [],
+        totalDistanceM: walk.distanceM ?? walk.distance ?? 0,
+        events: walk.events ?? [],
+      });
 
-      startWalkLiveActivity(
+      await startWalkLiveActivity(
         buildWalkActivityProps({
           walkId: walk.id,
           startedAt,
@@ -55,9 +62,8 @@ export function useWalkSession() {
         }),
       );
 
-      // GPS 点はストアへ即時反映し、永続化は tracking-manager 側のバッチ送信に任せます。
-      // distance はサーバ側 (track_point → Haversine 累積) の計算結果を walk クエリの
-      // ポーリング (walk-recording.tsx) で取り込みます。
+      // GPS 点はストアへ即時反映し、永続化とローカル距離更新も同じ点列から行います。
+      // サーバ側の再計算値は walk-recording.tsx のポーリングで上書きされます。
       await beginWalkTracking({
         walkId: walk.id,
         addWalkPoints: addWalkPointsMutation.mutateAsync,
@@ -75,7 +81,7 @@ export function useWalkSession() {
     async (walkId: string) => {
       // 未送信の GPS 点を送ってから、サーバー上の散歩を終了状態にします。
       // distance はサーバ側で track_point から算出して保存されるため、ここでは送りません。
-      stopWalkTracking();
+      await stopWalkTracking();
 
       await flushPendingWalkPoints({
         walkId,

--- a/apps/mobile/lib/providers.tsx
+++ b/apps/mobile/lib/providers.tsx
@@ -1,5 +1,6 @@
 import { QueryClientProvider } from '@tanstack/react-query';
 import { PropsWithChildren } from 'react';
+import { useActiveWalkSessionHydration } from '@/hooks/use-active-walk-session-hydration';
 import { useWalkLiveActivityInteractions } from '@/hooks/use-walk-live-activity-interactions';
 import { queryClient, setUnauthorizedHandler } from '@/lib/query-client';
 import { useAuthStore } from '@/stores/auth-store';
@@ -9,6 +10,7 @@ setUnauthorizedHandler(() => {
 });
 
 function WalkLiveActivityBridge({ children }: PropsWithChildren) {
+  useActiveWalkSessionHydration();
   useWalkLiveActivityInteractions();
   return children;
 }

--- a/apps/mobile/lib/walk/active-walk-session.test.ts
+++ b/apps/mobile/lib/walk/active-walk-session.test.ts
@@ -1,0 +1,84 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import type { Dog, WalkPoint } from '@/types/graphql';
+import {
+  ACTIVE_WALK_SESSION_STORAGE_KEY,
+  clearActiveWalkSession,
+  loadActiveWalkSession,
+  persistActiveWalkSession,
+} from './active-walk-session';
+
+jest.mock('@react-native-async-storage/async-storage', () => {
+  const store = new Map<string, string>();
+  return {
+    __esModule: true,
+    default: {
+      getItem: jest.fn(async (key: string) => store.get(key) ?? null),
+      setItem: jest.fn(async (key: string, value: string) => {
+        store.set(key, value);
+      }),
+      removeItem: jest.fn(async (key: string) => {
+        store.delete(key);
+      }),
+      __reset: () => store.clear(),
+    },
+  };
+});
+
+const dog: Dog = {
+  id: 'dog-1',
+  name: 'Mugi',
+  breed: null,
+  gender: 'OTHER',
+  createdAt: '2026-04-01T00:00:00Z',
+};
+
+const point: WalkPoint = {
+  lat: 35.6812,
+  lng: 139.7671,
+  recordedAt: '2026-04-01T00:00:05Z',
+};
+
+beforeEach(() => {
+  (AsyncStorage as unknown as { __reset: () => void }).__reset();
+});
+
+describe('active-walk-session', () => {
+  it('persists and loads the active recording snapshot', async () => {
+    const snapshot = {
+      walkId: 'walk-1',
+      startedAt: '2026-04-01T00:00:00.000Z',
+      selectedDogIds: ['dog-1'],
+      dogs: [dog],
+      points: [point],
+      flushedPointCount: 0,
+      totalDistanceM: 12,
+      events: [],
+    };
+
+    await persistActiveWalkSession(snapshot);
+
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      ACTIVE_WALK_SESSION_STORAGE_KEY,
+      JSON.stringify({ version: 1, session: snapshot }),
+    );
+    await expect(loadActiveWalkSession()).resolves.toEqual(snapshot);
+  });
+
+  it('clears the active recording snapshot', async () => {
+    await persistActiveWalkSession({
+      walkId: 'walk-1',
+      startedAt: '2026-04-01T00:00:00.000Z',
+      selectedDogIds: ['dog-1'],
+      dogs: [dog],
+      points: [point],
+      flushedPointCount: 0,
+      totalDistanceM: 12,
+      events: [],
+    });
+
+    await clearActiveWalkSession();
+
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith(ACTIVE_WALK_SESSION_STORAGE_KEY);
+    await expect(loadActiveWalkSession()).resolves.toBeNull();
+  });
+});

--- a/apps/mobile/lib/walk/active-walk-session.ts
+++ b/apps/mobile/lib/walk/active-walk-session.ts
@@ -1,0 +1,88 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import type { Dog, WalkEvent, WalkPoint } from '@/types/graphql';
+
+export const ACTIVE_WALK_SESSION_STORAGE_KEY = 'active_walk_session_v1';
+
+const SCHEMA_VERSION = 1;
+
+export interface ActiveWalkSessionSnapshot {
+  walkId: string;
+  startedAt: string;
+  selectedDogIds: string[];
+  dogs: Dog[];
+  points: WalkPoint[];
+  flushedPointCount: number;
+  totalDistanceM: number;
+  events: WalkEvent[];
+}
+
+interface ActiveWalkSessionFile {
+  version: number;
+  session: ActiveWalkSessionSnapshot;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function assertString(value: unknown, field: string): asserts value is string {
+  if (typeof value !== 'string') {
+    throw new Error(`Invalid active walk session: ${field} must be a string`);
+  }
+}
+
+function assertArray(value: unknown, field: string): asserts value is unknown[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`Invalid active walk session: ${field} must be an array`);
+  }
+}
+
+function parseActiveWalkSession(raw: string): ActiveWalkSessionSnapshot {
+  const parsed = JSON.parse(raw) as unknown;
+  if (!isObject(parsed) || parsed.version !== SCHEMA_VERSION || !isObject(parsed.session)) {
+    throw new Error('Invalid active walk session schema');
+  }
+
+  const session = parsed.session;
+  assertString(session.walkId, 'walkId');
+  assertString(session.startedAt, 'startedAt');
+  assertArray(session.selectedDogIds, 'selectedDogIds');
+  assertArray(session.dogs, 'dogs');
+  assertArray(session.points, 'points');
+  assertArray(session.events, 'events');
+
+  if (typeof session.flushedPointCount !== 'number') {
+    throw new Error('Invalid active walk session: flushedPointCount must be a number');
+  }
+  if (typeof session.totalDistanceM !== 'number') {
+    throw new Error('Invalid active walk session: totalDistanceM must be a number');
+  }
+
+  return {
+    walkId: session.walkId,
+    startedAt: session.startedAt,
+    selectedDogIds: session.selectedDogIds as string[],
+    dogs: session.dogs as Dog[],
+    points: session.points as WalkPoint[],
+    flushedPointCount: session.flushedPointCount,
+    totalDistanceM: session.totalDistanceM,
+    events: session.events as WalkEvent[],
+  };
+}
+
+export async function persistActiveWalkSession(
+  session: ActiveWalkSessionSnapshot,
+): Promise<void> {
+  const file: ActiveWalkSessionFile = { version: SCHEMA_VERSION, session };
+  await AsyncStorage.setItem(ACTIVE_WALK_SESSION_STORAGE_KEY, JSON.stringify(file));
+}
+
+export async function loadActiveWalkSession(): Promise<ActiveWalkSessionSnapshot | null> {
+  const raw = await AsyncStorage.getItem(ACTIVE_WALK_SESSION_STORAGE_KEY);
+  if (!raw) return null;
+  return parseActiveWalkSession(raw);
+}
+
+export async function clearActiveWalkSession(): Promise<void> {
+  await AsyncStorage.removeItem(ACTIVE_WALK_SESSION_STORAGE_KEY);
+}

--- a/apps/mobile/lib/walk/background-location-task.test.ts
+++ b/apps/mobile/lib/walk/background-location-task.test.ts
@@ -1,0 +1,155 @@
+import type { LocationObject } from 'expo-location';
+import * as Location from 'expo-location';
+import * as TaskManager from 'expo-task-manager';
+import {
+  ACTIVE_WALK_SESSION_STORAGE_KEY,
+  loadActiveWalkSession,
+  persistActiveWalkSession,
+} from './active-walk-session';
+import {
+  WALK_BACKGROUND_LOCATION_TASK,
+  handleWalkBackgroundLocations,
+  startWalkBackgroundLocationUpdates,
+  stopWalkBackgroundLocationUpdates,
+} from './background-location-task';
+import { updateWalkLiveActivity } from './live-activity-controller';
+
+jest.mock('expo-task-manager', () => ({
+  defineTask: jest.fn(),
+  isTaskRegisteredAsync: jest.fn(),
+  unregisterTaskAsync: jest.fn(),
+}));
+
+jest.mock('expo-location', () => ({
+  Accuracy: { High: 'high' },
+  ActivityType: { Fitness: 'fitness' },
+  startLocationUpdatesAsync: jest.fn(),
+}));
+
+jest.mock('./active-walk-session', () => ({
+  ACTIVE_WALK_SESSION_STORAGE_KEY: 'active_walk_session_v1',
+  loadActiveWalkSession: jest.fn(),
+  persistActiveWalkSession: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('./live-activity-controller', () => ({
+  updateWalkLiveActivity: jest.fn(() => Promise.resolve()),
+}));
+
+const definedTaskCall = (TaskManager.defineTask as jest.Mock).mock.calls[0];
+
+const location = (
+  latitude: number,
+  longitude: number,
+  timestamp: string,
+): LocationObject => ({
+  coords: {
+    latitude,
+    longitude,
+    altitude: null,
+    accuracy: 5,
+    altitudeAccuracy: null,
+    heading: null,
+    speed: null,
+  },
+  timestamp: Date.parse(timestamp),
+});
+
+describe('background-location-task', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('defines the background location task at module load', () => {
+    expect(definedTaskCall).toEqual([WALK_BACKGROUND_LOCATION_TASK, expect.any(Function)]);
+  });
+
+  it('registers high accuracy background location updates', async () => {
+    await startWalkBackgroundLocationUpdates();
+
+    expect(Location.startLocationUpdatesAsync).toHaveBeenCalledWith(WALK_BACKGROUND_LOCATION_TASK, {
+      accuracy: Location.Accuracy.High,
+      timeInterval: 5000,
+      distanceInterval: 5,
+      activityType: Location.ActivityType.Fitness,
+      pausesUpdatesAutomatically: false,
+      showsBackgroundLocationIndicator: true,
+    });
+  });
+
+  it('unregisters the background task when it is active', async () => {
+    (TaskManager.isTaskRegisteredAsync as jest.Mock).mockResolvedValue(true);
+
+    await stopWalkBackgroundLocationUpdates();
+
+    expect(TaskManager.isTaskRegisteredAsync).toHaveBeenCalledWith(WALK_BACKGROUND_LOCATION_TASK);
+    expect(TaskManager.unregisterTaskAsync).toHaveBeenCalledWith(WALK_BACKGROUND_LOCATION_TASK);
+  });
+
+  it('appends background locations, recomputes distance, updates live activity, and preserves pending points', async () => {
+    (loadActiveWalkSession as jest.Mock).mockResolvedValue({
+      walkId: 'walk-1',
+      startedAt: '2026-04-01T00:00:00.000Z',
+      selectedDogIds: ['dog-1'],
+      dogs: [
+        {
+          id: 'dog-1',
+          name: 'Mugi',
+          breed: null,
+          gender: 'OTHER',
+          createdAt: '2026-04-01T00:00:00Z',
+        },
+      ],
+      points: [
+        { lat: 35.6812, lng: 139.7671, recordedAt: '2026-04-01T00:00:00.000Z' },
+      ],
+      flushedPointCount: 0,
+      totalDistanceM: 0,
+      events: [],
+    });
+
+    await handleWalkBackgroundLocations([
+      location(35.6813, 139.7672, '2026-04-01T00:00:05.000Z'),
+      location(35.6814, 139.7673, '2026-04-01T00:00:10.000Z'),
+    ]);
+
+    expect(persistActiveWalkSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        walkId: 'walk-1',
+        flushedPointCount: 0,
+        points: [
+          { lat: 35.6812, lng: 139.7671, recordedAt: '2026-04-01T00:00:00.000Z' },
+          { lat: 35.6813, lng: 139.7672, recordedAt: '2026-04-01T00:00:05.000Z' },
+          { lat: 35.6814, lng: 139.7673, recordedAt: '2026-04-01T00:00:10.000Z' },
+        ],
+        totalDistanceM: expect.any(Number),
+      }),
+    );
+    expect((persistActiveWalkSession as jest.Mock).mock.calls[0][0].totalDistanceM).toBeGreaterThan(
+      0,
+    );
+    expect(updateWalkLiveActivity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        walkId: 'walk-1',
+        distanceLabel: expect.stringMatching(/m$/),
+      }),
+    );
+  });
+
+  it('unregisters stale background updates when no active walk session exists', async () => {
+    (loadActiveWalkSession as jest.Mock).mockResolvedValue(null);
+    (TaskManager.isTaskRegisteredAsync as jest.Mock).mockResolvedValue(true);
+
+    await handleWalkBackgroundLocations([
+      location(35.6813, 139.7672, '2026-04-01T00:00:05.000Z'),
+    ]);
+
+    expect(TaskManager.unregisterTaskAsync).toHaveBeenCalledWith(WALK_BACKGROUND_LOCATION_TASK);
+    expect(persistActiveWalkSession).not.toHaveBeenCalled();
+    expect(updateWalkLiveActivity).not.toHaveBeenCalled();
+  });
+
+  it('exports the storage key used by active walk persistence', () => {
+    expect(ACTIVE_WALK_SESSION_STORAGE_KEY).toBe('active_walk_session_v1');
+  });
+});

--- a/apps/mobile/lib/walk/background-location-task.ts
+++ b/apps/mobile/lib/walk/background-location-task.ts
@@ -1,0 +1,99 @@
+import * as Location from 'expo-location';
+import * as TaskManager from 'expo-task-manager';
+import {
+  type ActiveWalkSessionSnapshot,
+  loadActiveWalkSession,
+  persistActiveWalkSession,
+} from './active-walk-session';
+import { buildWalkActivityProps } from './live-activity';
+import { updateWalkLiveActivity } from './live-activity-controller';
+import { totalHaversineDistance } from './distance';
+import { useWalkStore } from '@/stores/walk-store';
+import type { WalkPoint } from '@/types/graphql';
+
+export const WALK_BACKGROUND_LOCATION_TASK = 'walking-dog-background-location';
+
+function locationToWalkPoint(location: Location.LocationObject): WalkPoint {
+  return {
+    lat: location.coords.latitude,
+    lng: location.coords.longitude,
+    recordedAt: new Date(location.timestamp).toISOString(),
+  };
+}
+
+function appendPointsToSession(
+  session: ActiveWalkSessionSnapshot,
+  incomingPoints: WalkPoint[],
+): ActiveWalkSessionSnapshot {
+  const points = [...session.points, ...incomingPoints];
+  return {
+    ...session,
+    points,
+    totalDistanceM: totalHaversineDistance(points),
+  };
+}
+
+function syncRuntimeStore(session: ActiveWalkSessionSnapshot) {
+  const state = useWalkStore.getState();
+  if (state.phase === 'recording' && state.walkId !== session.walkId) return;
+  state.hydrateRecordingSession(session);
+}
+
+export async function handleWalkBackgroundLocations(
+  locations: Location.LocationObject[],
+): Promise<void> {
+  if (locations.length === 0) return;
+
+  const session = await loadActiveWalkSession();
+  if (!session) {
+    await stopWalkBackgroundLocationUpdates();
+    return;
+  }
+
+  const nextSession = appendPointsToSession(session, locations.map(locationToWalkPoint));
+  await persistActiveWalkSession(nextSession);
+  syncRuntimeStore(nextSession);
+
+  await updateWalkLiveActivity(
+    buildWalkActivityProps({
+      walkId: nextSession.walkId,
+      startedAt: new Date(nextSession.startedAt),
+      distanceM: nextSession.totalDistanceM,
+      dogs: nextSession.dogs,
+      events: nextSession.events,
+    }),
+  );
+}
+
+TaskManager.defineTask(WALK_BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
+  if (error) {
+    console.error('[walk.backgroundLocation] task failed', error);
+    return;
+  }
+
+  const locations = (data as { locations?: Location.LocationObject[] } | undefined)?.locations;
+  if (!locations) return;
+
+  await handleWalkBackgroundLocations(locations);
+});
+
+export async function startWalkBackgroundLocationUpdates(): Promise<void> {
+  const isRegistered = await TaskManager.isTaskRegisteredAsync(WALK_BACKGROUND_LOCATION_TASK);
+  if (isRegistered) return;
+
+  await Location.startLocationUpdatesAsync(WALK_BACKGROUND_LOCATION_TASK, {
+    accuracy: Location.Accuracy.High,
+    timeInterval: 5000,
+    distanceInterval: 5,
+    activityType: Location.ActivityType.Fitness,
+    pausesUpdatesAutomatically: false,
+    showsBackgroundLocationIndicator: true,
+  });
+}
+
+export async function stopWalkBackgroundLocationUpdates(): Promise<void> {
+  const isRegistered = await TaskManager.isTaskRegisteredAsync(WALK_BACKGROUND_LOCATION_TASK);
+  if (!isRegistered) return;
+
+  await TaskManager.unregisterTaskAsync(WALK_BACKGROUND_LOCATION_TASK);
+}

--- a/apps/mobile/lib/walk/distance.ts
+++ b/apps/mobile/lib/walk/distance.ts
@@ -12,3 +12,10 @@ export function haversineDistance(
     Math.cos(toRad(p1.lat)) * Math.cos(toRad(p2.lat)) * Math.sin(dLng / 2) ** 2;
   return EARTH_RADIUS_M * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
 }
+
+export function totalHaversineDistance(points: { lat: number; lng: number }[]): number {
+  return points.reduce((total, point, index) => {
+    if (index === 0) return total;
+    return total + haversineDistance(points[index - 1], point);
+  }, 0);
+}

--- a/apps/mobile/lib/walk/gps-tracker.test.ts
+++ b/apps/mobile/lib/walk/gps-tracker.test.ts
@@ -1,45 +1,87 @@
+import * as Location from 'expo-location';
+import {
+  startWalkBackgroundLocationUpdates,
+  stopWalkBackgroundLocationUpdates,
+} from './background-location-task';
 import { requestPermission, startTracking } from './gps-tracker';
 
 jest.mock('expo-location', () => ({
+  Accuracy: { High: 'high' },
   requestForegroundPermissionsAsync: jest.fn(),
+  requestBackgroundPermissionsAsync: jest.fn(),
   watchPositionAsync: jest.fn(),
-  Accuracy: { High: 4 },
 }));
 
-import * as Location from 'expo-location';
+jest.mock('./background-location-task', () => ({
+  startWalkBackgroundLocationUpdates: jest.fn(),
+  stopWalkBackgroundLocationUpdates: jest.fn(),
+}));
 
-describe('requestPermission', () => {
-  it('returns true when permission granted', async () => {
-    (Location.requestForegroundPermissionsAsync as jest.Mock).mockResolvedValue({
-      status: 'granted',
-    });
-    const result = await requestPermission();
-    expect(result).toBe(true);
+describe('gps-tracker', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
-  it('returns false when permission denied', async () => {
-    (Location.requestForegroundPermissionsAsync as jest.Mock).mockResolvedValue({
-      status: 'denied',
-    });
-    const result = await requestPermission();
-    expect(result).toBe(false);
+  it('requests foreground and background location permissions for walks', async () => {
+    (Location.requestForegroundPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'granted' });
+    (Location.requestBackgroundPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'granted' });
+
+    await expect(requestPermission()).resolves.toBe(true);
+
+    expect(Location.requestForegroundPermissionsAsync).toHaveBeenCalledTimes(1);
+    expect(Location.requestBackgroundPermissionsAsync).toHaveBeenCalledTimes(1);
   });
-});
 
-describe('startTracking', () => {
-  it('calls watchPositionAsync and returns cleanup function', async () => {
-    const mockRemove = jest.fn();
-    (Location.watchPositionAsync as jest.Mock).mockResolvedValue({ remove: mockRemove });
+  it('allows foreground walk tracking when background permission is unavailable', async () => {
+    (Location.requestForegroundPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'granted' });
+    (Location.requestBackgroundPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'denied' });
 
-    const onPosition = jest.fn();
-    const stop = await startTracking(onPosition);
+    await expect(requestPermission()).resolves.toBe(true);
+  });
+
+  it('starts foreground watch and background task, then unregisters both on stop', async () => {
+    const remove = jest.fn();
+    (Location.watchPositionAsync as jest.Mock).mockResolvedValue({ remove });
+    (startWalkBackgroundLocationUpdates as jest.Mock).mockResolvedValue(undefined);
+    (stopWalkBackgroundLocationUpdates as jest.Mock).mockResolvedValue(undefined);
+
+    const stop = await startTracking(jest.fn());
 
     expect(Location.watchPositionAsync).toHaveBeenCalledWith(
-      expect.objectContaining({ accuracy: Location.Accuracy.High }),
+      {
+        accuracy: Location.Accuracy.High,
+        timeInterval: 5000,
+        distanceInterval: 5,
+      },
       expect.any(Function),
     );
+    expect(startWalkBackgroundLocationUpdates).toHaveBeenCalledTimes(1);
 
-    stop();
-    expect(mockRemove).toHaveBeenCalled();
+    await stop();
+
+    expect(remove).toHaveBeenCalledTimes(1);
+    expect(stopWalkBackgroundLocationUpdates).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps foreground tracking active when the background task cannot start', async () => {
+    const remove = jest.fn();
+    const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    (Location.watchPositionAsync as jest.Mock).mockResolvedValue({ remove });
+    (startWalkBackgroundLocationUpdates as jest.Mock).mockRejectedValue(new Error('Always denied'));
+
+    const stop = await startTracking(jest.fn());
+
+    expect(Location.watchPositionAsync).toHaveBeenCalledTimes(1);
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      '[walk.backgroundLocation.start] unavailable',
+      expect.any(Error),
+    );
+
+    await stop();
+
+    expect(remove).toHaveBeenCalledTimes(1);
+    expect(stopWalkBackgroundLocationUpdates).not.toHaveBeenCalled();
+
+    consoleWarnSpy.mockRestore();
   });
 });

--- a/apps/mobile/lib/walk/gps-tracker.ts
+++ b/apps/mobile/lib/walk/gps-tracker.ts
@@ -1,15 +1,23 @@
 import * as Location from 'expo-location';
 import type { WalkPoint } from '@/types/graphql';
+import {
+  startWalkBackgroundLocationUpdates,
+  stopWalkBackgroundLocationUpdates,
+} from './background-location-task';
 
 export async function requestPermission(): Promise<boolean> {
-  const { status } = await Location.requestForegroundPermissionsAsync();
-  return status === 'granted';
+  const foreground = await Location.requestForegroundPermissionsAsync();
+  if (foreground.status !== 'granted') return false;
+
+  await Location.requestBackgroundPermissionsAsync();
+  return true;
 }
 
 export async function startTracking(
   onPosition: (point: WalkPoint) => void,
-): Promise<() => void> {
-  const subscription = await Location.watchPositionAsync(
+): Promise<() => Promise<void>> {
+  let subscription: Location.LocationSubscription;
+  subscription = await Location.watchPositionAsync(
     {
       accuracy: Location.Accuracy.High,
       timeInterval: 5000,
@@ -24,5 +32,18 @@ export async function startTracking(
     },
   );
 
-  return () => subscription.remove();
+  let backgroundTrackingStarted = false;
+  try {
+    await startWalkBackgroundLocationUpdates();
+    backgroundTrackingStarted = true;
+  } catch (error) {
+    console.warn('[walk.backgroundLocation.start] unavailable', error);
+  }
+
+  return async () => {
+    subscription.remove();
+    if (backgroundTrackingStarted) {
+      await stopWalkBackgroundLocationUpdates();
+    }
+  };
 }

--- a/apps/mobile/lib/walk/live-activity-controller.test.ts
+++ b/apps/mobile/lib/walk/live-activity-controller.test.ts
@@ -28,22 +28,58 @@ describe('walk live activity controller', () => {
     jest.clearAllMocks();
   });
 
-  it('starts a live activity with a walk deep link', () => {
+  it('starts a live activity with an active recording deep link', async () => {
     const activity = { update: jest.fn(), end: jest.fn() };
     (WalkingDogWalkActivity.start as jest.Mock).mockReturnValue(activity);
+    (WalkingDogWalkActivity.getInstances as jest.Mock).mockReturnValue([]);
 
-    startWalkLiveActivity(props);
+    await startWalkLiveActivity(props);
 
     expect(WalkingDogWalkActivity.start).toHaveBeenCalledWith(
       props,
-      'walking-dog://walks/walk-1',
+      'walking-dog://walk-recording?walkId=walk-1',
     );
+  });
+
+  it('ends stale native instances before starting a new live activity', async () => {
+    const staleActivity = { update: jest.fn(), end: jest.fn() };
+    const newActivity = { update: jest.fn(), end: jest.fn() };
+    (WalkingDogWalkActivity.getInstances as jest.Mock).mockReturnValue([staleActivity]);
+    (WalkingDogWalkActivity.start as jest.Mock).mockReturnValue(newActivity);
+
+    await startWalkLiveActivity(props);
+
+    expect(staleActivity.end).toHaveBeenCalledWith('immediate', undefined);
+    expect(WalkingDogWalkActivity.start).toHaveBeenCalledTimes(1);
+  });
+
+  it('starts a new live activity even when ending a stale native instance fails', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const staleError = new Error('stale end failed');
+    const staleActivity = { update: jest.fn(), end: jest.fn().mockRejectedValue(staleError) };
+    const newActivity = { update: jest.fn(), end: jest.fn() };
+    (WalkingDogWalkActivity.getInstances as jest.Mock).mockReturnValue([staleActivity]);
+    (WalkingDogWalkActivity.start as jest.Mock).mockReturnValue(newActivity);
+
+    await startWalkLiveActivity(props);
+
+    expect(WalkingDogWalkActivity.start).toHaveBeenCalledWith(
+      props,
+      'walking-dog://walk-recording?walkId=walk-1',
+    );
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      '[walk.liveActivity.endExisting] failed',
+      staleError,
+    );
+
+    consoleErrorSpy.mockRestore();
   });
 
   it('updates the active live activity', async () => {
     const activity = { update: jest.fn(), end: jest.fn() };
     (WalkingDogWalkActivity.start as jest.Mock).mockReturnValue(activity);
-    startWalkLiveActivity(props);
+    (WalkingDogWalkActivity.getInstances as jest.Mock).mockReturnValue([]);
+    await startWalkLiveActivity(props);
 
     await updateWalkLiveActivity({ ...props, distanceLabel: '1.23 km' });
 
@@ -59,16 +95,39 @@ describe('walk live activity controller', () => {
     expect(activity.update).toHaveBeenCalledWith(props);
   });
 
+  it('updates every native instance so stale lock-screen activities do not display old timers', async () => {
+    const activityA = { update: jest.fn(), end: jest.fn() };
+    const activityB = { update: jest.fn(), end: jest.fn() };
+    (WalkingDogWalkActivity.getInstances as jest.Mock).mockReturnValue([activityA, activityB]);
+
+    await updateWalkLiveActivity(props);
+
+    expect(activityA.update).toHaveBeenCalledWith(props);
+    expect(activityB.update).toHaveBeenCalledWith(props);
+  });
+
   it('ends the active live activity immediately', async () => {
     const activity = { update: jest.fn(), end: jest.fn() };
     (WalkingDogWalkActivity.start as jest.Mock).mockReturnValue(activity);
-    startWalkLiveActivity(props);
+    (WalkingDogWalkActivity.getInstances as jest.Mock).mockReturnValue([]);
+    await startWalkLiveActivity(props);
 
     await endWalkLiveActivity({ ...props, distanceLabel: 'finished' });
 
     expect(activity.end).toHaveBeenCalledWith('immediate', {
       ...props,
       distanceLabel: 'finished',
-    }, expect.any(Date));
+    });
+  });
+
+  it('ends every native instance without passing a content date', async () => {
+    const activityA = { update: jest.fn(), end: jest.fn() };
+    const activityB = { update: jest.fn(), end: jest.fn() };
+    (WalkingDogWalkActivity.getInstances as jest.Mock).mockReturnValue([activityA, activityB]);
+
+    await endWalkLiveActivity(props);
+
+    expect(activityA.end).toHaveBeenCalledWith('immediate', props);
+    expect(activityB.end).toHaveBeenCalledWith('immediate', props);
   });
 });

--- a/apps/mobile/lib/walk/live-activity-controller.ts
+++ b/apps/mobile/lib/walk/live-activity-controller.ts
@@ -16,27 +16,56 @@ function getActivityFactory(): typeof import('./live-activity-widget').WalkingDo
   return activityFactory;
 }
 
-function getActiveActivity(): LiveActivity<WalkActivityProps> | null {
-  if (activeActivity) return activeActivity;
-  activeActivity = getActivityFactory().getInstances()[0] ?? null;
-  return activeActivity;
+function getKnownActivities(
+  factory: typeof import('./live-activity-widget').WalkingDogWalkActivity,
+): LiveActivity<WalkActivityProps>[] {
+  const nativeActivities = factory.getInstances();
+  if (!activeActivity) return nativeActivities;
+  return nativeActivities.includes(activeActivity)
+    ? nativeActivities
+    : [activeActivity, ...nativeActivities];
 }
 
-export function startWalkLiveActivity(props: WalkActivityProps): void {
-  activeActivity = getActivityFactory().start(props, `walking-dog://walks/${props.walkId}`);
+export function walkRecordingActivityUrl(walkId: string): string {
+  return `walking-dog://walk-recording?walkId=${encodeURIComponent(walkId)}`;
+}
+
+async function endExistingNativeActivities(
+  factory: typeof import('./live-activity-widget').WalkingDogWalkActivity,
+) {
+  const existingActivities = getKnownActivities(factory);
+  const results = await Promise.allSettled(
+    existingActivities.map((activity) => activity.end('immediate', undefined)),
+  );
+  for (const result of results) {
+    if (result.status === 'rejected') {
+      console.error('[walk.liveActivity.endExisting] failed', result.reason);
+    }
+  }
+  activeActivity = null;
+}
+
+export async function startWalkLiveActivity(props: WalkActivityProps): Promise<void> {
+  const factory = getActivityFactory();
+  await endExistingNativeActivities(factory);
+  activeActivity = factory.start(props, walkRecordingActivityUrl(props.walkId));
 }
 
 export async function updateWalkLiveActivity(props: WalkActivityProps): Promise<void> {
-  const activity = getActiveActivity();
-  if (!activity) return;
-  await activity.update(props);
+  const factory = getActivityFactory();
+  const activities = getKnownActivities(factory);
+  if (activities.length === 0) return;
+
+  await Promise.all(activities.map((activity) => activity.update(props)));
+  activeActivity = activities[0];
 }
 
 export async function endWalkLiveActivity(props?: WalkActivityProps): Promise<void> {
-  const activity = getActiveActivity();
-  if (!activity) return;
+  const factory = getActivityFactory();
+  const activities = getKnownActivities(factory);
+  if (activities.length === 0) return;
 
-  await activity.end('immediate', props, new Date());
+  await Promise.all(activities.map((activity) => activity.end('immediate', props)));
   activeActivity = null;
 }
 

--- a/apps/mobile/lib/walk/live-activity-widget.tsx
+++ b/apps/mobile/lib/walk/live-activity-widget.tsx
@@ -23,6 +23,10 @@ function WalkActivityLayout(props: WalkActivityProps, _environment: LiveActivity
   const foreground = '#F7FFF9';
   const secondary = '#D7E6DB';
   const startDate = new Date(props.startedAtMs);
+  const elapsedTimerInterval = {
+    lower: startDate,
+    upper: new Date(props.startedAtMs + 7 * 24 * 60 * 60 * 1000),
+  };
   const firstDog = props.dogs[0];
 
   const banner = (
@@ -38,8 +42,8 @@ function WalkActivityLayout(props: WalkActivityProps, _environment: LiveActivity
             Walking
           </Text>
           <Text
-            date={startDate}
-            dateStyle="timer"
+            timerInterval={elapsedTimerInterval}
+            countsDown={false}
             modifiers={[font({ size: 28, weight: 'bold', design: 'rounded' }), monospacedDigit(), foregroundStyle(foreground)]}
           />
         </VStack>
@@ -96,7 +100,7 @@ function WalkActivityLayout(props: WalkActivityProps, _environment: LiveActivity
     banner,
     compactLeading: <Image systemName="figure.walk" color={accent} />,
     compactTrailing: (
-      <Text date={startDate} dateStyle="timer" modifiers={[monospacedDigit(), foregroundStyle(foreground)]} />
+      <Text timerInterval={elapsedTimerInterval} countsDown={false} modifiers={[monospacedDigit(), foregroundStyle(foreground)]} />
     ),
     minimal: <Image systemName="pawprint.fill" color={accent} />,
     expandedLeading: (
@@ -110,7 +114,7 @@ function WalkActivityLayout(props: WalkActivityProps, _environment: LiveActivity
         <Text modifiers={[font({ size: 18, weight: 'bold' }), monospacedDigit(), foregroundStyle(foreground)]}>
           {props.distanceLabel}
         </Text>
-        <Text date={startDate} dateStyle="timer" modifiers={[font({ size: 12 }), monospacedDigit(), foregroundStyle(secondary)]} />
+        <Text timerInterval={elapsedTimerInterval} countsDown={false} modifiers={[font({ size: 12 }), monospacedDigit(), foregroundStyle(secondary)]} />
       </VStack>
     ),
     expandedBottom: firstDog ? (

--- a/apps/mobile/lib/walk/tracking-manager.ts
+++ b/apps/mobile/lib/walk/tracking-manager.ts
@@ -1,4 +1,5 @@
 import { startTracking } from '@/lib/walk/gps-tracker';
+import { stopWalkBackgroundLocationUpdates } from '@/lib/walk/background-location-task';
 import { useWalkStore } from '@/stores/walk-store';
 import type { WalkPoint, WalkPointInput } from '@/types/graphql';
 
@@ -56,9 +57,9 @@ export async function beginWalkTracking({
     void flushPendingWalkPoints({ walkId, addWalkPoints }).catch(logPeriodicFlushError);
   }, PERIODIC_FLUSH_INTERVAL_MS);
 
-  const cleanup = () => {
+  const cleanup = async () => {
     clearInterval(flushTimer);
-    stopTracking();
+    await stopTracking();
   };
 
   const attached = useWalkStore.getState().attachTrackingCleanup(trackingGeneration, cleanup);
@@ -69,12 +70,14 @@ export async function beginWalkTracking({
   return attached;
 }
 
-export function stopWalkTracking() {
-  useWalkStore.getState().stopTrackingSession();
+export async function stopWalkTracking() {
+  await useWalkStore.getState().stopTrackingSession();
+  await stopWalkBackgroundLocationUpdates();
 }
 
 export function resetWalkTrackingState() {
   useWalkStore.getState().resetTrackingSession();
+  void stopWalkBackgroundLocationUpdates();
 }
 
 async function flushPendingWalkPointsNow({

--- a/apps/mobile/package-lock.json
+++ b/apps/mobile/package-lock.json
@@ -35,6 +35,7 @@
         "expo-status-bar": "~56.0.4",
         "expo-symbols": "~56.0.5",
         "expo-system-ui": "~56.0.5",
+        "expo-task-manager": "~56.0.14",
         "expo-web-browser": "~56.0.5",
         "expo-widgets": "~56.0.14",
         "graffle": "8.0.0-next.223",
@@ -8883,6 +8884,19 @@
         }
       }
     },
+    "node_modules/expo-task-manager": {
+      "version": "56.0.14",
+      "resolved": "https://registry.npmjs.org/expo-task-manager/-/expo-task-manager-56.0.14.tgz",
+      "integrity": "sha512-bcv3+dcwIc243Ptup57BFfVbbdY9cAr9Ks3prW+c+FCFj9lT9pgnBqZR5ajz5IX3GKxXwSryL6WgU5ftomCZwA==",
+      "license": "MIT",
+      "dependencies": {
+        "unimodules-app-loader": "~56.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/expo-updates-interface": {
       "version": "56.0.2",
       "resolved": "https://registry.npmjs.org/expo-updates-interface/-/expo-updates-interface-56.0.2.tgz",
@@ -17080,6 +17094,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/unimodules-app-loader": {
+      "version": "56.0.1",
+      "resolved": "https://registry.npmjs.org/unimodules-app-loader/-/unimodules-app-loader-56.0.1.tgz",
+      "integrity": "sha512-Z801jeBOQMUF/ExklxT1BqhEV/oF2/Bii7PFYAj/8Sauxl7oKvZbf70peRzzAU0mG7UQ3yU/UO/EpD1JyJ2WcA==",
+      "license": "MIT"
     },
     "node_modules/unist-util-is": {
       "version": "6.0.1",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -48,6 +48,7 @@
     "expo-status-bar": "~56.0.4",
     "expo-symbols": "~56.0.5",
     "expo-system-ui": "~56.0.5",
+    "expo-task-manager": "~56.0.14",
     "expo-web-browser": "~56.0.5",
     "expo-widgets": "~56.0.14",
     "graffle": "8.0.0-next.223",

--- a/apps/mobile/stores/walk-store.test.ts
+++ b/apps/mobile/stores/walk-store.test.ts
@@ -1,7 +1,25 @@
 import { useWalkStore } from './walk-store';
-import type { WalkPoint, WalkEvent } from '@/types/graphql';
+import type { Dog, WalkPoint, WalkEvent } from '@/types/graphql';
+import {
+  clearActiveWalkSession,
+  persistActiveWalkSession,
+} from '@/lib/walk/active-walk-session';
+
+jest.mock('@/lib/walk/active-walk-session', () => ({
+  clearActiveWalkSession: jest.fn(() => Promise.resolve()),
+  persistActiveWalkSession: jest.fn(() => Promise.resolve()),
+}));
+
+const dog: Dog = {
+  id: 'dog-1',
+  name: 'Mugi',
+  breed: null,
+  gender: 'OTHER',
+  createdAt: '2026-04-01T00:00:00Z',
+};
 
 beforeEach(() => {
+  jest.clearAllMocks();
   useWalkStore.getState().reset();
 });
 
@@ -68,15 +86,28 @@ describe('walk-store', () => {
 
   it('startRecording transitions to recording phase', () => {
     useWalkStore.getState().markFlushedPointCount(99);
-    useWalkStore.getState().startRecording('walk-123');
+    useWalkStore.getState().startRecording('walk-123', {
+      startedAt: new Date('2026-04-01T00:00:00Z'),
+      dogs: [dog],
+      selectedDogIds: ['dog-1'],
+    });
     const state = useWalkStore.getState();
     expect(state.phase).toBe('recording');
     expect(state.walkId).toBe('walk-123');
-    expect(state.startedAt).toBeInstanceOf(Date);
+    expect(state.startedAt).toEqual(new Date('2026-04-01T00:00:00Z'));
     expect(state.flushedPointCount).toBe(0);
+    expect(state.dogs).toEqual([dog]);
+    expect(persistActiveWalkSession).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        walkId: 'walk-123',
+        startedAt: '2026-04-01T00:00:00.000Z',
+        selectedDogIds: ['dog-1'],
+        dogs: [dog],
+      }),
+    );
   });
 
-  it('addPoint accumulates points without computing distance locally', () => {
+  it('addPoint accumulates points, computes distance locally, and persists active state', () => {
     useWalkStore.getState().startRecording('walk-123');
     const p1: WalkPoint = { lat: 35.6812, lng: 139.7671, recordedAt: '2026-03-23T10:00:00Z' };
     const p2: WalkPoint = { lat: 35.6813, lng: 139.7672, recordedAt: '2026-03-23T10:00:05Z' };
@@ -84,8 +115,13 @@ describe('walk-store', () => {
     useWalkStore.getState().addPoint(p2);
     const state = useWalkStore.getState();
     expect(state.points).toHaveLength(2);
-    // distance はサーバ側計算のみ。setTotalDistanceM で外から書き込むまでは 0。
-    expect(state.totalDistanceM).toBe(0);
+    expect(state.totalDistanceM).toBeGreaterThan(0);
+    expect(persistActiveWalkSession).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        points: [p1, p2],
+        totalDistanceM: state.totalDistanceM,
+      }),
+    );
   });
 
   it('setTotalDistanceM overwrites totalDistanceM with the server-calculated value', () => {
@@ -119,6 +155,7 @@ describe('walk-store', () => {
     useWalkStore.getState().startRecording('walk-123');
     useWalkStore.getState().finish();
     expect(useWalkStore.getState().phase).toBe('finished');
+    expect(clearActiveWalkSession).toHaveBeenCalled();
   });
 
   it('reset returns to ready phase', () => {
@@ -131,6 +168,35 @@ describe('walk-store', () => {
     expect(state.points).toEqual([]);
     expect(state.flushedPointCount).toBe(0);
     expect(state.selectedDogIds).toEqual([]);
+    expect(clearActiveWalkSession).toHaveBeenCalled();
+  });
+
+  it('hydrates a persisted active walk as recording', () => {
+    const point: WalkPoint = {
+      lat: 35.6812,
+      lng: 139.7671,
+      recordedAt: '2026-04-01T00:00:05Z',
+    };
+
+    useWalkStore.getState().hydrateRecordingSession({
+      walkId: 'walk-123',
+      startedAt: '2026-04-01T00:00:00.000Z',
+      selectedDogIds: ['dog-1'],
+      dogs: [dog],
+      points: [point],
+      flushedPointCount: 0,
+      totalDistanceM: 12,
+      events: [],
+    });
+
+    const state = useWalkStore.getState();
+    expect(state.phase).toBe('recording');
+    expect(state.walkId).toBe('walk-123');
+    expect(state.startedAt).toEqual(new Date('2026-04-01T00:00:00.000Z'));
+    expect(state.selectedDogIds).toEqual(['dog-1']);
+    expect(state.dogs).toEqual([dog]);
+    expect(state.points).toEqual([point]);
+    expect(state.totalDistanceM).toBe(12);
   });
 
   describe('walk events', () => {

--- a/apps/mobile/stores/walk-store.ts
+++ b/apps/mobile/stores/walk-store.ts
@@ -1,19 +1,36 @@
 import { create } from 'zustand';
-import type { WalkPoint, WalkEvent } from '@/types/graphql';
+import type { Dog, WalkPoint, WalkEvent } from '@/types/graphql';
+import {
+  type ActiveWalkSessionSnapshot,
+  clearActiveWalkSession,
+  persistActiveWalkSession,
+} from '@/lib/walk/active-walk-session';
+import { haversineDistance } from '@/lib/walk/distance';
 
 type WalkPhase = 'ready' | 'recording' | 'finished';
+
+interface StartRecordingOptions {
+  startedAt?: Date;
+  selectedDogIds?: string[];
+  dogs?: Dog[];
+  points?: WalkPoint[];
+  flushedPointCount?: number;
+  totalDistanceM?: number;
+  events?: WalkEvent[];
+}
 
 interface WalkState {
   phase: WalkPhase;
   walkId: string | null;
   selectedDogIds: string[];
+  dogs: Dog[];
   points: WalkPoint[];
   flushedPointCount: number;
   totalDistanceM: number;
   startedAt: Date | null;
   events: WalkEvent[];
   trackingGeneration: number;
-  trackingCleanup: (() => void) | null;
+  trackingCleanup: (() => void | Promise<void>) | null;
   // Bumped to a fresh timestamp each time a quick action requests the camera
   // flow. WalkEventActions watches it and triggers handlePhoto. Using a
   // timestamp instead of a boolean gives a distinct value per request so repeat
@@ -23,7 +40,8 @@ interface WalkState {
   isMinimized: boolean;
   selectDog: (dogId: string) => void;
   setSelectedDogs: (dogIds: string[]) => void;
-  startRecording: (walkId: string) => void;
+  startRecording: (walkId: string, options?: StartRecordingOptions) => void;
+  hydrateRecordingSession: (session: ActiveWalkSessionSnapshot) => void;
   addPoint: (point: WalkPoint) => void;
   setTotalDistanceM: (distanceM: number) => void;
   markFlushedPointCount: (count: number) => void;
@@ -33,21 +51,52 @@ interface WalkState {
   clearCameraRequest: () => void;
   setMinimized: (value: boolean) => void;
   activateTrackingSession: () => number;
-  attachTrackingCleanup: (generation: number, cleanup: () => void) => boolean;
-  stopTrackingSession: () => void;
+  attachTrackingCleanup: (generation: number, cleanup: () => void | Promise<void>) => boolean;
+  stopTrackingSession: () => Promise<void>;
   resetTrackingSession: () => void;
   finish: () => void;
   reset: () => void;
 }
 
-function clearTrackingCleanup(cleanup: (() => void) | null) {
-  cleanup?.();
+async function runTrackingCleanup(cleanup: (() => void | Promise<void>) | null) {
+  await cleanup?.();
+}
+
+function buildActiveWalkSessionSnapshot(state: WalkState): ActiveWalkSessionSnapshot | null {
+  if (state.phase !== 'recording' || !state.walkId || !state.startedAt) return null;
+
+  return {
+    walkId: state.walkId,
+    startedAt: state.startedAt.toISOString(),
+    selectedDogIds: state.selectedDogIds,
+    dogs: state.dogs,
+    points: state.points,
+    flushedPointCount: state.flushedPointCount,
+    totalDistanceM: state.totalDistanceM,
+    events: state.events,
+  };
+}
+
+function persistRecordingState(state: WalkState) {
+  const snapshot = buildActiveWalkSessionSnapshot(state);
+  if (!snapshot) return;
+
+  void persistActiveWalkSession(snapshot).catch((error) => {
+    console.error('[walk.activeSession.persist] failed', error);
+  });
+}
+
+function clearPersistedRecordingState() {
+  void clearActiveWalkSession().catch((error) => {
+    console.error('[walk.activeSession.clear] failed', error);
+  });
 }
 
 export const useWalkStore = create<WalkState>((set, get) => ({
   phase: 'ready',
   walkId: null,
   selectedDogIds: [],
+  dogs: [],
   points: [],
   flushedPointCount: 0,
   totalDistanceM: 0,
@@ -58,37 +107,91 @@ export const useWalkStore = create<WalkState>((set, get) => ({
   cameraRequestedAt: null,
   isMinimized: false,
 
-  selectDog: (dogId) =>
-    set((state) => ({
-      selectedDogIds: state.selectedDogIds.includes(dogId)
-        ? state.selectedDogIds.filter((id) => id !== dogId)
-        : [...state.selectedDogIds, dogId],
-    })),
+  selectDog: (dogId) => {
+    set((state) => {
+      const nextState = {
+        selectedDogIds: state.selectedDogIds.includes(dogId)
+          ? state.selectedDogIds.filter((id) => id !== dogId)
+          : [...state.selectedDogIds, dogId],
+      };
+      return nextState;
+    });
+    persistRecordingState(get());
+  },
 
-  setSelectedDogs: (dogIds) => set({ selectedDogIds: dogIds }),
+  setSelectedDogs: (dogIds) => {
+    set({ selectedDogIds: dogIds });
+    persistRecordingState(get());
+  },
 
-  startRecording: (walkId) =>
-    set({ phase: 'recording', walkId, startedAt: new Date(), flushedPointCount: 0 }),
+  startRecording: (walkId, options) => {
+    const dogs = options?.dogs ?? [];
+    set({
+      phase: 'recording',
+      walkId,
+      startedAt: options?.startedAt ?? new Date(),
+      selectedDogIds: options?.selectedDogIds ?? dogs.map((dog) => dog.id),
+      dogs,
+      points: options?.points ?? [],
+      flushedPointCount: options?.flushedPointCount ?? 0,
+      totalDistanceM: options?.totalDistanceM ?? 0,
+      events: options?.events ?? [],
+    });
+    persistRecordingState(get());
+  },
 
-  // Distance はサーバ計算が真実の源。ローカルでは GPS 点を保持するだけにし、
-  // totalDistanceM は walk クエリのポーリング結果を setTotalDistanceM で反映する。
-  addPoint: (point) =>
-    set((state) => ({
-      points: [...state.points, point],
-    })),
+  hydrateRecordingSession: (session) => {
+    set({
+      phase: 'recording',
+      walkId: session.walkId,
+      startedAt: new Date(session.startedAt),
+      selectedDogIds: session.selectedDogIds,
+      dogs: session.dogs,
+      points: session.points,
+      flushedPointCount: session.flushedPointCount,
+      totalDistanceM: session.totalDistanceM,
+      events: session.events,
+    });
+    persistRecordingState(get());
+  },
 
-  setTotalDistanceM: (distanceM) => set({ totalDistanceM: distanceM }),
+  addPoint: (point) => {
+    set((state) => {
+      const previousPoint = state.points[state.points.length - 1];
+      const nextDistanceM = previousPoint
+        ? state.totalDistanceM + haversineDistance(previousPoint, point)
+        : state.totalDistanceM;
+
+      return {
+        points: [...state.points, point],
+        totalDistanceM: nextDistanceM,
+      };
+    });
+    persistRecordingState(get());
+  },
+
+  setTotalDistanceM: (distanceM) => {
+    set({ totalDistanceM: distanceM });
+    persistRecordingState(get());
+  },
 
   markFlushedPointCount: (count) =>
-    set((state) => ({
-      flushedPointCount: Math.min(state.points.length, Math.max(state.flushedPointCount, count)),
-    })),
+    {
+      set((state) => ({
+        flushedPointCount: Math.min(state.points.length, Math.max(state.flushedPointCount, count)),
+      }));
+      persistRecordingState(get());
+    },
 
-  addEvent: (event) =>
-    set((state) => ({ events: [...state.events, event] })),
+  addEvent: (event) => {
+    set((state) => ({ events: [...state.events, event] }));
+    persistRecordingState(get());
+  },
 
-  removeEvent: (eventId) =>
-    set((state) => ({ events: state.events.filter((e) => e.id !== eventId) })),
+  removeEvent: (eventId) => {
+    set((state) => ({ events: state.events.filter((e) => e.id !== eventId) }));
+    persistRecordingState(get());
+  },
 
   requestCamera: () => set({ cameraRequestedAt: Date.now() }),
 
@@ -100,7 +203,7 @@ export const useWalkStore = create<WalkState>((set, get) => ({
     const nextGeneration = get().trackingGeneration + 1;
     const cleanup = get().trackingCleanup;
     set({ trackingGeneration: nextGeneration, trackingCleanup: null });
-    clearTrackingCleanup(cleanup);
+    void runTrackingCleanup(cleanup);
     return nextGeneration;
   },
 
@@ -113,20 +216,23 @@ export const useWalkStore = create<WalkState>((set, get) => ({
     return true;
   },
 
-  stopTrackingSession: () => {
+  stopTrackingSession: async () => {
     const nextGeneration = get().trackingGeneration + 1;
     const cleanup = get().trackingCleanup;
     set({ trackingGeneration: nextGeneration, trackingCleanup: null });
-    clearTrackingCleanup(cleanup);
+    await runTrackingCleanup(cleanup);
   },
 
   resetTrackingSession: () => {
     const cleanup = get().trackingCleanup;
     set({ trackingGeneration: 0, trackingCleanup: null });
-    clearTrackingCleanup(cleanup);
+    void runTrackingCleanup(cleanup);
   },
 
-  finish: () => set({ phase: 'finished', cameraRequestedAt: null, isMinimized: false }),
+  finish: () => {
+    set({ phase: 'finished', cameraRequestedAt: null, isMinimized: false });
+    clearPersistedRecordingState();
+  },
 
   reset: () => {
     const cleanup = get().trackingCleanup;
@@ -134,6 +240,7 @@ export const useWalkStore = create<WalkState>((set, get) => ({
       phase: 'ready',
       walkId: null,
       selectedDogIds: [],
+      dogs: [],
       points: [],
       flushedPointCount: 0,
       totalDistanceM: 0,
@@ -144,6 +251,7 @@ export const useWalkStore = create<WalkState>((set, get) => ({
       cameraRequestedAt: null,
       isMinimized: false,
     });
-    clearTrackingCleanup(cleanup);
+    void runTrackingCleanup(cleanup);
+    clearPersistedRecordingState();
   },
 }));


### PR DESCRIPTION
## Summary
- Restore active walk sessions and route Live Activity/Dynamic Island taps back to the recording screen instead of stale walk detail routes.
- Keep foreground/background walk points, distance, pending uploads, and Live Activity state in sync during an active walk.
- Stabilize Live Activity timers/interactions, end stale activities before new starts, and stop stale background location tasks after a walk ends.

## Root Cause
- Active walk state lived mostly in foreground React state, so returning from system surfaces could lose the recording session and route/polyline.
- Live Activity updates used separate paths for interaction events and location points, which allowed stale ActivityKit state and timer display glitches.
- Ending activities passed an unsupported content date argument to the native end path, which caused the white-screen runtime error after End Walk.

## Validation
- `npm run typecheck` in `apps/mobile`
- `npm test -- --runTestsByPath lib/walk/live-activity.test.ts lib/walk/live-activity-controller.test.ts hooks/use-walk-live-activity-interactions.test.ts lib/walk/live-activity-interactions.test.ts lib/walk/background-location-task.test.ts hooks/use-walk-session.test.ts lib/walk/tracking-manager.test.ts lib/walk/gps-tracker.test.ts` in `apps/mobile` (8 suites / 49 tests)
- `npm test -- --runInBand` in `apps/mobile` (106 suites / 687 tests)

## Notes
- Simulator accessibility did not expose lock-screen Live Activity pee/poop buttons for direct automated tapping, so the ActivityKit timer fix is covered by code-level regression checks plus the broader Jest suite.