### PR TITLE
[codex] Enable Cognito refresh token rotation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@
 - API walk lifecycle and history semantics belong in `service::walk` and `service::walk_read_model`. GraphQL should translate inputs/outputs and keep ownership, active-walk checks, distance finalization, pagination totals, and aggregate SQL in those service modules.
 - API upload storage belongs behind `service::storage::StorageGateway`. GraphQL may adapt `Upload` into `StorageUpload`, but S3 clients, bucket/env handling, content-size policy, object keys, and avatar URL construction should stay in the storage service.
 - Cognito email delivery uses Amazon SES with the domain DNS records managed in Cloudflare. Keep Cloudflare dashboard runbooks under `infra/cloudflare`; Cloudflare API tokens are not needed for Cognito email delivery.
+- Cognito refresh uses `GetTokensFromRefreshToken` with refresh token rotation enabled. App clients must not include `ALLOW_REFRESH_TOKEN_AUTH`; API must reject Cognito refresh responses that omit access or refresh tokens instead of returning fallback token values.
 - Legal document drafts belong in `docs/legal/`. Draft-only legal work should not change app legal URLs or registration/settings behavior unless explicitly requested.
 - Sakura-published legal pages belong in `infra/sakura/legal/` and are served by Caddy at `/terms` and `/policy`; do not add API routes for legal document hosting.
 

