### PR TITLE
[codex] Show dog avatars for walk location

### DIFF
--- a/apps/mobile/CLAUDE.md
+++ b/apps/mobile/CLAUDE.md
@@ -42,6 +42,7 @@
 - Apple Watch の walk snapshot は Watch UI/complication 表示同期専用に保つ。iPhone JS state が無い状態から snapshot で active walk を復元しない。Watch command は iPhone 側の現在の active walk store と一致する場合だけ処理し、inactive/stale walk の command は ack して破棄する。
 - Live Activity と散歩記録をまたぐ修正では、ActivityKit 側だけを更新せず、前景 GPS・背景 GPS・永続化した active walk session・復帰時 navigation が同じ点列と `walkId` を参照する設計にする。Dynamic Island の tap は iOS がアプリ起動に予約しているため、tap URL は履歴詳細ではなく active recording route を指す。
 - Walk 開始・記録中などマップ主役の画面は、route 側で `ScreenHeader` / top-only `SafeAreaView` を挟まず、マップを全画面に敷いた上で `WalkMapShell` の overlay と NativeTabs/formSheet を重ねる。
+- 記録中マップの現在地表示は `useWalkStore().points` の最新点を単一の source of truth にする。犬プロフィール画像などの表示情報は route 側で選択犬を解決して `WalkMap` に渡し、`showsUserLocation` など別系統の現在地表示と併用しない。
 - Pee/poop の表示アイコンは全サーフェスで統一する。React Native 側は `lib/walk/events.ts` の `WALK_EVENT_EMOJIS` を単一ソースにし、pee は `💧`、poop/poo は `💩` を使う。Live Activity と Watch SwiftUI でも同じ emoji を表示し、SF Symbols の `drop.fill` などに分岐させない。`expo-widgets` の Live Activity layout は関数を文字列化して Widget 側 JSContext で再評価するため、layout 関数内では imported constant を参照せず、関数内 local literal と回帰テストで値を固定する。
 
 ## iOS Simulator 起動手順
@@ -51,6 +52,8 @@
 1. `npm run metro:kill`
 2. `npm run ios:clean`
 3. `npm run ios:sim:local`
+
+XcodeBuildMCP で同名の Simulator が複数ある環境を操作するときは、`simulatorName` ではなく `simulatorId` を指定する。名前解決だけだと停止中の別 OS ランタイムを選ぶことがある。
 
 ## Available Commands
 /plan, /code-review, /tdd, /build-fix, /perf, /upgrade, /debug, /deploy,

--- a/apps/mobile/app/walk-recording.tsx
+++ b/apps/mobile/app/walk-recording.tsx
@@ -82,7 +82,10 @@ export default function WalkRecordingScreen() {
 
   return (
     <View style={[styles.container, { backgroundColor: theme.background }]}>
-      <WalkMapShell map={<WalkMap mode="recording" />} top={<WalkTopChip dogs={selectedDogs} />} />
+      <WalkMapShell
+        map={<WalkMap mode="recording" dogs={selectedDogs} />}
+        top={<WalkTopChip dogs={selectedDogs} />}
+      />
     </View>
   );
 }

--- a/apps/mobile/components/walk/WalkMap.test.tsx
+++ b/apps/mobile/components/walk/WalkMap.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen } from '@testing-library/react-native';
+import { StyleSheet } from 'react-native';
 import { WalkMap } from './WalkMap';
