### PR TITLE
[codex] Remove walk sheet bounce

### DIFF
--- a/apps/mobile/CLAUDE.md
+++ b/apps/mobile/CLAUDE.md
@@ -47,6 +47,7 @@
 - Walk 開始・記録中などマップ主役の画面は、route 側で `ScreenHeader` / top-only `SafeAreaView` を挟まず、マップを全画面に敷いた上で `WalkMapShell` の overlay や必要な native surface を重ねる。
 - Walk タブの START → recording 遷移では、`WalkMapShell` / `WalkMap` / 下部 floating sheet の外枠を同じ route 内で維持し、route push で再 mount させない。`/walk-recording` は Live Activity / deep link 復帰用の互換 bridge として扱い、通常の記録 UI 所有者に戻さない。
 - 記録中の下部 controls は native `formSheet` route ではなく、Walk タブ内の map overlay として描画する。`useWalkStore().isMinimized` を単一の source of truth にし、縮小表示では pee/poop/photo などのイベント操作を出さず、経過時間・距離・LIVE 状態・展開操作だけに絞る。
+- 記録中の下部 floating controls の展開/縮小 layout transition は跳ねる spring motion にしない。`react-native-reanimated` の `springify` ではなく、短い duration-based transition で map overlay 上の操作面を落ち着いて切り替える。
 - Walk 開始前の preview マップは foreground の現在地 region へ寄せる。東京駅などの固定座標は GPS 現在地取得前に地図を描画するための初期領域に限定し、ready 画面の主表示として扱わない。
 - 記録中マップの現在地表示は `useWalkStore().points` の最新点を単一の source of truth にする。犬プロフィール画像などの表示情報は route 側で選択犬を解決して `WalkMap` に渡し、`showsUserLocation` など別系統の現在地表示と併用しない。
 - 散歩 GPS は foreground と background の位置情報権限を別々の capability として扱う。foreground が許可済みでも background が未許可なら `Location.startLocationUpdatesAsync` を呼ばず、foreground tracking のみで記録する。

--- a/apps/mobile/components/walk/WalkRecordingControlsOverlay.test.tsx
+++ b/apps/mobile/components/walk/WalkRecordingControlsOverlay.test.tsx
@@ -1,0 +1,74 @@
+import type { ReactNode } from 'react';
+import { render } from '@testing-library/react-native';
+import { LinearTransition } from 'react-native-reanimated';
+import { WalkRecordingControlsOverlay } from './WalkRecordingControlsOverlay';
+import type { Dog } from '@/types/graphql';
+
+jest.mock('@/hooks/use-color-scheme', () => ({ useColorScheme: () => 'light' }));
+
+const mockSetMinimized = jest.fn();
+const mockStoreState = {
+  walkId: 'walk-1',
+  isMinimized: false,
+  setMinimized: mockSetMinimized,
+};
+
+jest.mock('@/stores/walk-store', () => ({
+  useWalkStore: (selector: (s: typeof mockStoreState) => unknown) => selector(mockStoreState),
+}));
+
+jest.mock('@/hooks/use-walk-session', () => ({
+  useWalkSession: () => ({ stop: jest.fn() }),
+}));
+
+jest.mock('./WalkControls', () => {
+  const { View } = jest.requireActual('react-native');
+  return {
+    WalkControls: ({ children }: { children?: ReactNode }) => <View>{children}</View>,
+  };
+});
+
+jest.mock('./WalkEventActions', () => {
+  const { View } = jest.requireActual('react-native');
+  return { WalkEventActions: () => <View /> };
+});
+
+jest.mock('./WalkMinimizedControls', () => {
+  const { View } = jest.requireActual('react-native');
+  return { WalkMinimizedControls: () => <View /> };
+});
+
+const coco: Dog = {
+  id: 'dog-1',
+  name: 'Coco',
+  breed: null,
+  gender: null,
+  birthday: null,
+  photoUrl: null,
+  createdAt: '2026-01-01',
+};
+
+type AnimationBuilderMock = {
+  duration: jest.Mock;
+  springify: jest.Mock;
+  damping: jest.Mock;
+  stiffness: jest.Mock;
+};
+
+describe('WalkRecordingControlsOverlay', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockStoreState.isMinimized = false;
+  });
+
+  it('uses a non-spring layout transition so the floating sheet does not bounce', () => {
+    const transition = LinearTransition as unknown as AnimationBuilderMock;
+
+    render(<WalkRecordingControlsOverlay dogs={[coco]} />);
+
+    expect(transition.duration).toHaveBeenCalledWith(180);
+    expect(transition.springify).not.toHaveBeenCalled();
+    expect(transition.damping).not.toHaveBeenCalled();
+    expect(transition.stiffness).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/components/walk/WalkRecordingControlsOverlay.tsx
+++ b/apps/mobile/components/walk/WalkRecordingControlsOverlay.tsx
@@ -42,7 +42,7 @@ export function WalkRecordingControlsOverlay({ dogs }: WalkRecordingControlsOver
     <Animated.View
       entering={FadeIn.duration(140)}
       exiting={FadeOut.duration(100)}
-      layout={LinearTransition.springify().damping(24).stiffness(220)}
+      layout={LinearTransition.duration(180)}
       style={styles.root}
       testID="walk-recording-floating-controls"
     >

--- a/apps/mobile/jest.setup.ts
+++ b/apps/mobile/jest.setup.ts
@@ -19,18 +19,18 @@ jest.mock('react-native-reanimated', () => {
   const { Animated, Image, Text, View } = require('react-native');
 
   class AnimationBuilderMock {
-    duration() {
+    duration = jest.fn(() => {
       return this;
-    }
-    springify() {
+    });
+    springify = jest.fn(() => {
       return this;
-    }
-    damping() {
+    });
+    damping = jest.fn(() => {
       return this;
-    }
-    stiffness() {
+    });
+    stiffness = jest.fn(() => {
       return this;
-    }
+    });
   }
 
   return {


### PR DESCRIPTION
## Summary
- Replaced the recording walk floating controls layout spring with a short duration-based transition.
- Added a regression test that asserts the overlay does not use `springify`, `damping`, or `stiffness`.
- Documented the motion rule in the mobile development notes.

## Root Cause
The recording controls overlay used `LinearTransition.springify().damping(24).stiffness(220)`, which introduced a bouncing motion during expanded/minimized layout changes.

## Validation
- `npm test -- WalkRecordingControlsOverlay.test.tsx --runInBand`
- `npm test -- __tests__/app/tabs/walk.test.tsx --runInBand`
- `npm run typecheck`
- `npm run lint` (exit 0; existing unrelated warning remains in `components/dogs/DogForm.test.tsx:16`)