### PR TITLE
[codex] Add login email change flow

### DIFF
--- a/apps/api/schema.graphql
+++ b/apps/api/schema.graphql
@@ -39,7 +39,8 @@ input ChangeEmailInput {
 }
 
 type ChangeEmailOutput {
-	success: Boolean!
+	email: String!
+	codeLength: Int!
 }
 
 input ConfirmEmailChangeInput {
@@ -47,7 +48,7 @@ input ConfirmEmailChangeInput {
 }
 
 type ConfirmEmailChangeOutput {
-	success: Boolean!
+	email: String!
 }
 
 type Coordinate {
@@ -284,6 +285,7 @@ type User {
 	avatar: Url
 	createdAt: DateTime!
 	updatedAt: DateTime!
+	email: String!
 	dogs: [Dog!]!
 	walks(after: String, before: String, first: Int, last: Int): WalkConnection!
 }

--- a/apps/api/src/graphql/error.rs
+++ b/apps/api/src/graphql/error.rs
@@ -82,6 +82,7 @@ fn auth_error_status_code(operation: AuthOperation) -> i32 {
     match operation {
         AuthOperation::RequestOneTimePassword
         | AuthOperation::SignIn
+        | AuthOperation::GetUser
         | AuthOperation::AdminGetUser
         | AuthOperation::AdminDeleteUser
         | AuthOperation::VerifyOneTimePassword

--- a/apps/api/src/graphql/mutation/auth.rs
+++ b/apps/api/src/graphql/mutation/auth.rs
@@ -6,7 +6,10 @@ use crate::entity::user;
 use crate::graphql::AuthAccessToken;
 use crate::graphql::error::AppError;
 use crate::graphql::{error::AuthError, guard::AuthGuard};
-use crate::service::auth::{AuthTokenPair, OneTimePasswordChallenge, SharedAuthGateway};
+use crate::service::auth::{
+    AuthTokenPair, EmailChangeChallenge, EmailChangeConfirmation, OneTimePasswordChallenge,
+    SharedAuthGateway,
+};
 
 #[derive(Default, Debug)]
 pub struct AuthMutation;
@@ -84,11 +87,11 @@ impl AuthMutation {
         let authorization = ctx
             .data::<AuthAccessToken>()
             .map_err(|_| AppError::Unauthorized)?;
-        auth_gateway
+        let output = auth_gateway
             .change_email(authorization.token(), input.new_email)
             .await
             .map_err(AuthError::from)?;
-        Ok(ChangeEmailOutput { success: true })
+        Ok(output.into())
     }
 
     #[graphql(guard = "AuthGuard")]
@@ -101,11 +104,11 @@ impl AuthMutation {
         let authorization = ctx
             .data::<AuthAccessToken>()
             .map_err(|_| AppError::Unauthorized)?;
-        auth_gateway
+        let output = auth_gateway
             .confirm_email_change(authorization.token(), input.code)
             .await
             .map_err(AuthError::from)?;
-        Ok(ConfirmEmailChangeOutput { success: true })
+        Ok(output.into())
     }
 }
 
@@ -185,7 +188,17 @@ pub struct ChangeEmailInput {
 
 #[derive(SimpleObject)]
 pub struct ChangeEmailOutput {
-    success: bool,
+    email: String,
+    code_length: i32,
+}
+
+impl From<EmailChangeChallenge> for ChangeEmailOutput {
+    fn from(output: EmailChangeChallenge) -> Self {
+        Self {
+            email: output.email,
+            code_length: output.code_length,
+        }
+    }
 }
 
 #[derive(Clone, Debug, InputObject)]
@@ -195,5 +208,13 @@ pub struct ConfirmEmailChangeInput {
 
 #[derive(SimpleObject)]
 pub struct ConfirmEmailChangeOutput {
-    success: bool,
+    email: String,
+}
+
+impl From<EmailChangeConfirmation> for ConfirmEmailChangeOutput {
+    fn from(output: EmailChangeConfirmation) -> Self {
+        Self {
+            email: output.email,
+        }
+    }
 }

--- a/apps/api/src/graphql/object/user.rs
+++ b/apps/api/src/graphql/object/user.rs
@@ -9,11 +9,13 @@ use uuid::Uuid;
 use crate::{
     entity::{dog, user, user_dog},
     graphql::{
+        AuthAccessToken,
         cursor::UuidCursor,
         error::AppError,
         object::{dog::Dog, walk::Walk, walk_connection::WalkConnectionFields},
     },
     service::{
+        auth::SharedAuthGateway,
         storage::avatar_url_from_env as avatar_url,
         walk_read_model::{self, WalkHistoryRequest},
     },
@@ -31,6 +33,18 @@ pub struct User {
 
 #[ComplexObject]
 impl User {
+    async fn email(&self, ctx: &Context<'_>) -> Result<String> {
+        let auth_gateway = ctx.data::<SharedAuthGateway>().unwrap();
+        let authorization = ctx
+            .data::<AuthAccessToken>()
+            .map_err(|_| AppError::Unauthorized)?;
+        auth_gateway
+            .current_email(authorization.token())
+            .await
+            .map_err(crate::graphql::error::AuthError::from)
+            .map_err(Into::into)
+    }
+
     async fn dogs(&self, ctx: &Context<'_>) -> Result<Vec<Dog>> {
         let db = ctx.data::<sea_orm::DatabaseConnection>().unwrap();
         let dogs = dog::Entity::find()

--- a/apps/api/src/service/auth.rs
+++ b/apps/api/src/service/auth.rs
@@ -5,7 +5,7 @@ use aws_sdk_cognitoidentityprovider::{
     operation::{
         admin_delete_user::AdminDeleteUserError, admin_get_user::AdminGetUserError,
         confirm_sign_up::ConfirmSignUpError,
-        get_tokens_from_refresh_token::GetTokensFromRefreshTokenError,
+        get_tokens_from_refresh_token::GetTokensFromRefreshTokenError, get_user::GetUserError,
         global_sign_out::GlobalSignOutError, initiate_auth::InitiateAuthError,
         respond_to_auth_challenge::RespondToAuthChallengeError, sign_up::SignUpError,
         update_user_attributes::UpdateUserAttributesError,
@@ -19,9 +19,11 @@ pub type SharedAuthGateway = Arc<dyn AuthGateway>;
 
 const SIGN_UP_CONFIRMATION_CODE_LENGTH: i32 = 6;
 const SIGN_IN_ONE_TIME_PASSWORD_CODE_LENGTH: i32 = 8;
+const EMAIL_CHANGE_CONFIRMATION_CODE_LENGTH: i32 = 6;
 
 #[async_trait]
 pub trait AuthGateway: Send + Sync + 'static {
+    async fn current_email(&self, access_token: &str) -> Result<String, AuthGatewayError>;
     async fn request_one_time_password(
         &self,
         email: String,
@@ -39,12 +41,12 @@ pub trait AuthGateway: Send + Sync + 'static {
         &self,
         access_token: &str,
         new_email: String,
-    ) -> Result<(), AuthGatewayError>;
+    ) -> Result<EmailChangeChallenge, AuthGatewayError>;
     async fn confirm_email_change(
         &self,
         access_token: &str,
         code: String,
-    ) -> Result<(), AuthGatewayError>;
+    ) -> Result<EmailChangeConfirmation, AuthGatewayError>;
 }
 
 pub struct CognitoAuthGateway {
@@ -130,6 +132,10 @@ fn ensure_user_can_authenticate(
 
 #[async_trait]
 impl AuthGateway for CognitoAuthGateway {
+    async fn current_email(&self, access_token: &str) -> Result<String, AuthGatewayError> {
+        self.current_user_email(access_token).await
+    }
+
     async fn request_one_time_password(
         &self,
         email: String,
@@ -207,14 +213,15 @@ impl AuthGateway for CognitoAuthGateway {
         &self,
         access_token: &str,
         new_email: String,
-    ) -> Result<(), AuthGatewayError> {
+    ) -> Result<EmailChangeChallenge, AuthGatewayError> {
+        let new_email = normalize_email(new_email);
         self.client
             .update_user_attributes()
             .access_token(access_token)
             .user_attributes(
                 AttributeType::builder()
                     .name("email")
-                    .value(new_email)
+                    .value(&new_email)
                     .build()
                     .expect("email user attribute is valid"),
             )
@@ -223,14 +230,17 @@ impl AuthGateway for CognitoAuthGateway {
             .map_err(|error| {
                 AuthGatewayError::from_update_user_attributes_error(error.into_service_error())
             })?;
-        Ok(())
+        Ok(EmailChangeChallenge {
+            email: new_email,
+            code_length: EMAIL_CHANGE_CONFIRMATION_CODE_LENGTH,
+        })
     }
 
     async fn confirm_email_change(
         &self,
         access_token: &str,
         code: String,
-    ) -> Result<(), AuthGatewayError> {
+    ) -> Result<EmailChangeConfirmation, AuthGatewayError> {
         self.client
             .verify_user_attribute()
             .access_token(access_token)
@@ -241,11 +251,32 @@ impl AuthGateway for CognitoAuthGateway {
             .map_err(|error| {
                 AuthGatewayError::from_verify_user_attribute_error(error.into_service_error())
             })?;
-        Ok(())
+        Ok(EmailChangeConfirmation {
+            email: self.current_user_email(access_token).await?,
+        })
     }
 }
 
 impl CognitoAuthGateway {
+    async fn current_user_email(&self, access_token: &str) -> Result<String, AuthGatewayError> {
+        let output = self
+            .client
+            .get_user()
+            .access_token(access_token)
+            .send()
+            .await
+            .map_err(|error| AuthGatewayError::from_get_user_error(error.into_service_error()))?;
+        output
+            .user_attributes
+            .iter()
+            .find(|attribute| attribute.name() == "email")
+            .and_then(|attribute| attribute.value().map(ToOwned::to_owned))
+            .filter(|email| !email.is_empty())
+            .ok_or_else(|| {
+                AuthGatewayError::missing_provider_token(AuthOperation::GetUser, "email")
+            })
+    }
+
     async fn cognito_user_state(
         &self,
         email: &str,
@@ -454,6 +485,17 @@ pub struct AuthTokenPair {
     pub refresh_token: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmailChangeChallenge {
+    pub email: String,
+    pub code_length: i32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmailChangeConfirmation {
+    pub email: String,
+}
+
 impl AuthTokenPair {
     fn from_auth_result(
         operation: AuthOperation,
@@ -485,6 +527,7 @@ pub enum AuthOperation {
     RequestOneTimePassword,
     SignUp,
     SignIn,
+    GetUser,
     AdminGetUser,
     AdminDeleteUser,
     VerifyOneTimePassword,
@@ -500,6 +543,7 @@ impl fmt::Display for AuthOperation {
             AuthOperation::RequestOneTimePassword => "Request one-time password",
             AuthOperation::SignUp => "Sign up",
             AuthOperation::SignIn => "Sign in",
+            AuthOperation::GetUser => "Get user",
             AuthOperation::AdminGetUser => "Admin get user",
             AuthOperation::AdminDeleteUser => "Admin delete user",
             AuthOperation::VerifyOneTimePassword => "Verify one-time password",
@@ -592,6 +636,10 @@ impl AuthGatewayError {
 
     fn from_admin_get_user_error(error: AdminGetUserError) -> Self {
         Self::from_provider_error(AuthOperation::AdminGetUser, error)
+    }
+
+    fn from_get_user_error(error: GetUserError) -> Self {
+        Self::from_provider_error(AuthOperation::GetUser, error)
     }
 
     fn from_admin_delete_user_error(error: AdminDeleteUserError) -> Self {

--- a/apps/api/tests/auth_passwordless.rs
+++ b/apps/api/tests/auth_passwordless.rs
@@ -14,13 +14,17 @@ use walking_dog::{
     entity::user,
     graphql::{AuthAccessToken, attach_request_context, mutation::Mutation, query::Query},
     service::auth::{
-        AuthGateway, AuthGatewayError, AuthTokenPair, OneTimePasswordChallenge,
-        RequestOneTimePasswordResult, SharedAuthGateway,
+        AuthGateway, AuthGatewayError, AuthTokenPair, EmailChangeChallenge,
+        EmailChangeConfirmation, OneTimePasswordChallenge, RequestOneTimePasswordResult,
+        SharedAuthGateway,
     },
 };
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum AuthCall {
+    CurrentEmail {
+        access_token: String,
+    },
     RequestOneTimePassword {
         email: String,
     },
@@ -29,16 +33,32 @@ enum AuthCall {
         session: String,
         code: String,
     },
+    ChangeEmail {
+        access_token: String,
+        new_email: String,
+    },
+    ConfirmEmailChange {
+        access_token: String,
+        code: String,
+    },
 }
 
 #[derive(Default)]
 struct RecordingAuthGateway {
     calls: Arc<Mutex<Vec<AuthCall>>>,
     created_user_sub: Option<String>,
+    current_email: String,
 }
 
 #[async_trait]
 impl AuthGateway for RecordingAuthGateway {
+    async fn current_email(&self, access_token: &str) -> Result<String, AuthGatewayError> {
+        self.calls.lock().unwrap().push(AuthCall::CurrentEmail {
+            access_token: access_token.to_owned(),
+        });
+        Ok(self.current_email.clone())
+    }
+
     async fn request_one_time_password(
         &self,
         email: String,
@@ -92,18 +112,34 @@ impl AuthGateway for RecordingAuthGateway {
 
     async fn change_email(
         &self,
-        _access_token: &str,
-        _new_email: String,
-    ) -> Result<(), AuthGatewayError> {
-        unimplemented!("passwordless tests should not change email")
+        access_token: &str,
+        new_email: String,
+    ) -> Result<EmailChangeChallenge, AuthGatewayError> {
+        self.calls.lock().unwrap().push(AuthCall::ChangeEmail {
+            access_token: access_token.to_owned(),
+            new_email: new_email.clone(),
+        });
+        Ok(EmailChangeChallenge {
+            email: new_email,
+            code_length: 6,
+        })
     }
 
     async fn confirm_email_change(
         &self,
-        _access_token: &str,
-        _code: String,
-    ) -> Result<(), AuthGatewayError> {
-        unimplemented!("passwordless tests should not confirm email changes")
+        access_token: &str,
+        code: String,
+    ) -> Result<EmailChangeConfirmation, AuthGatewayError> {
+        self.calls
+            .lock()
+            .unwrap()
+            .push(AuthCall::ConfirmEmailChange {
+                access_token: access_token.to_owned(),
+                code,
+            });
+        Ok(EmailChangeConfirmation {
+            email: self.current_email.clone(),
+        })
     }
 }
 
@@ -133,6 +169,14 @@ fn user_model() -> user::Model {
         created_at: fixed_time(),
         updated_at: fixed_time(),
     }
+}
+
+fn authenticated_request(query: &str) -> Request {
+    attach_request_context(
+        Request::new(query),
+        Some(user_model()),
+        Some(AuthAccessToken::new("access-token")),
+    )
 }
 
 #[tokio::test]
@@ -296,6 +340,136 @@ async fn verify_one_time_password_returns_tokens() {
         vec![AuthCall::VerifyOneTimePassword {
             email: "mio@example.com".to_owned(),
             session: "otp-session".to_owned(),
+            code: "123456".to_owned(),
+        }]
+    );
+}
+
+#[tokio::test]
+async fn user_query_resolves_current_login_email_from_auth_gateway() {
+    let gateway = RecordingAuthGateway {
+        current_email: "mio@walk.app".to_owned(),
+        ..Default::default()
+    };
+    let calls = gateway.calls.clone();
+    let schema = Schema::build(Query::default(), Mutation::default(), EmptySubscription)
+        .data(Arc::new(gateway) as SharedAuthGateway)
+        .finish();
+    let request = authenticated_request(
+        r#"
+        query User {
+          user {
+            id
+            email
+          }
+        }
+        "#,
+    );
+
+    let response = schema.execute(request).await;
+
+    assert!(response.errors.is_empty(), "{:?}", response.errors);
+    assert_eq!(
+        response.data.into_json().unwrap(),
+        json!({
+            "user": {
+                "id": "019e0dc4-066b-7a22-b755-969ee6beb5e9",
+                "email": "mio@walk.app"
+            }
+        })
+    );
+    assert_eq!(
+        *calls.lock().unwrap(),
+        vec![AuthCall::CurrentEmail {
+            access_token: "access-token".to_owned(),
+        }]
+    );
+}
+
+#[tokio::test]
+async fn change_email_returns_confirmation_destination_and_code_length() {
+    let gateway = RecordingAuthGateway::default();
+    let calls = gateway.calls.clone();
+    let schema = Schema::build(Query::default(), Mutation::default(), EmptySubscription)
+        .data(Arc::new(gateway) as SharedAuthGateway)
+        .finish();
+    let request = authenticated_request(
+        r#"
+        mutation ChangeEmail($input: ChangeEmailInput!) {
+          changeEmail(input: $input) {
+            email
+            codeLength
+          }
+        }
+        "#,
+    )
+    .variables(Variables::from_json(json!({
+        "input": {
+            "newEmail": "new-mio@walk.app"
+        }
+    })));
+
+    let response = schema.execute(request).await;
+
+    assert!(response.errors.is_empty(), "{:?}", response.errors);
+    assert_eq!(
+        response.data.into_json().unwrap(),
+        json!({
+            "changeEmail": {
+                "email": "new-mio@walk.app",
+                "codeLength": 6
+            }
+        })
+    );
+    assert_eq!(
+        *calls.lock().unwrap(),
+        vec![AuthCall::ChangeEmail {
+            access_token: "access-token".to_owned(),
+            new_email: "new-mio@walk.app".to_owned(),
+        }]
+    );
+}
+
+#[tokio::test]
+async fn confirm_email_change_returns_confirmed_login_email() {
+    let gateway = RecordingAuthGateway {
+        current_email: "new-mio@walk.app".to_owned(),
+        ..Default::default()
+    };
+    let calls = gateway.calls.clone();
+    let schema = Schema::build(Query::default(), Mutation::default(), EmptySubscription)
+        .data(Arc::new(gateway) as SharedAuthGateway)
+        .finish();
+    let request = authenticated_request(
+        r#"
+        mutation ConfirmEmailChange($input: ConfirmEmailChangeInput!) {
+          confirmEmailChange(input: $input) {
+            email
+          }
+        }
+        "#,
+    )
+    .variables(Variables::from_json(json!({
+        "input": {
+            "code": "123456"
+        }
+    })));
+
+    let response = schema.execute(request).await;
+
+    assert!(response.errors.is_empty(), "{:?}", response.errors);
+    assert_eq!(
+        response.data.into_json().unwrap(),
+        json!({
+            "confirmEmailChange": {
+                "email": "new-mio@walk.app"
+            }
+        })
+    );
+    assert_eq!(
+        *calls.lock().unwrap(),
+        vec![AuthCall::ConfirmEmailChange {
+            access_token: "access-token".to_owned(),
             code: "123456".to_owned(),
         }]
     );

--- a/apps/api/tests/schema_auth_reset.rs
+++ b/apps/api/tests/schema_auth_reset.rs
@@ -38,4 +38,25 @@ fn schema_removes_password_lifecycle_mutations() {
     assert!(!sdl.contains("password: String!"));
     assert!(!sdl.contains("newPassword"));
     assert!(!sdl.contains("oldPassword"));
+    assert!(!sdl.contains("ChangePassword"));
+    assert!(!sdl.contains("changePassword"));
+}
+
+#[test]
+fn schema_exposes_email_change_without_legacy_success_flags() {
+    let schema =
+        async_graphql::Schema::build(Query::default(), Mutation::default(), EmptySubscription)
+            .finish();
+    let sdl = schema.sdl();
+
+    assert!(sdl.contains("email: String!"));
+    assert!(sdl.contains("changeEmail(input: ChangeEmailInput!): ChangeEmailOutput!"));
+    assert!(sdl.contains(
+        "confirmEmailChange(input: ConfirmEmailChangeInput!): ConfirmEmailChangeOutput!"
+    ));
+    assert!(sdl.contains("type ChangeEmailOutput"));
+    assert!(sdl.contains("codeLength: Int!"));
+    assert!(sdl.contains("type ConfirmEmailChangeOutput"));
+    assert!(!sdl.contains("type ChangeEmailOutput {\n\tsuccess: Boolean!"));
+    assert!(!sdl.contains("type ConfirmEmailChangeOutput {\n\tsuccess: Boolean!"));
 }

--- a/apps/mobile/__tests__/app/settings/email.test.tsx
+++ b/apps/mobile/__tests__/app/settings/email.test.tsx
@@ -1,0 +1,157 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import EmailSettingsScreen from '../../../app/settings/email';
+
+const mockBack = jest.fn();
+const mockChangeEmail = jest.fn();
+const mockConfirmEmailChange = jest.fn();
+const mockInvalidateUserQueries = jest.fn();
+const mockRefetch = jest.fn();
+let mockMe = {
+  id: 'user-1',
+  name: 'Mio Tanaka',
+  email: 'mio@walk.app',
+  avatar: null,
+  avatarUrl: null,
+  displayName: 'Mio Tanaka',
+  createdAt: '2024-03-10T00:00:00Z',
+  updatedAt: '2026-05-01T00:00:00Z',
+  dogs: [],
+};
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ back: mockBack }),
+}));
+
+jest.mock('@/hooks/use-color-scheme', () => ({
+  useColorScheme: () => 'light',
+}));
+
+jest.mock('@/hooks/use-auth', () => ({
+  useAuth: () => ({
+    changeEmail: mockChangeEmail,
+    confirmEmailChange: mockConfirmEmailChange,
+  }),
+}));
+
+jest.mock('@/hooks/use-me', () => ({
+  useMe: () => ({
+    data: mockMe,
+    isLoading: false,
+    error: null,
+    refetch: mockRefetch,
+  }),
+}));
+
+jest.mock('@/hooks/use-invalidate-user-queries', () => ({
+  useInvalidateUserQueries: () => mockInvalidateUserQueries,
+}));
+
+describe('EmailSettingsScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockMe = {
+      ...mockMe,
+      email: 'mio@walk.app',
+    };
+  });
+
+  it('shows the current login email and disables same-email submission', () => {
+    render(<EmailSettingsScreen />);
+
+    expect(screen.getByRole('header', { name: 'Change email' })).toBeTruthy();
+    expect(screen.getByText('mio@walk.app')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Change password' })).toBeNull();
+
+    fireEvent.changeText(screen.getByLabelText('New email'), 'mio@walk.app');
+    expect(screen.getByRole('button', { name: 'Send code' }).props.accessibilityState).toEqual({
+      disabled: true,
+    });
+  });
+
+  it('sends a code, confirms it, invalidates user data, and returns', async () => {
+    mockChangeEmail.mockResolvedValue({
+      email: 'new-mio@walk.app',
+      codeLength: 6,
+    });
+    mockConfirmEmailChange.mockResolvedValue({
+      email: 'new-mio@walk.app',
+    });
+    mockInvalidateUserQueries.mockResolvedValue(undefined);
+
+    render(<EmailSettingsScreen />);
+
+    fireEvent.changeText(screen.getByLabelText('New email'), 'new-mio@walk.app');
+    fireEvent.press(screen.getByRole('button', { name: 'Send code' }));
+
+    await waitFor(() => {
+      expect(mockChangeEmail).toHaveBeenCalledWith('new-mio@walk.app');
+    });
+    expect(screen.getByText('Enter the 6-digit code sent to new-mio@walk.app.')).toBeTruthy();
+
+    fireEvent.changeText(screen.getByLabelText('One-time password'), '123456');
+
+    await waitFor(() => {
+      expect(mockConfirmEmailChange).toHaveBeenCalledWith('123456');
+      expect(mockInvalidateUserQueries).toHaveBeenCalledTimes(1);
+      expect(mockBack).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('shows invalid code errors and allows retry', async () => {
+    mockChangeEmail.mockResolvedValue({
+      email: 'new-mio@walk.app',
+      codeLength: 6,
+    });
+    mockConfirmEmailChange
+      .mockRejectedValueOnce({ kind: 'code-mismatch', reason: 'invalid' })
+      .mockResolvedValueOnce({ email: 'new-mio@walk.app' });
+    mockInvalidateUserQueries.mockResolvedValue(undefined);
+
+    render(<EmailSettingsScreen />);
+
+    fireEvent.changeText(screen.getByLabelText('New email'), 'new-mio@walk.app');
+    fireEvent.press(screen.getByRole('button', { name: 'Send code' }));
+    await screen.findByLabelText('One-time password');
+
+    fireEvent.changeText(screen.getByLabelText('One-time password'), '000000');
+    await waitFor(() => {
+      expect(screen.getByText('Invalid code')).toBeTruthy();
+    });
+
+    fireEvent.changeText(screen.getByLabelText('One-time password'), '123456');
+    await waitFor(() => {
+      expect(mockConfirmEmailChange).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('shows expired code errors', async () => {
+    mockChangeEmail.mockResolvedValue({
+      email: 'new-mio@walk.app',
+      codeLength: 6,
+    });
+    mockConfirmEmailChange.mockRejectedValue({ kind: 'code-mismatch', reason: 'expired' });
+
+    render(<EmailSettingsScreen />);
+
+    fireEvent.changeText(screen.getByLabelText('New email'), 'new-mio@walk.app');
+    fireEvent.press(screen.getByRole('button', { name: 'Send code' }));
+    await screen.findByLabelText('One-time password');
+
+    fireEvent.changeText(screen.getByLabelText('One-time password'), '000000');
+    await waitFor(() => {
+      expect(screen.getByText('Code expired')).toBeTruthy();
+    });
+  });
+
+  it('shows network errors while sending a code', async () => {
+    mockChangeEmail.mockRejectedValue({ kind: 'network' });
+
+    render(<EmailSettingsScreen />);
+    fireEvent.changeText(screen.getByLabelText('New email'), 'other@walk.app');
+    fireEvent.press(screen.getByRole('button', { name: 'Send code' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Please check your network connection')).toBeTruthy();
+    });
+  });
+});

--- a/apps/mobile/__tests__/app/tabs/user.test.tsx
+++ b/apps/mobile/__tests__/app/tabs/user.test.tsx
@@ -61,6 +61,7 @@ describe('UserScreen', () => {
       status: 'ready',
       handleRetry: mockRetry,
       displayName: 'Mio Tanaka',
+      email: 'mio@walk.app',
       avatarUrl: null,
       initial: 'M',
       walkingSince: 'Walking since March 2024',
@@ -94,6 +95,7 @@ describe('UserScreen', () => {
     expect(screen.getByTestId('settings-header-left-action-slot')).toBeTruthy();
     expect(screen.getByTestId('settings-header-right-action-slot')).toBeTruthy();
     expect(screen.getByText('Mio Tanaka')).toBeTruthy();
+    expect(screen.getByText('mio@walk.app')).toBeTruthy();
     expect(screen.getByText('Walking since March 2024')).toBeTruthy();
     expect(screen.getByText('412.8')).toBeTruthy();
     expect(screen.getByText('This week')).toBeTruthy();
@@ -104,6 +106,9 @@ describe('UserScreen', () => {
 
     fireEvent.press(screen.getByRole('button', { name: 'Settings' }));
     expect(mockPush).toHaveBeenCalledWith('/settings');
+
+    fireEvent.press(screen.getByRole('button', { name: 'Change email' }));
+    expect(mockPush).toHaveBeenCalledWith('/settings/email');
 
     expect(screen.queryByRole('button', { name: 'Change password' })).toBeNull();
   });

--- a/apps/mobile/app/(tabs)/user.tsx
+++ b/apps/mobile/app/(tabs)/user.tsx
@@ -39,14 +39,25 @@ export default function UserScreen() {
         <UserSummary
           user={vm}
           footer={
-            <GroupedCard elevated={false} style={styles.settingsLinkCard}>
-              <GroupedRow
-                leading={<IconSymbol name="gearshape.fill" size={18} color={theme.interactive} />}
-                label={t('settings.openSettings')}
-                onPress={() => router.push('/settings')}
-                separator={false}
-              />
-            </GroupedCard>
+            <>
+              <GroupedCard elevated={false} style={styles.accountActionsCard}>
+                <GroupedRow
+                  leading={<IconSymbol name="envelope.fill" size={18} color={theme.interactive} />}
+                  label={t('user.account.changeEmail')}
+                  testID="account-change-email"
+                  onPress={() => router.push('/settings/email')}
+                  separator={false}
+                />
+              </GroupedCard>
+              <GroupedCard elevated={false} style={styles.settingsLinkCard}>
+                <GroupedRow
+                  leading={<IconSymbol name="gearshape.fill" size={18} color={theme.interactive} />}
+                  label={t('settings.openSettings')}
+                  onPress={() => router.push('/settings')}
+                  separator={false}
+                />
+              </GroupedCard>
+            </>
           }
         />
       </ScrollView>
@@ -61,7 +72,10 @@ const styles = StyleSheet.create({
     padding: spacing.lg,
     paddingBottom: spacing.xxl,
   },
-  settingsLinkCard: {
+  accountActionsCard: {
     marginTop: spacing.lg,
+  },
+  settingsLinkCard: {
+    marginTop: spacing.md,
   },
 });

--- a/apps/mobile/app/settings/_layout.tsx
+++ b/apps/mobile/app/settings/_layout.tsx
@@ -5,6 +5,7 @@ export default function SettingsLayout() {
   return (
     <Stack screenOptions={{ headerShown: false }}>
       <Stack.Screen name="index" />
+      <Stack.Screen name="email" />
     </Stack>
   );
 }

--- a/apps/mobile/app/settings/email.tsx
+++ b/apps/mobile/app/settings/email.tsx
@@ -1,0 +1,233 @@
+import { useRef, useState } from 'react';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useRouter } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { OneTimePasswordInput } from '@/components/auth/OneTimePasswordInput';
+import { emailKeyboardType } from '@/components/auth/emailKeyboard';
+import { Button } from '@/components/ui/Button';
+import { ErrorScreen } from '@/components/ui/ErrorScreen';
+import { GroupedCard } from '@/components/ui/GroupedCard';
+import { GroupedRow } from '@/components/ui/GroupedRow';
+import { LoadingScreen } from '@/components/ui/LoadingScreen';
+import { ScreenHeader } from '@/components/ui/ScreenHeader';
+import { TextInput } from '@/components/ui/TextInput';
+import { useAuth } from '@/hooks/use-auth';
+import { useColors } from '@/hooks/use-colors';
+import { useInvalidateUserQueries } from '@/hooks/use-invalidate-user-queries';
+import { useMe } from '@/hooks/use-me';
+import { toAuthError } from '@/lib/auth/errors';
+import { spacing, typography } from '@/theme/tokens';
+import type { EmailChangeChallenge } from '@/lib/auth/api';
+
+export default function EmailSettingsScreen() {
+  const { t } = useTranslation();
+  const { data: me, isLoading, error, refetch } = useMe();
+
+  if (isLoading) return <LoadingScreen />;
+  if (error || !me) {
+    return (
+      <ErrorScreen
+        message={t('user.loadError')}
+        onRetry={() => {
+          void refetch();
+        }}
+      />
+    );
+  }
+
+  return <EmailSettingsContent currentEmail={me.email} />;
+}
+
+function EmailSettingsContent({ currentEmail }: { currentEmail: string }) {
+  const { changeEmail, confirmEmailChange } = useAuth();
+  const invalidateUserQueries = useInvalidateUserQueries();
+  const { t } = useTranslation();
+  const router = useRouter();
+  const theme = useColors();
+
+  const [newEmail, setNewEmail] = useState('');
+  const [challenge, setChallenge] = useState<EmailChangeChallenge | null>(null);
+  const [code, setCode] = useState('');
+  const [error, setError] = useState('');
+  const [requestLoading, setRequestLoading] = useState(false);
+  const [verifyLoading, setVerifyLoading] = useState(false);
+  const verifyingCodeRef = useRef<string | null>(null);
+
+  const trimmedNewEmail = newEmail.trim();
+  const canRequestCode =
+    trimmedNewEmail.length > 0 &&
+    trimmedNewEmail.toLowerCase() !== currentEmail.trim().toLowerCase() &&
+    !requestLoading;
+
+  async function handleSubmit() {
+    if (!canRequestCode) return;
+
+    setError('');
+    setRequestLoading(true);
+    try {
+      const nextChallenge = await changeEmail(trimmedNewEmail);
+      setChallenge(nextChallenge);
+      setCode('');
+      verifyingCodeRef.current = null;
+    } catch (err: unknown) {
+      const authError = toAuthError(err);
+      switch (authError.kind) {
+        case 'user-exists':
+          setError(t('settings.emailChange.error.emailInUse'));
+          break;
+        case 'invalid-credentials':
+          setError(t('settings.emailChange.error.sessionExpired'));
+          break;
+        case 'network':
+          setError(t('auth.error.networkError'));
+          break;
+        default:
+          setError(t('settings.emailChange.error.sendGeneric'));
+      }
+    } finally {
+      setRequestLoading(false);
+    }
+  }
+
+  async function handleComplete(nextCode: string) {
+    if (!challenge || verifyLoading || verifyingCodeRef.current === nextCode) return;
+
+    verifyingCodeRef.current = nextCode;
+    setError('');
+    setVerifyLoading(true);
+    try {
+      await confirmEmailChange(nextCode);
+      await invalidateUserQueries();
+      router.back();
+    } catch (err: unknown) {
+      const authError = toAuthError(err);
+      switch (authError.kind) {
+        case 'code-mismatch':
+          setError(
+            authError.reason === 'expired'
+              ? t('auth.oneTimePassword.error.expiredCode')
+              : t('auth.oneTimePassword.error.invalidCode'),
+          );
+          break;
+        case 'invalid-credentials':
+          setError(t('settings.emailChange.error.sessionExpired'));
+          break;
+        case 'network':
+          setError(t('auth.error.networkError'));
+          break;
+        default:
+          setError(t('settings.emailChange.error.confirmGeneric'));
+      }
+      setCode('');
+      verifyingCodeRef.current = null;
+    } finally {
+      setVerifyLoading(false);
+    }
+  }
+
+  return (
+    <SafeAreaView edges={['top']} style={[styles.safeArea, { backgroundColor: theme.background }]}>
+      <ScreenHeader
+        variant="inline"
+        title={t('settings.emailChange.title')}
+        leftAction="back"
+      />
+      <ScrollView
+        style={styles.container}
+        contentContainerStyle={styles.content}
+        keyboardShouldPersistTaps="handled"
+      >
+        <GroupedCard elevated={false}>
+          <GroupedRow
+            label={t('settings.emailChange.currentEmail')}
+            value={currentEmail}
+            separator={false}
+            showChevron={false}
+          />
+        </GroupedCard>
+
+        {challenge ? (
+          <View style={styles.otpSection}>
+            <Text style={[styles.description, { color: theme.onSurfaceVariant }]}>
+              {t('auth.oneTimePassword.description', {
+                count: challenge.codeLength,
+                email: challenge.email,
+              })}
+            </Text>
+            <OneTimePasswordInput
+              value={code}
+              onChange={setCode}
+              onComplete={handleComplete}
+              length={challenge.codeLength}
+              disabled={verifyLoading}
+            />
+            {verifyLoading ? (
+              <Text style={[styles.status, { color: theme.onSurfaceVariant }]}>
+                {t('auth.oneTimePassword.verifying')}
+              </Text>
+            ) : null}
+          </View>
+        ) : (
+          <>
+            <GroupedCard elevated={false}>
+              <TextInput
+                label={t('settings.emailChange.newEmail')}
+                labelPosition="inline"
+                testID="email-change-new-email"
+                value={newEmail}
+                onChangeText={setNewEmail}
+                keyboardType={emailKeyboardType}
+                autoCapitalize="none"
+                autoCorrect={false}
+                spellCheck={false}
+                autoComplete="email"
+                textContentType="emailAddress"
+                returnKeyType="send"
+                onSubmitEditing={handleSubmit}
+              />
+            </GroupedCard>
+            <Button
+              label={t('settings.emailChange.sendCode')}
+              testID="email-change-send-code"
+              onPress={handleSubmit}
+              loading={requestLoading}
+              disabled={!canRequestCode}
+            />
+          </>
+        )}
+
+        {error ? (
+          <Text style={[styles.error, { color: theme.error }]}>{error}</Text>
+        ) : null}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: { flex: 1 },
+  container: { flex: 1 },
+  content: {
+    padding: spacing.lg,
+    paddingBottom: spacing.xxl,
+    gap: spacing.lg,
+  },
+  otpSection: {
+    width: '100%',
+  },
+  description: {
+    ...typography.subheadline,
+    marginBottom: spacing.lg,
+    textAlign: 'center',
+  },
+  status: {
+    ...typography.caption,
+    marginBottom: spacing.sm,
+    textAlign: 'center',
+  },
+  error: {
+    ...typography.caption,
+    textAlign: 'center',
+  },
+});

--- a/apps/mobile/components/auth/EmailAuthForm.tsx
+++ b/apps/mobile/components/auth/EmailAuthForm.tsx
@@ -148,6 +148,7 @@ export function EmailAuthForm({ onSuccess }: EmailAuthFormProps) {
       {!challenge ? (
         <Button
           label={t('auth.login.submit')}
+          testID="auth-submit-email"
           onPress={handleSubmit}
           loading={requestLoading}
           disabled={!canRequestCode}

--- a/apps/mobile/components/ui/icon-symbol.tsx
+++ b/apps/mobile/components/ui/icon-symbol.tsx
@@ -23,6 +23,7 @@ const MAPPING = {
   'bell.fill': 'notifications',
   'moon.fill': 'dark-mode',
   'gearshape.fill': 'settings',
+  'envelope.fill': 'email',
   'key.fill': 'vpn-key',
   'doc.text': 'description',
   'lock.fill': 'lock',

--- a/apps/mobile/components/user/UserSummary.tsx
+++ b/apps/mobile/components/user/UserSummary.tsx
@@ -26,6 +26,9 @@ export function UserSummary({ user, footer }: UserSummaryProps) {
         <Text style={[styles.name, { color: theme.onSurface }]} numberOfLines={1}>
           {user.displayName}
         </Text>
+        <Text style={[styles.email, { color: theme.onSurfaceVariant }]} numberOfLines={1}>
+          {user.email}
+        </Text>
         <Text style={[styles.since, { color: theme.onSurfaceVariant }]}>
           {user.walkingSince}
         </Text>
@@ -115,6 +118,10 @@ const styles = StyleSheet.create({
     marginTop: spacing.step12,
   },
   since: {
+    ...typography.footnote,
+    marginTop: spacing.xs,
+  },
+  email: {
     ...typography.footnote,
     marginTop: spacing.xs,
   },

--- a/apps/mobile/e2e/maestro/auth-onboarding.yaml
+++ b/apps/mobile/e2e/maestro/auth-onboarding.yaml
@@ -20,7 +20,8 @@ env:
 - tapOn:
     id: auth-email
 - inputText: ${E2E_EMAIL}
-- tapOn: Continue with email
+- tapOn:
+    id: auth-submit-email
 - extendedWaitUntil:
     visible: One-time password
     timeout: 15000

--- a/apps/mobile/hooks/use-auth.test.ts
+++ b/apps/mobile/hooks/use-auth.test.ts
@@ -4,6 +4,8 @@ import type * as AuthApiModule from '@/lib/auth/api';
 import type * as AuthStoreModule from '@/stores/auth-store';
 
 jest.mock('@/lib/auth/api', () => ({
+  changeEmail: jest.fn(),
+  confirmEmailChange: jest.fn(),
   refreshToken: jest.fn(),
   requestOneTimePassword: jest.fn(),
   signOut: jest.fn(),
@@ -104,5 +106,35 @@ describe('use-auth', () => {
 
     expect(mockAuthApi.signOut).toHaveBeenCalledWith('my-token');
     expect(mockClearAuth).toHaveBeenCalled();
+  });
+
+  it('changeEmail returns the email change challenge without changing auth tokens', async () => {
+    mockAuthApi.changeEmail.mockResolvedValue({
+      email: 'new-mio@walk.app',
+      codeLength: 6,
+    });
+
+    const { result } = renderHook(() => useAuth());
+
+    await expect(result.current.changeEmail('new-mio@walk.app')).resolves.toEqual({
+      email: 'new-mio@walk.app',
+      codeLength: 6,
+    });
+    expect(mockAuthApi.changeEmail).toHaveBeenCalledWith('new-mio@walk.app');
+    expect(mockSetAuth).not.toHaveBeenCalled();
+  });
+
+  it('confirmEmailChange returns the confirmed email without changing auth tokens', async () => {
+    mockAuthApi.confirmEmailChange.mockResolvedValue({
+      email: 'new-mio@walk.app',
+    });
+
+    const { result } = renderHook(() => useAuth());
+
+    await expect(result.current.confirmEmailChange('123456')).resolves.toEqual({
+      email: 'new-mio@walk.app',
+    });
+    expect(mockAuthApi.confirmEmailChange).toHaveBeenCalledWith('123456');
+    expect(mockSetAuth).not.toHaveBeenCalled();
   });
 });

--- a/apps/mobile/hooks/use-auth.ts
+++ b/apps/mobile/hooks/use-auth.ts
@@ -1,6 +1,8 @@
 import { useAuthStore } from '@/stores/auth-store';
 import * as authApi from '@/lib/auth/api';
 import type {
+  EmailChangeChallenge,
+  EmailChangeConfirmation,
   OneTimePasswordChallenge,
   VerifyOneTimePasswordInput,
 } from '@/lib/auth/api';
@@ -20,6 +22,14 @@ export function useAuth() {
     await setAuth(result.accessToken, result.refreshToken);
   }
 
+  async function changeEmail(newEmail: string): Promise<EmailChangeChallenge> {
+    return authApi.changeEmail(newEmail);
+  }
+
+  async function confirmEmailChange(code: string): Promise<EmailChangeConfirmation> {
+    return authApi.confirmEmailChange(code);
+  }
+
   async function signOut(): Promise<void> {
     // アクセストークンがある場合だけ、サーバーへサインアウトを通知します。
     if (accessToken) {
@@ -34,6 +44,8 @@ export function useAuth() {
     accessToken,
     requestOneTimePassword,
     verifyOneTimePassword,
+    changeEmail,
+    confirmEmailChange,
     signOut,
   };
 }

--- a/apps/mobile/hooks/use-user-screen-view-model.test.ts
+++ b/apps/mobile/hooks/use-user-screen-view-model.test.ts
@@ -21,6 +21,7 @@ const t = (key: string, values?: Record<string, unknown>): string => {
 const userData: UserProfileData = {
   user: {
     id: 'user-1',
+    email: 'mio@walk.app',
     name: 'Mio Tanaka',
     avatar: null,
     avatarUrl: null,
@@ -66,6 +67,7 @@ describe('buildUserScreenViewModel', () => {
     );
 
     expect(vm.displayName).toBe('Mio Tanaka');
+    expect(vm.email).toBe('mio@walk.app');
     expect(vm.initial).toBe('M');
     expect(vm.walkingSince).toBe('Walking since March 2024');
     expect(vm.metrics).toEqual([

--- a/apps/mobile/hooks/use-user-screen-view-model.ts
+++ b/apps/mobile/hooks/use-user-screen-view-model.ts
@@ -35,6 +35,7 @@ interface UserBaseViewModel {
 export interface UserReadyViewModel extends UserBaseViewModel {
   status: 'ready';
   displayName: string;
+  email: string;
   avatarUrl: string | null;
   initial: string;
   walkingSince: string;
@@ -80,6 +81,7 @@ export function buildUserScreenViewModel(
 
   return {
     displayName,
+    email: data.user.email,
     avatarUrl: data.user.avatar ?? data.user.avatarUrl ?? null,
     initial,
     walkingSince: t('user.walkingSince', {

--- a/apps/mobile/lib/auth/api.test.ts
+++ b/apps/mobile/lib/auth/api.test.ts
@@ -2,6 +2,8 @@ import { GraphQLError } from 'graphql';
 import { graphqlClient } from '../graphql/client';
 import { ClientError } from '../graphql/client-error';
 import {
+  changeEmail,
+  confirmEmailChange,
   refreshToken,
   signOut,
   requestOneTimePassword,
@@ -9,6 +11,7 @@ import {
 } from './api';
 
 jest.mock('../graphql/client', () => ({
+  authenticatedRequest: jest.fn(),
   graphqlClient: {
     request: jest.fn(),
   },
@@ -22,6 +25,9 @@ function makeClientError(message: string, status = 200): ClientError {
 }
 
 const mockRequest = graphqlClient.request as jest.Mock;
+const mockAuthenticatedRequest = (
+  require('../graphql/client') as { authenticatedRequest: jest.Mock }
+).authenticatedRequest;
 
 describe('auth api', () => {
   beforeEach(() => {
@@ -134,5 +140,46 @@ describe('auth api', () => {
     mockRequest.mockRejectedValue(networkError);
 
     await expect(refreshToken('old-refresh-token')).rejects.toBe(networkError);
+  });
+
+  it('changeEmail sends the new login email through an authenticated mutation', async () => {
+    mockAuthenticatedRequest.mockResolvedValue({
+      changeEmail: {
+        email: 'new-mio@walk.app',
+        codeLength: 6,
+      },
+    });
+
+    await expect(changeEmail('new-mio@walk.app')).resolves.toEqual({
+      email: 'new-mio@walk.app',
+      codeLength: 6,
+    });
+    expect(mockAuthenticatedRequest).toHaveBeenCalledWith(expect.any(String), {
+      input: { newEmail: 'new-mio@walk.app' },
+    });
+  });
+
+  it('confirmEmailChange returns the confirmed login email', async () => {
+    mockAuthenticatedRequest.mockResolvedValue({
+      confirmEmailChange: {
+        email: 'new-mio@walk.app',
+      },
+    });
+
+    await expect(confirmEmailChange('123456')).resolves.toEqual({
+      email: 'new-mio@walk.app',
+    });
+    expect(mockAuthenticatedRequest).toHaveBeenCalledWith(expect.any(String), {
+      input: { code: '123456' },
+    });
+  });
+
+  it('confirmEmailChange maps expired codes to code-mismatch', async () => {
+    mockAuthenticatedRequest.mockRejectedValue(makeClientError('ExpiredCodeException'));
+
+    await expect(confirmEmailChange('123456')).rejects.toMatchObject({
+      kind: 'code-mismatch',
+      reason: 'expired',
+    });
   });
 });

--- a/apps/mobile/lib/auth/api.ts
+++ b/apps/mobile/lib/auth/api.ts
@@ -1,5 +1,7 @@
-import { graphqlClient } from '../graphql/client';
+import { authenticatedRequest, graphqlClient } from '../graphql/client';
 import {
+  CHANGE_EMAIL_MUTATION,
+  CONFIRM_EMAIL_CHANGE_MUTATION,
   REQUEST_ONE_TIME_PASSWORD_MUTATION,
   VERIFY_ONE_TIME_PASSWORD_MUTATION,
   REFRESH_TOKEN_MUTATION,
@@ -26,6 +28,15 @@ export interface AuthTokenPair {
 
 export type RefreshTokenResult = AuthTokenPair;
 
+export interface EmailChangeChallenge {
+  email: string;
+  codeLength: number;
+}
+
+export interface EmailChangeConfirmation {
+  email: string;
+}
+
 interface RequestOneTimePasswordResponse {
   requestOneTimePassword: OneTimePasswordChallenge;
 }
@@ -40,6 +51,14 @@ interface RefreshTokenResponse {
 
 interface SignOutResponse {
   signOut: { success: boolean };
+}
+
+interface ChangeEmailResponse {
+  changeEmail: EmailChangeChallenge;
+}
+
+interface ConfirmEmailChangeResponse {
+  confirmEmailChange: EmailChangeConfirmation;
 }
 
 async function mapAuthRequestError<T>(request: () => Promise<T>): Promise<T> {
@@ -83,6 +102,24 @@ export async function verifyOneTimePassword(
     )
   );
   return data.verifyOneTimePassword;
+}
+
+export async function changeEmail(newEmail: string): Promise<EmailChangeChallenge> {
+  const data = await mapAuthRequestError(() =>
+    authenticatedRequest<ChangeEmailResponse>(CHANGE_EMAIL_MUTATION, {
+      input: { newEmail },
+    })
+  );
+  return data.changeEmail;
+}
+
+export async function confirmEmailChange(code: string): Promise<EmailChangeConfirmation> {
+  const data = await mapAuthRequestError(() =>
+    authenticatedRequest<ConfirmEmailChangeResponse>(CONFIRM_EMAIL_CHANGE_MUTATION, {
+      input: { code },
+    })
+  );
+  return data.confirmEmailChange;
 }
 
 export async function signOut(_accessToken: string): Promise<boolean> {

--- a/apps/mobile/lib/auth/errors.ts
+++ b/apps/mobile/lib/auth/errors.ts
@@ -68,7 +68,13 @@ export function toAuthError(error: unknown): AuthError {
     return { kind: 'invalid-credentials', message };
   }
 
-  if (includesAny(normalizedMessage, ['USER_EXISTS', 'USERNAMEEXISTSEXCEPTION'])) {
+  if (
+    includesAny(normalizedMessage, [
+      'USER_EXISTS',
+      'USERNAMEEXISTSEXCEPTION',
+      'ALIASEXISTSEXCEPTION',
+    ])
+  ) {
     return { kind: 'user-exists', message };
   }
 

--- a/apps/mobile/lib/graphql/mutations/auth.ts
+++ b/apps/mobile/lib/graphql/mutations/auth.ts
@@ -19,6 +19,23 @@ export const VERIFY_ONE_TIME_PASSWORD_MUTATION = gql`
   }
 `;
 
+export const CHANGE_EMAIL_MUTATION = gql`
+  mutation ChangeEmail($input: ChangeEmailInput!) {
+    changeEmail(input: $input) {
+      email
+      codeLength
+    }
+  }
+`;
+
+export const CONFIRM_EMAIL_CHANGE_MUTATION = gql`
+  mutation ConfirmEmailChange($input: ConfirmEmailChangeInput!) {
+    confirmEmailChange(input: $input) {
+      email
+    }
+  }
+`;
+
 export const REFRESH_TOKEN_MUTATION = gql`
   mutation RefreshToken($input: RefreshTokenInput!) {
     refreshToken(input: $input) {

--- a/apps/mobile/lib/graphql/queries/me.ts
+++ b/apps/mobile/lib/graphql/queries/me.ts
@@ -4,6 +4,7 @@ export const USER_QUERY = gql`
   query User {
     user {
       id
+      email
       name
       avatar
       createdAt

--- a/apps/mobile/lib/graphql/queries/user-profile.ts
+++ b/apps/mobile/lib/graphql/queries/user-profile.ts
@@ -4,6 +4,7 @@ export const USER_PROFILE_QUERY = gql`
   query UserProfile($first: Int) {
     user {
       id
+      email
       name
       avatar
       createdAt

--- a/apps/mobile/lib/i18n/locales/en.json
+++ b/apps/mobile/lib/i18n/locales/en.json
@@ -290,7 +290,19 @@
     "about": "About",
     "signOut": "Sign Out",
     "signOutConfirm": "Are you sure you want to sign out?",
-    "loadError": "Failed to load data"
+    "loadError": "Failed to load data",
+    "emailChange": {
+      "title": "Change email",
+      "currentEmail": "Current email",
+      "newEmail": "New email",
+      "sendCode": "Send code",
+      "error": {
+        "emailInUse": "That email is already in use",
+        "sessionExpired": "Please sign in again",
+        "sendGeneric": "Could not send a code",
+        "confirmGeneric": "Could not change email"
+      }
+    }
   },
   "user": {
     "edit": "Edit",
@@ -306,6 +318,9 @@
     "week": {
       "title": "This week",
       "total": "{{distance}} total"
+    },
+    "account": {
+      "changeEmail": "Change email"
     }
   },
   "userEdit": {

--- a/apps/mobile/lib/i18n/locales/ja.json
+++ b/apps/mobile/lib/i18n/locales/ja.json
@@ -290,7 +290,19 @@
     "about": "このアプリについて",
     "signOut": "サインアウト",
     "signOutConfirm": "サインアウトしますか？",
-    "loadError": "データの読み込みに失敗しました"
+    "loadError": "データの読み込みに失敗しました",
+    "emailChange": {
+      "title": "メールを変更",
+      "currentEmail": "現在のメール",
+      "newEmail": "新しいメール",
+      "sendCode": "コードを送信",
+      "error": {
+        "emailInUse": "このメールはすでに使われています",
+        "sessionExpired": "もう一度ログインしてください",
+        "sendGeneric": "コードを送信できませんでした",
+        "confirmGeneric": "メールを変更できませんでした"
+      }
+    }
   },
   "user": {
     "edit": "編集",
@@ -306,6 +318,9 @@
     "week": {
       "title": "今週",
       "total": "合計 {{distance}}"
+    },
+    "account": {
+      "changeEmail": "メールを変更"
     }
   },
   "userEdit": {

--- a/apps/mobile/types/graphql.ts
+++ b/apps/mobile/types/graphql.ts
@@ -156,6 +156,7 @@ export interface Walk {
 
 export interface User {
   id: string;
+  email: string;
   name?: string | null;
   avatar?: string | null;
   createdAt: string;
@@ -215,6 +216,7 @@ export interface ApiDog {
 
 export interface ApiUser {
   id: string;
+  email: string;
   name: string | null;
   avatar: string | null;
   createdAt: string;

--- a/infra/aws/cognito.tf
+++ b/infra/aws/cognito.tf
@@ -5,6 +5,10 @@ resource "aws_cognito_user_pool" "main" {
   auto_verified_attributes = ["email"]
   user_pool_tier           = "ESSENTIALS"
 
+  user_attribute_update_settings {
+    attributes_require_verification_before_update = ["email"]
+  }
+
   schema {
     name                = "name"
     attribute_data_type = "String"
@@ -169,6 +173,10 @@ resource "aws_cognito_user_pool" "local" {
   username_attributes      = ["email"]
   auto_verified_attributes = ["email"]
   user_pool_tier           = "ESSENTIALS"
+
+  user_attribute_update_settings {
+    attributes_require_verification_before_update = ["email"]
+  }
 
   schema {
     name                = "name"


### PR DESCRIPTION
## Summary
- Add Cognito-backed login email display and email change mutations.
- Add the mobile Me/Profile email surface and Change email flow with OTP confirmation.
- Keep password change out of the account actions because auth is passwordless.
- Configure Cognito user pools to keep the old email active while updates are verified.

## Product impact
- Dog experience: owner identity stays stable while login email changes.
- Walk data: Cognito sub remains unchanged, preserving dogs, walks, photos, and event history.
- Owner contribution: owners can self-serve login email changes and avoid account anxiety.

## Validation
- Maestro auth login E2E with matsuokashuheiii@gmail.com passed.
- Maestro email change E2E to matzuokashuhei@gmail.com passed.
- Terraform apply completed for Cognito update verification settings.
- apps/mobile npm test: 119 suites / 731 tests passed.
- apps/mobile npm run typecheck passed.
- apps/mobile npm run lint passed with 0 errors and one existing Expo generated type warning.
- node scripts/harness/validate-all.mjs passed.
