### PR TITLE
[codex] Allow zero-minute dog walk goals

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@
 ## Domain Notes
 
 - Walk goals are time-based, not distance-based. Store and edit them through `dog_walk_goal.walk_amount.minutes` plus `cycle_days` (`1` for DAILY, `7` for WEEKLY); keep distance metrics as separate stats.
+- Walk goal minute bounds are a shared API/Mobile contract. When changing selectable goal ranges, update `apps/api/src/service/dog_walk_goal.rs`, `apps/mobile/constants/walk.ts`, and their boundary tests together.
 - API track point storage details belong behind `service::track_point::TrackPointRepository`. GraphQL resolvers and queue handlers should use the service/domain `TrackPoint` contract instead of depending on DynamoDB table shape, timestamp encoding, or `AttributeValue` mapping.
 - API walk lifecycle and history semantics belong in `service::walk` and `service::walk_read_model`. GraphQL should translate inputs/outputs and keep ownership, active-walk checks, distance finalization, pagination totals, and aggregate SQL in those service modules.
 - API upload storage belongs behind `service::storage::StorageGateway`. GraphQL may adapt `Upload` into `StorageUpload`, but S3 clients, bucket/env handling, content-size policy, object keys, and avatar URL construction should stay in the storage service.

--- a/apps/api/src/service/dog_walk_goal.rs
+++ b/apps/api/src/service/dog_walk_goal.rs
@@ -12,7 +12,7 @@ use crate::{
     },
 };
 
-pub const MIN_DAILY_GOAL_MINUTES: i32 = 10;
+pub const MIN_DAILY_GOAL_MINUTES: i32 = 0;
 pub const MAX_DAILY_GOAL_MINUTES: i32 = 120;
 pub const DAILY_GOAL_CYCLE_DAYS: i32 = 1;
 pub const WEEKLY_GOAL_CYCLE_DAYS: i32 = 7;
