### PR TITLE
[codex] Open single-dog detail from Dogs tab

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,12 @@
 - API: `apps/api/CLAUDE.md`
 - Mobile: `apps/mobile/CLAUDE.md`
 
+## Product Behavior Notes
+
+- Mobile の Dogs タブは、Dog が1頭だけなら一覧ではなくその Dog 詳細へ遷移する。Dog が0頭なら空状態、2頭以上なら一覧を表示する。
+- `Today's walking goal` は Dogs 一覧ではなく Dog 詳細の Walks セクション直前に置き、Pack 合計ではなくその Dog 個別の今日距離で表示する。
+- API の散歩集計で `SUM` を使う場合、散歩0件や全値 `NULL` のケースを SQL 側で `COALESCE(..., 0)` し、GraphQL の non-null 数値 field へ `NULL` decode エラーを漏らさない。
+
 ## Directory Structure
 
 ```

--- a/apps/api/src/entity/walk.rs
+++ b/apps/api/src/entity/walk.rs
@@ -58,13 +58,11 @@ impl Entity {
             .select_only()
             .column_as(Expr::col(walk::Column::Id).count(), "total_count")
             .column_as(
-                Expr::col(walk::Column::Distance).sum().cast_as("bigint"),
+                Expr::cust("COALESCE(SUM(distance), 0)::bigint"),
                 "total_distance",
             )
             .column_as(
-                Expr::cust("EXTRACT(EPOCH FROM (ended_at - started_at))")
-                    .sum()
-                    .cast_as("bigint"),
+                Expr::cust("COALESCE(SUM(EXTRACT(EPOCH FROM (ended_at - started_at))), 0)::bigint"),
                 "total_duration",
             )
             .into_tuple()
@@ -72,5 +70,49 @@ impl Entity {
             .await?
             .unwrap_or_default();
         Ok((total_count, total_distance, total_duration))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use sea_orm::{ColumnTrait, DatabaseBackend, EntityTrait, MockDatabase, QueryFilter, Value};
+    use uuid::Uuid;
+
+    use super::*;
+
+    fn aggregate_row(
+        total_count: i64,
+        total_distance: i64,
+        total_duration: i64,
+    ) -> BTreeMap<&'static str, Value> {
+        BTreeMap::from([
+            ("total_count", total_count.into()),
+            ("total_distance", total_distance.into()),
+            ("total_duration", total_duration.into()),
+        ])
+    }
+
+    #[tokio::test]
+    async fn aggregate_coalesces_nullable_sums_to_zero() {
+        let user_id = Uuid::parse_str("019e0dc4-066b-7a22-b755-969ee6beb5e9").unwrap();
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([[aggregate_row(0, 0, 0)]])
+            .into_connection();
+        let query = Entity::find().filter(Column::UserId.eq(user_id));
+
+        let aggregate = Entity::aggregate(&db, query).await.unwrap();
+
+        assert_eq!(aggregate, (0, 0, 0));
+        let log = db.into_transaction_log();
+        let sql = log
+            .iter()
+            .flat_map(|entry| entry.statements())
+            .map(|statement| statement.sql.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(sql.contains("COALESCE(SUM(distance), 0)::bigint"));
+        assert!(sql.contains("COALESCE(SUM(EXTRACT(EPOCH FROM (ended_at - started_at))), 0)::bigint"));
     }
 }

--- a/apps/mobile/CLAUDE.md
+++ b/apps/mobile/CLAUDE.md
@@ -42,6 +42,7 @@
 - Apple Watch の walk snapshot は Watch UI/complication 表示同期専用に保つ。iPhone JS state が無い状態から snapshot で active walk を復元しない。Watch command は iPhone 側の現在の active walk store と一致する場合だけ処理し、inactive/stale walk の command は ack して破棄する。
 - Live Activity と散歩記録をまたぐ修正では、ActivityKit 側だけを更新せず、前景 GPS・背景 GPS・永続化した active walk session・復帰時 navigation が同じ点列と `walkId` を参照する設計にする。Dynamic Island の tap は iOS がアプリ起動に予約しているため、tap URL は履歴詳細ではなく active recording route を指す。
 - Walk 開始・記録中などマップ主役の画面は、route 側で `ScreenHeader` / top-only `SafeAreaView` を挟まず、マップを全画面に敷いた上で `WalkMapShell` の overlay と NativeTabs/formSheet を重ねる。
+- NativeTabs の tab route から条件付きで詳細画面へ送る場合は、`useEffect` 内の `router.replace` と待機用 `LoadingScreen` を組み合わせず、route の render 結果として Expo Router の `<Redirect href="..." />` を返す。タブの focus 前に副作用 navigation を走らせると、タブ画面のスピナーが残ったままになることがある。
 - Pee/poop の表示アイコンは全サーフェスで統一する。React Native 側は `lib/walk/events.ts` の `WALK_EVENT_EMOJIS` を単一ソースにし、pee は `💧`、poop/poo は `💩` を使う。Live Activity と Watch SwiftUI でも同じ emoji を表示し、SF Symbols の `drop.fill` などに分岐させない。`expo-widgets` の Live Activity layout は関数を文字列化して Widget 側 JSContext で再評価するため、layout 関数内では imported constant を参照せず、関数内 local literal と回帰テストで値を固定する。
 
 ## iOS Simulator 起動手順

--- a/apps/mobile/__tests__/app/dogs/dog-detail.test.tsx
+++ b/apps/mobile/__tests__/app/dogs/dog-detail.test.tsx
@@ -44,6 +44,12 @@ const mockDog: DogWithStats = {
 
 let mockMeData: { id: string } | undefined = { id: 'user-1' };
 let mockDogData: DogWithStats = mockDog;
+let mockPack = {
+  perDog: {
+    'dog-1': { todayKm: 1.42, totalWalks: 10, streakDays: 3 },
+  },
+  goalKm: 5,
+};
 
 jest.mock('@/hooks/use-dog', () => ({
   useDog: () => ({ data: mockDogData, isLoading: false }),
@@ -58,7 +64,7 @@ jest.mock('@/hooks/use-me', () => ({
 }));
 
 jest.mock('@/hooks/use-pack-progress', () => ({
-  usePackProgress: () => ({ perDog: {} }),
+  usePackProgress: () => mockPack,
 }));
 
 jest.mock('@/hooks/use-walks', () => ({
@@ -79,11 +85,40 @@ function renderWithProviders(ui: React.ReactElement) {
   );
 }
 
+function getNodeTestID(node: object): string | null {
+  if (!('props' in node) || !node.props || typeof node.props !== 'object') return null;
+  if (!('testID' in node.props) || typeof node.props.testID !== 'string') return null;
+  return node.props.testID;
+}
+
+function getNodeChildren(node: object): unknown[] {
+  if (!('children' in node) || !Array.isArray(node.children)) return [];
+  return node.children;
+}
+
+function collectTestIds(node: unknown): string[] {
+  if (!node || typeof node === 'string' || typeof node === 'number') return [];
+  if (Array.isArray(node)) return node.flatMap(collectTestIds);
+  if (typeof node !== 'object') return [];
+
+  const testID = getNodeTestID(node);
+  return [
+    ...(testID ? [testID] : []),
+    ...getNodeChildren(node).flatMap(collectTestIds),
+  ];
+}
+
 describe('DogDetailScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockMeData = { id: 'user-1' };
     mockDogData = mockDog;
+    mockPack = {
+      perDog: {
+        'dog-1': { todayKm: 1.42, totalWalks: 10, streakDays: 3 },
+      },
+      goalKm: 5,
+    };
     mockCanGoBack = true;
   });
 
@@ -161,6 +196,29 @@ describe('DogDetailScreen', () => {
     const style = StyleSheet.flatten(walksSection.props.style);
 
     expect(style.paddingHorizontal).toBe(spacing.md);
+  });
+
+  it('renders the dog-specific walking goal before walks', () => {
+    const rendered = renderWithProviders(<DogDetailScreen />);
+
+    expect(screen.getByText("Today's walking goal")).toBeTruthy();
+    expect(screen.getByText('1.42 / 5.0 km for Buddy')).toBeTruthy();
+    expect(screen.getByText('28%')).toBeTruthy();
+
+    const goalSection = screen.getByTestId('dog-detail-walking-goal-section');
+    const walksSection = screen.getByTestId('dog-detail-walks-section');
+    const sections = collectTestIds(rendered.toJSON()).filter(
+      (testID) =>
+        testID === 'dog-detail-walking-goal-section' ||
+        testID === 'dog-detail-walks-section',
+    );
+
+    expect(goalSection).toBeTruthy();
+    expect(walksSection).toBeTruthy();
+    expect(sections).toEqual([
+      'dog-detail-walking-goal-section',
+      'dog-detail-walks-section',
+    ]);
   });
 
   it('hides delete button when dog has no role', () => {

--- a/apps/mobile/__tests__/app/tabs/dogs.test.tsx
+++ b/apps/mobile/__tests__/app/tabs/dogs.test.tsx
@@ -1,24 +1,31 @@
 import { render, screen } from '@testing-library/react-native';
 import DogsScreen from '../../../app/(tabs)/dogs';
+import type { Dog } from '@/types/graphql';
+
+const mockRedirect = jest.fn(({ href }: { href: string }) => {
+  const { Text } = jest.requireActual('react-native');
+  return <Text>Redirect:{href}</Text>;
+});
+const mockRefetch = jest.fn();
+
+let mockDogs: Dog[] = [];
 
 jest.mock('@/hooks/use-color-scheme', () => ({
   useColorScheme: () => 'light',
 }));
 
 jest.mock('expo-router', () => ({
-  useRouter: () => ({ push: jest.fn() }),
+  Redirect: (props: { href: string }) => mockRedirect(props),
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
 }));
 
 jest.mock('@/hooks/use-me', () => ({
   useMe: () => ({
     data: {
-      dogs: [
-        { id: 'dog-1', name: 'Pochi', breed: 'Shiba Inu', photoUrl: null, createdAt: '2026-01-01' },
-        { id: 'dog-2', name: 'Hana', breed: null, photoUrl: null, createdAt: '2026-01-02' },
-      ],
+      dogs: mockDogs,
     },
     isLoading: false,
-    refetch: jest.fn(),
+    refetch: mockRefetch,
   }),
 }));
 
@@ -40,11 +47,17 @@ jest.mock('@/components/dogs/DogListItem', () => {
 });
 
 jest.mock('@/components/ui/EmptyState', () => ({
-  EmptyState: () => null,
+  EmptyState: ({ message }: { message: string }) => {
+    const { Text } = jest.requireActual('react-native');
+    return <Text>{message}</Text>;
+  },
 }));
 
 jest.mock('@/components/ui/LoadingScreen', () => ({
-  LoadingScreen: () => null,
+  LoadingScreen: () => {
+    const { Text } = jest.requireActual('react-native');
+    return <Text>Loading</Text>;
+  },
 }));
 
 jest.mock('@/components/ui/RingProgress', () => {
@@ -53,6 +66,14 @@ jest.mock('@/components/ui/RingProgress', () => {
 });
 
 describe('DogsScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDogs = [
+      { id: 'dog-1', name: 'Pochi', breed: 'Shiba Inu', photoUrl: null, createdAt: '2026-01-01' },
+      { id: 'dog-2', name: 'Hana', breed: null, photoUrl: null, createdAt: '2026-01-02' },
+    ] as Dog[];
+  });
+
   it('renders YOUR PACK section label', () => {
     render(<DogsScreen />);
     expect(screen.getByText('YOUR PACK')).toBeTruthy();
@@ -67,13 +88,35 @@ describe('DogsScreen', () => {
     expect(screen.getByTestId('dogs-header-right-action-slot')).toBeTruthy();
   });
 
-  it('renders Today walking goal rollup title', () => {
+  it('does not render Today walking goal in the dogs list', () => {
     render(<DogsScreen />);
-    expect(screen.getByText("Today's walking goal")).toBeTruthy();
+    expect(screen.queryByText("Today's walking goal")).toBeNull();
   });
 
   it('renders header + Add CTA', () => {
     render(<DogsScreen />);
     expect(screen.getByRole('button', { name: '+ Add' })).toBeTruthy();
+  });
+
+  it('redirects the dogs tab to the only dog detail without leaving a loading screen', () => {
+    mockDogs = [
+      { id: 'dog-1', name: 'Pochi', breed: 'Shiba Inu', photoUrl: null, createdAt: '2026-01-01' },
+    ] as Dog[];
+
+    render(<DogsScreen />);
+
+    expect(mockRedirect.mock.calls[0]?.[0]).toEqual({ href: '/dogs/dog-1' });
+    expect(screen.getByText('Redirect:/dogs/dog-1')).toBeTruthy();
+    expect(screen.queryByText('Loading')).toBeNull();
+    expect(screen.queryByRole('header', { name: 'Dogs' })).toBeNull();
+  });
+
+  it('keeps the empty dogs state when no dogs exist', () => {
+    mockDogs = [];
+
+    render(<DogsScreen />);
+
+    expect(screen.getByText('No dogs registered yet')).toBeTruthy();
+    expect(mockRedirect).not.toHaveBeenCalled();
   });
 });

--- a/apps/mobile/app/(tabs)/dogs.tsx
+++ b/apps/mobile/app/(tabs)/dogs.tsx
@@ -1,9 +1,9 @@
 import { FlatList, StyleSheet, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { Redirect } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useDogsScreenViewModel } from '@/hooks/use-dogs-screen-view-model';
 import { DogListItem } from '@/components/dogs/DogListItem';
-import { PackRollupCard } from '@/components/dogs/PackRollupCard';
 import { EmptyState } from '@/components/ui/EmptyState';
 import { LoadingScreen } from '@/components/ui/LoadingScreen';
 import { ScreenHeader } from '@/components/ui/ScreenHeader';
@@ -19,17 +19,13 @@ export default function DogsScreen() {
 
   if (vm.isLoading) return <LoadingScreen />;
 
-  // 一覧の先頭には pack の集計カードとセクション見出しをまとめて表示します。
+  if (vm.dogs.length === 1) {
+    return <Redirect href={`/dogs/${vm.dogs[0].id}`} />;
+  }
+
+  // 一覧の先頭には pack のセクション見出しを表示します。
   const ListHeader = (
     <View style={styles.headerContainer}>
-      <View style={styles.rollupWrap}>
-        <PackRollupCard
-          todayKm={vm.pack.todayKm}
-          goalKm={vm.pack.goalKm}
-          progressPct={vm.pack.progressPct}
-        />
-      </View>
-
       <SectionHeader
         label={t('dogs.list.sectionLabel')}
         style={styles.sectionHeader}
@@ -80,9 +76,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing.lg,
     paddingTop: spacing.sm,
     paddingBottom: spacing.md,
-  },
-  rollupWrap: {
-    marginBottom: spacing.xl,
   },
   sectionHeader: {
     paddingHorizontal: spacing.xs - spacing.xs,

--- a/apps/mobile/app/dogs/[id]/index.tsx
+++ b/apps/mobile/app/dogs/[id]/index.tsx
@@ -6,6 +6,7 @@ import { useDogDetailViewModel } from '@/hooks/use-dog-detail-view-model';
 import { DogHero } from '@/components/dogs/DogHero';
 import { DogStatsCard } from '@/components/dogs/DogStatsCard';
 import { DogWalksList } from '@/components/dogs/DogWalksList';
+import { WalkingGoalCard } from '@/components/dogs/WalkingGoalCard';
 import { LoadingScreen } from '@/components/ui/LoadingScreen';
 import { Button } from '@/components/ui/Button';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
@@ -74,6 +75,19 @@ export default function DogDetailScreen() {
             <DogStatsCard stats={vm.dog.walkStats} streakDays={vm.streakDays} />
           </View>
         ) : null}
+
+        <View testID="dog-detail-walking-goal-section" style={styles.walkingGoalSection}>
+          <WalkingGoalCard
+            todayKm={vm.walkingGoal.todayKm}
+            goalKm={vm.walkingGoal.goalKm}
+            progressPct={vm.walkingGoal.progressPct}
+            subtitle={t('dogs.detail.walkingGoalSubtitle', {
+              km: vm.walkingGoal.todayKm.toFixed(2),
+              goal: vm.walkingGoal.goalKm.toFixed(1),
+              name: vm.dog.name,
+            })}
+          />
+        </View>
 
         <View testID="dog-detail-walks-section" style={styles.walksSection}>
           <DogWalksList
@@ -173,6 +187,10 @@ const styles = StyleSheet.create({
     marginTop: spacing.xs / 2,
   },
   statsSection: {
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.lg,
+  },
+  walkingGoalSection: {
     paddingHorizontal: spacing.md,
     paddingTop: spacing.lg,
   },

--- a/apps/mobile/components/dogs/WalkingGoalCard.test.tsx
+++ b/apps/mobile/components/dogs/WalkingGoalCard.test.tsx
@@ -1,16 +1,23 @@
 import { fireEvent, render, screen } from '@testing-library/react-native';
-import { PackRollupCard } from './PackRollupCard';
+import { WalkingGoalCard } from './WalkingGoalCard';
 
 jest.mock('@/hooks/use-color-scheme', () => ({
   useColorScheme: () => 'light',
 }));
 
-describe('PackRollupCard', () => {
+describe('WalkingGoalCard', () => {
   it('renders the walking goal summary and progress label', () => {
-    render(<PackRollupCard todayKm={1.42} goalKm={5} progressPct={28} />);
+    render(
+      <WalkingGoalCard
+        todayKm={1.42}
+        goalKm={5}
+        progressPct={28}
+        subtitle="1.42 / 5.0 km for Coco"
+      />,
+    );
 
     expect(screen.getByText("Today's walking goal")).toBeTruthy();
-    expect(screen.getByText('1.42 / 5.0 km across your pack')).toBeTruthy();
+    expect(screen.getByText('1.42 / 5.0 km for Coco')).toBeTruthy();
     expect(screen.getByText('28%')).toBeTruthy();
   });
 
@@ -18,7 +25,13 @@ describe('PackRollupCard', () => {
     const onPress = jest.fn();
 
     render(
-      <PackRollupCard todayKm={1.42} goalKm={5} progressPct={28} onPress={onPress} />,
+      <WalkingGoalCard
+        todayKm={1.42}
+        goalKm={5}
+        progressPct={28}
+        subtitle="1.42 / 5.0 km for Coco"
+        onPress={onPress}
+      />,
     );
 
     fireEvent.press(screen.getByRole('button', { name: "Today's walking goal" }));
@@ -27,7 +40,14 @@ describe('PackRollupCard', () => {
   });
 
   it('does not render a button wrapper when onPress is omitted', () => {
-    render(<PackRollupCard todayKm={1.42} goalKm={5} progressPct={28} />);
+    render(
+      <WalkingGoalCard
+        todayKm={1.42}
+        goalKm={5}
+        progressPct={28}
+        subtitle="1.42 / 5.0 km for Coco"
+      />,
+    );
 
     expect(screen.queryByRole('button', { name: "Today's walking goal" })).toBeNull();
   });

--- a/apps/mobile/components/dogs/WalkingGoalCard.tsx
+++ b/apps/mobile/components/dogs/WalkingGoalCard.tsx
@@ -5,26 +5,23 @@ import { spacing, typography } from '@/theme/tokens';
 import { GroupedCard } from '@/components/ui/GroupedCard';
 import { RingProgress } from '@/components/ui/RingProgress';
 
-interface PackRollupCardProps {
+interface WalkingGoalCardProps {
   todayKm: number;
   goalKm: number;
   progressPct: number;
+  subtitle: string;
   onPress?: () => void;
 }
 
-export function PackRollupCard({
+export function WalkingGoalCard({
   todayKm,
   goalKm,
   progressPct,
+  subtitle,
   onPress,
-}: PackRollupCardProps) {
+}: WalkingGoalCardProps) {
   const { t } = useTranslation();
   const theme = useColors();
-
-  const subtitle = t('dogs.list.acrossPack', {
-    km: todayKm.toFixed(2),
-    goal: goalKm.toFixed(1),
-  });
 
   const content = (
     <>
@@ -60,6 +57,7 @@ export function PackRollupCard({
         <Pressable
           accessibilityRole="button"
           accessibilityLabel={t('dogs.list.todayGoal')}
+          accessibilityValue={{ min: 0, max: goalKm, now: todayKm }}
           onPress={onPress}
           style={styles.row}
         >

--- a/apps/mobile/hooks/use-dog-detail-view-model.test.ts
+++ b/apps/mobile/hooks/use-dog-detail-view-model.test.ts
@@ -64,12 +64,17 @@ let mockWalks: Walk[] = [
     events: [],
   },
 ];
-let mockPack = {
+let mockPack: {
+  todayKm: number;
+  goalKm: number;
+  progressPct: number;
+  perDog: Record<string, { todayKm: number; totalWalks: number; streakDays: number }>;
+} = {
   todayKm: 1,
   goalKm: 5,
   progressPct: 20,
   perDog: {
-    'dog-1': { streakDays: 5 },
+    'dog-1': { todayKm: 1.42, totalWalks: 10, streakDays: 5 },
   },
 };
 let mockMe = { id: 'user-1' };
@@ -190,7 +195,7 @@ describe('useDogDetailViewModel', () => {
       goalKm: 5,
       progressPct: 20,
       perDog: {
-        'dog-1': { streakDays: 5 },
+        'dog-1': { todayKm: 1.42, totalWalks: 10, streakDays: 5 },
       },
     };
     mockMe = { id: 'user-1' };
@@ -217,6 +222,33 @@ describe('useDogDetailViewModel', () => {
     expect(vm.streakDays).toBe(5);
     expect(vm.dogWalks.map((walk) => walk.id)).toEqual(['walk-1']);
     expect(vm.isOwner).toBe(true);
+  });
+
+  it('exposes dog-specific walking goal progress', () => {
+    const { result } = renderHook(() => useDogDetailViewModel());
+
+    expect(expectReadyViewModel(result.current).walkingGoal).toEqual({
+      todayKm: 1.42,
+      goalKm: 5,
+      progressPct: 28,
+    });
+  });
+
+  it('falls back to zero dog-specific walking goal progress when the dog has no walks', () => {
+    mockPack = {
+      todayKm: 3,
+      goalKm: 5,
+      progressPct: 60,
+      perDog: {},
+    };
+
+    const { result } = renderHook(() => useDogDetailViewModel());
+
+    expect(expectReadyViewModel(result.current).walkingGoal).toEqual({
+      todayKm: 0,
+      goalKm: 5,
+      progressPct: 0,
+    });
   });
 
   it('has no walks error when the walks query succeeds', () => {

--- a/apps/mobile/hooks/use-dog-detail-view-model.ts
+++ b/apps/mobile/hooks/use-dog-detail-view-model.ts
@@ -41,6 +41,11 @@ interface DogDetailReadyViewModel {
   dog: DogWithStats;
   meta: string;
   streakDays: number;
+  walkingGoal: {
+    todayKm: number;
+    goalKm: number;
+    progressPct: number;
+  };
   dogWalks: Walk[];
   // 散歩履歴の取得に失敗したときだけ非 null。空配列と「失敗」を画面側で区別するために持ちます。
   walksError: Error | null;
@@ -109,11 +114,20 @@ export function useDogDetailViewModel(): DogDetailViewModel {
     return { status: 'loading' };
   }
 
+  const dogTodayKm = pack.perDog[dog.id]?.todayKm ?? 0;
+  const walkingGoalProgressPct =
+    pack.goalKm > 0 ? Math.min(100, Math.round((dogTodayKm / pack.goalKm) * 100)) : 0;
+
   return {
     status: 'ready',
     dog,
     meta: buildMeta(dog),
     streakDays: pack.perDog[dog.id]?.streakDays ?? 0,
+    walkingGoal: {
+      todayKm: dogTodayKm,
+      goalKm: pack.goalKm,
+      progressPct: walkingGoalProgressPct,
+    },
     dogWalks,
     walksError,
     retryWalks,

--- a/apps/mobile/lib/i18n/locales/en.json
+++ b/apps/mobile/lib/i18n/locales/en.json
@@ -98,6 +98,7 @@
       "walks": "Walks",
       "walksError": "Couldn't load walks.",
       "seeAll": "See all",
+      "walkingGoalSubtitle": "{{km}} / {{goal}} km for {{name}}",
       "streakLabel": "Streak",
       "streakDays": "{{days}}d",
       "back": "Dogs"

--- a/apps/mobile/lib/i18n/locales/ja.json
+++ b/apps/mobile/lib/i18n/locales/ja.json
@@ -98,6 +98,7 @@
       "walks": "散歩",
       "walksError": "散歩を読み込めませんでした。",
       "seeAll": "すべて見る",
+      "walkingGoalSubtitle": "{{name}}: {{km}} / {{goal}} km",
       "streakLabel": "連続",
       "streakDays": "{{days}}日",
       "back": "愛犬"


### PR DESCRIPTION
## Summary
- Redirect the Dogs tab directly to the sole Dog detail screen with Expo Router `Redirect`, avoiding the stuck tab loading state.
- Move the walking goal card from the Dogs list to Dog detail above Walks, using per-dog progress.
- Fix API walk aggregation so empty or null walk sums return `0` instead of failing GraphQL decoding.

## Root Cause
The single-dog tab path rendered a loading screen while triggering `router.replace` from an effect. On NativeTabs this could leave the Dogs tab focused with the spinner visible. After redirecting into Dog detail, a separate API issue became visible: `SUM(...)` returned `NULL` for empty walk aggregates and failed decoding into non-null GraphQL fields.

## Verification
- `cd apps/mobile && npm test -- --runTestsByPath __tests__/app/tabs/dogs.test.tsx __tests__/app/dogs/dog-detail.test.tsx components/dogs/WalkingGoalCard.test.tsx hooks/use-dog-detail-view-model.test.ts hooks/use-pack-progress.test.ts`
- `cd apps/mobile && npm run typecheck`
- `cd apps/mobile && npm run lint`
- `cd apps/mobile && npm test -- --runInBand --forceExit`
- `docker compose -f apps/compose.yml exec -T api cargo test`
- `git diff --check`
- Verified on iOS Simulator: single-dog Dogs tab opens Dog detail, and Walks empty state renders without the GraphQL decode error.