### PR TITLE
[codex] remove dog detail delete action

### DIFF
--- a/apps/mobile/CLAUDE.md
+++ b/apps/mobile/CLAUDE.md
@@ -47,6 +47,7 @@
 - Walk 開始前の preview マップは foreground の現在地 region へ寄せる。東京駅などの固定座標は GPS 現在地取得前に地図を描画するための初期領域に限定し、ready 画面の主表示として扱わない。
 - 記録中マップの現在地表示は `useWalkStore().points` の最新点を単一の source of truth にする。犬プロフィール画像などの表示情報は route 側で選択犬を解決して `WalkMap` に渡し、`showsUserLocation` など別系統の現在地表示と併用しない。
 - Pee/poop の表示アイコンは全サーフェスで統一する。React Native 側は `lib/walk/events.ts` の `WALK_EVENT_EMOJIS` を単一ソースにし、pee は `💧`、poop/poo は `💩` を使う。Live Activity と Watch SwiftUI でも同じ emoji を表示し、SF Symbols の `drop.fill` などに分岐させない。`expo-widgets` の Live Activity layout は関数を文字列化して Widget 側 JSContext で再評価するため、layout 関数内では imported constant を参照せず、関数内 local literal と回帰テストで値を固定する。
+- Dog 詳細画面は閲覧と編集導線に集中させ、Delete ボタンや削除確認などの破壊的操作を置かない。犬の削除操作は編集画面の remove フローに集約する。
 
 ## iOS Simulator 起動手順
 

--- a/apps/mobile/__tests__/app/dogs/dog-detail.test.tsx
+++ b/apps/mobile/__tests__/app/dogs/dog-detail.test.tsx
@@ -42,19 +42,10 @@ const mockDog: DogWithStats = {
   walkStats: null,
 };
 