-import type { WalkEvent, WalkPoint } from '@/types/graphql';
+import { spacing } from '@/theme/tokens';
+import type { Dog, WalkEvent, WalkPoint } from '@/types/graphql';
 
 jest.mock('@/hooks/use-color-scheme', () => ({
   useColorScheme: () => 'light',
@@ -12,16 +14,34 @@ jest.mock('react-native-maps', () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { View } = require('react-native');
 
-  const MockMapView = ({ children, testID }: { children?: React.ReactNode; testID?: string }) =>
-    React.createElement(View, { testID: testID ?? 'MapView' }, children);
+  const MockMapView = React.forwardRef(
+    (
+      {
+        children,
+        testID,
+        ...props
+      }: {
+        children?: React.ReactNode;
+        testID?: string;
+      },
+      ref: React.Ref<{ animateToRegion: jest.Mock }>,
+    ) => {
+      React.useImperativeHandle(ref, () => ({ animateToRegion: jest.fn() }));
+      return React.createElement(View, { testID: testID ?? 'MapView', ...props }, children);
+    },
+  );
+  MockMapView.displayName = 'MapView';
 
   const MockMarker = ({
     testID,
     accessibilityLabel,
+    children,
+    ...props
   }: {
     testID?: string;
     accessibilityLabel?: string;
-  }) => React.createElement(View, { testID, accessibilityLabel });
+    children?: React.ReactNode;
+  }) => React.createElement(View, { testID, accessibilityLabel, ...props }, children);
 
   const MockPolyline = () => React.createElement(View, null);
 
@@ -32,6 +52,10 @@ jest.mock('react-native-maps', () => {
     Polyline: MockPolyline,
   };
 });
+
+jest.mock('expo-image', () => ({
+  Image: 'Image',
+}));
 
 let mockStorePoints: WalkPoint[] = [];
 let mockStoreEvents: WalkEvent[] = [];
@@ -67,6 +91,48 @@ const photoEventNoGps: WalkEvent = {
   photoUrl: 'https://cdn.example.com/walks/walk-123/photo.jpg',
 };
 
+const firstPoint: WalkPoint = {
+  lat: 35.6812,
+  lng: 139.7671,
+  recordedAt: '2026-04-12T10:00:00Z',
+};
+
+const secondPoint: WalkPoint = {
+  lat: 35.682,
+  lng: 139.768,
+  recordedAt: '2026-04-12T10:01:00Z',
+};
+
+const coco: Dog = {
+  id: 'dog-1',
+  name: 'Coco',
+  breed: 'Toy Poodle',
+  gender: null,
+  birthday: null,
+  photoUrl: 'https://cdn.example.com/dogs/coco.jpg',
+  createdAt: '2026-01-01',
+};
+
+const momo: Dog = {
+  id: 'dog-2',
+  name: 'Momo',
+  breed: 'Shiba Inu',
+  gender: null,
+  birthday: null,
+  photoUrl: 'https://cdn.example.com/dogs/momo.jpg',
+  createdAt: '2026-01-02',
+};
+
+const pochi: Dog = {
+  id: 'dog-3',
+  name: 'Pochi',
+  breed: null,
+  gender: null,
+  birthday: null,
+  photoUrl: 'https://cdn.example.com/dogs/pochi.jpg',
+  createdAt: '2026-01-03',
+};
+
 beforeEach(() => {
   mockStorePoints = [];
   mockStoreEvents = [];
@@ -98,5 +164,90 @@ describe('WalkMap', () => {
     render(<WalkMap />);
     expect(screen.getByTestId('event-marker-event-1')).toBeTruthy();
     expect(screen.getByTestId('event-marker-event-3')).toBeTruthy();
+  });
+
+  it('renders the latest recorded point as a dog avatar current-location marker', () => {
+    mockStorePoints = [firstPoint];
+    render(<WalkMap dogs={[coco]} />);
+
+    const marker = screen.getByTestId('current-location-marker');
+    expect(marker.props.coordinate).toEqual({
+      latitude: firstPoint.lat,
+      longitude: firstPoint.lng,
+    });
+    expect(marker.props.anchor).toEqual({ x: 0.5, y: 0.5 });
+    expect(screen.getByTestId('current-location-avatar-dog-1').props.source).toBe(
+      coco.photoUrl,
+    );
+  });
+
+  it('renders only the first two dog avatars for a group walk current location', () => {
+    mockStorePoints = [firstPoint];
+    render(<WalkMap dogs={[coco, momo, pochi]} />);
+
+    expect(screen.getByTestId('current-location-avatar-dog-1').props.source).toBe(
+      coco.photoUrl,
+    );
+    expect(screen.getByTestId('current-location-avatar-dog-2').props.source).toBe(
+      momo.photoUrl,
+    );
+    expect(screen.queryByTestId('current-location-avatar-dog-3')).toBeNull();
+  });
+
+  it('renders the map current-location avatar at half the original marker scale', () => {
+    mockStorePoints = [firstPoint];
+    render(<WalkMap dogs={[coco]} />);
+
+    const avatarStyle = StyleSheet.flatten(
+      screen.getByTestId('current-location-avatar-dog-1').props.style,
+    );
+
+    expect(avatarStyle).toEqual(
+      expect.objectContaining({
+        width: spacing.step44 / 2,
+        height: spacing.step44 / 2,
+        borderWidth: spacing.xs / 4,
+      }),
+    );
+  });
+
+  it('uses the existing app icon fallback for dogs without a profile image', () => {
+    mockStorePoints = [firstPoint];
+    render(<WalkMap dogs={[{ ...coco, photoUrl: null }]} />);
+
+    expect(screen.getByTestId('current-location-avatar-dog-1').props.source).toEqual(
+      require('@/assets/images/icon.png'),
+    );
+  });
+
+  it('does not enable the native user-location dot when rendering a dog marker', () => {
+    mockStorePoints = [firstPoint];
+    render(<WalkMap dogs={[coco]} />);
+
+    expect(screen.getByTestId('MapView').props.showsUserLocation).toBe(false);
+  });
+
+  it('does not render a current-location marker before the first GPS point', () => {
+    render(<WalkMap dogs={[coco]} />);
+
+    expect(screen.queryByTestId('current-location-marker')).toBeNull();
+  });
+
+  it('does not render a current-location marker when no dogs are available', () => {
+    mockStorePoints = [firstPoint];
+    render(<WalkMap dogs={[]} />);
+
+    expect(screen.queryByTestId('current-location-marker')).toBeNull();
+  });
+
+  it('keeps following the latest recorded point after replacing native user following', () => {
+    mockStorePoints = [firstPoint, secondPoint];
+    render(<WalkMap dogs={[coco]} />);
+
+    expect(screen.getByTestId('current-location-marker').props.coordinate).toEqual({
+      latitude: secondPoint.lat,
+      longitude: secondPoint.lng,
+    });
+    expect(screen.getByTestId('MapView').props.followsUserLocation).toBe(false);
   });
 });

--- a/apps/mobile/components/walk/WalkMap.tsx
+++ b/apps/mobile/components/walk/WalkMap.tsx
@@ -1,18 +1,37 @@
+import { useEffect, useRef } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
+import { Image } from 'expo-image';
 import MapView, { Polyline, Marker } from 'react-native-maps';
 import { useColors } from '@/hooks/use-colors';
 import { useWalkStore } from '@/stores/walk-store';
 import { MAP_EVENT_EMOJIS } from '@/lib/walk/events';
 import { TOKYO_STATION_COORDINATE } from '@/lib/walk/constants';
-import { spacing, typography } from '@/theme/tokens';
+import { radius, spacing, typography } from '@/theme/tokens';
+import type { Dog } from '@/types/graphql';
 
 interface WalkMapProps {
   mode?: 'preview' | 'recording';
+  dogs?: Dog[];
 }
 
+interface MapCoordinate {
+  latitude: number;
+  longitude: number;
+}
+
+const CURRENT_LOCATION_MARKER_SCALE = 0.5;
+const CURRENT_LOCATION_MARKER_SIZE = spacing.step60 * CURRENT_LOCATION_MARKER_SCALE;
+const CURRENT_LOCATION_AVATAR_SIZE = spacing.step44 * CURRENT_LOCATION_MARKER_SCALE;
+const CURRENT_LOCATION_AVATAR_OVERLAP =
+  -(spacing.step10 + spacing.xs / 2) * CURRENT_LOCATION_MARKER_SCALE;
+const CURRENT_LOCATION_BORDER_WIDTH = (spacing.xs / 2) * CURRENT_LOCATION_MARKER_SCALE;
+const FOLLOW_REGION_DELTA = 0.005;
+const FOLLOW_ANIMATION_MS = 500;
+
 // 散歩マップは GPS 軌跡と記録イベントを store から読み、地図表示の単一の情報源にします。
-export function WalkMap({ mode = 'recording' }: WalkMapProps) {
+export function WalkMap({ mode = 'recording', dogs = [] }: WalkMapProps) {
   const theme = useColors();
+  const mapRef = useRef<MapView | null>(null);
   const points = useWalkStore((s) => s.points);
   const events = useWalkStore((s) => s.events);
   const isRecording = mode === 'recording';
@@ -20,21 +39,40 @@ export function WalkMap({ mode = 'recording' }: WalkMapProps) {
   // 地図ライブラリ用の座標形式へ変換し、最後の地点を現在地表示の基準にします。
   const coordinates = points.map((p) => ({ latitude: p.lat, longitude: p.lng }));
   const lastPoint = coordinates[coordinates.length - 1];
+  const lastLatitude = lastPoint?.latitude;
+  const lastLongitude = lastPoint?.longitude;
+
+  useEffect(() => {
+    if (!isRecording || lastLatitude == null || lastLongitude == null) return;
+
+    mapRef.current?.animateToRegion(
+      {
+        latitude: lastLatitude,
+        longitude: lastLongitude,
+        latitudeDelta: FOLLOW_REGION_DELTA,
+        longitudeDelta: FOLLOW_REGION_DELTA,
+      },
+      FOLLOW_ANIMATION_MS,
+    );
+  }, [isRecording, lastLatitude, lastLongitude]);
+
+  const showCurrentLocationMarker = isRecording && lastPoint && dogs.length > 0;
 
   return (
     <View style={styles.container}>
       <MapView
+        ref={mapRef}
         style={styles.map}
-        showsUserLocation={isRecording}
-        followsUserLocation={isRecording}
+        showsUserLocation={false}
+        followsUserLocation={false}
         // 位置情報がまだないプレビューでは東京駅を初期表示にして、空の地図を避けます。
         initialRegion={
           lastPoint
             ? {
                 latitude: lastPoint.latitude,
                 longitude: lastPoint.longitude,
-                latitudeDelta: 0.005,
-                longitudeDelta: 0.005,
+                latitudeDelta: FOLLOW_REGION_DELTA,
+                longitudeDelta: FOLLOW_REGION_DELTA,
               }
             : {
                 latitude: TOKYO_STATION_COORDINATE.latitude,
@@ -51,7 +89,15 @@ export function WalkMap({ mode = 'recording' }: WalkMapProps) {
             strokeWidth={4}
           />
         ) : null}
-        {isRecording && lastPoint ? <Marker coordinate={lastPoint} /> : null}
+        {showCurrentLocationMarker ? (
+          <Marker
+            testID="current-location-marker"
+            coordinate={lastPoint}
+            anchor={{ x: 0.5, y: 0.5 }}
+          >
+            <CurrentLocationMarker dogs={dogs} coordinate={lastPoint} />
+          </Marker>
+        ) : null}
         {/* 座標を持つイベントだけをマーカー化し、記録操作と地図表示を同期させます。 */}
         {isRecording
           ? events
@@ -72,8 +118,76 @@ export function WalkMap({ mode = 'recording' }: WalkMapProps) {
   );
 }
 
+interface CurrentLocationMarkerProps {
+  dogs: Dog[];
+  coordinate: MapCoordinate;
+}
+
+function CurrentLocationMarker({ dogs, coordinate }: CurrentLocationMarkerProps) {
+  const theme = useColors();
+  const visibleDogs = dogs.slice(0, 2);
+
+  return (
+    <View
+      style={styles.currentLocationMarker}
+      accessibilityLabel={`Current walk location at ${coordinate.latitude}, ${coordinate.longitude}`}
+    >
+      <View
+        style={[
+          styles.currentLocationHalo,
+          { backgroundColor: theme.success, borderColor: theme.success },
+        ]}
+      />
+      <View style={styles.currentLocationAvatars}>
+        {visibleDogs.map((dog, index) => (
+          <Image
+            key={dog.id}
+            testID={`current-location-avatar-${dog.id}`}
+            source={dog.photoUrl ?? require('@/assets/images/icon.png')}
+            style={[
+              styles.currentLocationAvatar,
+              { borderColor: theme.surface },
+              index > 0 && styles.currentLocationAvatarOverlap,
+            ]}
+            contentFit="cover"
+            cachePolicy="memory-disk"
+          />
+        ))}
+      </View>
+    </View>
+  );
+}
+
 const styles = StyleSheet.create({
   container: { flex: 1, overflow: 'hidden' },
   map: { flex: 1 },
+  currentLocationMarker: {
+    width: CURRENT_LOCATION_MARKER_SIZE,
+    height: CURRENT_LOCATION_MARKER_SIZE,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  currentLocationHalo: {
+    position: 'absolute',
+    width: CURRENT_LOCATION_MARKER_SIZE,
+    height: CURRENT_LOCATION_MARKER_SIZE,
+    borderRadius: radius.full,
+    borderWidth: CURRENT_LOCATION_BORDER_WIDTH,
+    opacity: 0.18,
+  },
+  currentLocationAvatars: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  currentLocationAvatar: {
+    width: CURRENT_LOCATION_AVATAR_SIZE,
+    height: CURRENT_LOCATION_AVATAR_SIZE,
+    borderRadius: radius.full,
+    borderWidth: CURRENT_LOCATION_BORDER_WIDTH,
+  },
+  currentLocationAvatarOverlap: {
+    marginLeft: CURRENT_LOCATION_AVATAR_OVERLAP,
+  },
   eventMarker: { fontSize: typography.title2.fontSize - spacing.xs / 2 },
 });


### PR DESCRIPTION
## Summary
- Replace the recording map's native current-location dot with a custom dog avatar marker sourced from selected walk dogs.
- Render up to two dog profile images for group walks, with the existing app icon fallback only when a dog has no profile image.
- Keep map following behavior by animating to the latest recorded walk point, and scale the map marker down to half size.

## Validation
- `cd apps/mobile && npm test -- WalkMap.test.tsx --runInBand`
- `cd apps/mobile && npm run typecheck`
- `cd apps/mobile && npm run lint`
- `git diff --check`

## Notes
- Verified manually on iPhone 17 Pro Simulator with local API using the requested login user.
