### PR TITLE
[codex] Gate auth submits by password policy

### DIFF
--- a/apps/mobile/__tests__/app/user/change-password.test.tsx
+++ b/apps/mobile/__tests__/app/user/change-password.test.tsx
@@ -30,21 +30,27 @@ describe('ChangePasswordScreen', () => {
     expect(screen.getByRole('button', { name: 'Update password' })).toBeDisabled();
 
     fireEvent.changeText(screen.getByLabelText('Current password'), 'Currentpass1');
+    fireEvent.changeText(screen.getByLabelText('New password'), 'password123');
+    fireEvent.changeText(screen.getByLabelText('Confirm password'), 'password123');
+
+    expect(screen.getByRole('button', { name: 'Update password' })).toBeDisabled();
+
     fireEvent.changeText(screen.getByLabelText('New password'), 'Newpass1');
     fireEvent.changeText(screen.getByLabelText('Confirm password'), 'Newpass1');
 
     expect(screen.getByRole('button', { name: 'Update password' })).not.toBeDisabled();
   });
 
-  it('shows a mismatch error without calling the API', async () => {
+  it('keeps submit disabled until confirmation matches the new password', async () => {
     render(<ChangePasswordScreen />);
 
     fireEvent.changeText(screen.getByLabelText('Current password'), 'Currentpass1');
     fireEvent.changeText(screen.getByLabelText('New password'), 'Newpass1');
     fireEvent.changeText(screen.getByLabelText('Confirm password'), 'Different1');
-    fireEvent.press(screen.getByRole('button', { name: 'Update password' }));
 
-    expect(screen.getByText('Passwords do not match')).toBeTruthy();
+    const button = screen.getByRole('button', { name: 'Update password' });
+    expect(button).toBeDisabled();
+    fireEvent.press(button);
     expect(mockChangePassword).not.toHaveBeenCalled();
   });
 

--- a/apps/mobile/app/user/change-password.tsx
+++ b/apps/mobile/app/user/change-password.tsx
@@ -10,9 +10,9 @@ import { TextInput } from '@/components/ui/TextInput';
 import { useAuth } from '@/hooks/use-auth';
 import { useColors } from '@/hooks/use-colors';
 import { toAuthError } from '@/lib/auth/errors';
+import { isValidPassword, PASSWORD_RULES_DESCRIPTOR } from '@/lib/auth/password-policy';
 import { spacing, typography } from '@/theme/tokens';
 
-const PASSWORD_MIN_LENGTH = 8;
 const isE2EBuild = process.env.EXPO_PUBLIC_E2E === '1';
 
 export default function ChangePasswordScreen() {
@@ -28,8 +28,9 @@ export default function ChangePasswordScreen() {
 
   const canSubmit =
     currentPassword.length > 0 &&
-    newPassword.length >= PASSWORD_MIN_LENGTH &&
+    isValidPassword(newPassword) &&
     confirmPassword.length > 0 &&
+    newPassword === confirmPassword &&
     !submitting;
 
   async function handleSubmit() {
@@ -96,7 +97,7 @@ export default function ChangePasswordScreen() {
             onChangeText={setNewPassword}
             secureTextEntry={!isE2EBuild}
             textContentType={isE2EBuild ? 'none' : 'newPassword'}
-            passwordRules={isE2EBuild ? undefined : 'minlength: 8;'}
+            passwordRules={isE2EBuild ? undefined : PASSWORD_RULES_DESCRIPTOR}
             autoComplete={isE2EBuild ? 'off' : 'password-new'}
           />
           <TextInput
@@ -107,7 +108,7 @@ export default function ChangePasswordScreen() {
             onChangeText={setConfirmPassword}
             secureTextEntry={!isE2EBuild}
             textContentType={isE2EBuild ? 'none' : 'newPassword'}
-            passwordRules={isE2EBuild ? undefined : 'minlength: 8;'}
+            passwordRules={isE2EBuild ? undefined : PASSWORD_RULES_DESCRIPTOR}
             autoComplete={isE2EBuild ? 'off' : 'password-new'}
           />
         </GroupedCard>

--- a/apps/mobile/components/auth/PasswordResetForm.test.tsx
+++ b/apps/mobile/components/auth/PasswordResetForm.test.tsx
@@ -63,7 +63,25 @@ describe('PasswordResetForm', () => {
     expect(mockOnComplete).toHaveBeenCalledTimes(1);
   });
 
-  it('shows a password mismatch message without calling the reset API', async () => {
+  it('keeps reset disabled when the new password does not meet policy', async () => {
+    mockForgotPassword.mockResolvedValue(true);
+    render(<PasswordResetForm onComplete={mockOnComplete} />);
+
+    fireEvent.changeText(screen.getByLabelText('Email'), 'user@example.com');
+    fireEvent.press(screen.getByRole('button', { name: 'Send reset code' }));
+    await screen.findByText('Check your email');
+
+    fillCode('123456');
+    fireEvent.changeText(screen.getByLabelText('New password'), 'password123');
+    fireEvent.changeText(screen.getByLabelText('Confirm'), 'password123');
+
+    const button = screen.getByRole('button', { name: 'Reset password' });
+    expect(button).toBeDisabled();
+    fireEvent.press(button);
+    expect(mockConfirmForgotPassword).not.toHaveBeenCalled();
+  });
+
+  it('keeps reset disabled until confirmation matches the new password', async () => {
     mockForgotPassword.mockResolvedValue(true);
     render(<PasswordResetForm onComplete={mockOnComplete} />);
 
@@ -74,9 +92,10 @@ describe('PasswordResetForm', () => {
     fillCode('123456');
     fireEvent.changeText(screen.getByLabelText('New password'), 'Newpass1');
     fireEvent.changeText(screen.getByLabelText('Confirm'), 'Different1');
-    fireEvent.press(screen.getByRole('button', { name: 'Reset password' }));
 
-    expect(screen.getByText('Passwords do not match')).toBeTruthy();
+    const button = screen.getByRole('button', { name: 'Reset password' });
+    expect(button).toBeDisabled();
+    fireEvent.press(button);
     expect(mockConfirmForgotPassword).not.toHaveBeenCalled();
   });
 

--- a/apps/mobile/components/auth/PasswordResetForm.tsx
+++ b/apps/mobile/components/auth/PasswordResetForm.tsx
@@ -14,6 +14,7 @@ import { TextInput } from '@/components/ui/TextInput';
 import { useColors } from '@/hooks/use-colors';
 import { useOtpInput } from '@/hooks/use-otp-input';
 import { toAuthError } from '@/lib/auth/errors';
+import { isValidPassword, PASSWORD_RULES_DESCRIPTOR } from '@/lib/auth/password-policy';
 import { components, radius, spacing, typography } from '@/theme/tokens';
 
 interface PasswordResetFormProps {
@@ -23,7 +24,6 @@ interface PasswordResetFormProps {
 type Step = 'request' | 'confirm' | 'done';
 
 const CODE_LENGTH = 6;
-const PASSWORD_MIN_LENGTH = 8;
 
 export function PasswordResetForm({ onComplete }: PasswordResetFormProps) {
   const { forgotPassword, confirmForgotPassword } = useAuth();
@@ -42,8 +42,9 @@ export function PasswordResetForm({ onComplete }: PasswordResetFormProps) {
   const canRequestCode = email.length > 0;
   const canReset =
     otp.isComplete &&
-    newPassword.length >= PASSWORD_MIN_LENGTH &&
-    confirmPassword.length > 0;
+    isValidPassword(newPassword) &&
+    confirmPassword.length > 0 &&
+    newPassword === confirmPassword;
 
   async function handleRequestCode() {
     if (!canRequestCode) return;
@@ -192,7 +193,7 @@ export function PasswordResetForm({ onComplete }: PasswordResetFormProps) {
             onChangeText={setNewPassword}
             secureTextEntry
             textContentType="newPassword"
-            passwordRules="minlength: 8;"
+            passwordRules={PASSWORD_RULES_DESCRIPTOR}
             autoComplete="password-new"
           />
           <TextInput
@@ -203,7 +204,7 @@ export function PasswordResetForm({ onComplete }: PasswordResetFormProps) {
             onChangeText={setConfirmPassword}
             secureTextEntry
             textContentType="newPassword"
-            passwordRules="minlength: 8;"
+            passwordRules={PASSWORD_RULES_DESCRIPTOR}
             autoComplete="password-new"
           />
         </GroupedCard>

--- a/apps/mobile/components/auth/RegisterForm.test.tsx
+++ b/apps/mobile/components/auth/RegisterForm.test.tsx
@@ -30,10 +30,18 @@ describe('RegisterForm', () => {
     expect(screen.getByText(/dog's profile on the next step/i)).toBeTruthy();
   });
 
-  it('disables Continue when fields are empty or password too short', () => {
+  it('disables Continue when fields are empty or password does not meet policy', () => {
     render(<RegisterForm onSuccess={jest.fn()} />);
     const button = screen.getByRole('button', { name: 'Continue' });
     expect(button).toBeDisabled();
+
+    fireEvent.changeText(screen.getByLabelText('Your name'), 'Taro');
+    fireEvent.changeText(screen.getByLabelText('Email'), 'new@example.com');
+    fireEvent.changeText(screen.getByLabelText('Password'), 'password123');
+
+    expect(button).toBeDisabled();
+    fireEvent.press(button);
+    expect(mockSignUp).not.toHaveBeenCalled();
   });
 
   it('calls signUp with form values on Continue', async () => {
@@ -42,11 +50,11 @@ describe('RegisterForm', () => {
 
     fireEvent.changeText(screen.getByLabelText('Your name'), 'Taro');
     fireEvent.changeText(screen.getByLabelText('Email'), 'new@example.com');
-    fireEvent.changeText(screen.getByLabelText('Password'), 'password123');
+    fireEvent.changeText(screen.getByLabelText('Password'), 'Password123');
     fireEvent.press(screen.getByRole('button', { name: 'Continue' }));
 
     await waitFor(() => {
-      expect(mockSignUp).toHaveBeenCalledWith('new@example.com', 'password123', 'Taro');
+      expect(mockSignUp).toHaveBeenCalledWith('new@example.com', 'Password123', 'Taro');
     });
   });
 
@@ -56,7 +64,7 @@ describe('RegisterForm', () => {
 
     fireEvent.changeText(screen.getByLabelText('Your name'), 'Taro');
     fireEvent.changeText(screen.getByLabelText('Email'), 'new@example.com');
-    fireEvent.changeText(screen.getByLabelText('Password'), 'password123');
+    fireEvent.changeText(screen.getByLabelText('Password'), 'Password123');
     fireEvent.press(screen.getByRole('button', { name: 'Continue' }));
 
     await waitFor(() => {
@@ -70,7 +78,7 @@ describe('RegisterForm', () => {
 
     fireEvent.changeText(screen.getByLabelText('Your name'), 'Taro');
     fireEvent.changeText(screen.getByLabelText('Email'), 'new@example.com');
-    fireEvent.changeText(screen.getByLabelText('Password'), 'password123');
+    fireEvent.changeText(screen.getByLabelText('Password'), 'Password123');
     fireEvent.press(screen.getByRole('button', { name: 'Continue' }));
 
     await waitFor(() => {
@@ -84,7 +92,7 @@ describe('RegisterForm', () => {
 
     fireEvent.changeText(screen.getByLabelText('Your name'), 'Taro');
     fireEvent.changeText(screen.getByLabelText('Email'), 'new@example.com');
-    fireEvent.changeText(screen.getByLabelText('Password'), 'password123');
+    fireEvent.changeText(screen.getByLabelText('Password'), 'Password123');
     fireEvent.press(screen.getByRole('button', { name: 'Continue' }));
 
     await waitFor(() => {

--- a/apps/mobile/components/auth/RegisterForm.tsx
+++ b/apps/mobile/components/auth/RegisterForm.tsx
@@ -7,6 +7,7 @@ import { GroupedCard } from '@/components/ui/GroupedCard';
 import { TextInput } from '@/components/ui/TextInput';
 import { useColors } from '@/hooks/use-colors';
 import { toAuthError } from '@/lib/auth/errors';
+import { isValidPassword, PASSWORD_RULES_DESCRIPTOR } from '@/lib/auth/password-policy';
 import { PRIVACY_POLICY_URL, TERMS_URL } from '@/lib/legal-urls';
 import { spacing, typography } from '@/theme/tokens';
 
@@ -28,7 +29,7 @@ export function RegisterForm({ onSuccess }: RegisterFormProps) {
   const [loading, setLoading] = useState(false);
 
   const isValid =
-    email.length > 0 && password.length >= 8 && displayName.length > 0;
+    email.length > 0 && isValidPassword(password) && displayName.length > 0;
 
   async function handleSubmit() {
     if (!isValid) return;
@@ -62,7 +63,7 @@ export function RegisterForm({ onSuccess }: RegisterFormProps) {
   }
 
   const passwordError =
-    password.length > 0 && password.length < 8
+    password.length > 0 && !isValidPassword(password)
       ? t('auth.register.passwordError')
       : undefined;
 
@@ -99,7 +100,7 @@ export function RegisterForm({ onSuccess }: RegisterFormProps) {
           onChangeText={setPassword}
           secureTextEntry={!isE2EBuild}
           textContentType={isE2EBuild ? 'none' : 'newPassword'}
-          passwordRules={isE2EBuild ? undefined : 'minlength: 8;'}
+          passwordRules={isE2EBuild ? undefined : PASSWORD_RULES_DESCRIPTOR}
           autoComplete={isE2EBuild ? 'off' : 'password-new'}
           error={passwordError}
         />

--- a/apps/mobile/e2e/maestro/auth-onboarding.yaml
+++ b/apps/mobile/e2e/maestro/auth-onboarding.yaml
@@ -12,7 +12,7 @@ tags:
 env:
   E2E_NAME: Harness Owner
   E2E_EMAIL: harness-auth@example.com
-  E2E_PASSWORD: password123
+  E2E_PASSWORD: Password123
   E2E_NEW_PASSWORD: Newpass1
   E2E_CONFIRMATION_CODE: "123456"
 ---

--- a/apps/mobile/lib/auth/password-policy.test.ts
+++ b/apps/mobile/lib/auth/password-policy.test.ts
@@ -1,0 +1,29 @@
+import { isValidPassword, PASSWORD_RULES_DESCRIPTOR } from './password-policy';
+
+describe('password policy', () => {
+  it('accepts passwords that meet the Cognito policy', () => {
+    expect(isValidPassword('Password1')).toBe(true);
+  });
+
+  it('rejects passwords shorter than eight characters', () => {
+    expect(isValidPassword('Pass1')).toBe(false);
+  });
+
+  it('rejects passwords without an uppercase letter', () => {
+    expect(isValidPassword('password1')).toBe(false);
+  });
+
+  it('rejects passwords without a lowercase letter', () => {
+    expect(isValidPassword('PASSWORD1')).toBe(false);
+  });
+
+  it('rejects passwords without a number', () => {
+    expect(isValidPassword('Password')).toBe(false);
+  });
+
+  it('exports the native password rules descriptor for autofill', () => {
+    expect(PASSWORD_RULES_DESCRIPTOR).toBe(
+      'minlength: 8; required: upper; required: lower; required: digit;',
+    );
+  });
+});

--- a/apps/mobile/lib/auth/password-policy.ts
+++ b/apps/mobile/lib/auth/password-policy.ts
@@ -1,0 +1,18 @@
+export const PASSWORD_REQUIREMENTS = {
+  minimumLength: 8,
+  requiresUppercase: true,
+  requiresLowercase: true,
+  requiresNumber: true,
+} as const;
+
+export const PASSWORD_RULES_DESCRIPTOR =
+  'minlength: 8; required: upper; required: lower; required: digit;';
+
+export function isValidPassword(password: string): boolean {
+  return (
+    password.length >= PASSWORD_REQUIREMENTS.minimumLength &&
+    /[A-Z]/.test(password) &&
+    /[a-z]/.test(password) &&
+    /[0-9]/.test(password)
+  );
+}

--- a/apps/mobile/lib/i18n/locales/en.json
+++ b/apps/mobile/lib/i18n/locales/en.json
@@ -39,7 +39,7 @@
       "displayName": "Your name",
       "email": "Email",
       "password": "Password",
-      "passwordError": "Must be at least 8 characters",
+      "passwordError": "Use at least 8 characters with uppercase, lowercase, and a number.",
       "submit": "Continue",
       "loginLink": "Already have an account? Login",
       "back": "Back",

--- a/apps/mobile/lib/i18n/locales/ja.json
+++ b/apps/mobile/lib/i18n/locales/ja.json
@@ -39,7 +39,7 @@
       "displayName": "お名前",
       "email": "メール",
       "password": "パスワード",
-      "passwordError": "8文字以上で入力してください",
+      "passwordError": "8文字以上で、大文字・小文字・数字を含めてください。",
       "submit": "次へ",
       "loginLink": "ログインはこちら",
       "back": "戻る",


### PR DESCRIPTION
## Summary
- Add a shared mobile password policy helper matching Cognito requirements: 8+ characters, uppercase, lowercase, and number.
- Disable register, password reset, and password change submits until password policy and confirmation requirements are met.
- Update password autofill rules, localized password guidance, unit tests, and the Maestro auth onboarding password fixture.

## Product Impact
- Owner contribution: prevents avoidable failed auth submissions before owners continue setup or return to walks.
- Dog experience: keeps account setup and return flows smoother so owners can get back to dog setup and walks.
- Walk data: no direct data model change.

## Validation
- `cd apps/mobile && npm test -- --runInBand --forceExit` — 123 suites / 780 tests passed.
- `cd apps/mobile && npm run typecheck` — exit 0.
- `cd apps/mobile && npm run lint` — exit 0, with one existing `.expo/types/router.d.ts` unused eslint-disable warning.
- `node scripts/harness/validate-all.mjs` — exit 0.
- Maestro `apps/mobile/e2e/maestro/auth-onboarding.yaml` — exit 0 on iPhone 17 Pro simulator after Release build.