### PR TITLE
[codex] Reduce Sakura SQS idle polling

### DIFF
--- a/apps/api/src/bin/track_point_worker.rs
+++ b/apps/api/src/bin/track_point_worker.rs
@@ -1,4 +1,4 @@
-use std::{env, fmt, time::Duration};
+use std::{env, time::Duration};
 
 use anyhow::Result;
 use sqs_consumer::{Consumer, ConsumerOptions, TracingListener};
@@ -8,11 +8,12 @@ use walking_dog::{
     service::track_point::DynamoDbTrackPointRepository,
 };
 
-const DEFAULT_WORKER_CONCURRENCY: usize = 10;
+const DEFAULT_WORKER_CONCURRENCY: usize = 1;
 const DEFAULT_BATCH_SIZE: i32 = 10;
 const DEFAULT_VISIBILITY_TIMEOUT_SECONDS: i32 = 60;
 const DEFAULT_HEARTBEAT_INTERVAL_SECONDS: u64 = 30;
 const DEFAULT_HANDLER_TIMEOUT_SECONDS: u64 = 50;
+const DEFAULT_POLLING_WAIT_SECONDS: u64 = 60;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -23,21 +24,46 @@ async fn main() -> Result<()> {
     let sqs_client = build_sqs_client().await;
     let dynamodb_client = build_dynamodb_client().await;
     let queue_url = env::var("AWS_SQS_QUEUE_URL_TRACK_POINT")?;
-    let worker_concurrency =
-        positive_usize_env("TRACK_POINT_WORKER_CONCURRENCY", DEFAULT_WORKER_CONCURRENCY);
-    let batch_size = sqs_batch_size_env("TRACK_POINT_WORKER_BATCH_SIZE", DEFAULT_BATCH_SIZE);
-    let handler_timeout_seconds = positive_u64_env(
-        "TRACK_POINT_HANDLER_TIMEOUT_SECONDS",
-        DEFAULT_HANDLER_TIMEOUT_SECONDS,
-    );
+    let worker_concurrency = env::var("TRACK_POINT_WORKER_CONCURRENCY")
+        .map(|value| {
+            value
+                .parse::<usize>()
+                .expect("TRACK_POINT_WORKER_CONCURRENCY must be a usize")
+        })
+        .unwrap_or(DEFAULT_WORKER_CONCURRENCY);
 
     let options = ConsumerOptions::builder()
         .queue_url(queue_url)
         .sqs_client(sqs_client)
-        .batch_size(batch_size)
+        .batch_size(
+            env::var("TRACK_POINT_WORKER_BATCH_SIZE")
+                .map(|value| {
+                    value
+                        .parse::<i32>()
+                        .expect("TRACK_POINT_WORKER_BATCH_SIZE must be an i32")
+                })
+                .unwrap_or(DEFAULT_BATCH_SIZE),
+        )
         .wait_time_seconds(20)
+        .polling_wait_time(Duration::from_secs(
+            env::var("TRACK_POINT_WORKER_POLLING_WAIT_SECONDS")
+                .map(|value| {
+                    value
+                        .parse::<u64>()
+                        .expect("TRACK_POINT_WORKER_POLLING_WAIT_SECONDS must be a u64")
+                })
+                .unwrap_or(DEFAULT_POLLING_WAIT_SECONDS),
+        ))
         .visibility_timeout(DEFAULT_VISIBILITY_TIMEOUT_SECONDS)
-        .handle_message_timeout(Duration::from_secs(handler_timeout_seconds))
+        .handle_message_timeout(Duration::from_secs(
+            env::var("TRACK_POINT_HANDLER_TIMEOUT_SECONDS")
+                .map(|value| {
+                    value
+                        .parse::<u64>()
+                        .expect("TRACK_POINT_HANDLER_TIMEOUT_SECONDS must be a u64")
+                })
+                .unwrap_or(DEFAULT_HANDLER_TIMEOUT_SECONDS),
+        ))
         .heartbeat(sqs_consumer::HeartbeatConfig::new(Duration::from_secs(
             DEFAULT_HEARTBEAT_INTERVAL_SECONDS,
         )))
@@ -113,72 +139,6 @@ where
     Ok(())
 }
 
