### PR TITLE
[codex] Improve walk background location handling

### DIFF
--- a/apps/mobile/CLAUDE.md
+++ b/apps/mobile/CLAUDE.md
@@ -49,6 +49,7 @@
 - 記録中の下部 controls は native `formSheet` route ではなく、Walk タブ内の map overlay として描画する。`useWalkStore().isMinimized` を単一の source of truth にし、縮小表示では pee/poop/photo などのイベント操作を出さず、経過時間・距離・LIVE 状態・展開操作だけに絞る。
 - Walk 開始前の preview マップは foreground の現在地 region へ寄せる。東京駅などの固定座標は GPS 現在地取得前に地図を描画するための初期領域に限定し、ready 画面の主表示として扱わない。
 - 記録中マップの現在地表示は `useWalkStore().points` の最新点を単一の source of truth にする。犬プロフィール画像などの表示情報は route 側で選択犬を解決して `WalkMap` に渡し、`showsUserLocation` など別系統の現在地表示と併用しない。
+- 散歩 GPS は foreground と background の位置情報権限を別々の capability として扱う。foreground が許可済みでも background が未許可なら `Location.startLocationUpdatesAsync` を呼ばず、foreground tracking のみで記録する。
 - Pee/poop の表示アイコンは全サーフェスで統一する。React Native 側は `lib/walk/events.ts` の `WALK_EVENT_EMOJIS` を単一ソースにし、pee は `💧`、poop/poo は `💩` を使う。Live Activity と Watch SwiftUI でも同じ emoji を表示し、SF Symbols の `drop.fill` などに分岐させない。`expo-widgets` の Live Activity layout は関数を文字列化して Widget 側 JSContext で再評価するため、layout 関数内では imported constant を参照せず、関数内 local literal と回帰テストで値を固定する。
 - Dog 詳細画面は閲覧と編集導線に集中させ、Delete ボタンや削除確認などの破壊的操作を置かない。犬の削除操作は編集画面の remove フローに集約する。
 

--- a/apps/mobile/hooks/use-walk-mutations.ts
+++ b/apps/mobile/hooks/use-walk-mutations.ts
@@ -46,7 +46,7 @@ export function useFinishWalk() {
   });
 }
 
