### PR TITLE
[codex] Move dog goal progress to detail screen

### DIFF
--- a/apps/mobile/CLAUDE.md
+++ b/apps/mobile/CLAUDE.md
@@ -52,6 +52,7 @@
 - 散歩 GPS は foreground と background の位置情報権限を別々の capability として扱う。foreground が許可済みでも background が未許可なら `Location.startLocationUpdatesAsync` を呼ばず、foreground tracking のみで記録する。
 - Pee/poop の表示アイコンは全サーフェスで統一する。React Native 側は `lib/walk/events.ts` の `WALK_EVENT_EMOJIS` を単一ソースにし、pee は `💧`、poop/poo は `💩` を使う。Live Activity と Watch SwiftUI でも同じ emoji を表示し、SF Symbols の `drop.fill` などに分岐させない。`expo-widgets` の Live Activity layout は関数を文字列化して Widget 側 JSContext で再評価するため、layout 関数内では imported constant を参照せず、関数内 local literal と回帰テストで値を固定する。
 - Dog 詳細画面は閲覧と編集導線に集中させ、Delete ボタンや削除確認などの破壊的操作を置かない。犬の削除操作は編集画面の remove フローに集約する。
+- Dog 詳細画面の goal progress は犬単体の時間目標進捗として、summary stats と Walk 一覧の間に置く。散歩履歴取得エラー時は誤った 0 進捗を出さず、Walk 一覧側のエラー表示に集約する。
 
 ## iOS Simulator 起動手順
 

--- a/apps/mobile/__tests__/app/dogs/dog-detail.test.tsx
+++ b/apps/mobile/__tests__/app/dogs/dog-detail.test.tsx
@@ -2,7 +2,7 @@ import { StyleSheet } from 'react-native';
 import { fireEvent, render, screen } from '@testing-library/react-native';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import DogDetailScreen from '../../../app/dogs/[id]/index';
-import type { DogWithStats } from '@/types/graphql';
+import type { DogWithStats, Walk } from '@/types/graphql';
 import { spacing } from '@/theme/tokens';
 
 const mockPush = jest.fn();
@@ -42,18 +42,22 @@ const mockDog: DogWithStats = {
 };
 
 let mockDogData: DogWithStats = mockDog;
+let mockWalks: Walk[] = [];
 
 jest.mock('@/hooks/use-dog', () => ({
   useDog: () => ({ data: mockDogData, isLoading: false }),
 }));
 