--- a/apps/api/src/graphql/mutation/auth.rs
+++ b/apps/api/src/graphql/mutation/auth.rs
@@ -79,7 +79,6 @@ impl AuthMutation {
         let cognitoidentityprovider_client = ctx
             .data::<aws_sdk_cognitoidentityprovider::Client>()
             .unwrap();
-        // let output = cognitoidentityprovi))
         let output = cognitoidentityprovider_client
             .get_tokens_from_refresh_token()
             .client_id(std::env::var("AWS_COGNITO_CLIENT_ID").unwrap())
@@ -87,7 +86,9 @@ impl AuthMutation {
             .send()
             .await
             .map_err(|e| AuthError::RefreshTokenError(e.into_service_error()))?;
-        Ok(RefreshTokenOutput::from(output))
+        let output = RefreshTokenOutput::try_from(output)
+            .map_err(|error| AppError::InternalServerError(error.to_string()))?;
+        Ok(output)
     }
 
     #[graphql(guard = "AuthGuard")]
@@ -247,21 +248,40 @@ pub struct RefreshTokenOutput {
     refresh_token: String,
 }
 
-impl From<GetTokensFromRefreshTokenOutput> for RefreshTokenOutput {
-    fn from(output: GetTokensFromRefreshTokenOutput) -> Self {
-        RefreshTokenOutput {
-            access_token: output
-                .authentication_result
-                .as_ref()
-                .and_then(|result| result.access_token.clone())
-                .unwrap_or_default(),
-            refresh_token: output
-                .authentication_result
-                .as_ref()
-                .and_then(|result| result.refresh_token.clone())
-                .unwrap_or_default(),
-        }
+impl TryFrom<GetTokensFromRefreshTokenOutput> for RefreshTokenOutput {
+    type Error = RefreshTokenOutputError;
+
+    fn try_from(output: GetTokensFromRefreshTokenOutput) -> std::result::Result<Self, Self::Error> {
+        let result = output
+            .authentication_result
+            .as_ref()
+            .ok_or(RefreshTokenOutputError::MissingAuthenticationResult)?;
+        let access_token = result
+            .access_token
+            .clone()
+            .filter(|token| !token.is_empty())
+            .ok_or(RefreshTokenOutputError::MissingAccessToken)?;
+        let refresh_token = result
+            .refresh_token
+            .clone()
+            .filter(|token| !token.is_empty())
+            .ok_or(RefreshTokenOutputError::MissingRefreshToken)?;
+
+        Ok(Self {
+            access_token,
+            refresh_token,
+        })
     }
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum RefreshTokenOutputError {
+    #[error("Cognito refresh response is missing authentication result")]
+    MissingAuthenticationResult,
+    #[error("Cognito refresh response is missing access token")]
+    MissingAccessToken,
+    #[error("Cognito refresh response is missing refresh token")]
+    MissingRefreshToken,
 }
 
 #[derive(Clone, Debug, InputObject)]
@@ -290,22 +310,46 @@ pub struct ChangePasswordInput {
     new_password: String,
 }
 
-// impl SignInOutput {
-//     fn from_refresh_token_auth_output(output: InitiateAuthOutput, refresh_token: String) -> Self {
-//         SignInOutput::from_auth_output(output, Some(refresh_token))
-//     }
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aws_sdk_cognitoidentityprovider::types::AuthenticationResultType;
 
-//     fn from_auth_output(
-//         output: InitiateAuthOutput,
-//         fallback_refresh_token: Option<String>,
-//     ) -> Self {
-//         let result = output.authentication_result.unwrap();
-//         SignInOutput {
-//             access_token: result.access_token.unwrap_or_default(),
-//             refresh_token: result
-//                 .refresh_token
-//                 .or(fallback_refresh_token)
-//                 .unwrap_or_default(),
-//         }
-//     }
-// }
+    fn get_tokens_output(
+        access_token: Option<&str>,
+        refresh_token: Option<&str>,
+    ) -> GetTokensFromRefreshTokenOutput {
+        let mut authentication_result = AuthenticationResultType::builder();
+        if let Some(access_token) = access_token {
+            authentication_result = authentication_result.access_token(access_token);
+        }
+        if let Some(refresh_token) = refresh_token {
+            authentication_result = authentication_result.refresh_token(refresh_token);
+        }
+
+        GetTokensFromRefreshTokenOutput::builder()
+            .authentication_result(authentication_result.build())
+            .build()
+    }
+
+    #[test]
+    fn refresh_token_output_uses_rotated_tokens() {
+        let output = RefreshTokenOutput::try_from(get_tokens_output(
+            Some("new-access"),
+            Some("new-refresh"),
+        ))
+        .expect("rotated token output should be valid");
+
+        assert_eq!(output.access_token, "new-access");
+        assert_eq!(output.refresh_token, "new-refresh");
+    }
+
+    #[test]
+    fn refresh_token_output_rejects_missing_refresh_token() {
+        let error = RefreshTokenOutput::try_from(get_tokens_output(Some("new-access"), None))
+            .err()
+            .expect("missing refresh token should be rejected");
+
+        assert_eq!(error, RefreshTokenOutputError::MissingRefreshToken);
+    }
+}

--- a/apps/mobile/lib/auth/api.test.ts
+++ b/apps/mobile/lib/auth/api.test.ts
@@ -79,12 +79,12 @@ describe('auth api', () => {
 
   it('refreshToken returns refreshed tokens on success', async () => {
     mockRequest.mockResolvedValue({
-      refreshToken: { accessToken: 'new-access-token', refreshToken: 'old-refresh-token' },
+      refreshToken: { accessToken: 'new-access-token', refreshToken: 'new-refresh-token' },
     });
 
     await expect(refreshToken('old-refresh-token')).resolves.toEqual({
       accessToken: 'new-access-token',
-      refreshToken: 'old-refresh-token',
+      refreshToken: 'new-refresh-token',
     });
     expect(mockRequest).toHaveBeenCalledWith(
       expect.any(String),

--- a/infra/aws/cognito.tf
+++ b/infra/aws/cognito.tf
@@ -159,9 +159,13 @@ resource "aws_cognito_user_pool_client" "app" {
 
   explicit_auth_flows = [
     "ALLOW_USER_PASSWORD_AUTH",
-    "ALLOW_REFRESH_TOKEN_AUTH",
     "ALLOW_USER_SRP_AUTH",
   ]
+
+  refresh_token_rotation {
+    feature                    = "ENABLED"
+    retry_grace_period_seconds = 10
+  }
 
   access_token_validity  = 1
   id_token_validity      = 1


### PR DESCRIPTION
## Summary
- Enable Cognito refresh token rotation on the app client and remove `ALLOW_REFRESH_TOKEN_AUTH`.
- Keep API refresh on `GetTokensFromRefreshToken` and reject Cognito refresh responses that omit access or refresh tokens.
- Update mobile auth tests and development notes to match the rotated token contract.

## Validation
- `docker run --rm -v /Users/matsuokashuhei/.codex/worktrees/745d/walking-dog:/walking-dog -v apps_cargo_cache:/usr/local/cargo -v apps_api_target_cognito_rotation:/tmp/walking-dog-target -w /walking-dog/apps/api apps-api cargo fmt --check`
- `docker run --rm -v /Users/matsuokashuhei/.codex/worktrees/745d/walking-dog:/walking-dog -v apps_cargo_cache:/usr/local/cargo -v apps_api_target_cognito_rotation:/tmp/walking-dog-target -w /walking-dog/apps/api apps-api cargo test --target-dir /tmp/walking-dog-target -j 1`
- `npm test -- --runTestsByPath lib/auth/api.test.ts stores/auth-store.test.ts`
- `docker run --rm -v /Users/matsuokashuhei/.codex/worktrees/745d/walking-dog/infra/aws:/workspace -w /workspace hashicorp/terraform:1.14 fmt -check cognito.tf`
- `docker run --rm -v /Users/matsuokashuhei/.codex/worktrees/745d/walking-dog/infra/aws:/workspace -v /Users/matsuokashuhei/.aws:/root/.aws:ro -e AWS_PROFILE=personal -w /workspace hashicorp/terraform:1.14 validate`
- `docker run --rm -v /Users/matsuokashuhei/.codex/worktrees/745d/walking-dog/infra/aws:/workspace -v /Users/matsuokashuhei/.aws:/root/.aws:ro -e AWS_PROFILE=personal -w /workspace hashicorp/terraform:1.14 plan -no-color` (`No changes` after apply)