### PR TITLE
[codex] Make walk start transition seamless

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
       "type": "shell",
       "command": "cargo watch -x 'run --bin walking-dog'",
       "options": {
-        "cwd": "/walking-dog/apps/api"
+        "cwd": "${workspaceFolder}/apps/api"
       },
       "isBackground": true,
       "problemMatcher": []
@@ -16,7 +16,7 @@
       "type": "shell",
       "command": "cargo watch -x 'run --bin track_point_worker'",
       "options": {
-        "cwd": "/walking-dog/apps/api"
+        "cwd": "${workspaceFolder}/apps/api"
       },
       "isBackground": true,
       "problemMatcher": []
@@ -30,6 +30,66 @@
         "isDefault": true
       },
       "problemMatcher": []
-    }
+    },
+    {
+      "label": "watch: docker compose up",
+      "type": "shell",
+      "command": "docker compose -f apps/compose.yml up",
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "isBackground": true,
+      "problemMatcher": []
+    },
+    // {
+    //   "label": "watch: npm run metro:kill",
+    //   "type": "shell",
+    //   "command": "npm run metro:kill",
+    //   "options": {
+    //     "cwd": "${workspaceFolder}/apps/mobile"
+    //   },
+    //   "isBackground": true,
+    //   "problemMatcher": []
+    // },
+    // {
+    //   "label": "watch: npm run ios:clean",
+    //   "type": "shell",
+    //   "command": "npm run ios:clean",
+    //   "options": {
+    //     "cwd": "${workspaceFolder}/apps/mobile"
+    //   },
+    //   "isBackground": true,
+    //   "problemMatcher": []
+    // },
+    // {
+    //   "label": "watch: npm run ios:sim:local",
+    //   "type": "shell",
+    //   "command": "npm run ios:sim:local",
+    //   "options": {
+    //     "cwd": "${workspaceFolder}/apps/mobile"
+    //   },
+    //   "isBackground": true,
+    //   "problemMatcher": []
+    // },
+    // {
+    //   "label": "watch: npm",
+    //   "dependsOn": ["watch: npm run metro:kill", "watch: npm run ios:clean", "watch: npm run ios:sim:local"],
+    //   "dependsOrder": "sequence",
+    //   "group": {
+    //     "kind": "build",
+    //     "isDefault": true
+    //   },
+    //   "problemMatcher": []
+    // },
+    {
+      "label": "ios:sim:local",
+      "dependsOn": ["npm run metro:kill", "npm run ios:clean", "npm run ios:sim:local"],
+      "dependsOrder": "sequence",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "problemMatcher": []
+    },
   ]
 }

--- a/apps/mobile/CLAUDE.md
+++ b/apps/mobile/CLAUDE.md
@@ -44,6 +44,7 @@
 - Apple Watch の walk snapshot は Watch UI/complication 表示同期専用に保つ。iPhone JS state が無い状態から snapshot で active walk を復元しない。Watch command は iPhone 側の現在の active walk store と一致する場合だけ処理し、inactive/stale walk の command は ack して破棄する。
 - Live Activity と散歩記録をまたぐ修正では、ActivityKit 側だけを更新せず、前景 GPS・背景 GPS・永続化した active walk session・復帰時 navigation が同じ点列と `walkId` を参照する設計にする。Dynamic Island の tap は iOS がアプリ起動に予約しているため、tap URL は履歴詳細ではなく active recording route を指す。
 - Walk 開始・記録中などマップ主役の画面は、route 側で `ScreenHeader` / top-only `SafeAreaView` を挟まず、マップを全画面に敷いた上で `WalkMapShell` の overlay と NativeTabs/formSheet を重ねる。
+- Walk タブの START → recording 遷移では、`WalkMapShell` / `WalkMap` / 下部 floating sheet の外枠を同じ route 内で維持し、route push で再 mount させない。`/walk-recording` は Live Activity / deep link 復帰用の互換 bridge として扱い、通常の記録 UI 所有者に戻さない。
 - Walk 開始前の preview マップは foreground の現在地 region へ寄せる。東京駅などの固定座標は GPS 現在地取得前に地図を描画するための初期領域に限定し、ready 画面の主表示として扱わない。
 - 記録中マップの現在地表示は `useWalkStore().points` の最新点を単一の source of truth にする。犬プロフィール画像などの表示情報は route 側で選択犬を解決して `WalkMap` に渡し、`showsUserLocation` など別系統の現在地表示と併用しない。
 - Pee/poop の表示アイコンは全サーフェスで統一する。React Native 側は `lib/walk/events.ts` の `WALK_EVENT_EMOJIS` を単一ソースにし、pee は `💧`、poop/poo は `💩` を使う。Live Activity と Watch SwiftUI でも同じ emoji を表示し、SF Symbols の `drop.fill` などに分岐させない。`expo-widgets` の Live Activity layout は関数を文字列化して Widget 側 JSContext で再評価するため、layout 関数内では imported constant を参照せず、関数内 local literal と回帰テストで値を固定する。

--- a/apps/mobile/__tests__/app/tabs/walk.test.tsx
+++ b/apps/mobile/__tests__/app/tabs/walk.test.tsx
@@ -5,12 +5,34 @@ import type { Dog } from '@/types/graphql';
 
 jest.mock('@/hooks/use-color-scheme', () => ({ useColorScheme: () => 'light' }));
 jest.mock('expo-router', () => ({
+  router: { setParams: jest.fn() },
   useRouter: () => ({ push: jest.fn() }),
   useLocalSearchParams: () => ({}),
 }));
 jest.mock('expo-image', () => ({ Image: 'Image' }));
 
