### PR TITLE
[codex] fix nullable walk aggregates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,10 @@ This project uses the obra/superpowers plugin. Always check for relevant skills 
 
 - UI の設計・実装・リファクタリングで Expo / React Native / `@expo/ui` / `@expo/ui/swift-ui` を扱う場合は、最初に `.codex/skills/expo-ui-docs-first/SKILL.md` を読むこと。repo-local skill の自動検出が効かないセッションでも、このファイルを明示的に参照してから計画・実装する。
 
+## Local Docker Verification
+
+- 複数 worktree で `apps/compose.yml` を使うと、compose project 名 `apps` が衝突して `docker compose exec` が別 worktree の volume を見ていることがある。現在の worktree の API コードを検証するときは、必要に応じて `docker run --rm -v "$PWD":/walking-dog -v apps_cargo_cache:/usr/local/cargo -w /walking-dog/apps/api apps-api cargo test` のように明示的に current worktree を bind mount する。
+
 ## 開発フェーズとスキル
 
 各フェーズで以下の superpowers スキルを使うこと：

--- a/apps/api/src/entity/walk.rs
+++ b/apps/api/src/entity/walk.rs
@@ -58,13 +58,11 @@ impl Entity {
             .select_only()
             .column_as(Expr::col(walk::Column::Id).count(), "total_count")
             .column_as(
-                Expr::col(walk::Column::Distance).sum().cast_as("bigint"),
+                Expr::cust("COALESCE(SUM(distance), 0)::bigint"),
                 "total_distance",
             )
             .column_as(
-                Expr::cust("EXTRACT(EPOCH FROM (ended_at - started_at))")
-                    .sum()
-                    .cast_as("bigint"),
+                Expr::cust("COALESCE(SUM(EXTRACT(EPOCH FROM (ended_at - started_at))), 0)::bigint"),
                 "total_duration",
             )
             .into_tuple()
@@ -72,5 +70,40 @@ impl Entity {
             .await?
             .unwrap_or_default();
         Ok((total_count, total_distance, total_duration))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use sea_orm::{DatabaseBackend, EntityTrait, MockDatabase, Value};
+
+    use super::*;
+
+    fn aggregate_row(
+        total_count: i64,
+        total_distance: i64,
+        total_duration: i64,
+    ) -> BTreeMap<&'static str, Value> {
+        BTreeMap::from([
+            ("total_count", total_count.into()),
+            ("total_distance", total_distance.into()),
+            ("total_duration", total_duration.into()),
+        ])
+    }
+
+    #[tokio::test]
+    async fn aggregate_coalesces_nullable_sums_to_zero() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([[aggregate_row(1, 0, 0)]])
+            .into_connection();
+
+        let aggregate = Entity::aggregate(&db, Entity::find()).await.unwrap();
+
+        assert_eq!(aggregate, (1, 0, 0));
+        let log = db.into_transaction_log();
+        let sql = log[0].statements()[0].sql.to_uppercase();
+        assert!(sql.contains("COALESCE"));
     }
 }


### PR DESCRIPTION
## Summary
- Coalesce nullable walk distance and duration aggregate sums to zero in the API.
- Add a regression test that verifies aggregate SQL uses null-safe sums.
- Document the local Docker worktree verification caveat in `CLAUDE.md`.

## Root Cause
`SUM(distance)` and `SUM(EXTRACT(EPOCH FROM ...))` return `NULL` when the matching walks only contain in-progress/null values. The API decoded those aggregate columns into non-null `i64`, causing `user.walks` to fail with `A null value was encountered while decoding`.

## Validation
- `docker run --rm -v /Users/matsuokashuhei/.codex/worktrees/7060/walking-dog:/walking-dog -v apps_cargo_cache:/usr/local/cargo -w /walking-dog/apps/api apps-api cargo fmt --check`
- `docker run --rm -v /Users/matsuokashuhei/.codex/worktrees/7060/walking-dog:/walking-dog -v apps_cargo_cache:/usr/local/cargo -w /walking-dog/apps/api apps-api cargo test`
- `git diff --check`