-jest.mock('@/hooks/use-pack-progress', () => ({
-  usePackProgress: () => ({ perDog: {} }),
+jest.mock('@/hooks/use-walks', () => ({
+  useMyWalks: () => ({ data: mockWalks }),
 }));
 
-jest.mock('@/hooks/use-walks', () => ({
-  useMyWalks: () => ({ data: [] }),
-}));
+jest.mock('@/components/ui/RingProgress', () => {
+  const { Text } = jest.requireActual('react-native');
+  return {
+    RingProgress: ({ label }: { label?: string }) => <Text>{label}</Text>,
+  };
+});
 
 jest.mock('@/stores/auth-store', () => ({
   useAuthStore: (selector: (s: { isAuthenticated: boolean }) => unknown) =>
@@ -69,11 +73,36 @@ function renderWithProviders(ui: React.ReactElement) {
   );
 }
 
+function collectTestIds(node: unknown): string[] {
+  if (!node || typeof node !== 'object') return [];
+
+  const testNode = node as {
+    props?: { testID?: string };
+    children?: unknown;
+  };
+  return [
+    ...(testNode.props?.testID ? [testNode.props.testID] : []),
+    ...(Array.isArray(testNode.children)
+      ? testNode.children.flatMap(collectTestIds)
+      : []),
+  ];
+}
+
 describe('DogDetailScreen', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-04-20T12:00:00Z'));
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
   beforeEach(() => {
     jest.clearAllMocks();
     mockDogData = mockDog;
     mockCanGoBack = true;
+    mockWalks = [];
   });
 
   it('renders the large title screen header with dog title and back action', () => {
@@ -132,6 +161,45 @@ describe('DogDetailScreen', () => {
     const style = StyleSheet.flatten(walksSection.props.style);
 
     expect(style.paddingHorizontal).toBe(spacing.md);
+  });
+
+  it('renders dog goal progress between summary stats and walks', () => {
+    mockDogData = {
+      ...mockDog,
+      walkStats: { totalWalks: 4, totalDistanceM: 3200, totalDurationSec: 5400 },
+    };
+    mockWalks = [
+      {
+        id: 'walk-1',
+        dogs: [mockDogData],
+        status: 'FINISHED',
+        distanceM: 1000,
+        durationSec: 1200,
+        startedAt: '2026-04-20T08:00:00Z',
+        endedAt: '2026-04-20T08:20:00Z',
+        points: [],
+        events: [],
+      },
+    ];
+
+    const rendered = renderWithProviders(<DogDetailScreen />);
+
+    expect(screen.getByText('Goal progress')).toBeTruthy();
+    expect(screen.getByText('20 / 30 min today')).toBeTruthy();
+
+    const sectionOrder = collectTestIds(rendered.toJSON()).filter((testID) =>
+      [
+        'dog-detail-stats-section',
+        'dog-detail-goal-progress-section',
+        'dog-detail-walks-section',
+      ].includes(testID),
+    );
+
+    expect(sectionOrder).toEqual([
+      'dog-detail-stats-section',
+      'dog-detail-goal-progress-section',
+      'dog-detail-walks-section',
+    ]);
   });
 
 });

--- a/apps/mobile/__tests__/app/tabs/dogs.test.tsx
+++ b/apps/mobile/__tests__/app/tabs/dogs.test.tsx
@@ -69,9 +69,9 @@ describe('DogsScreen', () => {
     expect(screen.getByTestId('dogs-header-right-action-slot')).toBeTruthy();
   });
 
-  it('renders goal progress rollup title', () => {
+  it('does not render the goal progress rollup in the pack list header', () => {
     render(<DogsScreen />);
-    expect(screen.getByText('Goal progress')).toBeTruthy();
+    expect(screen.queryByText('Goal progress')).toBeNull();
   });
 
   it('renders header + Add CTA', () => {

--- a/apps/mobile/app/(tabs)/dogs.tsx
+++ b/apps/mobile/app/(tabs)/dogs.tsx
@@ -3,7 +3,6 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import { useDogsScreenViewModel } from '@/hooks/use-dogs-screen-view-model';
 import { DogListItem } from '@/components/dogs/DogListItem';
-import { PackRollupCard } from '@/components/dogs/PackRollupCard';
 import { EmptyState } from '@/components/ui/EmptyState';
 import { LoadingScreen } from '@/components/ui/LoadingScreen';
 import { ScreenHeader } from '@/components/ui/ScreenHeader';
@@ -19,17 +18,9 @@ export default function DogsScreen() {
 
   if (vm.isLoading) return <LoadingScreen />;
 
-  // 一覧の先頭には pack の集計カードとセクション見出しをまとめて表示します。
+  // 一覧の先頭には pack のセクション見出しだけを表示します。
   const ListHeader = (
     <View style={styles.headerContainer}>
-      <View style={styles.rollupWrap}>
-        <PackRollupCard
-          progressMinutes={vm.pack.goalProgressMinutes}
-          goalMinutes={vm.pack.goalMinutes}
-          progressPct={vm.pack.progressPct}
-        />
-      </View>
-
       <SectionHeader
         label={t('dogs.list.sectionLabel')}
         style={styles.sectionHeader}
@@ -80,9 +71,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing.lg,
     paddingTop: spacing.sm,
     paddingBottom: spacing.md,
-  },
-  rollupWrap: {
-    marginBottom: spacing.xl,
   },
   sectionHeader: {
     paddingHorizontal: spacing.xs - spacing.xs,

--- a/apps/mobile/app/dogs/[id]/index.tsx
+++ b/apps/mobile/app/dogs/[id]/index.tsx
@@ -3,7 +3,9 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useDogDetailViewModel } from '@/hooks/use-dog-detail-view-model';
+import { WEEKLY_GOAL_CYCLE_DAYS } from '@/constants/walk';
 import { DogHero } from '@/components/dogs/DogHero';
+import { GoalProgressCard } from '@/components/dogs/GoalProgressCard';
 import { DogStatsCard } from '@/components/dogs/DogStatsCard';
 import { DogWalksList } from '@/components/dogs/DogWalksList';
 import { LoadingScreen } from '@/components/ui/LoadingScreen';
@@ -68,8 +70,29 @@ export default function DogDetailScreen() {
 
         {/* 散歩取得に失敗しているときは 0/0/0 の誤った統計を出さず、エラーだけ見せます。 */}
         {vm.dog.walkStats && !vm.walksError ? (
-          <View style={styles.statsSection}>
+          <View testID="dog-detail-stats-section" style={styles.statsSection}>
             <DogStatsCard stats={vm.dog.walkStats} streakDays={vm.streakDays} />
+          </View>
+        ) : null}
+
+        {!vm.walksError ? (
+          <View
+            testID="dog-detail-goal-progress-section"
+            style={styles.goalProgressSection}
+          >
+            <GoalProgressCard
+              title={t('dogs.detail.goalProgressTitle')}
+              subtitle={t(
+                vm.goalProgress.goalCycleDays === WEEKLY_GOAL_CYCLE_DAYS
+                  ? 'dogs.detail.goalProgressWeekly'
+                  : 'dogs.detail.goalProgressDaily',
+                {
+                  minutes: vm.goalProgress.progressMinutes,
+                  goal: vm.goalProgress.goalMinutes,
+                },
+              )}
+              progressPct={vm.goalProgress.progressPct}
+            />
           </View>
         ) : null}
 
@@ -147,6 +170,9 @@ const styles = StyleSheet.create({
   statsSection: {
     paddingHorizontal: spacing.md,
     paddingTop: spacing.lg,
+  },
+  goalProgressSection: {
+    paddingHorizontal: spacing.md,
   },
   walksSection: {
     paddingHorizontal: spacing.md,

--- a/apps/mobile/components/dogs/GoalProgressCard.test.tsx
+++ b/apps/mobile/components/dogs/GoalProgressCard.test.tsx
@@ -1,24 +1,35 @@
 import { fireEvent, render, screen } from '@testing-library/react-native';
-import { PackRollupCard } from './PackRollupCard';
+import { GoalProgressCard } from './GoalProgressCard';
 
 jest.mock('@/hooks/use-color-scheme', () => ({
   useColorScheme: () => 'light',
 }));
 
-describe('PackRollupCard', () => {
+describe('GoalProgressCard', () => {
   it('renders the walking goal summary and progress label', () => {
-    render(<PackRollupCard progressMinutes={45} goalMinutes={90} progressPct={50} />);
+    render(
+      <GoalProgressCard
+        title="Goal progress"
+        subtitle="20 / 30 min today"
+        progressPct={67}
+      />,
+    );
 
     expect(screen.getByText('Goal progress')).toBeTruthy();
-    expect(screen.getByText('45 / 90 min across your pack')).toBeTruthy();
-    expect(screen.getByText('50%')).toBeTruthy();
+    expect(screen.getByText('20 / 30 min today')).toBeTruthy();
+    expect(screen.getByText('67%')).toBeTruthy();
   });
 
   it('becomes pressable when onPress is provided', () => {
     const onPress = jest.fn();
 
     render(
-      <PackRollupCard progressMinutes={45} goalMinutes={90} progressPct={50} onPress={onPress} />,
+      <GoalProgressCard
+        title="Goal progress"
+        subtitle="20 / 30 min today"
+        progressPct={67}
+        onPress={onPress}
+      />,
     );
 
     fireEvent.press(screen.getByRole('button', { name: 'Goal progress' }));
@@ -27,7 +38,13 @@ describe('PackRollupCard', () => {
   });
 
   it('does not render a button wrapper when onPress is omitted', () => {
-    render(<PackRollupCard progressMinutes={45} goalMinutes={90} progressPct={50} />);
+    render(
+      <GoalProgressCard
+        title="Goal progress"
+        subtitle="20 / 30 min today"
+        progressPct={67}
+      />,
+    );
 
     expect(screen.queryByRole('button', { name: 'Goal progress' })).toBeNull();
   });

--- a/apps/mobile/components/dogs/GoalProgressCard.tsx
+++ b/apps/mobile/components/dogs/GoalProgressCard.tsx
@@ -1,45 +1,50 @@
-import { Pressable, StyleSheet, Text, View } from 'react-native';
-import { useTranslation } from 'react-i18next';
+import {
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native';
 import { useColors } from '@/hooks/use-colors';
 import { spacing, typography } from '@/theme/tokens';
 import { GroupedCard } from '@/components/ui/GroupedCard';
 import { RingProgress } from '@/components/ui/RingProgress';
 
-interface PackRollupCardProps {
-  progressMinutes: number;
-  goalMinutes: number;
+interface GoalProgressCardProps {
+  title: string;
+  subtitle: string;
   progressPct: number;
   onPress?: () => void;
+  style?: StyleProp<ViewStyle>;
+  testID?: string;
 }
 
-export function PackRollupCard({
-  progressMinutes,
-  goalMinutes,
+export function GoalProgressCard({
+  title,
+  subtitle,
   progressPct,
   onPress,
-}: PackRollupCardProps) {
-  const { t } = useTranslation();
+  style,
+  testID,
+}: GoalProgressCardProps) {
   const theme = useColors();
-
-  const subtitle = t('dogs.list.acrossPack', {
-    minutes: progressMinutes,
-    goal: goalMinutes,
-  });
 
   const content = (
     <>
       <RingProgress
-        size={44}
-        strokeWidth={4}
+        size={spacing.step44}
+        strokeWidth={spacing.xs}
         progress={progressPct}
         color={theme.success}
         trackColor={theme.surfaceContainer}
         label={`${progressPct}%`}
-        labelFontSize={11}
+        labelFontSize={typography.metricLabel.fontSize}
+        accessibilityLabel={title}
       />
       <View style={styles.info}>
         <Text style={[styles.title, { color: theme.onSurface }]}>
-          {t('dogs.list.todayGoal')}
+          {title}
         </Text>
         <Text
           style={[styles.subtitle, { color: theme.onSurfaceVariant }]}
@@ -55,11 +60,11 @@ export function PackRollupCard({
   );
 
   return (
-    <GroupedCard elevated>
+    <GroupedCard elevated style={style} testID={testID}>
       {onPress ? (
         <Pressable
           accessibilityRole="button"
-          accessibilityLabel={t('dogs.list.todayGoal')}
+          accessibilityLabel={title}
           onPress={onPress}
           style={styles.row}
         >

--- a/apps/mobile/hooks/use-dog-detail-view-model.test.ts
+++ b/apps/mobile/hooks/use-dog-detail-view-model.test.ts
@@ -61,16 +61,6 @@ let mockWalks: Walk[] = [
     events: [],
   },
 ];
-let mockPack = {
-  todayKm: 1,
-  todayMinutes: 20,
-  goalProgressMinutes: 20,
-  goalMinutes: 30,
-  progressPct: 20,
-  perDog: {
-    'dog-1': { todayKm: 1, todayMinutes: 20, goalProgressMinutes: 20, goalMinutes: 30, goalCycleDays: 1, totalWalks: 1, streakDays: 5 },
-  },
-};
 jest.mock('expo-router', () => ({
   useLocalSearchParams: () => ({ id: 'dog-1' }),
   useRouter: () => ({ push: mockPush }),
@@ -82,10 +72,6 @@ jest.mock('@/hooks/use-dog', () => ({
 
 jest.mock('@/hooks/use-walks', () => ({
   useMyWalks: () => ({ data: mockWalks, error: mockWalksError, refetch: mockRefetchWalks }),
-}));
-
-jest.mock('@/hooks/use-pack-progress', () => ({
-  usePackProgress: () => mockPack,
 }));
 
 function expectReadyViewModel(
@@ -165,16 +151,6 @@ describe('useDogDetailViewModel', () => {
         events: [],
       },
     ];
-    mockPack = {
-      todayKm: 1,
-      todayMinutes: 20,
-      goalProgressMinutes: 20,
-      goalMinutes: 30,
-      progressPct: 20,
-      perDog: {
-        'dog-1': { todayKm: 1, todayMinutes: 20, goalProgressMinutes: 20, goalMinutes: 30, goalCycleDays: 1, totalWalks: 1, streakDays: 5 },
-      },
-    };
     mockWalksError = null;
   });
 
@@ -192,7 +168,13 @@ describe('useDogDetailViewModel', () => {
     const vm = expectReadyViewModel(result.current);
 
     expect(vm.meta).toBe('4y · Shiba Inu');
-    expect(vm.streakDays).toBe(5);
+    expect(vm.streakDays).toBe(1);
+    expect(vm.goalProgress).toEqual({
+      progressMinutes: 20,
+      goalMinutes: 30,
+      goalCycleDays: 1,
+      progressPct: 67,
+    });
     expect(vm.dogWalks.map((walk) => walk.id)).toEqual(['walk-1']);
     expect(Object.keys(vm)).not.toContain(['is', 'Ow', 'ner'].join(''));
   });

--- a/apps/mobile/hooks/use-dog-detail-view-model.ts
+++ b/apps/mobile/hooks/use-dog-detail-view-model.ts
@@ -1,7 +1,8 @@
 import { useCallback, useMemo } from 'react';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useDog } from '@/hooks/use-dog';
-import { usePackProgress } from '@/hooks/use-pack-progress';
+import { aggregatePackProgress } from '@/hooks/use-pack-progress';
+import type { GoalCycleDays } from '@/constants/walk';
 import { useMyWalks } from '@/hooks/use-walks';
 import type { Dog, DogWithStats, Walk } from '@/types/graphql';
 
@@ -38,6 +39,12 @@ interface DogDetailReadyViewModel {
   dog: DogWithStats;
   meta: string;
   streakDays: number;
+  goalProgress: {
+    progressMinutes: number;
+    goalMinutes: number;
+    goalCycleDays: GoalCycleDays;
+    progressPct: number;
+  };
   dogWalks: Walk[];
   // 散歩履歴の取得に失敗したときだけ非 null。空配列と「失敗」を画面側で区別するために持ちます。
   walksError: Error | null;
@@ -56,11 +63,14 @@ export function useDogDetailViewModel(): DogDetailViewModel {
   const { data: dog, isLoading } = useDog(dogId ?? '', 'ALL');
   const { data: walks = [], error: walksErrorRaw, refetch: refetchWalks } = useMyWalks(100);
   const walksError = walksErrorRaw ?? null;
-  const pack = usePackProgress();
 
   // 全散歩履歴から、現在表示している犬が参加した散歩だけを抽出します。
   const dogWalks = useMemo(
     () => (dog ? walks.filter((walk) => walk.dogs.some((walkDog) => walkDog.id === dog.id)) : []),
+    [dog, walks],
+  );
+  const dogProgress = useMemo(
+    () => (dog ? aggregatePackProgress(walks, [dog]).perDog[dog.id] : null),
     [dog, walks],
   );
 
@@ -79,12 +89,28 @@ export function useDogDetailViewModel(): DogDetailViewModel {
   if (isLoading || !dog) {
     return { status: 'loading' };
   }
+  const readyDogProgress = dogProgress!;
+  const progressPct =
+    readyDogProgress.goalMinutes > 0
+      ? Math.min(
+          100,
+          Math.round(
+            (readyDogProgress.goalProgressMinutes / readyDogProgress.goalMinutes) * 100,
+          ),
+        )
+      : 0;
 
   return {
     status: 'ready',
     dog,
     meta: buildMeta(dog),
-    streakDays: pack.perDog[dog.id]?.streakDays ?? 0,
+    streakDays: readyDogProgress.streakDays,
+    goalProgress: {
+      progressMinutes: readyDogProgress.goalProgressMinutes,
+      goalMinutes: readyDogProgress.goalMinutes,
+      goalCycleDays: readyDogProgress.goalCycleDays,
+      progressPct,
+    },
     dogWalks,
     walksError,
     retryWalks,

--- a/apps/mobile/lib/i18n/locales/en.json
+++ b/apps/mobile/lib/i18n/locales/en.json
@@ -79,8 +79,6 @@
       "empty": "No dogs registered yet",
       "addDog": "Add Dog",
       "addCta": "+ Add",
-      "todayGoal": "Goal progress",
-      "acrossPack": "{{minutes}} / {{goal}} min across your pack",
       "streak": "🔥 {{days}}d",
       "todayStats": "{{km}} km today · {{count}} walks"
     },
@@ -100,6 +98,9 @@
       "seeAll": "See all",
       "streakLabel": "Streak",
       "streakDays": "{{days}}d",
+      "goalProgressTitle": "Goal progress",
+      "goalProgressDaily": "{{minutes}} / {{goal}} min today",
+      "goalProgressWeekly": "{{minutes}} / {{goal}} min this week",
       "back": "Dogs"
     },
     "edit": {

--- a/apps/mobile/lib/i18n/locales/ja.json
+++ b/apps/mobile/lib/i18n/locales/ja.json
@@ -79,8 +79,6 @@
       "empty": "まだ犬が登録されていません",
       "addDog": "犬を追加",
       "addCta": "＋ 追加",
-      "todayGoal": "目標の進捗",
-      "acrossPack": "{{minutes}} / {{goal}}分（みんなの合計）",
       "streak": "🔥 {{days}}日",
       "todayStats": "今日 {{km}} km · {{count}}回"
     },
@@ -100,6 +98,9 @@
       "seeAll": "すべて見る",
       "streakLabel": "連続",
       "streakDays": "{{days}}日",
+      "goalProgressTitle": "目標の進捗",
+      "goalProgressDaily": "{{minutes}} / {{goal}}分（今日）",
+      "goalProgressWeekly": "{{minutes}} / {{goal}}分（今週）",
       "back": "愛犬"
     },
     "edit": {


### PR DESCRIPTION
## Summary
- Move Goal progress out of the Dogs tab header and into the Dog detail screen between summary stats and the Walk list.
- Reuse the progress card as `GoalProgressCard` and compute dog-specific time goal progress from that dog plus walk history.
- Hide dog goal progress when walk history fails so the screen does not show misleading zero progress.

## Validation
- `npm run typecheck`
- `npm run lint` (0 errors; existing `DogForm.test.tsx` require-import warning remains)
- `npm test -- --runInBand --forceExit`