### PR TITLE
[codex] Unify pee and poop icons

### DIFF
--- a/apps/mobile/CLAUDE.md
+++ b/apps/mobile/CLAUDE.md
@@ -40,6 +40,7 @@
 - `@bacons/apple-targets` を使う場合は `@expo/prebuild-config` を top-level devDependency として Expo SDK のバージョンに合わせて固定する。plugin が実行時に top-level require するため、Expo CLI 配下の nested dependency だけでは `expo prebuild` が失敗する。
 - Apple Watch の walk snapshot は Watch UI/complication 表示同期専用に保つ。iPhone JS state が無い状態から snapshot で active walk を復元しない。Watch command は iPhone 側の現在の active walk store と一致する場合だけ処理し、inactive/stale walk の command は ack して破棄する。
 - Live Activity と散歩記録をまたぐ修正では、ActivityKit 側だけを更新せず、前景 GPS・背景 GPS・永続化した active walk session・復帰時 navigation が同じ点列と `walkId` を参照する設計にする。Dynamic Island の tap は iOS がアプリ起動に予約しているため、tap URL は履歴詳細ではなく active recording route を指す。
+- Pee/poop の表示アイコンは全サーフェスで統一する。React Native 側は `lib/walk/events.ts` の `WALK_EVENT_EMOJIS` を単一ソースにし、pee は `💧`、poop/poo は `💩` を使う。Live Activity と Watch SwiftUI でも同じ emoji を表示し、SF Symbols の `drop.fill` などに分岐させない。`expo-widgets` の Live Activity layout は関数を文字列化して Widget 側 JSContext で再評価するため、layout 関数内では imported constant を参照せず、関数内 local literal と回帰テストで値を固定する。
 
 ## iOS Simulator 起動手順
 