-fn positive_usize_env(name: &str, default: usize) -> usize {
-    let value = env::var(name).ok();
-    positive_usize_env_value(name, value.as_deref(), default)
-}
-
-fn positive_usize_env_value(name: &str, value: Option<&str>, default: usize) -> usize {
-    let Some(value) = value else {
-        return default;
-    };
-    match value.parse::<usize>() {
-        Ok(parsed) if parsed > 0 => parsed,
-        _ => {
-            warn_invalid_env_value(name, value, default);
-            default
-        }
-    }
-}
-
-fn positive_u64_env(name: &str, default: u64) -> u64 {
-    let value = env::var(name).ok();
-    positive_u64_env_value(name, value.as_deref(), default)
-}
-
-fn positive_u64_env_value(name: &str, value: Option<&str>, default: u64) -> u64 {
-    let Some(value) = value else {
-        return default;
-    };
-    match value.parse::<u64>() {
-        Ok(parsed) if parsed > 0 => parsed,
-        _ => {
-            warn_invalid_env_value(name, value, default);
-            default
-        }
-    }
-}
-
-fn sqs_batch_size_env(name: &str, default: i32) -> i32 {
-    let value = env::var(name).ok();
-    sqs_batch_size_env_value(name, value.as_deref(), default)
-}
-
-fn sqs_batch_size_env_value(name: &str, value: Option<&str>, default: i32) -> i32 {
-    let Some(value) = value else {
-        return default;
-    };
-    match value.parse::<i32>() {
-        Ok(parsed) if (1..=10).contains(&parsed) => parsed,
-        _ => {
-            warn_invalid_env_value(name, value, default);
-            default
-        }
-    }
-}
-
-fn warn_invalid_env_value<T>(name: &str, value: &str, default: T)
-where
-    T: fmt::Display,
-{
-    tracing::warn!(
-        env_var = name,
-        value,
-        default = %default,
-        "invalid environment variable, using default"
-    );
-}
-
 async fn build_dynamodb_client() -> aws_sdk_dynamodb::Client {
     let config_loader = aws_config::from_env();
     let config = match env::var("AWS_DYNAMODB_ENDPOINT") {
@@ -195,73 +155,4 @@ async fn build_sqs_client() -> aws_sdk_sqs::Client {
         Err(_) => config_loader.load().await,
     };
     aws_sdk_sqs::Client::new(&config)
-}
-
-#[cfg(test)]
-mod tests {
-    use std::{
-        io::{Result as IoResult, Write},
-        sync::{Arc, Mutex},
-    };
-
-    use tracing_subscriber::fmt::MakeWriter;
-
-    use super::*;
-
-    #[test]
-    fn positive_env_helpers_read_valid_values() {
-        assert_eq!(positive_usize_env_value("TEST_USIZE", Some("5"), 10), 5);
-        assert_eq!(positive_u64_env_value("TEST_U64", Some("6"), 10), 6);
-        assert_eq!(sqs_batch_size_env_value("TEST_BATCH", Some("7"), 10), 7);
-    }
-
-    #[test]
-    fn invalid_env_helpers_use_defaults_and_warn() {
-        let output = capture_warnings(|| {
-            assert_eq!(positive_usize_env_value("TEST_USIZE", Some("foo"), 10), 10);
-            assert_eq!(positive_u64_env_value("TEST_U64", Some("0"), 10), 10);
-            assert_eq!(sqs_batch_size_env_value("TEST_BATCH", Some("11"), 10), 10);
-        });
-
-        assert!(output.contains("TEST_USIZE"));
-        assert!(output.contains("TEST_U64"));
-        assert!(output.contains("TEST_BATCH"));
-    }
-
-    fn capture_warnings(run: impl FnOnce()) -> String {
-        let output = Arc::new(Mutex::new(Vec::new()));
-        let subscriber = tracing_subscriber::fmt()
-            .with_max_level(tracing::Level::WARN)
-            .with_writer(BufferMakeWriter(output.clone()))
-            .without_time()
-            .finish();
-
-        tracing::subscriber::with_default(subscriber, run);
-
-        String::from_utf8(output.lock().unwrap().clone()).unwrap()
-    }
-
-    #[derive(Clone)]
-    struct BufferMakeWriter(Arc<Mutex<Vec<u8>>>);
-
-    impl<'a> MakeWriter<'a> for BufferMakeWriter {
-        type Writer = BufferWriter;
-
-        fn make_writer(&'a self) -> Self::Writer {
-            BufferWriter(self.0.clone())
-        }
-    }
-
-    struct BufferWriter(Arc<Mutex<Vec<u8>>>);
-
-    impl Write for BufferWriter {
-        fn write(&mut self, buf: &[u8]) -> IoResult<usize> {
-            self.0.lock().unwrap().extend_from_slice(buf);
-            Ok(buf.len())
-        }
-
-        fn flush(&mut self) -> IoResult<()> {
-            Ok(())
-        }
-    }
 }

--- a/docs/harness/lessons-learned.md
+++ b/docs/harness/lessons-learned.md
@@ -19,3 +19,7 @@ Date: 2026-06-13.
 - Do not hide failures in harness work. If a journey cannot be proven because seed
   data, GPS replay, camera fixtures, or logging is missing, record that as the
   next harness gap.
+- Sakura's track point worker env tuning should stay boring: read an env var when
+  present, otherwise use the default, and pass the value straight to
+  `ConsumerOptions`. Avoid wrapper config structs and custom validation fallback
+  helpers unless the worker gains a real shared configuration boundary.

--- a/infra/sakura/.env.example
+++ b/infra/sakura/.env.example
@@ -24,5 +24,9 @@ AWS_COGNITO_CLIENT_ID=64biiqesu1d3oku6olt817tmbl
 # API
 PORT=3000
 
+# Track point worker. Keep Sakura's idle SQS usage well below the free tier.
+TRACK_POINT_WORKER_CONCURRENCY=1
+TRACK_POINT_WORKER_POLLING_WAIT_SECONDS=60
+
 # Do NOT set *_ENDPOINT_URL variables.
 # Omitting them makes the AWS SDK connect to real AWS endpoints.

--- a/infra/sakura/README.md
+++ b/infra/sakura/README.md
@@ -102,9 +102,11 @@ vi .env
 | `AVATAR_CDN_URL` | `terraform output -raw cloudfront_avatars_url` |
 | `PHOTO_CDN_URL` | `terraform output -raw cloudfront_photos_url` |
 
-その他（`AWS_DYNAMODB_TABLE_TRACK_POINT`, `AWS_SQS_QUEUE_URL_TRACK_POINT`, `AWS_S3_BUCKET_AVATAR`, `AWS_S3_BUCKET_PHOTO`, `COGNITO_USER_POOL_ID`, `COGNITO_CLIENT_ID`）は `.env.example` の値をそのまま使う。
+その他（`AWS_DYNAMODB_TABLE_TRACK_POINT`, `AWS_SQS_QUEUE_URL_TRACK_POINT`, `AWS_S3_BUCKET_AVATAR`, `AWS_S3_BUCKET_PHOTO`, `COGNITO_USER_POOL_ID`, `COGNITO_CLIENT_ID`, `TRACK_POINT_WORKER_CONCURRENCY`, `TRACK_POINT_WORKER_POLLING_WAIT_SECONDS`）は `.env.example` の値をそのまま使う。
 
 `AVATAR_CDN_URL` / `PHOTO_CDN_URL` は API が GraphQL の `avatar` / `photoUrl` フィールドを組み立てるときに S3 オブジェクトキーの前に付ける CloudFront のベース URL。`.env.example` のデフォルト値で動くが、distribution を作り直した場合は `terraform output -raw cloudfront_avatars_url` / `cloudfront_photos_url` の値に差し替える。
+
+`TRACK_POINT_WORKER_CONCURRENCY=1` と `TRACK_POINT_WORKER_POLLING_WAIT_SECONDS=60` は Sakura テスト環境のアイドル時 SQS 使用量を抑えるための推奨値。worker は 20 秒の SQS long polling の後、空受信なら 60 秒待ってから再ポーリングするため、アイドル時は約 1,080 requests/day、約 32,400 requests/month になる。散歩検証で低レイテンシが必要なときだけ、一時的に値を上げる。
 
 ### 4. 初回デプロイ
 

--- a/scripts/harness/validate-architecture.mjs
+++ b/scripts/harness/validate-architecture.mjs
@@ -16,6 +16,14 @@ const RESOLVER_DIRS = [
   'apps/api/src/graphql/object',
 ];
 
+const TRACK_POINT_WORKER_PATH = 'apps/api/src/bin/track_point_worker.rs';
+const FORBIDDEN_TRACK_POINT_WORKER_ENV_CONFIG_PATTERNS = [
+  /\bstruct\s+WorkerRuntimeConfig\b/,
+  /\bimpl\s+WorkerRuntimeConfig\b/,
+  /\bfn\s+[a-z0-9_]*env[a-z0-9_]*value\b/,
+  /\bwarn_invalid_env_value\b/,
+];
+
 export function validateArchitecture({ root = process.cwd() } = {}) {
   const messages = [];
 
@@ -34,6 +42,7 @@ export function validateArchitecture({ root = process.cwd() } = {}) {
 
   validateMobileNavigationImports(root, messages);
   validateWalkGoalBounds(root, messages);
+  validateTrackPointWorkerEnvConfig(root, messages);
 
   return { ok: messages.length === 0, messages };
 }
@@ -72,6 +81,20 @@ function validateWalkGoalBounds(root, messages) {
   }
   if (apiMin !== mobileMin || apiMax !== mobileMax) {
     messages.push(`walk goal minute bounds drift: API ${apiMin}-${apiMax}, Mobile ${mobileMin}-${mobileMax}`);
+  }
+}
+
+function validateTrackPointWorkerEnvConfig(root, messages) {
+  const workerPath = join(root, TRACK_POINT_WORKER_PATH);
+  if (!fileExists(workerPath)) {
+    return;
+  }
+
+  const content = stripRustTestModules(readText(workerPath));
+  if (FORBIDDEN_TRACK_POINT_WORKER_ENV_CONFIG_PATTERNS.some((pattern) => pattern.test(content))) {
+    messages.push(
+      `${TRACK_POINT_WORKER_PATH}: track point worker env config should read env/defaults directly at the ConsumerOptions call site; avoid wrapper structs and custom validation fallback helpers`,
+    );
   }
 }
 

--- a/scripts/harness/validate-architecture.test.mjs
+++ b/scripts/harness/validate-architecture.test.mjs
@@ -41,6 +41,23 @@ test('validateArchitecture rejects API and Mobile walk goal range drift', (t) =>
   assert.match(result.messages.join('\n'), /walk goal minute bounds drift/);
 });
 
