### PR TITLE
[codex] Add password change flow

### DIFF
--- a/apps/api/schema.graphql
+++ b/apps/api/schema.graphql
@@ -47,6 +47,10 @@ input ChangePasswordInput {
 	newPassword: String!
 }
 
+type ChangePasswordOutput {
+	success: Boolean!
+}
+
 input ConfirmEmailChangeInput {
 	code: String!
 }
@@ -158,7 +162,7 @@ type Mutation {
 	signOut: SignOutOutput!
 	changeEmail(input: ChangeEmailInput!): ChangeEmailOutput!
 	confirmEmailChange(input: ConfirmEmailChangeInput!): ConfirmEmailChangeOutput!
-	changePassword(input: ChangePasswordInput!): SignOutOutput!
+	changePassword(input: ChangePasswordInput!): ChangePasswordOutput!
 	addDog(input: AddDogInput!): Dog!
 	updateDog(input: UpdateDogInput!): Dog!
 	removeDog(input: RemoveDogInput!): Dog!
@@ -439,4 +443,3 @@ schema {
 	query: Query
 	mutation: Mutation
 }
-

--- a/apps/api/src/graphql/mod.rs
+++ b/apps/api/src/graphql/mod.rs
@@ -8,14 +8,42 @@ pub(crate) mod upload;
 
 use std::{env, sync::Arc};
 
+use crate::entity::user;
 use crate::graphql::query::Query;
 use crate::queue::track_point::TrackPointEnqueuer;
 use crate::service::auth::{CognitoAuthGateway, SharedAuthGateway};
 use crate::service::storage::{S3StorageGateway, SharedStorageGateway};
 use crate::service::track_point::{DynamoDbTrackPointRepository, SharedTrackPointRepository};
 use anyhow::Result;
-use async_graphql::{EmptySubscription, extensions::Tracing};
+use async_graphql::{EmptySubscription, Request, extensions::Tracing};
 use tracing::info;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AuthAccessToken(String);
+
+impl AuthAccessToken {
+    pub fn new(token: impl Into<String>) -> Self {
+        Self(token.into())
+    }
+
+    pub fn token(&self) -> &str {
+        &self.0
+    }
+}
+
+pub fn attach_request_context(
+    mut request: Request,
+    user: Option<user::Model>,
+    access_token: Option<AuthAccessToken>,
+) -> Request {
+    if let Some(user) = user {
+        request = request.data(user);
+    }
+    if let Some(access_token) = access_token {
+        request = request.data(access_token);
+    }
+    request
+}
 
 pub async fn build_schema()
 -> anyhow::Result<async_graphql::Schema<Query, mutation::Mutation, EmptySubscription>> {

--- a/apps/api/src/graphql/mutation/auth.rs
+++ b/apps/api/src/graphql/mutation/auth.rs
@@ -1,9 +1,9 @@
 use anyhow::Result;
 use async_graphql::{Context, InputObject, Object, SimpleObject};
-use axum_extra::headers::authorization;
 use sea_orm::{ActiveModelTrait, ActiveValue::Set, DatabaseConnection};
 
 use crate::entity::user;
+use crate::graphql::AuthAccessToken;
 use crate::graphql::error::AppError;
 use crate::graphql::{error::AuthError, guard::AuthGuard};
 use crate::service::auth::{AuthTokenPair, SharedAuthGateway};
@@ -92,7 +92,9 @@ impl AuthMutation {
     #[graphql(guard = "AuthGuard")]
     async fn sign_out(&self, ctx: &Context<'_>) -> Result<SignOutOutput> {
         let auth_gateway = ctx.data::<SharedAuthGateway>().unwrap();
-        let authorization = ctx.data::<authorization::Bearer>().unwrap();
+        let authorization = ctx
+            .data::<AuthAccessToken>()
+            .map_err(|_| AppError::Unauthorized)?;
         auth_gateway
             .sign_out(authorization.token())
             .await
@@ -108,7 +110,7 @@ impl AuthMutation {
     ) -> Result<ChangeEmailOutput> {
         let auth_gateway = ctx.data::<SharedAuthGateway>().unwrap();
         let authorization = ctx
-            .data::<authorization::Bearer>()
+            .data::<AuthAccessToken>()
             .map_err(|_| AppError::Unauthorized)?;
         auth_gateway
             .change_email(authorization.token(), input.new_email)
@@ -125,7 +127,7 @@ impl AuthMutation {
     ) -> Result<ConfirmEmailChangeOutput> {
         let auth_gateway = ctx.data::<SharedAuthGateway>().unwrap();
         let authorization = ctx
-            .data::<authorization::Bearer>()
+            .data::<AuthAccessToken>()
             .map_err(|_| AppError::Unauthorized)?;
         auth_gateway
             .confirm_email_change(authorization.token(), input.code)
@@ -139,10 +141,10 @@ impl AuthMutation {
         &self,
         ctx: &Context<'_>,
         input: ChangePasswordInput,
-    ) -> Result<SignOutOutput> {
+    ) -> Result<ChangePasswordOutput> {
         let auth_gateway = ctx.data::<SharedAuthGateway>().unwrap();
         let authorization = ctx
-            .data::<authorization::Bearer>()
+            .data::<AuthAccessToken>()
             .map_err(|_| AppError::Unauthorized)?;
         auth_gateway
             .change_password(
@@ -152,7 +154,11 @@ impl AuthMutation {
             )
             .await
             .map_err(AuthError::from)?;
-        Ok(SignOutOutput { success: true })
+        auth_gateway
+            .sign_out(authorization.token())
+            .await
+            .map_err(AuthError::from)?;
+        Ok(ChangePasswordOutput { success: true })
     }
 }
 
@@ -270,4 +276,9 @@ pub struct ConfirmEmailChangeOutput {
 pub struct ChangePasswordInput {
     old_password: String,
     new_password: String,
+}
+
+#[derive(SimpleObject)]
+pub struct ChangePasswordOutput {
+    success: bool,
 }

--- a/apps/api/src/main.rs
+++ b/apps/api/src/main.rs
@@ -12,6 +12,10 @@ use axum::{
     response::{Html, IntoResponse},
     routing::get,
 };
+use axum_extra::{
+    TypedHeader,
+    headers::{Authorization, authorization::Bearer},
+};
 use migration::{Migrator, MigratorTrait};
 use sea_orm::Database;
 use tokio::net::TcpListener;
@@ -45,12 +49,16 @@ async fn main() -> anyhow::Result<()> {
 async fn graphql_handler(
     State(schema): State<Schema<Query, mutation::Mutation, EmptySubscription>>,
     user: Option<axum::Extension<user::Model>>,
+    authorization: Option<TypedHeader<Authorization<Bearer>>>,
     request: GraphQLRequest,
 ) -> GraphQLResponse {
-    let mut request = request.into_inner();
-    if let Some(axum::Extension(user)) = user {
-        request = request.data(user);
-    }
+    let access_token = authorization
+        .map(|TypedHeader(authorization)| graphql::AuthAccessToken::new(authorization.token()));
+    let request = graphql::attach_request_context(
+        request.into_inner(),
+        user.map(|axum::Extension(user)| user),
+        access_token,
+    );
     schema.execute(request).await.into()
 }
 

--- a/apps/api/src/service/auth.rs
+++ b/apps/api/src/service/auth.rs
@@ -13,6 +13,7 @@ use aws_sdk_cognitoidentityprovider::{
     types::{AttributeType, AuthFlowType},
 };
 use std::{fmt, sync::Arc};
+use tracing::warn;
 
 pub type SharedAuthGateway = Arc<dyn AuthGateway>;
 
@@ -60,15 +61,26 @@ pub trait AuthGateway: Send + Sync + 'static {
 pub struct CognitoAuthGateway {
     client: Client,
     client_id: String,
+    skip_global_sign_out: bool,
 }
 
 impl CognitoAuthGateway {
     pub fn from_env(client: Client) -> anyhow::Result<Self> {
+        let cognito_endpoint = std::env::var("AWS_COGNITO_ENDPOINT").ok();
         Ok(Self {
             client,
             client_id: std::env::var("AWS_COGNITO_CLIENT_ID")?,
+            skip_global_sign_out: cognito_endpoint
+                .as_deref()
+                .is_some_and(is_local_cognito_endpoint),
         })
     }
+}
+
+fn is_local_cognito_endpoint(endpoint: &str) -> bool {
+    endpoint.contains("cognito-local")
+        || endpoint.contains("localhost")
+        || endpoint.contains("127.0.0.1")
 }
 
 #[async_trait]
@@ -149,6 +161,13 @@ impl AuthGateway for CognitoAuthGateway {
     }
 
     async fn sign_out(&self, access_token: &str) -> Result<(), AuthGatewayError> {
+        if self.skip_global_sign_out {
+            warn!(
+                "Skipping Cognito GlobalSignOut because the configured local Cognito endpoint does not implement it"
+            );
+            return Ok(());
+        }
+
         self.client
             .global_sign_out()
             .access_token(access_token)

--- a/apps/api/tests/auth_change_password.rs
+++ b/apps/api/tests/auth_change_password.rs
@@ -1,0 +1,212 @@
+#![recursion_limit = "256"]
+
+use std::sync::{Arc, Mutex};
+
+use async_graphql::{Context, EmptyMutation, EmptySubscription, Object, Request, Schema, Variables};
+use async_trait::async_trait;
+use chrono::TimeZone;
+use serde_json::json;
+use uuid::Uuid;
+use walking_dog::{
+    entity::user,
+    graphql::{
+        attach_request_context,
+        mutation::Mutation,
+        query::Query,
+        AuthAccessToken,
+    },
+    service::auth::{AuthGateway, AuthGatewayError, AuthTokenPair, SharedAuthGateway, SignUpResult},
+};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum AuthCall {
+    ChangePassword {
+        access_token: String,
+        old_password: String,
+        new_password: String,
+    },
+    SignOut {
+        access_token: String,
+    },
+}
+
+#[derive(Default)]
+struct RecordingAuthGateway {
+    calls: Arc<Mutex<Vec<AuthCall>>>,
+}
+
+#[async_trait]
+impl AuthGateway for RecordingAuthGateway {
+    async fn sign_up(
+        &self,
+        _email: String,
+        _password: String,
+    ) -> Result<SignUpResult, AuthGatewayError> {
+        unimplemented!("change password mutation should not sign up")
+    }
+
+    async fn confirm_sign_up(&self, _email: String, _code: String) -> Result<(), AuthGatewayError> {
+        unimplemented!("change password mutation should not confirm sign up")
+    }
+
+    async fn sign_in(
+        &self,
+        _email: String,
+        _password: String,
+    ) -> Result<AuthTokenPair, AuthGatewayError> {
+        unimplemented!("change password mutation should not sign in")
+    }
+
+    async fn refresh_token(
+        &self,
+        _refresh_token: String,
+    ) -> Result<AuthTokenPair, AuthGatewayError> {
+        unimplemented!("change password mutation should not refresh tokens")
+    }
+
+    async fn sign_out(&self, access_token: &str) -> Result<(), AuthGatewayError> {
+        self.calls.lock().unwrap().push(AuthCall::SignOut {
+            access_token: access_token.to_owned(),
+        });
+        Ok(())
+    }
+
+    async fn forgot_password(&self, _email: String) -> Result<(), AuthGatewayError> {
+        unimplemented!("change password mutation should not start forgot password")
+    }
+
+    async fn confirm_forgot_password(
+        &self,
+        _email: String,
+        _code: String,
+        _new_password: String,
+    ) -> Result<(), AuthGatewayError> {
+        unimplemented!("change password mutation should not confirm forgot password")
+    }
+
+    async fn change_email(
+        &self,
+        _access_token: &str,
+        _new_email: String,
+    ) -> Result<(), AuthGatewayError> {
+        unimplemented!("change password mutation should not change email")
+    }
+
+    async fn confirm_email_change(
+        &self,
+        _access_token: &str,
+        _code: String,
+    ) -> Result<(), AuthGatewayError> {
+        unimplemented!("change password mutation should not confirm email")
+    }
+
+    async fn change_password(
+        &self,
+        access_token: &str,
+        old_password: String,
+        new_password: String,
+    ) -> Result<(), AuthGatewayError> {
+        self.calls.lock().unwrap().push(AuthCall::ChangePassword {
+            access_token: access_token.to_owned(),
+            old_password,
+            new_password,
+        });
+        Ok(())
+    }
+}
+
+struct TokenQuery;
+
+#[Object]
+impl TokenQuery {
+    async fn token(&self, ctx: &Context<'_>) -> async_graphql::Result<String> {
+        Ok(ctx.data::<AuthAccessToken>()?.token().to_owned())
+    }
+}
+
+fn fixed_time() -> sea_orm::prelude::DateTimeWithTimeZone {
+    chrono::Utc
+        .with_ymd_and_hms(2026, 6, 13, 9, 0, 0)
+        .single()
+        .unwrap()
+        .into()
+}
+
+fn user_model() -> user::Model {
+    user::Model {
+        id: Uuid::parse_str("019e0dc4-066b-7a22-b755-969ee6beb5e9").unwrap(),
+        name: Some("Mio Tanaka".to_owned()),
+        avatar: None,
+        cognito_sub: "owner-sub".to_owned(),
+        created_at: fixed_time(),
+        updated_at: fixed_time(),
+    }
+}
+
+#[tokio::test]
+async fn request_context_attaches_access_token_for_resolvers() {
+    let schema = Schema::build(TokenQuery, EmptyMutation, EmptySubscription).finish();
+    let request = attach_request_context(
+        Request::new("{ token }"),
+        Some(user_model()),
+        Some(AuthAccessToken::new("access-token")),
+    );
+
+    let response = schema.execute(request).await;
+
+    assert!(response.errors.is_empty(), "{:?}", response.errors);
+    assert_eq!(
+        response.data.into_json().unwrap(),
+        json!({ "token": "access-token" })
+    );
+}
+
+#[tokio::test]
+async fn change_password_uses_access_token_then_signs_out_globally() {
+    let gateway = RecordingAuthGateway::default();
+    let calls = gateway.calls.clone();
+    let schema = Schema::build(Query::default(), Mutation::default(), EmptySubscription)
+        .data(Arc::new(gateway) as SharedAuthGateway)
+        .finish();
+    let request = Request::new(
+        r#"
+        mutation ChangePassword($input: ChangePasswordInput!) {
+          changePassword(input: $input) {
+            success
+          }
+        }
+        "#,
+    )
+    .variables(Variables::from_json(json!({
+        "input": {
+            "oldPassword": "Currentpass1",
+            "newPassword": "Newpass1"
+        }
+    })));
+    let request = attach_request_context(
+        request,
+        Some(user_model()),
+        Some(AuthAccessToken::new("access-token")),
+    );
+
+    let response = schema.execute(request).await;
+
+    assert!(response.errors.is_empty(), "{:?}", response.errors);
+    assert_eq!(
+        response.data.into_json().unwrap(),
+        json!({ "changePassword": { "success": true } })
+    );
+    assert_eq!(
+        *calls.lock().unwrap(),
+        vec![
+            AuthCall::ChangePassword {
+                access_token: "access-token".to_owned(),
+                old_password: "Currentpass1".to_owned(),
+                new_password: "Newpass1".to_owned(),
+            },
+            AuthCall::SignOut {
+                access_token: "access-token".to_owned(),
+            },
+        ]
+    );
+}

--- a/apps/api/tests/schema_auth_reset.rs
+++ b/apps/api/tests/schema_auth_reset.rs
@@ -15,3 +15,15 @@ fn schema_exposes_password_reset_mutations() {
     assert!(sdl.contains("input ForgotPasswordInput"));
     assert!(sdl.contains("input ConfirmForgotPasswordInput"));
 }
+
+#[test]
+fn schema_exposes_change_password_mutation() {
+    let schema =
+        async_graphql::Schema::build(Query::default(), Mutation::default(), EmptySubscription)
+            .finish();
+    let sdl = schema.sdl();
+
+    assert!(sdl.contains("changePassword(input: ChangePasswordInput!): ChangePasswordOutput!"));
+    assert!(sdl.contains("input ChangePasswordInput"));
+    assert!(sdl.contains("type ChangePasswordOutput"));
+}

--- a/apps/mobile/__tests__/app/tabs/user.test.tsx
+++ b/apps/mobile/__tests__/app/tabs/user.test.tsx
@@ -104,5 +104,8 @@ describe('UserScreen', () => {
 
     fireEvent.press(screen.getByRole('button', { name: 'Settings' }));
     expect(mockPush).toHaveBeenCalledWith('/settings');
+
+    fireEvent.press(screen.getByRole('button', { name: 'Change password' }));
+    expect(mockPush).toHaveBeenCalledWith('/user/change-password');
   });
 });

--- a/apps/mobile/__tests__/app/user/change-password.test.tsx
+++ b/apps/mobile/__tests__/app/user/change-password.test.tsx
@@ -1,0 +1,79 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import ChangePasswordScreen from '../../../app/user/change-password';
+
+const mockBack = jest.fn();
+const mockReplace = jest.fn();
+const mockChangePassword = jest.fn();
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ back: mockBack, replace: mockReplace }),
+}));
+
+jest.mock('@/hooks/use-color-scheme', () => ({
+  useColorScheme: () => 'light',
+}));
+
+jest.mock('@/hooks/use-auth', () => ({
+  useAuth: () => ({
+    changePassword: mockChangePassword,
+  }),
+}));
+
+describe('ChangePasswordScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('keeps submit disabled until all password fields are valid', () => {
+    render(<ChangePasswordScreen />);
+
+    expect(screen.getByRole('button', { name: 'Update password' })).toBeDisabled();
+
+    fireEvent.changeText(screen.getByLabelText('Current password'), 'Currentpass1');
+    fireEvent.changeText(screen.getByLabelText('New password'), 'Newpass1');
+    fireEvent.changeText(screen.getByLabelText('Confirm password'), 'Newpass1');
+
+    expect(screen.getByRole('button', { name: 'Update password' })).not.toBeDisabled();
+  });
+
+  it('shows a mismatch error without calling the API', async () => {
+    render(<ChangePasswordScreen />);
+
+    fireEvent.changeText(screen.getByLabelText('Current password'), 'Currentpass1');
+    fireEvent.changeText(screen.getByLabelText('New password'), 'Newpass1');
+    fireEvent.changeText(screen.getByLabelText('Confirm password'), 'Different1');
+    fireEvent.press(screen.getByRole('button', { name: 'Update password' }));
+
+    expect(screen.getByText('Passwords do not match')).toBeTruthy();
+    expect(mockChangePassword).not.toHaveBeenCalled();
+  });
+
+  it('changes the password and returns to sign-in', async () => {
+    mockChangePassword.mockResolvedValue(undefined);
+    render(<ChangePasswordScreen />);
+
+    fireEvent.changeText(screen.getByLabelText('Current password'), 'Currentpass1');
+    fireEvent.changeText(screen.getByLabelText('New password'), 'Newpass1');
+    fireEvent.changeText(screen.getByLabelText('Confirm password'), 'Newpass1');
+    fireEvent.press(screen.getByRole('button', { name: 'Update password' }));
+
+    await waitFor(() => {
+      expect(mockChangePassword).toHaveBeenCalledWith('Currentpass1', 'Newpass1');
+    });
+    expect(mockReplace).toHaveBeenCalledWith('/(auth)/login');
+  });
+
+  it('maps current password errors to an actionable message', async () => {
+    mockChangePassword.mockRejectedValue({ kind: 'invalid-credentials' });
+    render(<ChangePasswordScreen />);
+
+    fireEvent.changeText(screen.getByLabelText('Current password'), 'Wrongpass1');
+    fireEvent.changeText(screen.getByLabelText('New password'), 'Newpass1');
+    fireEvent.changeText(screen.getByLabelText('Confirm password'), 'Newpass1');
+    fireEvent.press(screen.getByRole('button', { name: 'Update password' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Current password is incorrect')).toBeTruthy();
+    });
+  });
+});