--- a/apps/mobile/components/walk/WalkEventTimeline.test.tsx
+++ b/apps/mobile/components/walk/WalkEventTimeline.test.tsx
@@ -58,7 +58,7 @@ describe('WalkEventTimeline', () => {
 
   it('renders pee event with emoji and translated label', () => {
     render(<WalkEventTimeline events={[peeEvent]} />);
-    expect(screen.getByText('🚽')).toBeTruthy();
+    expect(screen.getByText('💧')).toBeTruthy();
     // i18n en locale returns 'Pee' for walk.event.pee
     expect(screen.getByText('Pee')).toBeTruthy();
   });
@@ -80,7 +80,7 @@ describe('WalkEventTimeline', () => {
 
   it('renders all three event types when provided', () => {
     render(<WalkEventTimeline events={[peeEvent, pooEvent, photoEvent]} />);
-    expect(screen.getByText('🚽')).toBeTruthy();
+    expect(screen.getByText('💧')).toBeTruthy();
     expect(screen.getByText('💩')).toBeTruthy();
     expect(screen.getByText('📷')).toBeTruthy();
   });

--- a/apps/mobile/components/walk/WalkEventTimeline.tsx
+++ b/apps/mobile/components/walk/WalkEventTimeline.tsx
@@ -6,15 +6,8 @@ import { useTranslation } from 'react-i18next';
 import { useColors } from '@/hooks/use-colors';
 import { spacing, radius, typography } from '@/theme/tokens';
 import { formatClockTime } from '@/lib/walk/format';
-import type { WalkEvent, WalkEventType } from '@/types/graphql';
-
-const EVENT_CONFIG: Record<WalkEventType, { emoji: string }> = {
-  pee: { emoji: '🚽' },
-  poo: { emoji: '💩' },
-  sniff: { emoji: '🐽' },
-  greet: { emoji: '🐾' },
-  photo: { emoji: '📷' },
-};
+import { WALK_EVENT_EMOJIS } from '@/lib/walk/events';
+import type { WalkEvent } from '@/types/graphql';
 
 interface WalkEventTimelineProps {
   events: WalkEvent[];
@@ -34,14 +27,14 @@ export function WalkEventTimeline({ events }: WalkEventTimelineProps) {
     <View style={styles.container}>
       {events.map((event) => {
         // イベント種別から表示アイコンと翻訳ラベルを決め、発生時刻と一緒に表示します。
-        const config = EVENT_CONFIG[event.eventType];
+        const emoji = WALK_EVENT_EMOJIS[event.eventType];
         const label = t(`walk.event.${event.eventType}`);
         const time = formatClockTime(event.occurredAt);
 
         return (
           <View key={event.id} style={[styles.row, { borderBottomColor: theme.border + '33' }]}>
             <Text style={styles.time}>{time}</Text>
-            <Text style={styles.emoji}>{config.emoji}</Text>
+            <Text style={styles.emoji}>{emoji}</Text>
             <Text style={[styles.label, { color: theme.onSurface }]}>{label}</Text>
             {/* 写真イベントだけサムネイルを押せるようにし、通常イベントは文字表示に留めます。 */}
             {event.eventType === 'photo' && event.photoUrl ? (

--- a/apps/mobile/components/walk/WalkQuickActions.tsx
+++ b/apps/mobile/components/walk/WalkQuickActions.tsx
@@ -7,6 +7,7 @@ import { elevation, radius, spacing, typography } from '@/theme/tokens';
 import { useWalkStore } from '@/stores/walk-store';
 import { useMutationWithAlert } from '@/hooks/use-mutation-with-alert';
 import { useRecordWalkEvent } from '@/hooks/use-walk-event-mutations';
+import { UI_EVENT_EMOJIS } from '@/lib/walk/events';
 import type { Dog } from '@/types/graphql';
 
 interface WalkQuickActionsProps {
@@ -64,7 +65,7 @@ export function WalkQuickActions({ dogs }: WalkQuickActionsProps) {
       {isSingleDog ? (
         <>
           <Pill
-            label={`💧 ${t('walk.event.pee')}`}
+            label={`${UI_EVENT_EMOJIS.pee} ${t('walk.event.pee')}`}
             onPress={() => handlePeeOrPoo('pee', dogs[0].id)}
             disabled={isDisabled}
             bg={theme.surface}
@@ -73,7 +74,7 @@ export function WalkQuickActions({ dogs }: WalkQuickActionsProps) {
             accessibilityLabel={`${dogs[0].name} ${t('walk.event.pee')}`}
           />
           <Pill
-            label={`💩 ${t('walk.event.poo')}`}
+            label={`${UI_EVENT_EMOJIS.poo} ${t('walk.event.poo')}`}
             onPress={() => handlePeeOrPoo('poo', dogs[0].id)}
             disabled={isDisabled}
             bg={theme.surface}
@@ -86,7 +87,7 @@ export function WalkQuickActions({ dogs }: WalkQuickActionsProps) {
         dogs.flatMap((dog) => [
           <Pill
             key={`pee-${dog.id}`}
-            label={`💧 ${dog.name}`}
+            label={`${UI_EVENT_EMOJIS.pee} ${dog.name}`}
             onPress={() => handlePeeOrPoo('pee', dog.id)}
             disabled={isDisabled}
             bg={theme.surface}
@@ -96,7 +97,7 @@ export function WalkQuickActions({ dogs }: WalkQuickActionsProps) {
           />,
           <Pill
             key={`poo-${dog.id}`}
-            label={`💩 ${dog.name}`}
+            label={`${UI_EVENT_EMOJIS.poo} ${dog.name}`}
             onPress={() => handlePeeOrPoo('poo', dog.id)}
             disabled={isDisabled}
             bg={theme.surface}

--- a/apps/mobile/lib/walk/events.test.ts
+++ b/apps/mobile/lib/walk/events.test.ts
@@ -14,8 +14,8 @@ describe('EVENT_ORDER', () => {
 });
 
 describe('MAP_EVENT_EMOJIS (map markers)', () => {
-  it('uses the toilet emoji for pee on map pins', () => {
-    expect(MAP_EVENT_EMOJIS.pee).toBe('🚽');
+  it('uses the droplet emoji for pee on map pins', () => {
+    expect(MAP_EVENT_EMOJIS.pee).toBe('💧');
   });
 
   it('maps poo to poop emoji', () => {

--- a/apps/mobile/lib/walk/events.ts
+++ b/apps/mobile/lib/walk/events.ts
@@ -4,21 +4,16 @@ type CountedWalkEventType = Extract<WalkEventType, 'pee' | 'poo' | 'photo'>;
 
 export const EVENT_ORDER: readonly CountedWalkEventType[] = ['pee', 'poo'] as const;
 
-export const MAP_EVENT_EMOJIS: Record<WalkEventType, string> = {
-  pee: '🚽',
-  poo: '💩',
-  sniff: '🐽',
-  greet: '🐾',
-  photo: '📷',
-};
-
-export const UI_EVENT_EMOJIS: Record<WalkEventType, string> = {
+export const WALK_EVENT_EMOJIS: Record<WalkEventType, string> = {
   pee: '💧',
   poo: '💩',
   sniff: '🐽',
   greet: '🐾',
   photo: '📷',
 };
+
+export const MAP_EVENT_EMOJIS = WALK_EVENT_EMOJIS;
+export const UI_EVENT_EMOJIS = WALK_EVENT_EMOJIS;
 
 export interface CountableEvent {
   eventType: WalkEventType;

--- a/apps/mobile/lib/walk/live-activity-widget.test.tsx
+++ b/apps/mobile/lib/walk/live-activity-widget.test.tsx
@@ -1,0 +1,42 @@
+describe('walk live activity widget layout', () => {
+  it('keeps pee and poop emoji literals inside the widget function source', () => {
+    let capturedLayout: unknown;
+
+    jest.isolateModules(() => {
+      jest.doMock('@expo/ui/swift-ui', () => ({
+        Button: 'Button',
+        HStack: 'HStack',
+        Image: 'Image',
+        Spacer: 'Spacer',
+        Text: 'Text',
+        VStack: 'VStack',
+      }));
+      jest.doMock('@expo/ui/swift-ui/modifiers', () => ({
+        buttonStyle: jest.fn((value) => ({ buttonStyle: value })),
+        containerBackground: jest.fn((color, target) => ({ containerBackground: { color, target } })),
+        controlSize: jest.fn((value) => ({ controlSize: value })),
+        font: jest.fn((value) => ({ font: value })),
+        foregroundStyle: jest.fn((value) => ({ foregroundStyle: value })),
+        frame: jest.fn((value) => ({ frame: value })),
+        lineLimit: jest.fn((value) => ({ lineLimit: value })),
+        monospacedDigit: jest.fn(() => ({ monospacedDigit: true })),
+        padding: jest.fn((value) => ({ padding: value })),
+        tint: jest.fn((value) => ({ tint: value })),
+      }));
+      jest.doMock('expo-widgets', () => ({
+        createLiveActivity: jest.fn((_name, layout) => {
+          capturedLayout = layout;
+          return { getInstances: jest.fn(), start: jest.fn() };
+        }),
+      }));
+
+      require('./live-activity-widget');
+    });
+
+    const layoutSource = String(capturedLayout);
+
+    expect(layoutSource).toContain('💧');
+    expect(layoutSource).toContain('💩');
+    expect(layoutSource).not.toContain('WALK_EVENT_EMOJIS');
+  });
+});

--- a/apps/mobile/lib/walk/live-activity-widget.tsx
+++ b/apps/mobile/lib/walk/live-activity-widget.tsx
@@ -17,6 +17,8 @@ import { WALK_ACTIVITY_NAME, type WalkActivityProps } from './live-activity';
 function WalkActivityLayout(props: WalkActivityProps, _environment: LiveActivityEnvironment) {
   'widget';
 
+  const peeEmoji = '💧';
+  const pooEmoji = '💩';
   const accent = '#4F8A63';
   const destructive = '#C94D3F';
   const background = '#1F2A24';
@@ -72,14 +74,12 @@ function WalkActivityLayout(props: WalkActivityProps, _environment: LiveActivity
             </Text>
             <Spacer minLength={2} />
             <Button
-              label={`Pee ${dog.peeCount}`}
-              systemImage="drop.fill"
+              label={`${peeEmoji} Pee ${dog.peeCount}`}
               target={dog.peeTarget}
               modifiers={[buttonStyle('bordered'), controlSize('small'), tint(accent)]}
             />
             <Button
-              label={`Poop ${dog.pooCount}`}
-              systemImage="circle.fill"
+              label={`${pooEmoji} Poop ${dog.pooCount}`}
               target={dog.pooTarget}
               modifiers={[buttonStyle('bordered'), controlSize('small'), tint('#8A6F4F')]}
             />
@@ -131,14 +131,12 @@ function WalkActivityLayout(props: WalkActivityProps, _environment: LiveActivity
           </Text>
           <Spacer minLength={2} />
           <Button
-            label={`Pee ${firstDog.peeCount}`}
-            systemImage="drop.fill"
+            label={`${peeEmoji} Pee ${firstDog.peeCount}`}
             target={firstDog.peeTarget}
             modifiers={[buttonStyle('bordered'), controlSize('small'), tint(accent)]}
           />
           <Button
-            label={`Poop ${firstDog.pooCount}`}
-            systemImage="circle.fill"
+            label={`${pooEmoji} Poop ${firstDog.pooCount}`}
             target={firstDog.pooTarget}
             modifiers={[buttonStyle('bordered'), controlSize('small'), tint('#8A6F4F')]}
           />

--- a/apps/mobile/targets/watch/WatchWalkControlsView.swift
+++ b/apps/mobile/targets/watch/WatchWalkControlsView.swift
@@ -43,7 +43,11 @@ struct WatchWalkControlsView: View {
         Button {
           handleEventTap(.pee)
         } label: {
-          Label("Pee", systemImage: "drop.fill")
+          Label {
+            Text("Pee")
+          } icon: {
+            Text(WatchEventType.pee.emoji)
+          }
             .frame(maxWidth: .infinity)
         }
         .disabled(!store.canRecordEvent)
@@ -51,7 +55,11 @@ struct WatchWalkControlsView: View {
         Button {
           handleEventTap(.poo)
         } label: {
-          Label("Poop", systemImage: "pawprint.fill")
+          Label {
+            Text("Poop")
+          } icon: {
+            Text(WatchEventType.poo.emoji)
+          }
             .frame(maxWidth: .infinity)
         }
         .disabled(!store.canRecordEvent)
@@ -151,7 +159,7 @@ private struct WatchDogPickerView: View {
         dismiss()
       } label: {
         HStack {
-          Image(systemName: eventType.symbolName)
+          Text(eventType.emoji)
           VStack(alignment: .leading) {
             Text(dog.name)
             Text("Pee \(dog.peeCount) / Poop \(dog.pooCount)")

--- a/apps/mobile/targets/watch/WatchWalkModels.swift
+++ b/apps/mobile/targets/watch/WatchWalkModels.swift
@@ -61,12 +61,12 @@ enum WatchEventType: String, Codable, Identifiable {
     }
   }
 
-  var symbolName: String {
+  var emoji: String {
     switch self {
     case .pee:
-      return "drop.fill"
+      return "💧"
     case .poo:
-      return "pawprint.fill"
+      return "💩"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Unifies walk event icon rendering so pee uses 💧 and poop uses 💩 across the mobile app, Live Activity, and Apple Watch surfaces.
- Routes app UI surfaces through the shared walk event emoji mapping while keeping Live Activity widget literals inside the widget layout function to avoid Widget JSContext scope errors.
- Adds a regression test that checks the stringified Live Activity layout does not reference `WALK_EVENT_EMOJIS`.

## Root cause
The Live Activity layout function is stringified by `expo-widgets` and evaluated in the Widget JSContext. Imported constants are not available in that environment, so referencing `WALK_EVENT_EMOJIS` caused `ReferenceError` on the lock screen.

## Validation
- `npm test -- --runInBand lib/walk/live-activity-widget.test.tsx lib/walk/events.test.ts components/walk/WalkEventTimeline.test.tsx components/walk/WalkEventActions.test.tsx components/walk/WalkMap.test.tsx components/walk/PerDogSummaryCard.test.tsx components/dogs/DogWalkRow.test.tsx`
- `npm run typecheck`
- `xcrun swiftc -parse apps/mobile/targets/watch/WatchWalkModels.swift apps/mobile/targets/watch/WatchWalkControlsView.swift`
- `rg -n "🚽|WALK_EVENT_EMOJIS\.pee|WALK_EVENT_EMOJIS\.poo|drop\.fill|circle\.fill|symbolName" apps/mobile/components apps/mobile/app apps/mobile/lib apps/mobile/targets/watch apps/mobile/targets/watch-widget apps/mobile/CLAUDE.md`