-// GPS 点をサーバーへまとめて追加します。
+// API は trackPoint の単点 mutation を公開しているため、ローカルでまとめた GPS 点を順に送信します。
 export function useAddWalkPoints() {
   return useMutation<boolean, Error, { walkId: string; points: WalkPointInput[] }>({
     mutationFn: async ({ walkId, points }) => {

--- a/apps/mobile/hooks/use-walk-permissions.test.ts
+++ b/apps/mobile/hooks/use-walk-permissions.test.ts
@@ -11,16 +11,18 @@ beforeEach(() => {
 });
 
 describe('useWalkPermissions', () => {
-  it('requestGpsPermission returns true when location permission is granted', async () => {
-    (gpsTracker.requestPermission as jest.Mock).mockResolvedValue(true);
+  it('requestGpsPermission returns foreground and background permission capability', async () => {
+    const permission = { foregroundGranted: true, backgroundGranted: false };
+    (gpsTracker.requestPermission as jest.Mock).mockResolvedValue(permission);
     const { result } = renderHook(() => useWalkPermissions());
-    expect(await result.current.requestGpsPermission()).toBe(true);
+    expect(await result.current.requestGpsPermission()).toBe(permission);
     expect(gpsTracker.requestPermission).toHaveBeenCalledTimes(1);
   });
 
-  it('requestGpsPermission returns false when location permission is denied', async () => {
-    (gpsTracker.requestPermission as jest.Mock).mockResolvedValue(false);
+  it('requestGpsPermission returns denied foreground capability', async () => {
+    const permission = { foregroundGranted: false, backgroundGranted: false };
+    (gpsTracker.requestPermission as jest.Mock).mockResolvedValue(permission);
     const { result } = renderHook(() => useWalkPermissions());
-    expect(await result.current.requestGpsPermission()).toBe(false);
+    expect(await result.current.requestGpsPermission()).toBe(permission);
   });
 });

--- a/apps/mobile/hooks/use-walk-screen-view-model.test.ts
+++ b/apps/mobile/hooks/use-walk-screen-view-model.test.ts
@@ -60,7 +60,10 @@ describe('useWalkScreenViewModel', () => {
     mockSelectedDogIds = ['dog-1'];
     mockAction = undefined;
     mockWalkSessionIsStarting = false;
-    mockRequestGpsPermission.mockResolvedValue(true);
+    mockRequestGpsPermission.mockResolvedValue({
+      foregroundGranted: true,
+      backgroundGranted: true,
+    });
     mockWalkSessionStart.mockResolvedValue('walk-1');
   });
 
@@ -84,7 +87,10 @@ describe('useWalkScreenViewModel', () => {
   });
 
   it('alerts and aborts when GPS permission is denied', async () => {
-    mockRequestGpsPermission.mockResolvedValue(false);
+    mockRequestGpsPermission.mockResolvedValue({
+      foregroundGranted: false,
+      backgroundGranted: false,
+    });
     const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(jest.fn());
 
     const { result } = renderHook(() => useWalkScreenViewModel());
@@ -110,6 +116,7 @@ describe('useWalkScreenViewModel', () => {
 
     expect(mockWalkSessionStart).toHaveBeenCalledWith({
       selectedDogIds: ['dog-1'],
+      backgroundLocationEnabled: true,
     });
   });
 
@@ -124,6 +131,25 @@ describe('useWalkScreenViewModel', () => {
 
     expect(mockWalkSessionStart).toHaveBeenCalledWith({
       selectedDogIds: ['dog-1', 'dog-2'],
+      backgroundLocationEnabled: true,
+    });
+  });
+
+  it('starts foreground-only tracking when background permission is unavailable', async () => {
+    mockRequestGpsPermission.mockResolvedValue({
+      foregroundGranted: true,
+      backgroundGranted: false,
+    });
+
+    const { result } = renderHook(() => useWalkScreenViewModel());
+
+    await act(async () => {
+      await result.current.handleStart();
+    });
+
+    expect(mockWalkSessionStart).toHaveBeenCalledWith({
+      selectedDogIds: ['dog-1'],
+      backgroundLocationEnabled: false,
     });
   });
 

--- a/apps/mobile/hooks/use-walk-screen-view-model.ts
+++ b/apps/mobile/hooks/use-walk-screen-view-model.ts
@@ -23,14 +23,17 @@ export function useWalkScreenViewModel(): WalkScreenViewModel {
 
   // 散歩開始時は GPS 権限を確認してから散歩セッションを開始します。
   const handleStart = useCallback(async () => {
-    const gpsGranted = await permissions.requestGpsPermission();
-    if (!gpsGranted) {
+    const locationPermission = await permissions.requestGpsPermission();
+    if (!locationPermission.foregroundGranted) {
       Alert.alert(t('walk.permission.title'), t('walk.permission.message'));
       return;
     }
 
     try {
-      await walkSession.start({ selectedDogIds });
+      await walkSession.start({
+        selectedDogIds,
+        backgroundLocationEnabled: locationPermission.backgroundGranted,
+      });
     } catch (error) {
       console.error('[walk.start] failed', error);
       Alert.alert(t('common.error'), t('walk.error.startFailed'));

--- a/apps/mobile/hooks/use-walk-session.test.ts
+++ b/apps/mobile/hooks/use-walk-session.test.ts
@@ -176,11 +176,15 @@ describe('useWalkSession.start', () => {
     await act(async () => {
       walkId = await result.current.start({
         selectedDogIds: ['dog-1'],
+        backgroundLocationEnabled: false,
       });
     });
 
     expect(mockStartWalkMutateAsync).toHaveBeenCalledWith(['dog-1']);
     expect(walkId).toBe('walk-1');
+    expect(gpsTracker.startTracking).toHaveBeenCalledWith(expect.any(Function), {
+      backgroundLocationEnabled: false,
+    });
   });
 
   it('calls startRecording on the walk store with the walk id', async () => {

--- a/apps/mobile/hooks/use-walk-session.ts
+++ b/apps/mobile/hooks/use-walk-session.ts
@@ -26,6 +26,7 @@ async function endLiveActivityAfterSavedWalk() {
 // 散歩開始時に必要な犬 ID です。
 export interface WalkSessionStartOptions {
   selectedDogIds: string[];
+  backgroundLocationEnabled?: boolean;
 }
 
 // 散歩の開始・終了、GPS トラッキングを一括で管理します。
@@ -37,7 +38,10 @@ export function useWalkSession() {
   const finish = useWalkStore((s) => s.finish);
 
   const start = useCallback(
-    async ({ selectedDogIds }: WalkSessionStartOptions): Promise<string> => {
+    async ({
+      selectedDogIds,
+      backgroundLocationEnabled = false,
+    }: WalkSessionStartOptions): Promise<string> => {
       // 既存の GPS 監視を止めてから、新しい散歩と端末側の記録状態を開始します。
       await stopWalkTracking();
 
@@ -67,6 +71,7 @@ export function useWalkSession() {
       await beginWalkTracking({
         walkId: walk.id,
         addWalkPoints: addWalkPointsMutation.mutateAsync,
+        backgroundLocationEnabled,
         onPoint: (point) => {
           useWalkStore.getState().addPoint(point);
         },

--- a/apps/mobile/lib/walk/background-location-task.test.ts
+++ b/apps/mobile/lib/walk/background-location-task.test.ts
@@ -24,6 +24,9 @@ jest.mock('expo-location', () => ({
   Accuracy: { High: 'high' },
   ActivityType: { Fitness: 'fitness' },
   startLocationUpdatesAsync: jest.fn(),
+  getForegroundPermissionsAsync: jest.fn(),
+  getBackgroundPermissionsAsync: jest.fn(),
+  getProviderStatusAsync: jest.fn(),
 }));
 
 jest.mock('./active-walk-session', () => ({
@@ -58,10 +61,40 @@ const location = (
 describe('background-location-task', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    (TaskManager.isTaskRegisteredAsync as jest.Mock).mockResolvedValue(false);
   });
 
   it('defines the background location task at module load', () => {
     expect(definedTaskCall).toEqual([WALK_BACKGROUND_LOCATION_TASK, expect.any(Function)]);
+  });
+
+  it('logs diagnostics when the native background task reports an error', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const nativeError = { code: 0, message: 'Error Domain=kCLErrorDomain Code=0 "(null)"' };
+    const taskHandler = definedTaskCall[1] as (event: {
+      data?: unknown;
+      error?: unknown;
+    }) => Promise<void>;
+    (Location.getForegroundPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'granted' });
+    (Location.getBackgroundPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'denied' });
+    (Location.getProviderStatusAsync as jest.Mock).mockResolvedValue({
+      locationServicesEnabled: true,
+    });
+    (TaskManager.isTaskRegisteredAsync as jest.Mock).mockResolvedValue(true);
+
+    await taskHandler({ error: nativeError });
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith('[walk.backgroundLocation] task failed', {
+      error: nativeError,
+      diagnostics: {
+        foregroundPermission: 'granted',
+        backgroundPermission: 'denied',
+        providerStatus: { locationServicesEnabled: true },
+        taskRegistered: true,
+      },
+    });
+
+    consoleErrorSpy.mockRestore();
   });
 
   it('registers high accuracy background location updates', async () => {
@@ -132,6 +165,39 @@ describe('background-location-task', () => {
       expect.objectContaining({
         walkId: 'walk-1',
         distanceLabel: expect.stringMatching(/m$/),
+      }),
+    );
+  });
+
+  it('does not append duplicate background locations already captured by foreground tracking', async () => {
+    const duplicate = location(35.6813, 139.7672, '2026-04-01T00:00:05.000Z');
+    (loadActiveWalkSession as jest.Mock).mockResolvedValue({
+      walkId: 'walk-1',
+      startedAt: '2026-04-01T00:00:00.000Z',
+      selectedDogIds: ['dog-1'],
+      dogs: [],
+      points: [
+        { lat: 35.6812, lng: 139.7671, recordedAt: '2026-04-01T00:00:00.000Z' },
+        { lat: 35.6813, lng: 139.7672, recordedAt: '2026-04-01T00:00:05.000Z' },
+      ],
+      flushedPointCount: 1,
+      totalDistanceM: 14,
+      events: [],
+    });
+
+    await handleWalkBackgroundLocations([
+      duplicate,
+      location(35.6814, 139.7673, '2026-04-01T00:00:10.000Z'),
+    ]);
+
+    expect(persistActiveWalkSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        flushedPointCount: 1,
+        points: [
+          { lat: 35.6812, lng: 139.7671, recordedAt: '2026-04-01T00:00:00.000Z' },
+          { lat: 35.6813, lng: 139.7672, recordedAt: '2026-04-01T00:00:05.000Z' },
+          { lat: 35.6814, lng: 139.7673, recordedAt: '2026-04-01T00:00:10.000Z' },
+        ],
       }),
     );
   });

--- a/apps/mobile/lib/walk/background-location-task.ts
+++ b/apps/mobile/lib/walk/background-location-task.ts
@@ -8,6 +8,7 @@ import {
 import { buildWalkActivityProps } from './live-activity';
 import { updateWalkLiveActivity } from './live-activity-controller';
 import { totalHaversineDistance } from './distance';
+import { appendUniqueWalkPoints } from './points';
 import { useWalkStore } from '@/stores/walk-store';
 import type { WalkPoint } from '@/types/graphql';
 
@@ -25,7 +26,7 @@ function appendPointsToSession(
   session: ActiveWalkSessionSnapshot,
   incomingPoints: WalkPoint[],
 ): ActiveWalkSessionSnapshot {
-  const points = [...session.points, ...incomingPoints];
+  const points = appendUniqueWalkPoints(session.points, incomingPoints);
   return {
     ...session,
     points,
@@ -37,6 +38,44 @@ function syncRuntimeStore(session: ActiveWalkSessionSnapshot) {
   const state = useWalkStore.getState();
   if (state.phase === 'recording' && state.walkId !== session.walkId) return;
   state.hydrateRecordingSession(session);
+}
+
+type DiagnosticValue<T> = T | { error: string };
+
+interface BackgroundLocationDiagnostics {
+  foregroundPermission: DiagnosticValue<string>;
+  backgroundPermission: DiagnosticValue<string>;
+  providerStatus: DiagnosticValue<Location.LocationProviderStatus>;
+  taskRegistered: DiagnosticValue<boolean>;
+}
+
+function diagnosticError(error: unknown): { error: string } {
+  return { error: error instanceof Error ? error.message : String(error) };
+}
+
+async function readDiagnostic<T>(operation: () => Promise<T>): Promise<DiagnosticValue<T>> {
+  try {
+    return await operation();
+  } catch (error) {
+    return diagnosticError(error);
+  }
+}
+
+async function readBackgroundLocationDiagnostics(): Promise<BackgroundLocationDiagnostics> {
+  const [foregroundPermission, backgroundPermission, providerStatus, taskRegistered] =
+    await Promise.all([
+      readDiagnostic(async () => (await Location.getForegroundPermissionsAsync()).status),
+      readDiagnostic(async () => (await Location.getBackgroundPermissionsAsync()).status),
+      readDiagnostic(() => Location.getProviderStatusAsync()),
+      readDiagnostic(() => TaskManager.isTaskRegisteredAsync(WALK_BACKGROUND_LOCATION_TASK)),
+    ]);
+
+  return {
+    foregroundPermission,
+    backgroundPermission,
+    providerStatus,
+    taskRegistered,
+  };
 }
 
 export async function handleWalkBackgroundLocations(
@@ -67,7 +106,10 @@ export async function handleWalkBackgroundLocations(
 
 TaskManager.defineTask(WALK_BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
   if (error) {
-    console.error('[walk.backgroundLocation] task failed', error);
+    console.error('[walk.backgroundLocation] task failed', {
+      error,
+      diagnostics: await readBackgroundLocationDiagnostics(),
+    });
     return;
   }
 

--- a/apps/mobile/lib/walk/gps-tracker.test.ts
+++ b/apps/mobile/lib/walk/gps-tracker.test.ts
@@ -9,6 +9,7 @@ jest.mock('expo-location', () => ({
   Accuracy: { High: 'high' },
   requestForegroundPermissionsAsync: jest.fn(),
   requestBackgroundPermissionsAsync: jest.fn(),
+  getBackgroundPermissionsAsync: jest.fn(),
   watchPositionAsync: jest.fn(),
 }));
 
@@ -22,30 +23,36 @@ describe('gps-tracker', () => {
     jest.clearAllMocks();
   });
 
-  it('requests foreground and background location permissions for walks', async () => {
+  it('reports foreground and background location permissions for walks', async () => {
     (Location.requestForegroundPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'granted' });
     (Location.requestBackgroundPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'granted' });
 
-    await expect(requestPermission()).resolves.toBe(true);
+    await expect(requestPermission()).resolves.toEqual({
+      foregroundGranted: true,
+      backgroundGranted: true,
+    });
 
     expect(Location.requestForegroundPermissionsAsync).toHaveBeenCalledTimes(1);
     expect(Location.requestBackgroundPermissionsAsync).toHaveBeenCalledTimes(1);
   });
 
-  it('allows foreground walk tracking when background permission is unavailable', async () => {
+  it('keeps foreground permission separate when background permission is unavailable', async () => {
     (Location.requestForegroundPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'granted' });
     (Location.requestBackgroundPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'denied' });
 
-    await expect(requestPermission()).resolves.toBe(true);
+    await expect(requestPermission()).resolves.toEqual({
+      foregroundGranted: true,
+      backgroundGranted: false,
+    });
   });
 
-  it('starts foreground watch and background task, then unregisters both on stop', async () => {
+  it('starts foreground watch and background task when background tracking is enabled', async () => {
     const remove = jest.fn();
     (Location.watchPositionAsync as jest.Mock).mockResolvedValue({ remove });
     (startWalkBackgroundLocationUpdates as jest.Mock).mockResolvedValue(undefined);
     (stopWalkBackgroundLocationUpdates as jest.Mock).mockResolvedValue(undefined);
 
-    const stop = await startTracking(jest.fn());
+    const stop = await startTracking(jest.fn(), { backgroundLocationEnabled: true });
 
     expect(Location.watchPositionAsync).toHaveBeenCalledWith(
       {
@@ -63,13 +70,28 @@ describe('gps-tracker', () => {
     expect(stopWalkBackgroundLocationUpdates).toHaveBeenCalledTimes(1);
   });
 
+  it('skips the background task when background tracking is not enabled', async () => {
+    const remove = jest.fn();
+    (Location.watchPositionAsync as jest.Mock).mockResolvedValue({ remove });
+
+    const stop = await startTracking(jest.fn(), { backgroundLocationEnabled: false });
+
+    expect(Location.watchPositionAsync).toHaveBeenCalledTimes(1);
+    expect(startWalkBackgroundLocationUpdates).not.toHaveBeenCalled();
+
+    await stop();
+
+    expect(remove).toHaveBeenCalledTimes(1);
+    expect(stopWalkBackgroundLocationUpdates).not.toHaveBeenCalled();
+  });
+
   it('keeps foreground tracking active when the background task cannot start', async () => {
     const remove = jest.fn();
     const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     (Location.watchPositionAsync as jest.Mock).mockResolvedValue({ remove });
     (startWalkBackgroundLocationUpdates as jest.Mock).mockRejectedValue(new Error('Always denied'));
 
-    const stop = await startTracking(jest.fn());
+    const stop = await startTracking(jest.fn(), { backgroundLocationEnabled: true });
 
     expect(Location.watchPositionAsync).toHaveBeenCalledTimes(1);
     expect(consoleWarnSpy).toHaveBeenCalledWith(

--- a/apps/mobile/lib/walk/gps-tracker.ts
+++ b/apps/mobile/lib/walk/gps-tracker.ts
@@ -5,16 +5,31 @@ import {
   stopWalkBackgroundLocationUpdates,
 } from './background-location-task';
 
-export async function requestPermission(): Promise<boolean> {
-  const foreground = await Location.requestForegroundPermissionsAsync();
-  if (foreground.status !== 'granted') return false;
+export interface WalkLocationPermissions {
+  foregroundGranted: boolean;
+  backgroundGranted: boolean;
+}
 
-  await Location.requestBackgroundPermissionsAsync();
-  return true;
+export interface StartTrackingOptions {
+  backgroundLocationEnabled: boolean;
+}
+
+export async function requestPermission(): Promise<WalkLocationPermissions> {
+  const foreground = await Location.requestForegroundPermissionsAsync();
+  if (foreground.status !== 'granted') {
+    return { foregroundGranted: false, backgroundGranted: false };
+  }
+
+  const background = await Location.requestBackgroundPermissionsAsync();
+  return {
+    foregroundGranted: true,
+    backgroundGranted: background.status === 'granted',
+  };
 }
 
 export async function startTracking(
   onPosition: (point: WalkPoint) => void,
+  { backgroundLocationEnabled }: StartTrackingOptions = { backgroundLocationEnabled: false },
 ): Promise<() => Promise<void>> {
   let subscription: Location.LocationSubscription;
   subscription = await Location.watchPositionAsync(
@@ -33,11 +48,13 @@ export async function startTracking(
   );
 
   let backgroundTrackingStarted = false;
-  try {
-    await startWalkBackgroundLocationUpdates();
-    backgroundTrackingStarted = true;
-  } catch (error) {
-    console.warn('[walk.backgroundLocation.start] unavailable', error);
+  if (backgroundLocationEnabled) {
+    try {
+      await startWalkBackgroundLocationUpdates();
+      backgroundTrackingStarted = true;
+    } catch (error) {
+      console.warn('[walk.backgroundLocation.start] unavailable', error);
+    }
   }
 
   return async () => {

--- a/apps/mobile/lib/walk/points.ts
+++ b/apps/mobile/lib/walk/points.ts
@@ -1,0 +1,26 @@
+import type { WalkPoint } from '@/types/graphql';
+
+const DUPLICATE_COORDINATE_TOLERANCE = 0.0000001;
+
+export function isDuplicateWalkPoint(points: WalkPoint[], point: WalkPoint): boolean {
+  return points.some(
+    (existing) =>
+      existing.recordedAt === point.recordedAt &&
+      Math.abs(existing.lat - point.lat) <= DUPLICATE_COORDINATE_TOLERANCE &&
+      Math.abs(existing.lng - point.lng) <= DUPLICATE_COORDINATE_TOLERANCE,
+  );
+}
+
+export function appendUniqueWalkPoints(points: WalkPoint[], incomingPoints: WalkPoint[]): WalkPoint[] {
+  let nextPoints = points;
+
+  for (const point of incomingPoints) {
+    if (isDuplicateWalkPoint(nextPoints, point)) continue;
+    if (nextPoints === points) {
+      nextPoints = [...points];
+    }
+    nextPoints.push(point);
+  }
+
+  return nextPoints;
+}

--- a/apps/mobile/lib/walk/tracking-manager.test.ts
+++ b/apps/mobile/lib/walk/tracking-manager.test.ts
@@ -69,6 +69,7 @@ describe('beginWalkTracking', () => {
       addWalkPoints: jest.fn().mockResolvedValue(true),
       onPoint,
       onDistanceChange,
+      backgroundLocationEnabled: false,
     });
 
     const point: WalkPoint = { lat: 35.68, lng: 139.76, recordedAt: '2026-04-01T00:01:00Z' };
@@ -87,6 +88,9 @@ describe('beginWalkTracking', () => {
     expect(onPoint).not.toHaveBeenCalled();
     expect(onDistanceChange).not.toHaveBeenCalled();
     expect(stopTracking).toHaveBeenCalledTimes(1);
+    expect(startTracking).toHaveBeenCalledWith(expect.any(Function), {
+      backgroundLocationEnabled: false,
+    });
   });
 
   it('cleans up an older subscription when a newer session starts before it resolves', async () => {
@@ -233,9 +237,9 @@ describe('flushPendingWalkPoints', () => {
   it('keeps progress from successful batches when a later batch fails', async () => {
     useWalkStore.getState().startRecording('walk-1');
     const points: WalkPoint[] = Array.from({ length: MAX_POINTS_PER_BATCH + 50 }, (_, index) => ({
-      lat: 35.68,
-      lng: 139.76,
-      recordedAt: `2026-04-01T00:${String(index % 60).padStart(2, '0')}:00Z`,
+      lat: 35.68 + index * 0.00001,
+      lng: 139.76 + index * 0.00001,
+      recordedAt: new Date(Date.parse('2026-04-01T00:00:00Z') + index * 1000).toISOString(),
     }));
     points.forEach((point) => useWalkStore.getState().addPoint(point));
 

--- a/apps/mobile/lib/walk/tracking-manager.ts
+++ b/apps/mobile/lib/walk/tracking-manager.ts
@@ -3,8 +3,8 @@ import { stopWalkBackgroundLocationUpdates } from '@/lib/walk/background-locatio
 import { useWalkStore } from '@/stores/walk-store';
 import type { WalkPoint, WalkPointInput } from '@/types/graphql';
 
-// Server-side validation rejects payloads over ~200 points per addWalkPoints
-// call (request size cap). Keep batches under this ceiling when flushing.
+// Keep each local flush bounded; useAddWalkPoints currently submits these points as
+// individual trackPoint mutations, so this also caps one flush cycle's request count.
 export const MAX_POINTS_PER_BATCH = 200;
 export const PERIODIC_FLUSH_INTERVAL_MS = 30_000;
 
@@ -16,6 +16,7 @@ let queuedFlushRequest: FlushPendingWalkPointsOptions | null = null;
 interface BeginWalkTrackingOptions {
   walkId: string;
   addWalkPoints: AddWalkPointsFn;
+  backgroundLocationEnabled?: boolean;
   onPoint: (point: WalkPoint) => void;
   onDistanceChange?: (distanceM: number) => void;
 }
@@ -39,19 +40,23 @@ function logPeriodicFlushError(error: unknown) {
 export async function beginWalkTracking({
   walkId,
   addWalkPoints,
+  backgroundLocationEnabled = false,
   onPoint,
   onDistanceChange,
 }: BeginWalkTrackingOptions) {
   const trackingGeneration = useWalkStore.getState().activateTrackingSession();
 
-  const stopTracking = await startTracking((point) => {
-    const state = useWalkStore.getState();
-    if (state.trackingGeneration !== trackingGeneration) return;
-    if (state.phase !== 'recording') return;
+  const stopTracking = await startTracking(
+    (point) => {
+      const state = useWalkStore.getState();
+      if (state.trackingGeneration !== trackingGeneration) return;
+      if (state.phase !== 'recording') return;
 
-    onPoint(point);
-    onDistanceChange?.(useWalkStore.getState().totalDistanceM);
-  });
+      onPoint(point);
+      onDistanceChange?.(useWalkStore.getState().totalDistanceM);
+    },
+    { backgroundLocationEnabled },
+  );
 
   const flushTimer = setInterval(() => {
     void flushPendingWalkPoints({ walkId, addWalkPoints }).catch(logPeriodicFlushError);

--- a/apps/mobile/modules/walking-dog-watch-bridge/ios/WalkingDogWatchBridgeModule.swift
+++ b/apps/mobile/modules/walking-dog-watch-bridge/ios/WalkingDogWatchBridgeModule.swift
@@ -57,6 +57,10 @@ private final class WalkingDogWatchBridgeManager: NSObject, WCSessionDelegate {
 
     let payload = ["snapshotJson": snapshotJson]
     let session = WCSession.default
+    guard canPublishToWatch(session) else {
+      return
+    }
+
     do {
       try session.updateApplicationContext(payload)
     } catch {
@@ -143,9 +147,16 @@ private final class WalkingDogWatchBridgeManager: NSObject, WCSessionDelegate {
     return json
   }
 
+  private func canPublishToWatch(_ session: WCSession) -> Bool {
+    session.isPaired && session.isWatchAppInstalled
+  }
+
   private func sendAckCommand(id commandId: String) {
     let payload = ["ackCommandId": commandId]
     let session = WCSession.default
+    guard canPublishToWatch(session) else {
+      return
+    }
 
     if session.activationState != .activated {
       session.activate()

--- a/apps/mobile/stores/walk-store.test.ts
+++ b/apps/mobile/stores/walk-store.test.ts
@@ -124,6 +124,18 @@ describe('walk-store', () => {
     );
   });
 
+  it('addPoint ignores duplicate points from overlapping foreground and background sources', () => {
+    useWalkStore.getState().startRecording('walk-123');
+    const point: WalkPoint = { lat: 35.6812, lng: 139.7671, recordedAt: '2026-03-23T10:00:00Z' };
+
+    useWalkStore.getState().addPoint(point);
+    jest.clearAllMocks();
+    useWalkStore.getState().addPoint({ ...point });
+
+    expect(useWalkStore.getState().points).toEqual([point]);
+    expect(persistActiveWalkSession).not.toHaveBeenCalled();
+  });
+
   it('setTotalDistanceM overwrites totalDistanceM with the server-calculated value', () => {
     useWalkStore.getState().setTotalDistanceM(1234);
     expect(useWalkStore.getState().totalDistanceM).toBe(1234);

--- a/apps/mobile/stores/walk-store.ts
+++ b/apps/mobile/stores/walk-store.ts
@@ -6,6 +6,7 @@ import {
   persistActiveWalkSession,
 } from '@/lib/walk/active-walk-session';
 import { haversineDistance } from '@/lib/walk/distance';
+import { isDuplicateWalkPoint } from '@/lib/walk/points';
 
 type WalkPhase = 'ready' | 'recording' | 'finished';
 
@@ -156,18 +157,26 @@ export const useWalkStore = create<WalkState>((set, get) => ({
   },
 
   addPoint: (point) => {
+    let didAddPoint = false;
     set((state) => {
+      if (isDuplicateWalkPoint(state.points, point)) {
+        return {};
+      }
+
       const previousPoint = state.points[state.points.length - 1];
       const nextDistanceM = previousPoint
         ? state.totalDistanceM + haversineDistance(previousPoint, point)
         : state.totalDistanceM;
+      didAddPoint = true;
 
       return {
         points: [...state.points, point],
         totalDistanceM: nextDistanceM,
       };
     });
-    persistRecordingState(get());
+    if (didAddPoint) {
+      persistRecordingState(get());
+    }
   },
 
   setTotalDistanceM: (distanceM) => {


### PR DESCRIPTION
## Summary
- Treat foreground and background location permissions as separate capabilities before starting walk tracking.
- Gate Expo background location registration on actual background permission and add diagnostics for native background task errors.
- De-duplicate overlapping foreground/background GPS points and avoid WatchConnectivity publishing when no Watch app is paired/installed.

## Root Cause
The app requested background location permission but treated foreground permission as sufficient, so it could register background updates even when iOS had not granted Always/background location. Foreground and background location streams could also append the same GPS point independently.

## Validation
- `npm test -- --runInBand --forceExit` (119 suites / 751 tests passed)
- `npm run typecheck`
- `npm run lint` (0 errors, 1 existing warning in `components/dogs/DogForm.test.tsx`)

## Notes
- The Swift Watch bridge change has not been compiled by an iOS build in this branch verification pass.