+test('validateArchitecture rejects track point worker env config wrappers', (t) => {
+  const root = mkdtempSync(join(tmpdir(), 'wd-architecture-'));
+  writeFixture(root, {
+    'apps/api/src/bin/track_point_worker.rs': [
+      'struct WorkerRuntimeConfig { worker_concurrency: usize }',
+      'fn positive_usize_env_value(value: Option<&str>, default: usize) -> usize { default }',
+    ].join('\n'),
+    'apps/api/src/service/dog_walk_goal.rs': 'pub const MIN_DAILY_GOAL_MINUTES: i32 = 0;\npub const MAX_DAILY_GOAL_MINUTES: i32 = 120;\n',
+    'apps/mobile/constants/walk.ts': 'export const MIN_DAILY_GOAL_MINUTES = 0;\nexport const MAX_DAILY_GOAL_MINUTES = 120;\n',
+  });
+
+  const result = validateArchitecture({ root });
+
+  assert.equal(result.ok, false);
+  assert.match(result.messages.join('\n'), /track point worker env config/);
+});
+
 test('validateArchitecture accepts clean resolver boundaries and matching walk goal bounds', (t) => {
   const root = mkdtempSync(join(tmpdir(), 'wd-architecture-'));
   writeFixture(root, {


### PR DESCRIPTION
## Summary

- Reduce the track point worker's default concurrency from 10 to 1.
- Add `TRACK_POINT_WORKER_POLLING_WAIT_SECONDS` so empty SQS receives pause before the next poll.
- Document Sakura's recommended worker settings and expected idle request volume.
- Harness the review lesson by rejecting track point worker env config wrapper structs/custom fallback validators in `validateArchitecture`.

## Why

Sakura was approaching the AWS SQS free-tier monthly request limit even though walk testing is occasional. CloudWatch showed the usage was dominated by empty receives, not real walk messages: the existing worker ran 10 long-polling consumers continuously, producing about 43,000 empty receives per day while idle.

With the new defaults, the Sakura worker uses one consumer and waits 60 seconds after an empty long poll. That brings idle usage down to roughly 1,080 requests per day, or about 32,400 requests per month, while still preserving queued track points during test walks.

The follow-up review clarified that this env tuning should stay simple: read env values when present, use defaults otherwise, and pass those values directly to `ConsumerOptions`. The harness now preserves that lesson.

## Impact

- Dog experience: no user-facing behavior change; walk track points remain queued and processed.
- Walk data: lower idle AWS usage without dropping queued track points.
- Owner contribution: keeps the Sakura test environment sustainable for occasional walk validation.

## Validation

- Pre-commit mobile lint ran during commit.
- `node --test scripts/harness/validate-architecture.test.mjs`
- `node scripts/harness/validate-all.mjs`
- `docker run --rm -v "$PWD":/walking-dog -v apps_cargo_cache:/usr/local/cargo -v apps_api_target_harness:/tmp/walking-dog-target -w /walking-dog/apps/api apps-api cargo test --target-dir /tmp/walking-dog-target -j 1`