-jest.mock('@/components/walk/WalkMap', () => ({ WalkMap: () => null }));
+let mockWalkMapMounts = 0;
+let mockWalkMapUnmounts = 0;
+const mockWalkMapProps: Array<Record<string, unknown>> = [];
+
+jest.mock('@/components/walk/WalkMap', () => {
+  const React = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+
+  return {
+    WalkMap: (props: Record<string, unknown>) => {
+      mockWalkMapProps.push(props);
+      React.useEffect(() => {
+        mockWalkMapMounts += 1;
+        return () => {
+          mockWalkMapUnmounts += 1;
+        };
+      }, []);
+
+      return <View testID="walk-map" />;
+    },
+  };
+});
 jest.mock('@/components/walk/WalkMapShell', () => {
   const { View } = jest.requireActual('react-native');
   return {
@@ -32,10 +54,37 @@ jest.mock('@/components/walk/WalkMapShell', () => {
   };
 });
 jest.mock('@/components/walk/WalkSummaryCard', () => ({ WalkSummaryCard: () => null }));
+jest.mock('@/components/walk/WalkControls', () => {
+  const { Text, View } = jest.requireActual('react-native');
+  return {
+    WalkControls: ({ children }: { children?: ReactNode }) => (
+      <View>
+        <Text>Recording controls</Text>
+        {children}
+      </View>
+    ),
+  };
+});
+jest.mock('@/components/walk/WalkEventActions', () => {
+  const { Text } = jest.requireActual('react-native');
+  return {
+    WalkEventActions: () => <Text>Event actions</Text>,
+  };
+});
+jest.mock('@/hooks/use-walk-session', () => ({
+  useWalkSession: () => ({ stop: jest.fn() }),
+}));
+jest.mock('@/hooks/use-active-walk-snapshot-sync', () => ({
+  useActiveWalkSnapshotSync: jest.fn(),
+}));
+jest.mock('@/hooks/use-walk-live-activity-sync', () => ({
+  useWalkLiveActivitySync: jest.fn(),
+}));
 
 type Phase = 'ready' | 'recording' | 'finished';
 let mockDogs: Dog[] = [];
 let mockPhase: Phase = 'ready';
+let mockSelectedDogIds: string[] = [];
 
 jest.mock('@/hooks/use-me', () => ({
   useMe: () => ({ data: { dogs: mockDogs }, isLoading: false }),
@@ -57,17 +106,23 @@ jest.mock('@/hooks/use-pack-progress', () => ({
 type StoreState = {
   selectedDogIds: string[];
   phase: Phase;
+  dogs: Dog[];
+  walkId: string | null;
   selectDog: (id: string) => void;
   setSelectedDogs: (ids: string[]) => void;
+  requestCamera: () => void;
 };
 
 jest.mock('@/stores/walk-store', () => ({
   useWalkStore: (selector: (s: StoreState) => unknown) =>
     selector({
-      selectedDogIds: [],
+      selectedDogIds: mockSelectedDogIds,
       phase: mockPhase,
+      dogs: mockDogs,
+      walkId: mockPhase === 'recording' ? 'walk-1' : null,
       selectDog: jest.fn(),
       setSelectedDogs: jest.fn(),
+      requestCamera: jest.fn(),
     }),
 }));
 
@@ -95,6 +150,10 @@ describe('Walk tab route', () => {
   beforeEach(() => {
     mockDogs = [];
     mockPhase = 'ready';
+    mockSelectedDogIds = [];
+    mockWalkMapMounts = 0;
+    mockWalkMapUnmounts = 0;
+    mockWalkMapProps.length = 0;
   });
 
   it('shows the NoDogsBody CTA when there are zero dogs', () => {
@@ -116,9 +175,33 @@ describe('Walk tab route', () => {
     expect(screen.getByText('Walking with')).toBeTruthy();
   });
 
-  it('does not show the Walk header while redirecting to the active walk screen', () => {
+  it('renders recording controls in the Walk tab instead of an empty redirect placeholder', () => {
     mockPhase = 'recording';
+    mockDogs = [buildDog({})];
+    mockSelectedDogIds = ['d1'];
+
     render(<WalkScreen />);
+
     expect(screen.queryByRole('header', { name: 'Walk' })).toBeNull();
+    expect(screen.getByText('Recording controls')).toBeTruthy();
+    expect(screen.getByText('Event actions')).toBeTruthy();
+  });
+
+  it('keeps the same map mounted when the phase changes from ready to recording', () => {
+    mockDogs = [buildDog({})];
+    mockSelectedDogIds = ['d1'];
+    const { rerender } = render(<WalkScreen />);
+
+    expect(screen.getByTestId('walk-map')).toBeTruthy();
+    expect(mockWalkMapMounts).toBe(1);
+    expect(mockWalkMapProps.at(-1)).toEqual(expect.objectContaining({ mode: 'preview' }));
+
+    mockPhase = 'recording';
+    rerender(<WalkScreen />);
+
+    expect(screen.getByText('Recording controls')).toBeTruthy();
+    expect(mockWalkMapMounts).toBe(1);
+    expect(mockWalkMapUnmounts).toBe(0);
+    expect(mockWalkMapProps.at(-1)).toEqual(expect.objectContaining({ mode: 'recording' }));
   });
 });

--- a/apps/mobile/__tests__/app/walk-recording.test.tsx
+++ b/apps/mobile/__tests__/app/walk-recording.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen } from '@testing-library/react-native';
+import WalkRecordingScreen from '../../app/walk-recording';
+import type { Dog } from '@/types/graphql';
+
+const mockReplace = jest.fn();
+const mockPush = jest.fn();
+let mockParams: { action?: string; walkId?: string } = {};
+
+jest.mock('expo-router', () => ({
+  router: {
+    push: (...args: unknown[]) => mockPush(...args),
+    replace: (...args: unknown[]) => mockReplace(...args),
+  },
+  useLocalSearchParams: () => mockParams,
+}));
+
+jest.mock('@/hooks/use-color-scheme', () => ({
+  useColorScheme: () => 'light',
+}));
+
+jest.mock('@/hooks/use-me', () => ({
+  useMe: () => ({ data: { dogs: mockDogs } }),
+}));
+
+jest.mock('@/hooks/use-walks', () => ({
+  useWalk: () => ({ data: null }),
+}));
+
+jest.mock('@/hooks/use-walk-live-activity-sync', () => ({
+  useWalkLiveActivitySync: jest.fn(),
+}));
+
+jest.mock('@/components/walk/WalkMap', () => {
+  const { View } = jest.requireActual('react-native');
+  return {
+    WalkMap: () => <View testID="recording-route-map" />,
+  };
+});
+
+jest.mock('@/components/walk/WalkMapShell', () => {
+  const { View } = jest.requireActual('react-native');
+  return {
+    WalkMapShell: ({ map }: { map: React.ReactNode }) => (
+      <View testID="recording-route-shell">{map}</View>
+    ),
+  };
+});
+
+jest.mock('@/components/walk/WalkTopChip', () => ({
+  WalkTopChip: () => null,
+}));
+
+type StoreState = {
+  phase: 'ready' | 'recording' | 'finished';
+  selectedDogIds: string[];
+  dogs: Dog[];
+  walkId: string | null;
+  setTotalDistanceM: (distanceM: number) => void;
+  hydrateRecordingSession: (session: unknown) => void;
+};
+
+let mockDogs: Dog[] = [];
+let mockStoreState: StoreState;
+
+jest.mock('@/stores/walk-store', () => ({
+  useWalkStore: (selector: (s: StoreState) => unknown) => selector(mockStoreState),
+}));
+
+describe('WalkRecordingScreen bridge route', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockParams = { walkId: 'walk-1' };
+    mockDogs = [];
+    mockStoreState = {
+      phase: 'recording',
+      selectedDogIds: ['dog-1'],
+      dogs: [],
+      walkId: 'walk-1',
+      setTotalDistanceM: jest.fn(),
+      hydrateRecordingSession: jest.fn(),
+    };
+  });
+
+  it('redirects active walk deep links back to the Walk tab without rendering recording UI', () => {
+    render(<WalkRecordingScreen />);
+
+    expect(mockReplace).toHaveBeenCalledWith({
+      pathname: '/(tabs)/walk',
+      params: { walkId: 'walk-1' },
+    });
+    expect(mockPush).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('recording-route-shell')).toBeNull();
+  });
+
+  it('preserves a camera action while bridging back to the Walk tab', () => {
+    mockParams = { action: 'camera', walkId: 'walk-1' };
+
+    render(<WalkRecordingScreen />);
+
+    expect(mockReplace).toHaveBeenCalledWith({
+      pathname: '/(tabs)/walk',
+      params: { action: 'camera', walkId: 'walk-1' },
+    });
+  });
+});

--- a/apps/mobile/app/(tabs)/walk.tsx
+++ b/apps/mobile/app/(tabs)/walk.tsx
@@ -1,30 +1,82 @@
+import { useEffect } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { router, useLocalSearchParams } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useColors } from '@/hooks/use-colors';
+import { useActiveWalkSnapshotSync } from '@/hooks/use-active-walk-snapshot-sync';
+import { useRecordingWalkDogs } from '@/hooks/use-recording-walk-dogs';
+import { useWalkLiveActivitySync } from '@/hooks/use-walk-live-activity-sync';
+import { useWalkReadySelection } from '@/hooks/use-walk-ready-selection';
 import { useWalkScreenViewModel } from '@/hooks/use-walk-screen-view-model';
 import { ScreenHeader } from '@/components/ui/ScreenHeader';
-import { WalkReadyView } from '@/components/walk/WalkReadyView';
+import { WalkFloatingSheet } from '@/components/walk/WalkFloatingSheet';
+import { WalkMap } from '@/components/walk/WalkMap';
+import { WalkMapShell } from '@/components/walk/WalkMapShell';
+import { WalkReadySheetContent } from '@/components/walk/WalkReadySheetContent';
+import { WalkRecordingSheetContent } from '@/components/walk/WalkRecordingSheetContent';
 import { WalkSummaryCard } from '@/components/walk/WalkSummaryCard';
+import { WalkTopChip } from '@/components/walk/WalkTopChip';
+import { useWalkStore } from '@/stores/walk-store';
 
 // 散歩タブは現在の散歩フェーズに応じて、開始前または終了後サマリーを表示します。
 export default function WalkScreen() {
   const { t } = useTranslation();
   const theme = useColors();
   const vm = useWalkScreenViewModel();
+  const params = useLocalSearchParams<{ action?: string; walkId?: string }>();
+  const routeWalkId = typeof params.walkId === 'string' ? params.walkId : undefined;
+  const readySelection = useWalkReadySelection({ enabled: vm.phase === 'ready' });
+  const recordingDogs = useRecordingWalkDogs();
+  const walkId = useWalkStore((s) => s.walkId);
+  const requestCamera = useWalkStore((s) => s.requestCamera);
 
-  if (vm.phase === 'ready') {
-    // 開始前はヘッダーを挟まず、マップ全面の準備画面に開始操作を委譲します。
+  useActiveWalkSnapshotSync(routeWalkId);
+  useWalkLiveActivitySync(recordingDogs);
+
+  useEffect(() => {
+    if (params.action !== 'camera') return;
+    if (vm.phase !== 'recording' || !walkId) return;
+
+    requestCamera();
+    router.setParams({ action: undefined });
+  }, [params.action, requestCamera, vm.phase, walkId]);
+
+  if (vm.phase === 'ready' || vm.phase === 'recording') {
+    const isRecording = vm.phase === 'recording';
+    const chipDogs = isRecording ? recordingDogs : readySelection.selectedDogs;
+
     return (
       <View style={[styles.container, { backgroundColor: theme.background }]}>
-        <WalkReadyView onStart={vm.handleStart} isStarting={vm.isStarting} />
+        <WalkMapShell
+          map={
+            <WalkMap
+              mode={isRecording ? 'recording' : 'preview'}
+              dogs={isRecording ? recordingDogs : []}
+            />
+          }
+          top={
+            <WalkTopChip
+              dogs={chipDogs}
+              label={isRecording ? undefined : t('walk.ready.topLabelStatic')}
+            />
+          }
+          bottom={
+            <WalkFloatingSheet>
+              {isRecording ? (
+                <WalkRecordingSheetContent dogs={recordingDogs} />
+              ) : (
+                <WalkReadySheetContent
+                  selection={readySelection}
+                  onStart={vm.handleStart}
+                  isStarting={vm.isStarting}
+                />
+              )}
+            </WalkFloatingSheet>
+          }
+        />
       </View>
     );
-  }
-
-  if (vm.phase === 'recording') {
-    // 記録中は専用の全画面マップ route へ遷移するため、タブルート側にヘッダーを残しません。
-    return <View style={[styles.container, { backgroundColor: theme.background }]} />;
   }
 
   return (

--- a/apps/mobile/app/walk-recording.tsx
+++ b/apps/mobile/app/walk-recording.tsx
@@ -1,95 +1,28 @@
-import { useEffect, useMemo, useRef } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { useEffect, useMemo } from 'react';
 import { router, useLocalSearchParams } from 'expo-router';
-import { useColors } from '@/hooks/use-colors';
-import { useWalkStore } from '@/stores/walk-store';
-import { useMe } from '@/hooks/use-me';
-import { useWalk } from '@/hooks/use-walks';
-import { useWalkLiveActivitySync } from '@/hooks/use-walk-live-activity-sync';
-import { WalkMap } from '@/components/walk/WalkMap';
-import { WalkMapShell } from '@/components/walk/WalkMapShell';
-import { WalkTopChip } from '@/components/walk/WalkTopChip';
-import type { Dog } from '@/types/graphql';
+import { useActiveWalkSnapshotSync } from '@/hooks/use-active-walk-snapshot-sync';
 
-// サーバが track_point から再計算した distance をポーリングする間隔。
-const WALK_DISTANCE_POLL_INTERVAL_MS = 10_000;
-
-// 記録中画面は全画面マップを表示し、操作パネル route を重ねて開きます。
+// 旧 deep link / Live Activity URL 互換用 route。記録 UI は Walk タブ内の永続 shell が所有します。
 export default function WalkRecordingScreen() {
-  const theme = useColors();
-  const phase = useWalkStore((s) => s.phase);
-  const selectedDogIds = useWalkStore((s) => s.selectedDogIds);
-  const storedDogs = useWalkStore((s) => s.dogs);
-  const walkId = useWalkStore((s) => s.walkId);
-  const setTotalDistanceM = useWalkStore((s) => s.setTotalDistanceM);
-  const hydrateRecordingSession = useWalkStore((s) => s.hydrateRecordingSession);
   const params = useLocalSearchParams<{ action?: string; walkId?: string }>();
-
-  const { data: me } = useMe();
-
-  // サーバ側 (track_point → Haversine 累積) で計算した distance を定期取得し、
-  // ストアの totalDistanceM へ反映します。
-  const isRecording = phase === 'recording';
   const routeWalkId = typeof params.walkId === 'string' ? params.walkId : undefined;
-  const effectiveWalkId = walkId ?? routeWalkId ?? '';
-  const { data: walkSnapshot } = useWalk(effectiveWalkId, {
-    refetchIntervalMs: isRecording ? WALK_DISTANCE_POLL_INTERVAL_MS : undefined,
-  });
+  const action = params.action === 'camera' ? 'camera' : undefined;
+
+  useActiveWalkSnapshotSync(routeWalkId);
+
+  const nextParams = useMemo(() => {
+    const entries: { action?: string; walkId?: string } = {};
+    if (action) entries.action = action;
+    if (routeWalkId) entries.walkId = routeWalkId;
+    return Object.keys(entries).length > 0 ? entries : undefined;
+  }, [action, routeWalkId]);
 
   useEffect(() => {
-    const distance = walkSnapshot?.distanceM ?? walkSnapshot?.distance;
-    if (typeof distance !== 'number') return;
-    setTotalDistanceM(distance);
-  }, [walkSnapshot?.distance, walkSnapshot?.distanceM, setTotalDistanceM]);
-
-  useEffect(() => {
-    if (!routeWalkId || !walkSnapshot || walkSnapshot.status !== 'ACTIVE') return;
-    if (phase === 'recording' && walkId === walkSnapshot.id) return;
-
-    hydrateRecordingSession({
-      walkId: walkSnapshot.id,
-      startedAt: walkSnapshot.startedAt,
-      selectedDogIds: walkSnapshot.dogs.map((dog) => dog.id),
-      dogs: walkSnapshot.dogs,
-      points: walkSnapshot.points ?? [],
-      flushedPointCount: walkSnapshot.points?.length ?? 0,
-      totalDistanceM: walkSnapshot.distanceM ?? walkSnapshot.distance ?? 0,
-      events: walkSnapshot.events ?? [],
+    router.replace({
+      pathname: '/(tabs)/walk',
+      params: nextParams,
     });
-  }, [hydrateRecordingSession, phase, routeWalkId, walkId, walkSnapshot]);
+  }, [nextParams]);
 
-  const hasPushedRef = useRef(false);
-  useEffect(() => {
-    // 記録フェーズに入った最初の 1 回だけ form sheet の操作パネルを表示します。
-    if (phase !== 'recording') return;
-    if (hasPushedRef.current) return;
-    hasPushedRef.current = true;
-    router.push({
-      pathname: '/walk-recording-controls',
-      params: params.action === 'camera' ? { action: 'camera' } : undefined,
-    });
-  }, [phase, params.action]);
-
-  // 選択済み犬 ID から表示用の犬情報を引き直し、上部チップの単一情報源にします。
-  const selectedDogs = useMemo<Dog[]>(
-    () => {
-      const dogs = (me?.dogs ?? []).filter((d) => selectedDogIds.includes(d.id));
-      return dogs.length > 0 ? dogs : storedDogs;
-    },
-    [me?.dogs, selectedDogIds, storedDogs],
-  );
-  useWalkLiveActivitySync(selectedDogs);
-
-  return (
-    <View style={[styles.container, { backgroundColor: theme.background }]}>
-      <WalkMapShell
-        map={<WalkMap mode="recording" dogs={selectedDogs} />}
-        top={<WalkTopChip dogs={selectedDogs} />}
-      />
-    </View>
-  );
+  return null;
 }
-
-const styles = StyleSheet.create({
-  container: { flex: 1 },
-});

--- a/apps/mobile/components/walk/WalkFloatingSheet.tsx
+++ b/apps/mobile/components/walk/WalkFloatingSheet.tsx
@@ -1,0 +1,47 @@
+import type { ReactNode } from 'react';
+import { StyleSheet, View, type StyleProp, type ViewStyle } from 'react-native';
+import { GroupedCard } from '@/components/ui/GroupedCard';
+import { useColors } from '@/hooks/use-colors';
+import { elevation, spacing } from '@/theme/tokens';
+
+interface WalkFloatingSheetProps {
+  children: ReactNode;
+  style?: StyleProp<ViewStyle>;
+}
+
+// Walk 画面の下部シート外枠。開始前後でこの外枠は維持し、中身だけ差し替えます。
+export function WalkFloatingSheet({ children, style }: WalkFloatingSheetProps) {
+  const theme = useColors();
+
+  return (
+    <GroupedCard
+      style={[
+        styles.card,
+        { backgroundColor: theme.material, borderColor: theme.border },
+        elevation.mid,
+        style,
+      ]}
+    >
+      <View style={[styles.grabber, { backgroundColor: theme.textDisabled }]} />
+      {children}
+    </GroupedCard>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderWidth: StyleSheet.hairlineWidth,
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.md,
+    paddingBottom: spacing.lg,
+  },
+  grabber: {
+    width: 36,
+    height: 5,
+    borderRadius: spacing.step6 / 2,
+    alignSelf: 'center',
+    marginTop: -spacing.xs,
+    marginBottom: spacing.md,
+    opacity: 0.6,
+  },
+});

--- a/apps/mobile/components/walk/WalkReadySheetContent.tsx
+++ b/apps/mobile/components/walk/WalkReadySheetContent.tsx
@@ -1,0 +1,104 @@
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { DogPickerCard } from '@/components/walk/DogPickerCard';
+import { NoDogsBody } from '@/components/walk/NoDogsBody';
+import { WalkReadyStatsRow } from '@/components/walk/WalkReadyStatsRow';
+import { WalkStartButton } from '@/components/walk/WalkStartButton';
+import { useColors } from '@/hooks/use-colors';
+import type { WalkReadySelection } from '@/hooks/use-walk-ready-selection';
+import { components, spacing, typography } from '@/theme/tokens';
+
+interface WalkReadySheetContentProps {
+  selection: WalkReadySelection;
+  onStart: () => void;
+  isStarting: boolean;
+}
+
+// 開始前シートの中身だけを担当します。外枠は WalkFloatingSheet が所有します。
+export function WalkReadySheetContent({
+  selection,
+  onStart,
+  isStarting,
+}: WalkReadySheetContentProps) {
+  const { t } = useTranslation();
+  const theme = useColors();
+  const {
+    dogs,
+    selectedDogs,
+    validSelectedDogIds,
+    isSingleDog,
+    allSelected,
+    selectDog,
+    handleSelectAll,
+  } = selection;
+
+  const canStart = selectedDogs.length > 0 && !isStarting;
+  const selectAllLabel = allSelected
+    ? t('walk.ready.deselectAll')
+    : t('walk.ready.selectAll');
+
+  if (dogs.length === 0) {
+    return <NoDogsBody />;
+  }
+
+  if (isSingleDog) {
+    return (
+      <View style={styles.bodyColumn}>
+        <DogPickerCard
+          dogs={[dogs[0]]}
+          selectedIds={validSelectedDogIds}
+          onToggle={() => undefined}
+          variant="single"
+        />
+        <WalkReadyStatsRow />
+        <WalkStartButton onPress={onStart} disabled={!canStart} loading={isStarting} />
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.bodyColumn}>
+      <View style={styles.sectionHeader}>
+        <Text style={[styles.sectionTitle, { color: theme.onSurfaceVariant }]}>
+          {t('walk.ready.walkingWith')}
+        </Text>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={selectAllLabel}
+          onPress={handleSelectAll}
+          hitSlop={8}
+        >
+          <Text style={[styles.selectAll, { color: theme.interactive }]}>
+            {selectAllLabel}
+          </Text>
+        </Pressable>
+      </View>
+      <DogPickerCard
+        dogs={dogs}
+        selectedIds={validSelectedDogIds}
+        onToggle={selectDog}
+        variant="multi"
+      />
+      <WalkReadyStatsRow />
+      <WalkStartButton onPress={onStart} disabled={!canStart} loading={isStarting} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  bodyColumn: {
+    gap: spacing.md,
+  },
+  sectionHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  sectionTitle: {
+    ...typography.metricLabel,
+  },
+  selectAll: {
+    ...typography.footnote,
+    fontWeight: components.button.fontPrimary.fontWeight,
+  },
+});

--- a/apps/mobile/components/walk/WalkReadyView.tsx
+++ b/apps/mobile/components/walk/WalkReadyView.tsx
@@ -1,134 +1,35 @@
-import { useCallback, useEffect, useMemo } from 'react';
-import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
-import { GroupedCard } from '@/components/ui/GroupedCard';
-import { DogPickerCard } from '@/components/walk/DogPickerCard';
-import { NoDogsBody } from '@/components/walk/NoDogsBody';
+import { WalkFloatingSheet } from '@/components/walk/WalkFloatingSheet';
 import { WalkMap } from '@/components/walk/WalkMap';
 import { WalkMapShell } from '@/components/walk/WalkMapShell';
-import { WalkReadyStatsRow } from '@/components/walk/WalkReadyStatsRow';
-import { WalkStartButton } from '@/components/walk/WalkStartButton';
+import { WalkReadySheetContent } from '@/components/walk/WalkReadySheetContent';
 import { WalkTopChip } from '@/components/walk/WalkTopChip';
-import { useColors } from '@/hooks/use-colors';
-import { useMe } from '@/hooks/use-me';
-import { useWalkStore } from '@/stores/walk-store';
-import { components, elevation, spacing, typography } from '@/theme/tokens';
-import type { Dog } from '@/types/graphql';
+import { useWalkReadySelection } from '@/hooks/use-walk-ready-selection';
 
 interface WalkReadyViewProps {
   onStart: () => void;
   isStarting: boolean;
 }
 
-function sameIds(left: string[], right: string[]): boolean {
-  return left.length === right.length && left.every((id, index) => id === right[index]);
-}
-
-// 散歩開始前の画面です。犬の選択、統計、開始ボタンをマップ上の下部カードにまとめます。
+// 散歩開始前のスタンドアロン表示。Walk タブ本体では同じ部品を永続 shell の中で使います。
 export function WalkReadyView({ onStart, isStarting }: WalkReadyViewProps) {
   const { t } = useTranslation();
-  const theme = useColors();
-  const { data: me } = useMe();
-  const dogs = useMemo<Dog[]>(() => me?.dogs ?? [], [me?.dogs]);
-  const selectedDogIds = useWalkStore((s) => s.selectedDogIds);
-  const selectDog = useWalkStore((s) => s.selectDog);
-  const setSelectedDogs = useWalkStore((s) => s.setSelectedDogs);
-
-  const isSingleDog = dogs.length === 1;
-  const dogIds = useMemo(() => dogs.map((dog) => dog.id), [dogs]);
-  const validSelectedDogIds = useMemo(
-    () => selectedDogIds.filter((id) => dogIds.includes(id)),
-    [dogIds, selectedDogIds],
-  );
-  const selectedDogs = useMemo(
-    () => dogs.filter((dog) => validSelectedDogIds.includes(dog.id)),
-    [dogs, validSelectedDogIds],
-  );
-
-  // 認証切替や犬削除後に残った stale ID を落とし、単頭では開始できるよう自動選択します。
-  useEffect(() => {
-    const nextSelectedDogIds =
-      isSingleDog && validSelectedDogIds.length === 0 ? [dogs[0].id] : validSelectedDogIds;
-
-    if (!sameIds(selectedDogIds, nextSelectedDogIds)) {
-      setSelectedDogs(nextSelectedDogIds);
-    }
-  }, [dogs, isSingleDog, selectedDogIds, setSelectedDogs, validSelectedDogIds]);
-
-  const allSelected =
-    dogs.length > 0 && dogs.every((d) => validSelectedDogIds.includes(d.id));
-
-  // 複数犬の選択をまとめて切り替え、全選択済みなら解除にします。
-  const handleSelectAll = useCallback(() => {
-    if (allSelected) {
-      setSelectedDogs([]);
-    } else {
-      setSelectedDogs(dogs.map((d) => d.id));
-    }
-  }, [allSelected, dogs, setSelectedDogs]);
-
-  const canStart = selectedDogs.length > 0 && !isStarting;
-  const selectAllLabel = allSelected
-    ? t('walk.ready.deselectAll')
-    : t('walk.ready.selectAll');
+  const selection = useWalkReadySelection();
 
   return (
     <View style={styles.container}>
       <WalkMapShell
         map={<WalkMap mode="preview" />}
-        top={<WalkTopChip dogs={selectedDogs} label={t('walk.ready.topLabelStatic')} />}
+        top={<WalkTopChip dogs={selection.selectedDogs} label={t('walk.ready.topLabelStatic')} />}
         bottom={
-          <GroupedCard
-            style={[
-              styles.bottomCard,
-              { backgroundColor: theme.material, borderColor: theme.border },
-              elevation.mid,
-            ]}
-          >
-            <View style={[styles.grabber, { backgroundColor: theme.textDisabled }]} />
-
-            {/* 犬の登録状態と頭数に応じて、空状態・単体・複数選択の表示を切り替えます。 */}
-            {dogs.length === 0 ? (
-              <NoDogsBody />
-            ) : isSingleDog ? (
-              <View style={styles.bodyColumn}>
-                <DogPickerCard
-                  dogs={[dogs[0]]}
-                  selectedIds={validSelectedDogIds}
-                  onToggle={() => undefined}
-                  variant="single"
-                />
-                <WalkReadyStatsRow />
-                <WalkStartButton onPress={onStart} disabled={!canStart} loading={isStarting} />
-              </View>
-            ) : (
-              <View style={styles.bodyColumn}>
-                <View style={styles.sectionHeader}>
-                  <Text style={[styles.sectionTitle, { color: theme.onSurfaceVariant }]}>
-                    {t('walk.ready.walkingWith')}
-                  </Text>
-                  <Pressable
-                    accessibilityRole="button"
-                    accessibilityLabel={selectAllLabel}
-                    onPress={handleSelectAll}
-                    hitSlop={8}
-                  >
-                    <Text style={[styles.selectAll, { color: theme.interactive }]}>
-                      {selectAllLabel}
-                    </Text>
-                  </Pressable>
-                </View>
-                <DogPickerCard
-                  dogs={dogs}
-                  selectedIds={validSelectedDogIds}
-                  onToggle={selectDog}
-                  variant="multi"
-                />
-                <WalkReadyStatsRow />
-                <WalkStartButton onPress={onStart} disabled={!canStart} loading={isStarting} />
-              </View>
-            )}
-          </GroupedCard>
+          <WalkFloatingSheet>
+            <WalkReadySheetContent
+              selection={selection}
+              onStart={onStart}
+              isStarting={isStarting}
+            />
+          </WalkFloatingSheet>
         }
       />
     </View>
@@ -138,35 +39,5 @@ export function WalkReadyView({ onStart, isStarting }: WalkReadyViewProps) {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-  },
-  bottomCard: {
-    borderWidth: StyleSheet.hairlineWidth,
-    paddingHorizontal: spacing.md,
-    paddingTop: spacing.md,
-    paddingBottom: spacing.lg,
-  },
-  grabber: {
-    width: 36,
-    height: 5,
-    borderRadius: spacing.step6 / 2,
-    alignSelf: 'center',
-    marginTop: -spacing.xs,
-    marginBottom: spacing.md,
-    opacity: 0.6,
-  },
-  bodyColumn: {
-    gap: spacing.md,
-  },
-  sectionHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-  },
-  sectionTitle: {
-    ...typography.metricLabel,
-  },
-  selectAll: {
-    ...typography.footnote,
-    fontWeight: components.button.fontPrimary.fontWeight,
   },
 });

--- a/apps/mobile/components/walk/WalkRecordingSheetContent.tsx
+++ b/apps/mobile/components/walk/WalkRecordingSheetContent.tsx
@@ -1,0 +1,38 @@
+import { useCallback, useState } from 'react';
+import { Alert } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { useWalkSession } from '@/hooks/use-walk-session';
+import { useWalkStore } from '@/stores/walk-store';
+import { WalkControls } from '@/components/walk/WalkControls';
+import { WalkEventActions } from '@/components/walk/WalkEventActions';
+import type { Dog } from '@/types/graphql';
+
+interface WalkRecordingSheetContentProps {
+  dogs: Dog[];
+}
+
+// 記録中シートの中身。外枠は開始前と同じ WalkFloatingSheet を使い続けます。
+export function WalkRecordingSheetContent({ dogs }: WalkRecordingSheetContentProps) {
+  const { t } = useTranslation();
+  const walkId = useWalkStore((s) => s.walkId);
+  const walkSession = useWalkSession();
+  const [isStopping, setIsStopping] = useState(false);
+
+  const handleStop = useCallback(async () => {
+    if (!walkId) return;
+    setIsStopping(true);
+    try {
+      await walkSession.stop(walkId);
+    } catch {
+      Alert.alert(t('common.error'), t('walk.error.finishFailed'));
+    } finally {
+      setIsStopping(false);
+    }
+  }, [walkId, walkSession, t]);
+
+  return (
+    <WalkControls dogs={dogs} onStop={handleStop} isStopping={isStopping}>
+      <WalkEventActions dogs={dogs} />
+    </WalkControls>
+  );
+}

--- a/apps/mobile/hooks/use-active-walk-snapshot-sync.ts
+++ b/apps/mobile/hooks/use-active-walk-snapshot-sync.ts
@@ -1,0 +1,41 @@
+import { useEffect } from 'react';
+import { useWalk } from '@/hooks/use-walks';
+import { useWalkStore } from '@/stores/walk-store';
+
+const WALK_DISTANCE_POLL_INTERVAL_MS = 10_000;
+
+// Active walk のサーバ snapshot を、復帰 route と通常の記録中タブの両方で同期します。
+export function useActiveWalkSnapshotSync(routeWalkId?: string) {
+  const phase = useWalkStore((s) => s.phase);
+  const walkId = useWalkStore((s) => s.walkId);
+  const setTotalDistanceM = useWalkStore((s) => s.setTotalDistanceM);
+  const hydrateRecordingSession = useWalkStore((s) => s.hydrateRecordingSession);
+
+  const isRecording = phase === 'recording';
+  const effectiveWalkId = walkId ?? routeWalkId ?? '';
+  const { data: walkSnapshot } = useWalk(effectiveWalkId, {
+    refetchIntervalMs: isRecording ? WALK_DISTANCE_POLL_INTERVAL_MS : undefined,
+  });
+
+  useEffect(() => {
+    const distance = walkSnapshot?.distanceM ?? walkSnapshot?.distance;
+    if (typeof distance !== 'number') return;
+    setTotalDistanceM(distance);
+  }, [walkSnapshot?.distance, walkSnapshot?.distanceM, setTotalDistanceM]);
+
+  useEffect(() => {
+    if (!routeWalkId || !walkSnapshot || walkSnapshot.status !== 'ACTIVE') return;
+    if (phase === 'recording' && walkId === walkSnapshot.id) return;
+
+    hydrateRecordingSession({
+      walkId: walkSnapshot.id,
+      startedAt: walkSnapshot.startedAt,
+      selectedDogIds: walkSnapshot.dogs.map((dog) => dog.id),
+      dogs: walkSnapshot.dogs,
+      points: walkSnapshot.points ?? [],
+      flushedPointCount: walkSnapshot.points?.length ?? 0,
+      totalDistanceM: walkSnapshot.distanceM ?? walkSnapshot.distance ?? 0,
+      events: walkSnapshot.events ?? [],
+    });
+  }, [hydrateRecordingSession, phase, routeWalkId, walkId, walkSnapshot]);
+}

--- a/apps/mobile/hooks/use-recording-walk-dogs.ts
+++ b/apps/mobile/hooks/use-recording-walk-dogs.ts
@@ -1,0 +1,16 @@
+import { useMemo } from 'react';
+import { useMe } from '@/hooks/use-me';
+import { useWalkStore } from '@/stores/walk-store';
+import type { Dog } from '@/types/graphql';
+
+// 記録中の表示対象犬を、最新の user dog list と active session snapshot から復元します。
+export function useRecordingWalkDogs(): Dog[] {
+  const selectedDogIds = useWalkStore((s) => s.selectedDogIds);
+  const storedDogs = useWalkStore((s) => s.dogs);
+  const { data: me } = useMe();
+
+  return useMemo<Dog[]>(() => {
+    const dogs = (me?.dogs ?? []).filter((d) => selectedDogIds.includes(d.id));
+    return dogs.length > 0 ? dogs : storedDogs;
+  }, [me?.dogs, selectedDogIds, storedDogs]);
+}

--- a/apps/mobile/hooks/use-walk-ready-selection.ts
+++ b/apps/mobile/hooks/use-walk-ready-selection.ts
@@ -1,0 +1,76 @@
+import { useCallback, useEffect, useMemo } from 'react';
+import { useMe } from '@/hooks/use-me';
+import { useWalkStore } from '@/stores/walk-store';
+import type { Dog } from '@/types/graphql';
+
+interface UseWalkReadySelectionOptions {
+  enabled?: boolean;
+}
+
+export interface WalkReadySelection {
+  dogs: Dog[];
+  selectedDogs: Dog[];
+  validSelectedDogIds: string[];
+  isSingleDog: boolean;
+  allSelected: boolean;
+  selectDog: (dogId: string) => void;
+  handleSelectAll: () => void;
+}
+
+function sameIds(left: string[], right: string[]): boolean {
+  return left.length === right.length && left.every((id, index) => id === right[index]);
+}
+
+// 開始前の犬選択状態を一箇所に集約し、マップ上部チップと下部シートで共有します。
+export function useWalkReadySelection({
+  enabled = true,
+}: UseWalkReadySelectionOptions = {}): WalkReadySelection {
+  const { data: me } = useMe();
+  const dogs = useMemo<Dog[]>(() => me?.dogs ?? [], [me?.dogs]);
+  const selectedDogIds = useWalkStore((s) => s.selectedDogIds);
+  const selectDog = useWalkStore((s) => s.selectDog);
+  const setSelectedDogs = useWalkStore((s) => s.setSelectedDogs);
+
+  const isSingleDog = dogs.length === 1;
+  const dogIds = useMemo(() => dogs.map((dog) => dog.id), [dogs]);
+  const validSelectedDogIds = useMemo(
+    () => selectedDogIds.filter((id) => dogIds.includes(id)),
+    [dogIds, selectedDogIds],
+  );
+  const selectedDogs = useMemo(
+    () => dogs.filter((dog) => validSelectedDogIds.includes(dog.id)),
+    [dogs, validSelectedDogIds],
+  );
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const nextSelectedDogIds =
+      isSingleDog && validSelectedDogIds.length === 0 ? [dogs[0].id] : validSelectedDogIds;
+
+    if (!sameIds(selectedDogIds, nextSelectedDogIds)) {
+      setSelectedDogs(nextSelectedDogIds);
+    }
+  }, [dogs, enabled, isSingleDog, selectedDogIds, setSelectedDogs, validSelectedDogIds]);
+
+  const allSelected =
+    dogs.length > 0 && dogs.every((d) => validSelectedDogIds.includes(d.id));
+
+  const handleSelectAll = useCallback(() => {
+    if (allSelected) {
+      setSelectedDogs([]);
+    } else {
+      setSelectedDogs(dogs.map((d) => d.id));
+    }
+  }, [allSelected, dogs, setSelectedDogs]);
+
+  return {
+    dogs,
+    selectedDogs,
+    validSelectedDogIds,
+    isSingleDog,
+    allSelected,
+    selectDog,
+    handleSelectAll,
+  };
+}

--- a/apps/mobile/hooks/use-walk-screen-view-model.test.ts
+++ b/apps/mobile/hooks/use-walk-screen-view-model.test.ts
@@ -74,16 +74,13 @@ describe('useWalkScreenViewModel', () => {
     expect(result.current.isStarting).toBe(true);
   });
 
-  it('redirects to walk-recording and preserves the camera action', () => {
+  it('does not redirect to walk-recording when the phase becomes recording', () => {
     mockPhase = 'recording';
     mockAction = 'camera';
 
     renderHook(() => useWalkScreenViewModel());
 
-    expect(mockPush).toHaveBeenCalledWith({
-      pathname: '/walk-recording',
-      params: { action: 'camera' },
-    });
+    expect(mockPush).not.toHaveBeenCalled();
   });
 
   it('alerts and aborts when GPS permission is denied', async () => {

--- a/apps/mobile/hooks/use-walk-screen-view-model.ts
+++ b/apps/mobile/hooks/use-walk-screen-view-model.ts
@@ -1,6 +1,5 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback } from 'react';
 import { Alert } from 'react-native';
-import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useWalkPermissions } from '@/hooks/use-walk-permissions';
 import { useWalkSession } from '@/hooks/use-walk-session';
@@ -16,22 +15,11 @@ export interface WalkScreenViewModel {
 // Walk 画面で必要な状態取得、画面遷移、散歩開始処理をまとめるフックです。
 export function useWalkScreenViewModel(): WalkScreenViewModel {
   const { t } = useTranslation();
-  const router = useRouter();
   const phase = useWalkStore((state) => state.phase) as WalkScreenViewModel['phase'];
   const selectedDogIds = useWalkStore((state) => state.selectedDogIds);
-  const { action } = useLocalSearchParams<{ action?: string }>();
 
   const walkSession = useWalkSession();
   const permissions = useWalkPermissions();
-
-  // 散歩記録中になったら、必要なアクションを引き継いで記録画面へ移動します。
-  useEffect(() => {
-    if (phase !== 'recording') return;
-    router.push({
-      pathname: '/walk-recording',
-      params: action === 'camera' ? { action: 'camera' } : undefined,
-    });
-  }, [action, phase, router]);
 
   // 散歩開始時は GPS 権限を確認してから散歩セッションを開始します。
   const handleStart = useCallback(async () => {


### PR DESCRIPTION
## Summary
- Keep the Walk tab map and floating sheet shell mounted when START WALK enters recording mode, swapping only the sheet content.
- Move active recording snapshot sync and dog selection logic into reusable hooks used by the persistent Walk tab and compatibility bridge.
- Preserve `/walk-recording` deep link / Live Activity behavior by redirecting back to the Walk tab, and include the VS Code task updates in this branch.

## Validation
- `git diff --check`
- Mobile Jest suite passed: 120 suites / 757 tests
- Mobile typecheck passed
- iOS Simulator E2E: Select all -> START WALK -> recording controls visible -> End Walk -> Save walk

## Notes
- `gh auth status` reports the local GitHub CLI token is invalid, so the PR was created via the GitHub connector after pushing the branch with `git`.