### PR TITLE
[codex] Make walk map fullscreen

### DIFF
--- a/apps/mobile/CLAUDE.md
+++ b/apps/mobile/CLAUDE.md
@@ -40,6 +40,7 @@
 - `@bacons/apple-targets` を使う場合は `@expo/prebuild-config` を top-level devDependency として Expo SDK のバージョンに合わせて固定する。plugin が実行時に top-level require するため、Expo CLI 配下の nested dependency だけでは `expo prebuild` が失敗する。
 - Apple Watch の walk snapshot は Watch UI/complication 表示同期専用に保つ。iPhone JS state が無い状態から snapshot で active walk を復元しない。Watch command は iPhone 側の現在の active walk store と一致する場合だけ処理し、inactive/stale walk の command は ack して破棄する。
 - Live Activity と散歩記録をまたぐ修正では、ActivityKit 側だけを更新せず、前景 GPS・背景 GPS・永続化した active walk session・復帰時 navigation が同じ点列と `walkId` を参照する設計にする。Dynamic Island の tap は iOS がアプリ起動に予約しているため、tap URL は履歴詳細ではなく active recording route を指す。
+- Walk 開始・記録中などマップ主役の画面は、route 側で `ScreenHeader` / top-only `SafeAreaView` を挟まず、マップを全画面に敷いた上で `WalkMapShell` の overlay と NativeTabs/formSheet を重ねる。
 
 ## iOS Simulator 起動手順
 

--- a/apps/mobile/__tests__/app/tabs/walk.test.tsx
+++ b/apps/mobile/__tests__/app/tabs/walk.test.tsx
@@ -98,7 +98,7 @@ describe('Walk tab route', () => {
   it('shows the NoDogsBody CTA when there are zero dogs', () => {
     mockDogs = [];
     render(<WalkScreen />);
-    expect(screen.getByRole('header', { name: 'Walk' })).toBeTruthy();
+    expect(screen.queryByRole('header', { name: 'Walk' })).toBeNull();
     expect(screen.getByRole('button', { name: 'Add your first dog' })).toBeTruthy();
   });
 
@@ -112,5 +112,11 @@ describe('Walk tab route', () => {
     mockDogs = [buildDog({}), buildDog({ id: 'd2', name: 'Momo' })];
     render(<WalkScreen />);
     expect(screen.getByText('Walking with')).toBeTruthy();
+  });
+
+  it('does not show the Walk header while redirecting to the active walk screen', () => {
+    mockPhase = 'recording';
+    render(<WalkScreen />);
+    expect(screen.queryByRole('header', { name: 'Walk' })).toBeNull();
   });
 });

--- a/apps/mobile/app/(tabs)/walk.tsx
+++ b/apps/mobile/app/(tabs)/walk.tsx
@@ -1,4 +1,4 @@
-import { StyleSheet } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import { useColors } from '@/hooks/use-colors';
@@ -14,13 +14,17 @@ export default function WalkScreen() {
   const vm = useWalkScreenViewModel();
 
   if (vm.phase === 'ready') {
-    // 開始前はマップ付きの準備画面に開始操作を委譲します。
+    // 開始前はヘッダーを挟まず、マップ全面の準備画面に開始操作を委譲します。
     return (
-      <SafeAreaView edges={['top']} style={[styles.container, { backgroundColor: theme.background }]}>
-        <ScreenHeader title={t('tabs.walk')} />
+      <View style={[styles.container, { backgroundColor: theme.background }]}>
         <WalkReadyView onStart={vm.handleStart} isStarting={vm.isStarting} />
-      </SafeAreaView>
+      </View>
     );
+  }
+
+  if (vm.phase === 'recording') {
+    // 記録中は専用の全画面マップ route へ遷移するため、タブルート側にヘッダーを残しません。
+    return <View style={[styles.container, { backgroundColor: theme.background }]} />;
   }
 
   return (


### PR DESCRIPTION
## Summary
- Remove the inline Walk header from the ready walk tab so the map fills the screen behind the floating controls.
- Keep the tab route headerless while redirecting into the active walk map route.
- Add route-level regression coverage and document the map-first Walk screen rule.

## Why
The design spec for 04b Walk - Start and 05 Walk - Active shows the map as the full-screen base layer, with controls floating above it. The previous tab route wrapped the ready screen in a top SafeAreaView and ScreenHeader, which prevented that layout.

## Test Plan
- `npm test -- __tests__/app/tabs/walk.test.tsx components/walk/WalkReadyView.test.tsx --runInBand`
- `npm run typecheck`
- `git diff --check`

Simulator visual QA was not run in this thread.