--- a/apps/mobile/app/(tabs)/user.tsx
+++ b/apps/mobile/app/(tabs)/user.tsx
@@ -44,6 +44,12 @@ export default function UserScreen() {
                 leading={<IconSymbol name="gearshape.fill" size={18} color={theme.interactive} />}
                 label={t('settings.openSettings')}
                 onPress={() => router.push('/settings')}
+              />
+              <GroupedRow
+                leading={<IconSymbol name="key.fill" size={18} color={theme.interactive} />}
+                label={t('settings.changePassword')}
+                onPress={() => router.push('/user/change-password')}
+                testID="user-change-password-row"
                 separator={false}
               />
             </GroupedCard>

--- a/apps/mobile/app/user/_layout.tsx
+++ b/apps/mobile/app/user/_layout.tsx
@@ -5,6 +5,7 @@ export default function UserLayout() {
   return (
     <Stack screenOptions={{ headerShown: false }}>
       <Stack.Screen name="edit" />
+      <Stack.Screen name="change-password" />
     </Stack>
   );
 }

--- a/apps/mobile/app/user/change-password.tsx
+++ b/apps/mobile/app/user/change-password.tsx
@@ -1,0 +1,152 @@
+import { useState } from 'react';
+import { ScrollView, StyleSheet, Text } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useRouter } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui/Button';
+import { GroupedCard } from '@/components/ui/GroupedCard';
+import { ScreenHeader } from '@/components/ui/ScreenHeader';
+import { TextInput } from '@/components/ui/TextInput';
+import { useAuth } from '@/hooks/use-auth';
+import { useColors } from '@/hooks/use-colors';
+import { toAuthError } from '@/lib/auth/errors';
+import { spacing, typography } from '@/theme/tokens';
+
+const PASSWORD_MIN_LENGTH = 8;
+const isE2EBuild = process.env.EXPO_PUBLIC_E2E === '1';
+
+export default function ChangePasswordScreen() {
+  const router = useRouter();
+  const { t } = useTranslation();
+  const theme = useColors();
+  const { changePassword } = useAuth();
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [error, setError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const canSubmit =
+    currentPassword.length > 0 &&
+    newPassword.length >= PASSWORD_MIN_LENGTH &&
+    confirmPassword.length > 0 &&
+    !submitting;
+
+  async function handleSubmit() {
+    if (!canSubmit) return;
+    if (newPassword !== confirmPassword) {
+      setError(t('userChangePassword.error.passwordMismatch'));
+      return;
+    }
+
+    setError('');
+    setSubmitting(true);
+    try {
+      await changePassword(currentPassword, newPassword);
+      router.replace('/(auth)/login');
+    } catch (err: unknown) {
+      const authError = toAuthError(err);
+      switch (authError.kind) {
+        case 'invalid-credentials':
+          setError(t('userChangePassword.error.currentPassword'));
+          break;
+        case 'invalid-password':
+          setError(t('userChangePassword.error.invalidPassword'));
+          break;
+        case 'network':
+          setError(t('auth.error.networkError'));
+          break;
+        default:
+          setError(t('userChangePassword.error.generic'));
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <SafeAreaView edges={['top']} style={[styles.safeArea, { backgroundColor: theme.background }]}>
+      <ScreenHeader
+        variant="inline"
+        title={t('userChangePassword.title')}
+        leftAction="back"
+      />
+      <ScrollView
+        contentContainerStyle={styles.content}
+        keyboardShouldPersistTaps="handled"
+      >
+        <GroupedCard elevated={false}>
+          <TextInput
+            label={t('userChangePassword.currentPassword')}
+            labelPosition="inline"
+            separator
+            testID="change-password-current"
+            value={currentPassword}
+            onChangeText={setCurrentPassword}
+            secureTextEntry={!isE2EBuild}
+            textContentType={isE2EBuild ? 'none' : 'password'}
+            autoComplete={isE2EBuild ? 'off' : 'current-password'}
+          />
+          <TextInput
+            label={t('userChangePassword.newPassword')}
+            labelPosition="inline"
+            separator
+            testID="change-password-new"
+            value={newPassword}
+            onChangeText={setNewPassword}
+            secureTextEntry={!isE2EBuild}
+            textContentType={isE2EBuild ? 'none' : 'newPassword'}
+            passwordRules={isE2EBuild ? undefined : 'minlength: 8;'}
+            autoComplete={isE2EBuild ? 'off' : 'password-new'}
+          />
+          <TextInput
+            label={t('userChangePassword.confirmPassword')}
+            labelPosition="inline"
+            testID="change-password-confirm"
+            value={confirmPassword}
+            onChangeText={setConfirmPassword}
+            secureTextEntry={!isE2EBuild}
+            textContentType={isE2EBuild ? 'none' : 'newPassword'}
+            passwordRules={isE2EBuild ? undefined : 'minlength: 8;'}
+            autoComplete={isE2EBuild ? 'off' : 'password-new'}
+          />
+        </GroupedCard>
+
+        <Text style={[styles.hint, { color: theme.onSurfaceVariant }]}>
+          {t('userChangePassword.passwordHint')}
+        </Text>
+
+        {error ? (
+          <Text style={[styles.error, { color: theme.error }]}>{error}</Text>
+        ) : null}
+
+        <Button
+          label={t('userChangePassword.submit')}
+          onPress={handleSubmit}
+          loading={submitting}
+          disabled={!canSubmit}
+          testID="change-password-submit"
+        />
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: { flex: 1 },
+  content: {
+    flexGrow: 1,
+    padding: spacing.lg,
+  },
+  hint: {
+    ...typography.footnote,
+    marginTop: spacing.step10,
+    marginBottom: spacing.step20,
+    paddingHorizontal: spacing.xs,
+  },
+  error: {
+    ...typography.caption,
+    marginBottom: spacing.md,
+    textAlign: 'center',
+  },
+});

--- a/apps/mobile/components/auth/RegisterForm.tsx
+++ b/apps/mobile/components/auth/RegisterForm.tsx
@@ -10,6 +10,8 @@ import { toAuthError } from '@/lib/auth/errors';
 import { PRIVACY_POLICY_URL, TERMS_URL } from '@/lib/legal-urls';
 import { spacing, typography } from '@/theme/tokens';
 
+const isE2EBuild = process.env.EXPO_PUBLIC_E2E === '1';
+
 interface RegisterFormProps {
   onSuccess: (email: string, userConfirmed: boolean) => void;
 }
@@ -95,10 +97,10 @@ export function RegisterForm({ onSuccess }: RegisterFormProps) {
           testID="register-password"
           value={password}
           onChangeText={setPassword}
-          secureTextEntry
-          textContentType="newPassword"
-          passwordRules="minlength: 8;"
-          autoComplete="password-new"
+          secureTextEntry={!isE2EBuild}
+          textContentType={isE2EBuild ? 'none' : 'newPassword'}
+          passwordRules={isE2EBuild ? undefined : 'minlength: 8;'}
+          autoComplete={isE2EBuild ? 'off' : 'password-new'}
           error={passwordError}
         />
       </GroupedCard>

--- a/apps/mobile/components/ui/icon-symbol.tsx
+++ b/apps/mobile/components/ui/icon-symbol.tsx
@@ -23,6 +23,7 @@ const MAPPING = {
   'bell.fill': 'notifications',
   'moon.fill': 'dark-mode',
   'gearshape.fill': 'settings',
+  'key.fill': 'vpn-key',
   'doc.text': 'description',
   'lock.fill': 'lock',
   'info.circle': 'info',

--- a/apps/mobile/e2e/maestro/auth-onboarding.yaml
+++ b/apps/mobile/e2e/maestro/auth-onboarding.yaml
@@ -13,6 +13,7 @@ env:
   E2E_NAME: Harness Owner
   E2E_EMAIL: harness-auth@example.com
   E2E_PASSWORD: password123
+  E2E_NEW_PASSWORD: Newpass1
   E2E_CONFIRMATION_CODE: "123456"
 ---
 - launchApp:
@@ -34,12 +35,51 @@ env:
     when:
       visible: Email Verification
     commands:
-      - tapOn: Confirmation Code
-      - inputText: ${E2E_CONFIRMATION_CODE}
+      - tapOn: "1"
+      - tapOn: "2"
+      - tapOn: "3"
+      - tapOn: "4"
+      - tapOn: "5"
+      - tapOn: "6"
       - tapOn: Confirm
 - extendedWaitUntil:
-    visible: Dogs
+    visible: Welcome back
+    timeout: 15000
+- tapOn:
+    id: login-email
+- inputText: ${E2E_EMAIL}
+- tapOn:
+    id: login-password
+- inputText: ${E2E_PASSWORD}
+- tapOn: Sign in
+- waitForAnimationToEnd:
+    timeout: 5000
+- runFlow:
+    when:
+      visible: Save Password?
+    commands:
+      - tapOn: Not Now
+- extendedWaitUntil:
+    visible: No dogs yet
     timeout: 15000
 - assertVisible: Walk
 - assertVisible: Me
+- tapOn: Me
+- tapOn:
+    id: user-change-password-row
+- assertVisible: Change password
+- tapOn:
+    id: change-password-current
+- inputText: ${E2E_PASSWORD}
+- tapOn:
+    id: change-password-new
+- inputText: ${E2E_NEW_PASSWORD}
+- tapOn:
+    id: change-password-confirm
+- inputText: ${E2E_NEW_PASSWORD}
+- tapOn:
+    id: change-password-submit
+- extendedWaitUntil:
+    visible: Welcome back
+    timeout: 15000
 - takeScreenshot: harness-auth-onboarding

--- a/apps/mobile/hooks/use-auth.test.ts
+++ b/apps/mobile/hooks/use-auth.test.ts
@@ -4,6 +4,7 @@ import type * as AuthApiModule from '@/lib/auth/api';
 import type * as AuthStoreModule from '@/stores/auth-store';
 
 jest.mock('@/lib/auth/api', () => ({
+  changePassword: jest.fn(),
   confirmForgotPassword: jest.fn(),
   confirmSignUp: jest.fn(),
   forgotPassword: jest.fn(),
@@ -103,5 +104,39 @@ describe('use-auth', () => {
       '123456',
       'Newpass1',
     );
+  });
+
+  it('changePassword delegates to authApi then clears local auth', async () => {
+    mockAuthApi.changePassword.mockResolvedValue(true);
+    mockUseAuthStore.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+      accessToken: 'my-token',
+      setAuth: mockSetAuth,
+      clearAuth: mockClearAuth,
+      initialize: jest.fn(),
+    });
+
+    const { result } = renderHook(() => useAuth());
+    await act(async () => {
+      await result.current.changePassword('Currentpass1', 'Newpass1');
+    });
+
+    expect(mockAuthApi.changePassword).toHaveBeenCalledWith('Currentpass1', 'Newpass1');
+    expect(mockAuthApi.signOut).not.toHaveBeenCalled();
+    expect(mockClearAuth).toHaveBeenCalled();
+  });
+
+  it('changePassword leaves local auth intact when the API fails', async () => {
+    mockAuthApi.changePassword.mockRejectedValue({ kind: 'invalid-credentials' });
+
+    const { result } = renderHook(() => useAuth());
+    await act(async () => {
+      await expect(
+        result.current.changePassword('Wrongpass1', 'Newpass1')
+      ).rejects.toMatchObject({ kind: 'invalid-credentials' });
+    });
+
+    expect(mockClearAuth).not.toHaveBeenCalled();
   });
 });

--- a/apps/mobile/hooks/use-auth.ts
+++ b/apps/mobile/hooks/use-auth.ts
@@ -35,6 +35,14 @@ export function useAuth() {
     await authApi.confirmForgotPassword(email, code, newPassword);
   }
 
+  async function changePassword(
+    oldPassword: string,
+    newPassword: string
+  ): Promise<void> {
+    await authApi.changePassword(oldPassword, newPassword);
+    await clearAuth();
+  }
+
   async function signOut(): Promise<void> {
     // アクセストークンがある場合だけ、サーバーへサインアウトを通知します。
     if (accessToken) {
@@ -52,6 +60,7 @@ export function useAuth() {
     confirmSignUp,
     forgotPassword,
     confirmForgotPassword,
+    changePassword,
     signOut,
   };
 }

--- a/apps/mobile/hooks/use-otp-input.test.ts
+++ b/apps/mobile/hooks/use-otp-input.test.ts
@@ -37,12 +37,21 @@ describe('useOtpInput', () => {
     expect(result.current.digits[0]).toBe('5');
   });
 
-  it('setDigit keeps only the last character of multi-character input', () => {
+  it('setDigit distributes multi-character input from the given index', () => {
     const { result } = renderHook(() => useOtpInput(6));
     act(() => {
-      result.current.setDigit(0, '12');
+      result.current.setDigit(0, '123456');
     });
-    expect(result.current.digits[0]).toBe('2');
+    expect(result.current.digits).toEqual(['1', '2', '3', '4', '5', '6']);
+    expect(result.current.code).toBe('123456');
+  });
+
+  it('setDigit distributes multi-character input without overflowing', () => {
+    const { result } = renderHook(() => useOtpInput(6));
+    act(() => {
+      result.current.setDigit(4, '789');
+    });
+    expect(result.current.digits).toEqual(['', '', '', '', '7', '8']);
   });
 
   it('setDigit with empty value clears the digit', () => {
@@ -68,6 +77,18 @@ describe('useOtpInput', () => {
       result.current.setDigit(0, '4');
     });
     expect(input1.focus).toHaveBeenCalledTimes(1);
+  });
+
+  it('setDigit advances focus after distributed multi-character input', () => {
+    const { result } = renderHook(() => useOtpInput(6));
+    const input3 = makeMockInput();
+    act(() => {
+      result.current.setInputRef(3)(input3);
+    });
+    act(() => {
+      result.current.setDigit(0, '123');
+    });
+    expect(input3.focus).toHaveBeenCalledTimes(1);
   });
 
   it('setDigit on the last index does not attempt to focus beyond the end', () => {

--- a/apps/mobile/hooks/use-otp-input.ts
+++ b/apps/mobile/hooks/use-otp-input.ts
@@ -13,15 +13,26 @@ export function useOtpInput(length: number) {
 
   const setDigit = useCallback(
     (index: number, value: string) => {
-      // 貼り付けやキーボード入力から数字 1 桁だけを採用し、次の欄へ進めます。
-      const digit = value.replace(/[^0-9]/g, '').slice(-1);
+      const numericInput = value.replace(/[^0-9]/g, '');
       setDigits((prev) => {
         const next = [...prev];
-        next[index] = digit;
+        if (!numericInput) {
+          next[index] = '';
+          return next;
+        }
+        numericInput
+          .slice(0, length - index)
+          .split('')
+          .forEach((digit, offset) => {
+            next[index + offset] = digit;
+          });
         return next;
       });
-      if (digit && index < length - 1) {
-        inputRefs.current[index + 1]?.focus();
+      if (numericInput) {
+        const nextIndex = index + numericInput.length;
+        if (nextIndex < length) {
+          inputRefs.current[nextIndex]?.focus();
+        }
       }
     },
     [length],

--- a/apps/mobile/lib/auth/api.test.ts
+++ b/apps/mobile/lib/auth/api.test.ts
@@ -2,11 +2,13 @@ import { GraphQLError } from 'graphql';
 import { graphqlClient } from '../graphql/client';
 import { ClientError } from '../graphql/client-error';
 import {
+  changePassword,
   confirmForgotPassword,
   confirmSignUp,
   forgotPassword,
   refreshToken,
   signIn,
+  signOut,
   signUp,
 } from './api';
 
@@ -127,6 +129,41 @@ describe('auth api', () => {
     ).rejects.toMatchObject({
       kind: 'invalid-password',
     });
+  });
+
+  it('changePassword sends the current and new password for the signed-in user', async () => {
+    mockRequest.mockResolvedValue({ changePassword: { success: true } });
+
+    await expect(changePassword('Currentpass1', 'Newpass1')).resolves.toBe(true);
+    expect(mockRequest).toHaveBeenCalledWith(expect.any(String), {
+      input: {
+        oldPassword: 'Currentpass1',
+        newPassword: 'Newpass1',
+      },
+    });
+  });
+
+  it('changePassword maps incorrect current passwords to invalid-credentials', async () => {
+    mockRequest.mockRejectedValue(makeClientError('NotAuthorizedException'));
+
+    await expect(changePassword('Wrongpass1', 'Newpass1')).rejects.toMatchObject({
+      kind: 'invalid-credentials',
+    });
+  });
+
+  it('changePassword maps password policy failures to invalid-password', async () => {
+    mockRequest.mockRejectedValue(makeClientError('PasswordHistoryPolicyViolationException'));
+
+    await expect(changePassword('Currentpass1', 'Currentpass1')).rejects.toMatchObject({
+      kind: 'invalid-password',
+    });
+  });
+
+  it('signOut calls the authenticated sign out mutation', async () => {
+    mockRequest.mockResolvedValue({ signOut: { success: true } });
+
+    await expect(signOut('access-token')).resolves.toBe(true);
+    expect(mockRequest).toHaveBeenCalledWith(expect.any(String));
   });
 
   it('refreshToken returns refreshed tokens on success', async () => {

--- a/apps/mobile/lib/auth/api.ts
+++ b/apps/mobile/lib/auth/api.ts
@@ -4,8 +4,10 @@ import {
   CONFIRM_SIGN_UP_MUTATION,
   FORGOT_PASSWORD_MUTATION,
   CONFIRM_FORGOT_PASSWORD_MUTATION,
+  CHANGE_PASSWORD_MUTATION,
   SIGN_IN_MUTATION,
   REFRESH_TOKEN_MUTATION,
+  SIGN_OUT_MUTATION,
 } from '../graphql/mutations/auth';
 import { toAuthError } from './errors';
 
@@ -40,12 +42,20 @@ interface ConfirmForgotPasswordResponse {
   confirmForgotPassword: { success: boolean };
 }
 
+interface ChangePasswordResponse {
+  changePassword: { success: boolean };
+}
+
 interface SignInResponse {
   signIn: SignInResult;
 }
 
 interface RefreshTokenResponse {
   refreshToken: RefreshTokenResult;
+}
+
+interface SignOutResponse {
+  signOut: { success: boolean };
 }
 
 async function mapAuthRequestError<T>(request: () => Promise<T>): Promise<T> {
@@ -125,7 +135,22 @@ export async function signIn(email: string, password: string): Promise<SignInRes
 }
 
 export async function signOut(_accessToken: string): Promise<boolean> {
-  return true;
+  const data = await mapAuthRequestError(() =>
+    graphqlClient.request<SignOutResponse>(SIGN_OUT_MUTATION)
+  );
+  return data.signOut.success;
+}
+
+export async function changePassword(
+  oldPassword: string,
+  newPassword: string,
+): Promise<boolean> {
+  const data = await mapAuthRequestError(() =>
+    graphqlClient.request<ChangePasswordResponse>(CHANGE_PASSWORD_MUTATION, {
+      input: { oldPassword, newPassword },
+    })
+  );
+  return data.changePassword.success;
 }
 
 export async function refreshToken(refreshTokenValue: string): Promise<RefreshTokenResult> {

--- a/apps/mobile/lib/auth/errors.ts
+++ b/apps/mobile/lib/auth/errors.ts
@@ -75,7 +75,13 @@ export function toAuthError(error: unknown): AuthError {
     return { kind: 'user-exists', message };
   }
 
-  if (includesAny(normalizedMessage, ['INVALID_PASSWORD', 'INVALIDPASSWORDEXCEPTION'])) {
+  if (
+    includesAny(normalizedMessage, [
+      'INVALID_PASSWORD',
+      'INVALIDPASSWORDEXCEPTION',
+      'PASSWORDHISTORYPOLICYVIOLATIONEXCEPTION',
+    ])
+  ) {
     return { kind: 'invalid-password', message };
   }
 

--- a/apps/mobile/lib/graphql/mutations/auth.ts
+++ b/apps/mobile/lib/graphql/mutations/auth.ts
@@ -32,6 +32,14 @@ export const CONFIRM_FORGOT_PASSWORD_MUTATION = gql`
   }
 `;
 
+export const CHANGE_PASSWORD_MUTATION = gql`
+  mutation ChangePassword($input: ChangePasswordInput!) {
+    changePassword(input: $input) {
+      success
+    }
+  }
+`;
+
 export const SIGN_IN_MUTATION = gql`
   mutation SignIn($input: SignInInput!) {
     signIn(input: $input) {
@@ -46,6 +54,14 @@ export const REFRESH_TOKEN_MUTATION = gql`
     refreshToken(input: $input) {
       accessToken
       refreshToken
+    }
+  }
+`;
+
+export const SIGN_OUT_MUTATION = gql`
+  mutation SignOut {
+    signOut {
+      success
     }
   }
 `;

--- a/apps/mobile/lib/i18n/locales/en.json
+++ b/apps/mobile/lib/i18n/locales/en.json
@@ -340,6 +340,7 @@
     "notifications": "Notifications",
     "notificationsValue": "On",
     "openSettings": "Settings",
+    "changePassword": "Change password",
     "terms": "Terms of Service",
     "privacy": "Privacy Policy",
     "about": "About",
@@ -370,6 +371,20 @@
     "photoPermissionDenied": "Photo access denied",
     "photoPermissionMessage": "Allow photo access to update your user picture.",
     "saveError": "Failed to save user. Please try again."
+  },
+  "userChangePassword": {
+    "title": "Change password",
+    "currentPassword": "Current password",
+    "newPassword": "New password",
+    "confirmPassword": "Confirm password",
+    "passwordHint": "Use at least 8 characters with uppercase, lowercase, and a number.",
+    "submit": "Update password",
+    "error": {
+      "currentPassword": "Current password is incorrect",
+      "invalidPassword": "Password does not meet requirements",
+      "passwordMismatch": "Passwords do not match",
+      "generic": "Password change failed"
+    }
   },
   "nativePermissions": {
     "locationWhenInUse": "Walking Dog uses your location to record walk routes.",

--- a/apps/mobile/lib/i18n/locales/ja.json
+++ b/apps/mobile/lib/i18n/locales/ja.json
@@ -340,6 +340,7 @@
     "notifications": "通知",
     "notificationsValue": "オン",
     "openSettings": "設定",
+    "changePassword": "パスワードを変更",
     "terms": "利用規約",
     "privacy": "プライバシーポリシー",
     "about": "このアプリについて",
@@ -370,6 +371,20 @@
     "photoPermissionDenied": "写真へのアクセスが拒否されました",
     "photoPermissionMessage": "ユーザー写真を更新するには写真へのアクセスを許可してください。",
     "saveError": "ユーザー情報の保存に失敗しました。もう一度お試しください。"
+  },
+  "userChangePassword": {
+    "title": "パスワードを変更",
+    "currentPassword": "現在のパスワード",
+    "newPassword": "新しいパスワード",
+    "confirmPassword": "確認用パスワード",
+    "passwordHint": "8文字以上で、大文字・小文字・数字を含めてください。",
+    "submit": "パスワードを更新",
+    "error": {
+      "currentPassword": "現在のパスワードが正しくありません",
+      "invalidPassword": "パスワードの要件を満たしていません",
+      "passwordMismatch": "パスワードが一致しません",
+      "generic": "パスワード変更に失敗しました"
+    }
   },
   "nativePermissions": {
     "locationWhenInUse": "Walking Dog は散歩ルートを記録するために位置情報を使用します。",

--- a/docs/harness/journeys/auth-onboarding.md
+++ b/docs/harness/journeys/auth-onboarding.md
@@ -15,7 +15,8 @@
 ## Scope
 
 A new owner creates an account, confirms email when required, signs in, and reaches
-the authenticated app with the expected Dogs, Walk, and Me surfaces.
+the authenticated app with the expected Dogs, Walk, and Me surfaces. A signed-in
+owner can also change their password from Me and must sign in again afterward.
 
 ## Acceptance Criteria
 
@@ -25,13 +26,21 @@ the authenticated app with the expected Dogs, Walk, and Me surfaces.
   requires confirmation.
 - Sign-in stores tokens through secure storage, not AsyncStorage.
 - Authenticated navigation shows Dogs, Walk, and Me tabs.
+- Changing password requires the current password, a valid new password, and
+  matching confirmation before submitting.
+- Successful password change clears local auth and returns the owner to sign-in.
+- Real Cognito invalidates sessions through `GlobalSignOut`; `cognito-local`
+  supports `ChangePassword` but not `GlobalSignOut`, so local harness proof
+  treats local token clearing as the enforced re-login boundary.
 - Invalid credentials and network failures surface actionable errors without
   silently falling back to an authenticated state.
 
 ## Evidence
 
 - Maestro: `apps/mobile/e2e/maestro/auth-onboarding.yaml`.
-- API: GraphQL sign-up, confirm, and sign-in request/response snippets.
-- Mobile: screenshot of authenticated tabs and command output for auth tests.
+- API: GraphQL sign-up, confirm, sign-in, and change-password request/response
+  snippets with password variables redacted.
+- Mobile: screenshot of authenticated tabs, password-change entry, and command
+  output for auth tests.
 - Observability: API logs showing the auth mutation path and no token values in
   logs.


### PR DESCRIPTION
## Summary
- Add authenticated `changePassword` GraphQL support that uses the request access token and signs the user out after a successful password change.
- Add the mobile Change Password screen from the Me tab, auth API wiring, localized copy, and focused unit coverage.
- Extend the auth onboarding Maestro journey to cover registration, confirmation, sign-in, and password change, with OTP entry stability improvements.

## Impact
- Owners can change their password from the app and are returned to sign-in so the new password is used immediately.
- Auth E2E coverage now exercises the full account lifecycle through password change.
- OTP paste/multi-character input now distributes digits across fields, improving both E2E reliability and user input behavior.

## Validation
- Maestro E2E on iPhone 17 Pro Simulator / iOS 26.5: sign up -> confirm -> sign in -> change password -> Welcome back.
- `npm test -- --runInBand --forceExit`
- `npm run typecheck`
- `npm run lint` (0 errors, existing Expo generated warning only)
- Docker API tests: `cargo test --target-dir /tmp/walking-dog-target -j 1`
- `node scripts/harness/validate-all.mjs`
- `git diff --check`