### PR TITLE
[codex] Add Expo UI docs-first skill

### DIFF
--- a/.codex/skills/expo-ui-docs-first/SKILL.md
+++ b/.codex/skills/expo-ui-docs-first/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: expo-ui-docs-first
+description: Use when designing, implementing, or refactoring UI in Expo or React Native apps, especially with @expo/ui, @expo/ui/swift-ui, native-feeling controls, sheets, forms, lists, widgets, Live Activity UI, or platform UI.
+---
+
+# Expo UI Docs First
+
+## Core Rule
+
+Before planning or editing Expo UI code, read the relevant official Expo UI docs and state what you read. Do not guess component APIs from memory.
+
+## Workflow
+
+1. Read the relevant overview first:
+   - [SwiftUI](https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/)
+   - [Universal](https://docs.expo.dev/versions/latest/sdk/ui/universal/)
+2. Pick the surface:
+   - Prefer Universal (`@expo/ui`) for cross-platform UI.
+   - Use SwiftUI (`@expo/ui/swift-ui`) when the UI needs SwiftUI-specific views, modifiers, widgets, Live Activity UI, or iOS-only presentation.
+3. Read every component page you plan to use before implementation.
+4. Before code edits, write a short plan listing:
+   - docs read
+   - selected components
+   - import paths
+   - `Host` / `RNHostView` wrapper structure
+   - verification steps
+5. Every Expo UI tree must be wrapped in `Host`. Use `RNHostView` when embedding React Native components inside a native UI tree.
+6. If required docs are unavailable because browsing or network access is blocked, stop and say which docs could not be read instead of inventing the API.
+
+## Component Docs
+
+### SwiftUI
+
+- [AccessoryWidgetBackground](https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/accessorywidgetbackground/)
+- [Alert](https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/alert/)
+- [BottomSheet](https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/bottomsheet/)
+- [Button](https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/button/)
+- [ColorPicker](https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/colorpicker/)
+- [ConfirmationDialog](https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/confirmationdialog/)
+- [ContextMenu](https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/contextmenu/)
+- [ControlGroup](https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/controlgroup/)
+- [DatePicker](https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/datepicker/)
+- [DisclosureGroup](https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/disclosuregroup/)
+- [Divider](https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/divider/)
+- [Form](https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/form/)
+- [Gauge](https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/gauge/)
+- [Group](https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/group/)
+- [Host](https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/host/)
+- [HStack](https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/hstack/)
+- [Image](https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/image/)
+- [Label](https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/label/)
+- [LazyHStack](https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/lazyhstack/)
+- [LazyVStack](https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/lazyvstack/)
+- [Link](https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/link/)
+- [List](https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/list/)
+- [Menu](https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/menu/)
+- [Modifiers](https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/modifiers/)
+- [Namespace](https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/namespace/)
+- [Overlay](https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/overlay/)
+- [Picker](https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/picker/)
+- [Popover](https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/popover/)
+- [ProgressView](https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/progressview/)
+- [RNHostView](https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/rnhostview/)
+- [ScrollView](https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/scrollview/)
+- [Section](https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/section/)
+- [SecureField](https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/securefield/)
+- [Slider](https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/slider/)
+- [Spacer](https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/spacer/)
+- [SwipeActions](https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/swipeactions/)
+- [TabView](https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/tabview/)
+- [Text](https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/text/)
+- [TextField](https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/textfield/)
+- [Toggle](https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/toggle/)
+- [useNativeState](https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/usenativestate/)
+- [VStack](https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/vstack/)
+- [ZStack](https://docs.expo.dev/versions/latest/sdk/ui/swift-ui/zstack/)
+
+### Universal
+
+- [BottomSheet](https://docs.expo.dev/versions/latest/sdk/ui/universal/bottomsheet/)
+- [Button](https://docs.expo.dev/versions/latest/sdk/ui/universal/button/)
+- [Checkbox](https://docs.expo.dev/versions/latest/sdk/ui/universal/checkbox/)
+- [Collapsible](https://docs.expo.dev/versions/latest/sdk/ui/universal/collapsible/)
+- [Column](https://docs.expo.dev/versions/latest/sdk/ui/universal/column/)
+- [FieldGroup](https://docs.expo.dev/versions/latest/sdk/ui/universal/fieldgroup/)
+- [Host](https://docs.expo.dev/versions/latest/sdk/ui/universal/host/)
+- [Icon](https://docs.expo.dev/versions/latest/sdk/ui/universal/icon/)
+- [List](https://docs.expo.dev/versions/latest/sdk/ui/universal/list/)
+- [Picker](https://docs.expo.dev/versions/latest/sdk/ui/universal/picker/)
+- [RNHostView](https://docs.expo.dev/versions/latest/sdk/ui/universal/rnhostview/)
+- [Row](https://docs.expo.dev/versions/latest/sdk/ui/universal/row/)
+- [ScrollView](https://docs.expo.dev/versions/latest/sdk/ui/universal/scrollview/)
+- [Slider](https://docs.expo.dev/versions/latest/sdk/ui/universal/slider/)
+- [Spacer](https://docs.expo.dev/versions/latest/sdk/ui/universal/spacer/)
+- [Switch](https://docs.expo.dev/versions/latest/sdk/ui/universal/switch/)
+- [Text](https://docs.expo.dev/versions/latest/sdk/ui/universal/text/)
+- [TextInput](https://docs.expo.dev/versions/latest/sdk/ui/universal/textinput/)
+
+## Common Mistakes
+
+- Starting implementation before reading the component docs.
+- Choosing SwiftUI when Universal covers the cross-platform need.
+- Forgetting `Host` around the native UI tree.
+- Embedding React Native components directly instead of wrapping them with `RNHostView`.

--- a/.codex/skills/expo-ui-docs-first/agents/openai.yaml
+++ b/.codex/skills/expo-ui-docs-first/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Expo UI Docs First"
+  short_description: "Read Expo UI docs before UI work"
+  default_prompt: "Use $expo-ui-docs-first to plan an Expo UI implementation from the official docs before editing code."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,10 @@ walking-dog/
 
 This project uses the obra/superpowers plugin. Always check for relevant skills before taking any action.
 
+## Project-scoped Skills
+
+- UI の設計・実装・リファクタリングで Expo / React Native / `@expo/ui` / `@expo/ui/swift-ui` を扱う場合は、最初に `.codex/skills/expo-ui-docs-first/SKILL.md` を読むこと。repo-local skill の自動検出が効かないセッションでも、このファイルを明示的に参照してから計画・実装する。
+
 ## 開発フェーズとスキル
 
 各フェーズで以下の superpowers スキルを使うこと：


### PR DESCRIPTION
## Summary
- Add a repo-local Codex skill that requires reading Expo UI docs before Expo / React Native UI work.
- Include SwiftUI and Universal component doc links plus planning requirements for components, imports, wrappers, and verification.
- Add a root instruction pointer so the skill is still found if repo-local skill auto-discovery is unavailable.

## Validation
- `PYTHONPATH=/private/tmp/codex-pyyaml python3 /Users/matsuokashuhei/.codex/skills/.system/skill-creator/scripts/quick_validate.py /Users/matsuokashuhei/.codex/worktrees/aea2/walking-dog/.codex/skills/expo-ui-docs-first` -> `Skill is valid!`
- `git status --short --branch --untracked-files=all` -> clean on `codex/expo-ui-docs-first-skill`

## Notes
- Draft PR because this is generated by Codex and may need review of repo-local skill discovery behavior in a fresh session.