@@ -37,7 +37,7 @@ pub enum GoalUpsertPlan {
 pub fn validate_daily_goal_minutes(minutes: i32) -> ServiceResult<i32> {
     if !(MIN_DAILY_GOAL_MINUTES..=MAX_DAILY_GOAL_MINUTES).contains(&minutes) {
         return Err(ServiceError::UnprocessableEntity(
-            "dailyGoalMinutes must be between 10 and 120".into(),
+            "dailyGoalMinutes must be between 0 and 120".into(),
         ));
     }
     Ok(minutes)
@@ -48,14 +48,14 @@ pub fn validate_goal_walk_amount(input: &walk_amount::Model) -> ServiceResult<wa
         DAILY_GOAL_CYCLE_DAYS => {
             if !(MIN_DAILY_GOAL_MINUTES..=MAX_DAILY_GOAL_MINUTES).contains(&input.minutes) {
                 return Err(ServiceError::UnprocessableEntity(
-                    "walkGoal.minutes must be between 10 and 120 for DAILY".into(),
+                    "walkGoal.minutes must be between 0 and 120 for DAILY".into(),
                 ));
             }
         }
         WEEKLY_GOAL_CYCLE_DAYS => {
             if !(MIN_WEEKLY_GOAL_MINUTES..=MAX_WEEKLY_GOAL_MINUTES).contains(&input.minutes) {
                 return Err(ServiceError::UnprocessableEntity(
-                    "walkGoal.minutes must be between 70 and 840 for WEEKLY".into(),
+                    "walkGoal.minutes must be between 0 and 840 for WEEKLY".into(),
                 ));
             }
         }

--- a/apps/api/tests/dog_walk_goal_service.rs
+++ b/apps/api/tests/dog_walk_goal_service.rs
@@ -1,6 +1,8 @@
 use walking_dog::{
     entity::{dog_walk_goal, walk_amount},
-    service::dog_walk_goal::{GoalUpsertPlan, plan_goal_upsert, validate_goal_walk_amount},
+    service::dog_walk_goal::{
+        GoalUpsertPlan, plan_goal_upsert, validate_daily_goal_minutes, validate_goal_walk_amount,
+    },
 };
 
 fn current_goal(
@@ -89,13 +91,22 @@ fn goal_plan_updates_when_cycle_days_changes_even_if_minutes_match() {
 
 #[test]
 fn goal_walk_amount_is_validated_in_service_layer() {
-    assert!(validate_goal_walk_amount(&walk_amount(9, 1)).is_err());
+    assert!(validate_goal_walk_amount(&walk_amount(-1, 1)).is_err());
     assert!(validate_goal_walk_amount(&walk_amount(121, 1)).is_err());
-    assert!(validate_goal_walk_amount(&walk_amount(69, 7)).is_err());
+    assert!(validate_goal_walk_amount(&walk_amount(-1, 7)).is_err());
     assert!(validate_goal_walk_amount(&walk_amount(841, 7)).is_err());
     assert!(validate_goal_walk_amount(&walk_amount(30, 2)).is_err());
+    assert_eq!(
+        validate_goal_walk_amount(&walk_amount(0, 1)).unwrap(),
+        walk_amount(0, 1)
+    );
+    assert_eq!(
+        validate_goal_walk_amount(&walk_amount(0, 7)).unwrap(),
+        walk_amount(0, 7)
+    );
     assert_eq!(
         validate_goal_walk_amount(&walk_amount(210, 7)).unwrap(),
         walk_amount(210, 7)
     );
+    assert_eq!(validate_daily_goal_minutes(0).unwrap(), 0);
 }

--- a/apps/mobile/components/dogs/DogForm.test.tsx
+++ b/apps/mobile/components/dogs/DogForm.test.tsx
@@ -7,13 +7,14 @@ import {
   isDogFormValid,
   type DogFormValues,
 } from './DogForm';
+import { spacing } from '@/theme/tokens';
 
 jest.mock('@/components/ui/icon-symbol', () => ({
   IconSymbol: () => null,
 }));
 
 jest.mock('@expo/ui/swift-ui', () => {
-  const React = require('react');
+  const React = jest.requireActual<typeof import('react')>('react');
   const { View } = jest.requireActual('react-native');
   return {
     Host: ({ children, ...props }: { children: React.ReactNode }) => (
@@ -33,6 +34,11 @@ jest.mock('@expo/ui/swift-ui', () => {
     ),
   };
 });
+
+jest.mock('@expo/ui/swift-ui/modifiers', () => ({
+  clipped: (clipped = true) => ({ $type: 'clipped', clipped }),
+  frame: (params: Record<string, unknown>) => ({ $type: 'frame', ...params }),
+}));
 
 function makeValues(overrides: Partial<DogFormValues> = {}): DogFormValues {
   return {
@@ -84,7 +90,7 @@ describe('DogForm', () => {
     );
     expect(screen.getByText('Time')).toBeTruthy();
     expect(screen.getByText('30 min')).toBeTruthy();
-    expect(screen.getByText('10 min')).toBeTruthy();
+    expect(screen.getByText('0 min')).toBeTruthy();
     expect(screen.getByText('120 min')).toBeTruthy();
   });
 
@@ -94,7 +100,7 @@ describe('DogForm', () => {
       true,
     );
     expect(screen.getByText('210 min')).toBeTruthy();
-    expect(screen.getByText('70 min')).toBeTruthy();
+    expect(screen.getByText('0 min')).toBeTruthy();
     expect(screen.getByText('840 min')).toBeTruthy();
   });
 
@@ -134,19 +140,35 @@ describe('DogForm', () => {
 
     fireEvent(screen.getByTestId('dog-goal-slider'), 'valueChange', 65);
 
-    expect(onChange).toHaveBeenLastCalledWith(makeValues({ goalMinutes: 70, goalCycleDays: 7 }));
+    expect(onChange).toHaveBeenLastCalledWith(makeValues({ goalMinutes: 65, goalCycleDays: 7 }));
   });
 
   it('updates the goal from the native slider value change', () => {
     const { onChange } = setup(makeValues({ goalMinutes: 30, goalCycleDays: 1 }));
     const slider = screen.getByTestId('dog-goal-slider');
 
-    expect(slider.props.min).toBe(10);
+    expect(slider.props.min).toBe(0);
     expect(slider.props.max).toBe(120);
     expect(slider.props.step).toBe(5);
     fireEvent(slider, 'valueChange', 120);
 
     expect(onChange).toHaveBeenCalledWith(makeValues({ goalMinutes: 120, goalCycleDays: 1 }));
+  });
+
+  it('keeps the native goal slider host tight to the slider track', () => {
+    setup();
+    const slider = screen.getByTestId('dog-goal-slider');
+
+    expect(screen.getByTestId('dog-goal-slider-host').props.style).toEqual(
+      expect.objectContaining({
+        height: spacing.xl,
+        width: '100%',
+      }),
+    );
+    expect(slider.props.modifiers).toEqual([
+      { $type: 'frame', height: spacing.xl },
+      { $type: 'clipped', clipped: true },
+    ]);
   });
 
   it('renders birthday in the profile group without an empty-state value', () => {

--- a/apps/mobile/components/dogs/DogForm.tsx
+++ b/apps/mobile/components/dogs/DogForm.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { Host, Slider as SwiftUISlider } from '@expo/ui/swift-ui';
+import { clipped, frame } from '@expo/ui/swift-ui/modifiers';
 import { GroupedCard } from '@/components/ui/GroupedCard';
 import { SegmentedControl } from '@/components/ui/SegmentedControl';
 import { IconSymbol } from '@/components/ui/icon-symbol';
@@ -55,6 +56,11 @@ const DEFAULT_DAY_COUNT = 31;
 const MONTH_SAMPLE_YEAR = 2020;
 const MONTH_SAMPLE_DAY = 1;
 const DOG_GENDER_VALUES = ['MALE', 'FEMALE', 'OTHER'] as const;
+const GOAL_SLIDER_HEIGHT = spacing.xl;
+const GOAL_SLIDER_MODIFIERS = [
+  frame({ height: GOAL_SLIDER_HEIGHT }),
+  clipped(),
+];
 type DogGenderValue = (typeof DOG_GENDER_VALUES)[number];
 
 // 02b. Dog edit の inset-grouped 形式: 1 枚のカードに行を積み上げ、hairline で区切る。
@@ -372,13 +378,14 @@ function GoalSection({ minutes, cycleDays, onChange }: GoalSectionProps) {
             {t('dogs.form.goalMinutes', { count: clampedMinutes })}
           </Text>
         </View>
-        <Host style={styles.goalSliderHost}>
+        <Host style={styles.goalSliderHost} testID="dog-goal-slider-host">
           <SwiftUISlider
             value={clampedMinutes}
             min={minMinutes}
             max={maxMinutes}
             step={DAILY_GOAL_STEP_MINUTES}
             onValueChange={setFromMinutes}
+            modifiers={GOAL_SLIDER_MODIFIERS}
             testID="dog-goal-slider"
           />
         </Host>
@@ -661,7 +668,7 @@ const styles = StyleSheet.create({
     fontVariant: ['tabular-nums'],
   },
   goalSliderHost: {
-    height: spacing.step44,
+    height: GOAL_SLIDER_HEIGHT,
     width: '100%',
   },
   goalLimits: {

--- a/apps/mobile/constants/walk.ts
+++ b/apps/mobile/constants/walk.ts
@@ -1,5 +1,5 @@
 export const DEFAULT_DAILY_GOAL_MINUTES = 30;
-export const MIN_DAILY_GOAL_MINUTES = 10;
+export const MIN_DAILY_GOAL_MINUTES = 0;
 export const MAX_DAILY_GOAL_MINUTES = 120;
 export const DAILY_GOAL_STEP_MINUTES = 5;
 export const DAILY_GOAL_CYCLE_DAYS = 1;


### PR DESCRIPTION
## Summary
- Allow Edit dog GOAL time selection to start at 0 minutes for both daily and weekly cycles.
- Keep mobile and API walk goal minute bounds aligned so 0-minute goals can be saved.
- Constrain the native SwiftUI slider display area to remove the extra lower track line.

## Root Cause
The mobile GOAL slider minimum was backed by a 10-minute daily lower bound, with weekly bounds derived from it. The API service still validated the same old lower bound, so changing only the UI would have made 0-minute selections fail on save. The slider also hosted SwiftUI's Slider in a taller React Native Host without clipping the native layout.

## Test Plan
- `npm run lint`
- `npm run typecheck`
- `npm test -- DogForm.test.tsx --runInBand`
- `docker run --rm -v /Users/matsuokashuhei/.codex/worktrees/c3d3/walking-dog:/walking-dog -v apps_cargo_cache:/usr/local/cargo -w /walking-dog/apps/api apps-api cargo test --test dog_walk_goal_service`