-let mockMeData: { id: string } | undefined = { id: 'user-1' };
 let mockDogData: DogWithStats = mockDog;
 
 jest.mock('@/hooks/use-dog', () => ({
   useDog: () => ({ data: mockDogData, isLoading: false }),
-}));
-
-jest.mock('@/hooks/use-dog-mutations', () => ({
-  useDeleteDog: () => ({ mutateAsync: jest.fn() }),
-}));
-
-jest.mock('@/hooks/use-me', () => ({
-  useMe: () => ({ data: mockMeData }),
 }));
 
 jest.mock('@/hooks/use-pack-progress', () => ({
@@ -82,21 +73,8 @@ function renderWithProviders(ui: React.ReactElement) {
 describe('DogDetailScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockMeData = { id: 'user-1' };
     mockDogData = mockDog;
     mockCanGoBack = true;
-  });
-
-  it('shows delete button for owner', () => {
-    mockMeData = { id: 'user-1' }; // owner
-    renderWithProviders(<DogDetailScreen />);
-    expect(screen.getByText('Delete')).toBeTruthy();
-  });
-
-  it('hides delete button for non-owner member', () => {
-    mockDogData = { ...mockDog, role: 'member' };
-    renderWithProviders(<DogDetailScreen />);
-    expect(screen.queryByText('Delete')).toBeNull();
   });
 
   it('renders the large title screen header with dog title and back action', () => {
@@ -163,9 +141,4 @@ describe('DogDetailScreen', () => {
     expect(style.paddingHorizontal).toBe(spacing.md);
   });
 
-  it('hides delete button when dog has no role', () => {
-    mockDogData = { ...mockDog, role: undefined };
-    renderWithProviders(<DogDetailScreen />);
-    expect(screen.queryByText('Delete')).toBeNull();
-  });
 });

--- a/apps/mobile/app/dogs/[id]/index.tsx
+++ b/apps/mobile/app/dogs/[id]/index.tsx
@@ -7,8 +7,6 @@ import { DogHero } from '@/components/dogs/DogHero';
 import { DogStatsCard } from '@/components/dogs/DogStatsCard';
 import { DogWalksList } from '@/components/dogs/DogWalksList';
 import { LoadingScreen } from '@/components/ui/LoadingScreen';
-import { Button } from '@/components/ui/Button';
-import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { IconSymbol } from '@/components/ui/icon-symbol';
 import { useColors } from '@/hooks/use-colors';
 import { layout, spacing, typography } from '@/theme/tokens';
@@ -29,7 +27,7 @@ const NAME_OVERLAP = 50;
 // Pins the absolute overlay to both screen edges.
 const SCREEN_EDGE = 0;
 
-// 犬詳細画面はヒーロー表示、散歩統計、メンバー/友達導線、削除操作をまとめます。
+// 犬詳細画面はヒーロー表示、散歩統計、メンバー/友達導線をまとめます。
 export default function DogDetailScreen() {
   const { t } = useTranslation();
   const router = useRouter();
@@ -83,30 +81,6 @@ export default function DogDetailScreen() {
             onRetry={vm.retryWalks}
           />
         </View>
-
-        {vm.isOwner ? (
-          // 削除操作は owner のみに限定し、確認ダイアログを経由して実行します。
-          <View style={styles.actions}>
-            <Button
-              label={t('dogs.detail.delete')}
-              variant="destructive"
-              onPress={vm.openDeleteConfirm}
-              style={styles.actionButton}
-            />
-          </View>
-        ) : null}
-
-        {vm.isOwner ? (
-          <ConfirmDialog
-            visible={vm.showDeleteConfirm}
-            title={t('dogs.detail.deleteTitle')}
-            message={t('dogs.detail.deleteConfirm', { name: vm.dog.name })}
-            confirmLabel={t('dogs.detail.delete')}
-            onConfirm={vm.handleDelete}
-            onCancel={vm.closeDeleteConfirm}
-            destructive
-          />
-        ) : null}
       </ScrollView>
 
       <View
@@ -178,13 +152,6 @@ const styles = StyleSheet.create({
   },
   walksSection: {
     paddingHorizontal: spacing.md,
-  },
-  actions: {
-    paddingHorizontal: spacing.lg,
-    paddingTop: spacing.lg,
-  },
-  actionButton: {
-    width: '100%',
   },
   headerOverlay: {
     position: 'absolute',

--- a/apps/mobile/hooks/use-dog-detail-view-model.test.ts
+++ b/apps/mobile/hooks/use-dog-detail-view-model.test.ts
@@ -3,9 +3,6 @@ import { useDogDetailViewModel } from './use-dog-detail-view-model';
 import type { DogWithStats, Walk } from '@/types/graphql';
 
 const mockPush = jest.fn();
-const mockReplace = jest.fn();
-const mockDeleteDog = jest.fn();
-const mockRunWithAlert = jest.fn();
 const mockRefetchWalks = jest.fn();
 let mockWalksError: Error | null = null;
 
@@ -74,12 +71,11 @@ let mockPack = {
     'dog-1': { todayKm: 1, todayMinutes: 20, goalProgressMinutes: 20, goalMinutes: 30, goalCycleDays: 1, totalWalks: 1, streakDays: 5 },
   },
 };
-let mockMe = { id: 'user-1' };
 let mockIsOwner = true;
 
 jest.mock('expo-router', () => ({
   useLocalSearchParams: () => ({ id: 'dog-1' }),
-  useRouter: () => ({ push: mockPush, replace: mockReplace }),
+  useRouter: () => ({ push: mockPush }),
 }));
 
 jest.mock('@/hooks/use-dog', () => ({
@@ -92,18 +88,6 @@ jest.mock('@/hooks/use-walks', () => ({
 
 jest.mock('@/hooks/use-pack-progress', () => ({
   usePackProgress: () => mockPack,
-}));
-
-jest.mock('@/hooks/use-dog-mutations', () => ({
-  useDeleteDog: () => ({ mutateAsync: mockDeleteDog }),
-}));
-
-jest.mock('@/hooks/use-me', () => ({
-  useMe: () => ({ data: mockMe }),
-}));
-
-jest.mock('@/hooks/use-mutation-with-alert', () => ({
-  useMutationWithAlert: () => mockRunWithAlert,
 }));
 
 jest.mock('@/hooks/use-dog-detail-authorization', () => ({
@@ -197,11 +181,8 @@ describe('useDogDetailViewModel', () => {
         'dog-1': { todayKm: 1, todayMinutes: 20, goalProgressMinutes: 20, goalMinutes: 30, goalCycleDays: 1, totalWalks: 1, streakDays: 5 },
       },
     };
-    mockMe = { id: 'user-1' };
     mockIsOwner = true;
     mockWalksError = null;
-    mockDeleteDog.mockResolvedValue(true);
-    mockRunWithAlert.mockImplementation(async (fn: () => Promise<unknown>) => fn());
   });
 
   it('returns loading until the dog query resolves', () => {
@@ -256,44 +237,4 @@ describe('useDogDetailViewModel', () => {
     expect(mockPush).toHaveBeenCalledTimes(1);
   });
 
-  it('toggles delete confirmation visibility inside the view model', () => {
-    const { result } = renderHook(() => useDogDetailViewModel());
-    const vm = expectReadyViewModel(result.current);
-
-    act(() => {
-      vm.openDeleteConfirm();
-    });
-    expect(expectReadyViewModel(result.current).showDeleteConfirm).toBe(true);
-
-    act(() => {
-      vm.closeDeleteConfirm();
-    });
-    expect(expectReadyViewModel(result.current).showDeleteConfirm).toBe(false);
-  });
-
-  it('deletes the dog through the alert helper and returns to the dogs tab on success', async () => {
-    const { result } = renderHook(() => useDogDetailViewModel());
-    const vm = expectReadyViewModel(result.current);
-
-    await act(async () => {
-      await vm.handleDelete();
-    });
-
-    expect(mockRunWithAlert).toHaveBeenCalledWith(expect.any(Function), 'dogs.detail.deleteError');
-    expect(mockDeleteDog).toHaveBeenCalledWith('dog-1');
-    expect(mockReplace).toHaveBeenCalledWith('/(tabs)/dogs');
-  });
-
-  it('does not navigate away when delete returns null', async () => {
-    mockRunWithAlert.mockResolvedValue(null);
-
-    const { result } = renderHook(() => useDogDetailViewModel());
-    const vm = expectReadyViewModel(result.current);
-
-    await act(async () => {
-      await vm.handleDelete();
-    });
-
-    expect(mockReplace).not.toHaveBeenCalled();
-  });
 });

--- a/apps/mobile/hooks/use-dog-detail-view-model.ts
+++ b/apps/mobile/hooks/use-dog-detail-view-model.ts
@@ -1,9 +1,7 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useDog } from '@/hooks/use-dog';
 import { useDogDetailAuthorization } from '@/hooks/use-dog-detail-authorization';
-import { useDeleteDog } from '@/hooks/use-dog-mutations';
-import { useMutationWithAlert } from '@/hooks/use-mutation-with-alert';
 import { usePackProgress } from '@/hooks/use-pack-progress';
 import { useMyWalks } from '@/hooks/use-walks';
 import type { Dog, DogWithStats, Walk } from '@/types/graphql';
@@ -46,11 +44,7 @@ interface DogDetailReadyViewModel {
   walksError: Error | null;
   retryWalks: () => void;
   isOwner: boolean;
-  showDeleteConfirm: boolean;
   handleOpenWalk: (walkId: string) => void;
-  openDeleteConfirm: () => void;
-  closeDeleteConfirm: () => void;
-  handleDelete: () => Promise<void>;
 }
 
 export type DogDetailViewModel = DogDetailLoadingViewModel | DogDetailReadyViewModel;
@@ -65,10 +59,7 @@ export function useDogDetailViewModel(): DogDetailViewModel {
   const { data: walks = [], error: walksErrorRaw, refetch: refetchWalks } = useMyWalks(100);
   const walksError = walksErrorRaw ?? null;
   const pack = usePackProgress();
-  const { mutateAsync: deleteDog } = useDeleteDog();
-  const runWithAlert = useMutationWithAlert();
   const { isOwner } = useDogDetailAuthorization(dog ?? undefined);
-  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
   // 全散歩履歴から、現在表示している犬が参加した散歩だけを抽出します。
   const dogWalks = useMemo(
@@ -87,23 +78,6 @@ export function useDogDetailViewModel(): DogDetailViewModel {
     void refetchWalks?.();
   }, [refetchWalks]);
 
-  const openDeleteConfirm = useCallback(() => {
-    setShowDeleteConfirm(true);
-  }, []);
-
-  const closeDeleteConfirm = useCallback(() => {
-    setShowDeleteConfirm(false);
-  }, []);
-
-  // 削除は共通のアラート処理を通し、成功時だけ犬一覧へ戻します。
-  const handleDelete = useCallback(async () => {
-    if (!dogId) return;
-    const ok = await runWithAlert(() => deleteDog(dogId), 'dogs.detail.deleteError');
-    if (ok) {
-      router.replace('/(tabs)/dogs');
-    }
-  }, [deleteDog, dogId, router, runWithAlert]);
-
   // 詳細表示に必要なデータが揃うまで、画面側へ loading として返します。
   if (isLoading || !dog) {
     return { status: 'loading' };
@@ -118,10 +92,6 @@ export function useDogDetailViewModel(): DogDetailViewModel {
     walksError,
     retryWalks,
     isOwner,
-    showDeleteConfirm,
     handleOpenWalk,
-    openDeleteConfirm,
-    closeDeleteConfirm,
-    handleDelete,
   };
 }


### PR DESCRIPTION
## Summary
- Remove the Delete button and confirmation dialog from the Dog detail screen.
- Remove Dog detail view model state and handlers that only supported the removed delete action.
- Keep dog removal centralized in the edit screen and document that rule in `apps/mobile/CLAUDE.md`.

## Test Plan
- `npm test -- __tests__/app/dogs/dog-detail.test.tsx hooks/use-dog-detail-view-model.test.ts`
- `npm run typecheck`
- `npm run lint` (passes with an existing warning in `components/dogs/DogForm.test.tsx:16`)