### PR TITLE
[codex] Split auth sign-in and sign-up screens

### DIFF
--- a/apps/mobile/__tests__/app/auth/layout.test.tsx
+++ b/apps/mobile/__tests__/app/auth/layout.test.tsx
@@ -1,0 +1,28 @@
+import { render } from '@testing-library/react-native';
+import AuthLayout from '../../../app/(auth)/_layout';
+
+const mockStack = jest.fn();
+
+jest.mock('expo-router', () => ({
+  Stack: (props: unknown) => {
+    mockStack(props);
+    return null;
+  },
+}));
+
+describe('AuthLayout', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('uses a stack slide transition for sign-in to sign-up navigation', () => {
+    render(<AuthLayout />);
+
+    expect(mockStack).toHaveBeenCalledWith({
+      screenOptions: {
+        animation: 'slide_from_right',
+        headerShown: false,
+      },
+    });
+  });
+});

--- a/apps/mobile/__tests__/app/auth/login.test.tsx
+++ b/apps/mobile/__tests__/app/auth/login.test.tsx
@@ -1,0 +1,37 @@
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import LoginScreen from '../../../app/(auth)/login';
+
+const mockPush = jest.fn();
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock('expo-linear-gradient', () => ({
+  LinearGradient: 'LinearGradient',
+}));
+
+jest.mock('react-native-svg', () => ({
+  __esModule: true,
+  default: 'Svg',
+  Path: 'Path',
+}));
+
+describe('LoginScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders a sign-in focused screen and links to sign-up', () => {
+    render(<LoginScreen />);
+
+    expect(screen.getByRole('image', { name: /walking dog/i })).toBeTruthy();
+    expect(screen.getByText('Welcome back')).toBeTruthy();
+    expect(screen.getByText('Sign in to keep walking with your dog.')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Sign in' })).toBeTruthy();
+
+    fireEvent.press(screen.getByRole('button', { name: 'Create an account' }));
+
+    expect(mockPush).toHaveBeenCalledWith('/(auth)/signup');
+  });
+});

--- a/apps/mobile/__tests__/app/auth/signup.test.tsx
+++ b/apps/mobile/__tests__/app/auth/signup.test.tsx
@@ -1,0 +1,29 @@
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import SignUpScreen from '../../../app/(auth)/signup';
+
+const mockReplace = jest.fn();
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ replace: mockReplace }),
+}));
+
+describe('SignUpScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders a sign-up focused screen with the same email OTP form', () => {
+    render(<SignUpScreen />);
+
+    expect(screen.getByText("Let's meet your dog.")).toBeTruthy();
+    expect(screen.getByText("Create your account and you'll be walking in a minute.")).toBeTruthy();
+    expect(screen.getByLabelText('Email')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Continue' })).toBeTruthy();
+    expect(screen.getByText('Terms')).toBeTruthy();
+    expect(screen.getByText('Privacy Policy')).toBeTruthy();
+
+    fireEvent.press(screen.getByRole('button', { name: 'Back' }));
+
+    expect(mockReplace).toHaveBeenCalledWith('/(auth)/login');
+  });
+});

--- a/apps/mobile/__tests__/app/auth/signup.test.tsx
+++ b/apps/mobile/__tests__/app/auth/signup.test.tsx
@@ -1,15 +1,22 @@
 import { fireEvent, render, screen } from '@testing-library/react-native';
 import SignUpScreen from '../../../app/(auth)/signup';
 
+const mockBack = jest.fn();
+const mockCanGoBack = jest.fn();
 const mockReplace = jest.fn();
 
 jest.mock('expo-router', () => ({
-  useRouter: () => ({ replace: mockReplace }),
+  useRouter: () => ({
+    back: mockBack,
+    canGoBack: mockCanGoBack,
+    replace: mockReplace,
+  }),
 }));
 
 describe('SignUpScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockCanGoBack.mockReturnValue(true);
   });
 
   it('renders a sign-up focused screen with the same email OTP form', () => {
@@ -21,9 +28,25 @@ describe('SignUpScreen', () => {
     expect(screen.getByRole('button', { name: 'Continue' })).toBeTruthy();
     expect(screen.getByText('Terms')).toBeTruthy();
     expect(screen.getByText('Privacy Policy')).toBeTruthy();
+  });
+
+  it('pops back to the sign-in screen when opened from sign-in', () => {
+    render(<SignUpScreen />);
 
     fireEvent.press(screen.getByRole('button', { name: 'Back' }));
 
+    expect(mockBack).toHaveBeenCalled();
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the sign-in route when there is no navigation history', () => {
+    mockCanGoBack.mockReturnValue(false);
+
+    render(<SignUpScreen />);
+
+    fireEvent.press(screen.getByRole('button', { name: 'Back' }));
+
+    expect(mockBack).not.toHaveBeenCalled();
     expect(mockReplace).toHaveBeenCalledWith('/(auth)/login');
   });
 });

--- a/apps/mobile/app/(auth)/_layout.tsx
+++ b/apps/mobile/app/(auth)/_layout.tsx
@@ -3,6 +3,11 @@ import { Stack } from 'expo-router';
 // 認証画面群は独立した Stack として、アプリ本体のタブ UI を表示しません。
 export default function AuthLayout() {
   return (
-    <Stack screenOptions={{ headerShown: false }} />
+    <Stack
+      screenOptions={{
+        animation: 'slide_from_right',
+        headerShown: false,
+      }}
+    />
   );
 }

--- a/apps/mobile/app/(auth)/login.tsx
+++ b/apps/mobile/app/(auth)/login.tsx
@@ -1,112 +1,62 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
-import {
-  Keyboard,
-  Platform,
-  StyleSheet,
-  Text,
-  useWindowDimensions,
-  View,
-} from 'react-native';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
-import { AppMark } from '@/components/auth/AppMark';
+import { AuthScreenLayout } from '@/components/auth/AuthScreenLayout';
 import { EmailAuthForm } from '@/components/auth/EmailAuthForm';
 import { useColors } from '@/hooks/use-colors';
-import { spacing, typography } from '@/theme/tokens';
+import { components, spacing, typography } from '@/theme/tokens';
 
 // 認証画面はメールOTPフォームだけを担当し、成功後の遷移はルートの認証ガードに任せます。
 export default function LoginScreen() {
   const { t } = useTranslation();
   const theme = useColors();
-  const { height: windowHeight } = useWindowDimensions();
-  const formRef = useRef<View>(null);
-  const [keyboardTop, setKeyboardTop] = useState<number | null>(null);
-  const [formFrame, setFormFrame] = useState({ y: 0, height: 0 });
-
-  const measureForm = useCallback(() => {
-    requestAnimationFrame(() => {
-      formRef.current?.measureInWindow((_x, y, _width, height) => {
-        setFormFrame({ y, height });
-      });
-    });
-  }, []);
-
-  useEffect(() => {
-    const showEvent = Platform.OS === 'ios' ? 'keyboardWillChangeFrame' : 'keyboardDidShow';
-    const hideEvent = Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
-
-    const showSubscription = Keyboard.addListener(showEvent, (event) => {
-      measureForm();
-      setKeyboardTop(event.endCoordinates.screenY);
-    });
-    const hideSubscription = Keyboard.addListener(hideEvent, () => {
-      setKeyboardTop(null);
-    });
-
-    return () => {
-      showSubscription.remove();
-      hideSubscription.remove();
-    };
-  }, [measureForm]);
-
-  const formBottom = formFrame.y + formFrame.height;
-  const keyboardGap = spacing.md;
-  const keyboardOverlap = Math.max(
-    0,
-    formBottom + keyboardGap - (keyboardTop ?? windowHeight),
-  );
+  const router = useRouter();
 
   return (
-    <View style={[styles.container, { backgroundColor: theme.background }]}>
-      <View style={styles.content}>
-        <View style={styles.hero}>
-          <AppMark />
-          <Text style={[styles.heading, { color: theme.onSurface }]}>
-            {t('auth.login.heading')}
+    <AuthScreenLayout
+      heading={t('auth.login.heading')}
+      subtitle={t('auth.login.subtitle')}
+      showAppMark
+      footer={
+        <View style={styles.footerRow}>
+          <Text style={[styles.footerText, { color: theme.onSurfaceVariant }]}>
+            {t('auth.login.signupPrompt')}
           </Text>
-          <Text style={[styles.sub, { color: theme.onSurfaceVariant }]}>
-            {t('auth.login.subtitle')}
-          </Text>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={t('auth.login.signupAction')}
+            onPress={() => router.push('/(auth)/signup')}
+          >
+            <Text style={[styles.footerLink, { color: theme.interactive }]}>
+              {t('auth.login.signupAction')}
+            </Text>
+          </Pressable>
         </View>
-        <View
-          ref={formRef}
-          onLayout={measureForm}
-          style={[
-            styles.form,
-            { transform: [{ translateY: -keyboardOverlap }] },
-          ]}
-        >
-          <EmailAuthForm
-            onSuccess={() => {
-              // 認証後の遷移は _layout.tsx の NavigationGuard が一元管理します。
-            }}
-          />
-        </View>
-      </View>
-    </View>
+      }
+    >
+      <EmailAuthForm
+        submitLabel={t('auth.login.primaryAction')}
+        onSuccess={() => {
+          // 認証後の遷移は _layout.tsx の NavigationGuard が一元管理します。
+        }}
+      />
+    </AuthScreenLayout>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    paddingHorizontal: spacing.xl,
-  },
-  content: {
-    flex: 1,
+  footerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    flexWrap: 'wrap',
     justifyContent: 'center',
   },
-  hero: {
-    marginBottom: spacing.xl,
+  footerText: {
+    ...typography.footnote,
   },
-  heading: {
-    ...typography.largeTitle,
-    marginTop: spacing.lg,
-    marginBottom: spacing.xs,
-  },
-  sub: {
-    ...typography.subheadline,
-  },
-  form: {
-    width: '100%',
+  footerLink: {
+    ...typography.footnote,
+    fontWeight: components.button.fontGhost.fontWeight,
   },
 });

--- a/apps/mobile/app/(auth)/signup.tsx
+++ b/apps/mobile/app/(auth)/signup.tsx
@@ -11,6 +11,14 @@ export default function SignUpScreen() {
   const { t } = useTranslation();
   const theme = useColors();
   const router = useRouter();
+  const handleBack = () => {
+    if (router.canGoBack()) {
+      router.back();
+      return;
+    }
+
+    router.replace('/(auth)/login');
+  };
 
   return (
     <AuthScreenLayout
@@ -20,7 +28,7 @@ export default function SignUpScreen() {
         <Pressable
           accessibilityRole="button"
           accessibilityLabel={t('common.action.back')}
-          onPress={() => router.replace('/(auth)/login')}
+          onPress={handleBack}
         >
           <Text style={[styles.back, { color: theme.interactive }]}>
             {t('common.action.back')}

--- a/apps/mobile/app/(auth)/signup.tsx
+++ b/apps/mobile/app/(auth)/signup.tsx
@@ -1,0 +1,46 @@
+import { Pressable, StyleSheet, Text } from 'react-native';
+import { useRouter } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { AuthScreenLayout } from '@/components/auth/AuthScreenLayout';
+import { EmailAuthForm } from '@/components/auth/EmailAuthForm';
+import { useColors } from '@/hooks/use-colors';
+import { typography } from '@/theme/tokens';
+
+// 新規登録画面も既存のメールOTP認証を使い、成功後の遷移は認証ガードに任せます。
+export default function SignUpScreen() {
+  const { t } = useTranslation();
+  const theme = useColors();
+  const router = useRouter();
+
+  return (
+    <AuthScreenLayout
+      heading={t('auth.signup.heading')}
+      subtitle={t('auth.signup.subtitle')}
+      topAction={
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={t('common.action.back')}
+          onPress={() => router.replace('/(auth)/login')}
+        >
+          <Text style={[styles.back, { color: theme.interactive }]}>
+            {t('common.action.back')}
+          </Text>
+        </Pressable>
+      }
+    >
+      <EmailAuthForm
+        submitLabel={t('auth.signup.submit')}
+        supportingText={t('auth.signup.supporting')}
+        onSuccess={() => {
+          // 認証後の遷移は _layout.tsx の NavigationGuard が一元管理します。
+        }}
+      />
+    </AuthScreenLayout>
+  );
+}
+
+const styles = StyleSheet.create({
+  back: {
+    ...typography.body,
+  },
+});

--- a/apps/mobile/app/(auth)/signup.tsx
+++ b/apps/mobile/app/(auth)/signup.tsx
@@ -1,15 +1,12 @@
-import { Pressable, StyleSheet, Text } from 'react-native';
 import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { AuthScreenLayout } from '@/components/auth/AuthScreenLayout';
 import { EmailAuthForm } from '@/components/auth/EmailAuthForm';
-import { useColors } from '@/hooks/use-colors';
-import { typography } from '@/theme/tokens';
+import { BackButton } from '@/components/ui/BackButton';
 
 // 新規登録画面も既存のメールOTP認証を使い、成功後の遷移は認証ガードに任せます。
 export default function SignUpScreen() {
   const { t } = useTranslation();
-  const theme = useColors();
   const router = useRouter();
   const handleBack = () => {
     if (router.canGoBack()) {
@@ -24,17 +21,7 @@ export default function SignUpScreen() {
     <AuthScreenLayout
       heading={t('auth.signup.heading')}
       subtitle={t('auth.signup.subtitle')}
-      topAction={
-        <Pressable
-          accessibilityRole="button"
-          accessibilityLabel={t('common.action.back')}
-          onPress={handleBack}
-        >
-          <Text style={[styles.back, { color: theme.interactive }]}>
-            {t('common.action.back')}
-          </Text>
-        </Pressable>
-      }
+      topAction={<BackButton onPress={handleBack} />}
     >
       <EmailAuthForm
         submitLabel={t('auth.signup.submit')}
@@ -46,9 +33,3 @@ export default function SignUpScreen() {
     </AuthScreenLayout>
   );
 }
-
-const styles = StyleSheet.create({
-  back: {
-    ...typography.body,
-  },
-});

--- a/apps/mobile/app/dogs/[id]/index.tsx
+++ b/apps/mobile/app/dogs/[id]/index.tsx
@@ -8,8 +8,8 @@ import { DogHero } from '@/components/dogs/DogHero';
 import { GoalProgressCard } from '@/components/dogs/GoalProgressCard';
 import { DogStatsCard } from '@/components/dogs/DogStatsCard';
 import { DogWalksList } from '@/components/dogs/DogWalksList';
+import { BackButton } from '@/components/ui/BackButton';
 import { LoadingScreen } from '@/components/ui/LoadingScreen';
-import { IconSymbol } from '@/components/ui/icon-symbol';
 import { useColors } from '@/hooks/use-colors';
 import { layout, spacing, typography } from '@/theme/tokens';
 
@@ -116,20 +116,14 @@ export default function DogDetailScreen() {
           testID="dog-detail-header-action-row"
           style={styles.headerActionRow}
         >
-          <Pressable
-            accessibilityRole="button"
+          <BackButton
             accessibilityLabel={t('dogs.detail.back')}
-            hitSlop={spacing.step12}
+            label={t('dogs.detail.back')}
             onPress={handleBack}
+            color={OVERLAY_TEXT}
+            labelStyle={styles.headerText}
             style={styles.headerLeft}
-          >
-            <IconSymbol
-              name="chevron.backward"
-              size={typography.body.fontSize}
-              color={OVERLAY_TEXT}
-            />
-            <Text style={styles.headerText}>{t('dogs.detail.back')}</Text>
-          </Pressable>
+          />
 
           <Pressable
             accessibilityRole="button"

--- a/apps/mobile/app/walks/_layout.tsx
+++ b/apps/mobile/app/walks/_layout.tsx
@@ -1,8 +1,7 @@
 import { Stack, useRouter } from 'expo-router';
-import { Pressable, Text, StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
+import { BackButton } from '@/components/ui/BackButton';
 import { useColors } from '@/hooks/use-colors';
-import { spacing, typography } from '@/theme/tokens';
 
 // 散歩詳細 Stack は独自の戻るボタンを使い、タブ内の履歴から自然に戻します。
 export default function WalksLayout() {
@@ -18,27 +17,13 @@ export default function WalksLayout() {
           title: t('walk.detail.title'),
           headerStyle: { backgroundColor: theme.background },
           headerLeft: () => (
-            <Pressable
-              accessibilityRole="button"
-              accessibilityLabel={t('common.back')}
+            <BackButton
               onPress={() => router.back()}
-              hitSlop={12}
-            >
-              <Text style={[styles.backButton, { color: theme.onSurface }]}>
-                {'‹'}
-              </Text>
-            </Pressable>
+              color={theme.interactive}
+            />
           ),
         }}
       />
     </Stack>
   );
 }
-
-const styles = StyleSheet.create({
-  backButton: {
-    fontSize: typography.numericBig.fontSize,
-    lineHeight: spacing.step44 - spacing.sm,
-    paddingRight: spacing.sm,
-  },
-});

--- a/apps/mobile/components/auth/AuthScreenLayout.tsx
+++ b/apps/mobile/components/auth/AuthScreenLayout.tsx
@@ -1,0 +1,165 @@
+import {
+  Keyboard,
+  Platform,
+  StyleSheet,
+  Text,
+  useWindowDimensions,
+  View,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import { AppMark } from '@/components/auth/AppMark';
+import { useColors } from '@/hooks/use-colors';
+import { layout, spacing, typography } from '@/theme/tokens';
+
+interface AuthScreenLayoutProps {
+  heading: string;
+  subtitle: string;
+  children: ReactNode;
+  footer?: ReactNode;
+  topAction?: ReactNode;
+  showAppMark?: boolean;
+  contentStyle?: StyleProp<ViewStyle>;
+}
+
+export function AuthScreenLayout({
+  heading,
+  subtitle,
+  children,
+  footer,
+  topAction,
+  showAppMark = false,
+  contentStyle,
+}: AuthScreenLayoutProps) {
+  const theme = useColors();
+  const { height: windowHeight } = useWindowDimensions();
+  const formRef = useRef<View>(null);
+  const [keyboardTop, setKeyboardTop] = useState<number | null>(null);
+  const [formFrame, setFormFrame] = useState({ y: 0, height: 0 });
+
+  const measureForm = useCallback(() => {
+    requestAnimationFrame(() => {
+      formRef.current?.measureInWindow((_x, y, _width, height) => {
+        setFormFrame({ y, height });
+      });
+    });
+  }, []);
+
+  useEffect(() => {
+    const showEvent = Platform.OS === 'ios' ? 'keyboardWillChangeFrame' : 'keyboardDidShow';
+    const hideEvent = Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
+
+    const showSubscription = Keyboard.addListener(showEvent, (event) => {
+      measureForm();
+      setKeyboardTop(event.endCoordinates.screenY);
+    });
+    const hideSubscription = Keyboard.addListener(hideEvent, () => {
+      setKeyboardTop(null);
+    });
+
+    return () => {
+      showSubscription.remove();
+      hideSubscription.remove();
+    };
+  }, [measureForm]);
+
+  const formBottom = formFrame.y + formFrame.height;
+  const keyboardOverlap = Math.max(
+    0,
+    formBottom + spacing.md - (keyboardTop ?? windowHeight),
+  );
+
+  return (
+    <SafeAreaView
+      edges={['top', 'bottom']}
+      style={[styles.safeArea, { backgroundColor: theme.background }]}
+    >
+      <View style={styles.container}>
+        {topAction ? <View style={styles.topAction}>{topAction}</View> : null}
+        <View
+          style={[
+            styles.content,
+            topAction ? styles.contentAfterTopAction : styles.contentFromTop,
+            contentStyle,
+          ]}
+        >
+          <View style={styles.hero}>
+            {showAppMark ? <View style={styles.mark}><AppMark /></View> : null}
+            <Text style={[styles.heading, { color: theme.onSurface }]}>
+              {heading}
+            </Text>
+            <Text style={[styles.subtitle, { color: theme.onSurfaceVariant }]}>
+              {subtitle}
+            </Text>
+          </View>
+          <View
+            ref={formRef}
+            onLayout={measureForm}
+            style={[
+              styles.form,
+              { transform: [{ translateY: -keyboardOverlap }] },
+            ]}
+          >
+            {children}
+          </View>
+        </View>
+        {footer ? <View style={styles.footer}>{footer}</View> : null}
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+  },
+  container: {
+    flex: 1,
+    paddingHorizontal: spacing.xl,
+  },
+  topAction: {
+    height: layout.navBar,
+    justifyContent: 'center',
+    alignItems: 'flex-start',
+  },
+  content: {
+    flex: 1,
+  },
+  contentFromTop: {
+    paddingTop: spacing.step60,
+  },
+  contentAfterTopAction: {
+    paddingTop: spacing.md,
+  },
+  hero: {
+    marginBottom: spacing.xl,
+  },
+  mark: {
+    marginBottom: spacing.lg,
+  },
+  heading: {
+    ...typography.largeTitle,
+    letterSpacing: spacing.none,
+    marginBottom: spacing.sm,
+  },
+  subtitle: {
+    ...typography.subheadline,
+  },
+  form: {
+    width: '100%',
+  },
+  footer: {
+    minHeight: layout.safeBottom,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingBottom: spacing.md,
+  },
+});

--- a/apps/mobile/components/auth/EmailAuthForm.test.tsx
+++ b/apps/mobile/components/auth/EmailAuthForm.test.tsx
@@ -47,6 +47,23 @@ describe('EmailAuthForm', () => {
     expect(screen.getByLabelText('One-time password')).toBeTruthy();
   });
 
+  it('uses a custom submit label while preserving the one-time password request', async () => {
+    mockRequestOneTimePassword.mockResolvedValue({
+      email: 'test@example.com',
+      session: 'otp-session',
+      codeLength: 8,
+    });
+    render(<EmailAuthForm onSuccess={jest.fn()} submitLabel="Sign in" />);
+
+    fireEvent.changeText(screen.getByLabelText('Email'), ' test@example.com ');
+    fireEvent.press(screen.getByRole('button', { name: 'Sign in' }));
+
+    await waitFor(() => {
+      expect(mockRequestOneTimePassword).toHaveBeenCalledWith('test@example.com');
+    });
+    expect(screen.getByLabelText('One-time password')).toBeTruthy();
+  });
+
   it('verifies a pasted eight-digit code once and calls onSuccess', async () => {
     const onSuccess = jest.fn();
     mockRequestOneTimePassword.mockResolvedValue({

--- a/apps/mobile/components/auth/EmailAuthForm.tsx
+++ b/apps/mobile/components/auth/EmailAuthForm.tsx
@@ -15,9 +15,15 @@ import { spacing, typography } from '@/theme/tokens';
 
 interface EmailAuthFormProps {
   onSuccess: () => void;
+  submitLabel?: string;
+  supportingText?: string;
 }
 
-export function EmailAuthForm({ onSuccess }: EmailAuthFormProps) {
+export function EmailAuthForm({
+  onSuccess,
+  submitLabel,
+  supportingText,
+}: EmailAuthFormProps) {
   const { requestOneTimePassword, verifyOneTimePassword } = useAuth();
   const { t } = useTranslation();
   const theme = useColors();
@@ -135,6 +141,12 @@ export function EmailAuthForm({ onSuccess }: EmailAuthFormProps) {
         </GroupedCard>
       )}
 
+      {!challenge && supportingText ? (
+        <Text style={[styles.supporting, { color: theme.onSurfaceVariant }]}>
+          {supportingText}
+        </Text>
+      ) : null}
+
       {verifyLoading ? (
         <Text style={[styles.status, { color: theme.onSurfaceVariant }]}>
           {t('auth.oneTimePassword.verifying')}
@@ -147,7 +159,7 @@ export function EmailAuthForm({ onSuccess }: EmailAuthFormProps) {
 
       {!challenge ? (
         <Button
-          label={t('auth.login.submit')}
+          label={submitLabel ?? t('auth.login.submit')}
           testID="auth-submit-email"
           onPress={handleSubmit}
           loading={requestLoading}
@@ -189,6 +201,12 @@ const styles = StyleSheet.create({
     ...typography.caption,
     marginBottom: spacing.sm,
     textAlign: 'center',
+  },
+  supporting: {
+    ...typography.footnote,
+    marginHorizontal: spacing.xs,
+    marginTop: spacing.sm,
+    marginBottom: spacing.lg,
   },
   error: {
     ...typography.caption,

--- a/apps/mobile/components/ui/BackButton.test.tsx
+++ b/apps/mobile/components/ui/BackButton.test.tsx
@@ -1,0 +1,69 @@
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { StyleSheet } from 'react-native';
+import { changeLanguage } from 'i18next';
+import { colors, layout, spacing, typography } from '@/theme/tokens';
+import { BackButton } from './BackButton';
+
+jest.mock('@/hooks/use-color-scheme', () => ({
+  useColorScheme: () => 'light',
+}));
+
+jest.mock('@/components/ui/icon-symbol', () => {
+  const { Text } = jest.requireActual<typeof import('react-native')>('react-native');
+
+  return {
+    IconSymbol: ({ name }: { name: string }) => <Text>{name}</Text>,
+  };
+});
+
+describe('BackButton', () => {
+  beforeEach(async () => {
+    await changeLanguage('en');
+  });
+
+  it('renders the shared back icon and English label', () => {
+    const onPress = jest.fn();
+
+    render(<BackButton onPress={onPress} />);
+
+    const button = screen.getByRole('button', { name: 'Back' });
+    const label = screen.getByText('Back');
+    const style = StyleSheet.flatten(button.props.style);
+
+    expect(screen.getByText('chevron.backward')).toBeTruthy();
+    expect(style.minWidth).toBe(spacing.step60);
+    expect(style.minHeight).toBe(layout.navBar);
+    expect(StyleSheet.flatten(label.props.style).fontSize).toBe(
+      typography.body.fontSize,
+    );
+
+    fireEvent.press(button);
+
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the Japanese back label from i18n', async () => {
+    await changeLanguage('ja');
+
+    render(<BackButton onPress={jest.fn()} />);
+
+    expect(screen.getByRole('button', { name: '戻る' })).toBeTruthy();
+  });
+
+  it('supports custom labels and disabled state', () => {
+    const onPress = jest.fn();
+
+    render(<BackButton label="Dogs" onPress={onPress} disabled />);
+
+    const button = screen.getByRole('button', { name: 'Dogs' });
+    const label = screen.getByText('Dogs');
+
+    fireEvent.press(button);
+
+    expect(onPress).not.toHaveBeenCalled();
+    expect(button.props.accessibilityState?.disabled).toBe(true);
+    expect(StyleSheet.flatten(label.props.style).color).toBe(
+      colors.light.textDisabled,
+    );
+  });
+});

--- a/apps/mobile/components/ui/BackButton.tsx
+++ b/apps/mobile/components/ui/BackButton.tsx
@@ -1,0 +1,74 @@
+import {
+  Pressable,
+  StyleSheet,
+  Text,
+  type StyleProp,
+  type TextStyle,
+  type ViewStyle,
+} from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { useColors } from '@/hooks/use-colors';
+import { layout, spacing, typography } from '@/theme/tokens';
+import { IconSymbol } from './icon-symbol';
+
+interface BackButtonProps {
+  onPress: () => void;
+  label?: string;
+  accessibilityLabel?: string;
+  color?: string;
+  disabled?: boolean;
+  style?: StyleProp<ViewStyle>;
+  labelStyle?: StyleProp<TextStyle>;
+  testID?: string;
+}
+
+export function BackButton({
+  onPress,
+  label,
+  accessibilityLabel,
+  color,
+  disabled = false,
+  style,
+  labelStyle,
+  testID,
+}: BackButtonProps) {
+  const { t } = useTranslation();
+  const theme = useColors();
+  const resolvedLabel = label ?? t('common.action.back');
+  const actionColor = disabled ? theme.textDisabled : (color ?? theme.interactive);
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel ?? resolvedLabel}
+      accessibilityState={{ disabled }}
+      disabled={disabled}
+      hitSlop={spacing.step12}
+      onPress={onPress}
+      style={[styles.button, style]}
+      testID={testID}
+    >
+      <IconSymbol
+        name="chevron.backward"
+        size={typography.body.fontSize}
+        color={actionColor}
+      />
+      <Text style={[styles.label, { color: actionColor }, labelStyle]}>
+        {resolvedLabel}
+      </Text>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    minWidth: spacing.step60,
+    minHeight: layout.navBar,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.step6,
+  },
+  label: {
+    ...typography.body,
+  },
+});

--- a/apps/mobile/components/ui/ScreenHeader.tsx
+++ b/apps/mobile/components/ui/ScreenHeader.tsx
@@ -3,7 +3,7 @@ import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useColors } from '@/hooks/use-colors';
 import { layout, spacing, typography } from '@/theme/tokens';
-import { IconSymbol } from './icon-symbol';
+import { BackButton } from './BackButton';
 
 export interface ScreenHeaderProps {
   /** 表示タイトル。i18n 済みの文字列を渡す。 */
@@ -93,35 +93,41 @@ export function ScreenHeader({
         ]}
       >
         {action ? (
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel={action.label}
-            accessibilityState={{ disabled: isDisabled }}
-            disabled={isDisabled}
-            hitSlop={spacing.step12}
-            onPress={action.onPress}
-            style={[
-              styles.actionButton,
-              side === 'left' ? styles.leftActionButton : styles.rightActionButton,
-            ]}
-          >
-            {action.icon ? (
-              <IconSymbol
-                name={action.icon}
-                size={typography.body.fontSize}
-                color={actionColor}
-              />
-            ) : null}
-            <Text
+          action.icon === 'chevron.backward' ? (
+            <BackButton
+              label={action.label}
+              onPress={action.onPress}
+              color={actionColor}
+              disabled={isDisabled}
               style={[
-                styles.actionLabel,
-                isStrong ? styles.strongActionLabel : null,
-                { color: actionColor },
+                styles.actionButton,
+                side === 'left' ? styles.leftActionButton : styles.rightActionButton,
+              ]}
+            />
+          ) : (
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={action.label}
+              accessibilityState={{ disabled: isDisabled }}
+              disabled={isDisabled}
+              hitSlop={spacing.step12}
+              onPress={action.onPress}
+              style={[
+                styles.actionButton,
+                side === 'left' ? styles.leftActionButton : styles.rightActionButton,
               ]}
             >
-              {action.label}
-            </Text>
-          </Pressable>
+              <Text
+                style={[
+                  styles.actionLabel,
+                  isStrong ? styles.strongActionLabel : null,
+                  { color: actionColor },
+                ]}
+              >
+                {action.label}
+              </Text>
+            </Pressable>
+          )
         ) : null}
       </View>
     );

--- a/apps/mobile/e2e/maestro/auth-onboarding.yaml
+++ b/apps/mobile/e2e/maestro/auth-onboarding.yaml
@@ -17,6 +17,9 @@ env:
 - launchApp:
     clearState: true
 - assertVisible: Walking Dog
+- assertVisible: Welcome back
+- tapOn: Create an account
+- assertVisible: Let's meet your dog.
 - tapOn:
     id: auth-email
 - inputText: ${E2E_EMAIL}

--- a/apps/mobile/lib/i18n/locales/en.json
+++ b/apps/mobile/lib/i18n/locales/en.json
@@ -16,14 +16,23 @@
   "auth": {
     "login": {
       "title": "Walking Dog",
-      "heading": "Continue with email",
-      "subtitle": "We'll send a one-time code if this email can use Walking Dog.",
+      "heading": "Welcome back",
+      "subtitle": "Sign in to keep walking with your dog.",
       "email": "Email",
       "submit": "Continue with email",
+      "primaryAction": "Sign in",
+      "signupPrompt": "New here?",
+      "signupAction": "Create an account",
       "error": {
         "invalidCredentials": "Could not send a code to that email",
         "generic": "Could not send a code"
       }
+    },
+    "signup": {
+      "heading": "Let's meet your dog.",
+      "subtitle": "Create your account and you'll be walking in a minute.",
+      "supporting": "You can add your dog's profile on the next step. We'll remember pace, goals, and photos.",
+      "submit": "Continue"
     },
     "legal": {
       "agreePrefix": "By continuing you agree to the ",

--- a/apps/mobile/lib/i18n/locales/ja.json
+++ b/apps/mobile/lib/i18n/locales/ja.json
@@ -16,14 +16,23 @@
   "auth": {
     "login": {
       "title": "Walking Dog",
-      "heading": "メールで続ける",
-      "subtitle": "利用できるメールにワンタイムコードを送ります。",
+      "heading": "おかえりなさい",
+      "subtitle": "愛犬との散歩を続けるためにログインします。",
       "email": "メール",
       "submit": "メールで続ける",
+      "primaryAction": "ログイン",
+      "signupPrompt": "はじめてですか？",
+      "signupAction": "アカウントを作成",
       "error": {
         "invalidCredentials": "このメールにコードを送れませんでした",
         "generic": "コードを送信できませんでした"
       }
+    },
+    "signup": {
+      "heading": "愛犬との散歩を始めましょう。",
+      "subtitle": "アカウントを作成すれば、すぐに散歩を始められます。",
+      "supporting": "犬のプロフィールは次のステップで追加できます。ペース、目標、写真を記録します。",
+      "submit": "続ける"
     },
     "legal": {
       "agreePrefix": "続けることで、",

--- a/docs/harness/journeys/auth-onboarding.md
+++ b/docs/harness/journeys/auth-onboarding.md
@@ -14,15 +14,19 @@
 
 ## Scope
 
-A new or returning owner enters email, verifies the email one-time password,
+A new or returning owner lands on a sign-in screen, can choose the sign-up
+screen when they are new, enters email, verifies the email one-time password,
 and reaches the authenticated app with the expected Dogs, Walk, and Me
-surfaces. The backend creates a Cognito and `users` row automatically when the
-email is not registered.
+surfaces. The backend continues to create a Cognito and `users` row
+automatically when the email is not registered.
 
 ## Acceptance Criteria
 
 - Authentication requires email only.
-- The UI does not ask the owner to choose sign-in versus account creation.
+- The initial auth UI separates sign-in and sign-up screens so owners can choose
+  the path that matches their intent.
+- Sign-up uses the same email one-time password flow and does not ask for name,
+  password, dog profile, or other new account fields.
 - Terms and privacy links open the configured `/terms` and `/policy` URLs.
 - Email one-time password accepts the operator-provided AWS Cognito code.
 - Completing the one-time password automatically verifies without a


### PR DESCRIPTION
## Summary

- Split the auth entry point into separate Sign In and Sign Up screens while keeping the existing email one-time-password flow.
- Added a shared auth screen layout so both screens retain the design direction from the reference Sign In / Sign Up mocks.
- Updated translations, auth onboarding documentation, Maestro journey expectations, and focused screen/form tests.

## Impact

- Dog experience: clearer onboarding reduces hesitation before owners start using Walking Dog with their dog.
- Walk data: keeps the same account creation and OTP path, preserving downstream walk data ownership semantics.
- Owner contribution: makes the sign-in vs account creation choice explicit without adding extra required fields.

## Validation

- `apps/mobile`: `npm run typecheck`
- `apps/mobile`: `npm run lint`
- `apps/mobile`: `npm test -- --runInBand --forceExit`
- repo root: `node scripts/harness/validate-all.mjs`
- iOS Simulator Release build on iPhone 17 Pro
- Maestro UI smoke: Sign In visible -> Create an account -> Sign Up visible -> Back -> Sign In visible

## E2E Note

The full existing `auth-onboarding.yaml` flow was also invoked with the README Java setup. It reached Sign Up and submitted the email, then stopped before the OTP screen because the local API returned `The security token included in the request is invalid.` from AWS Cognito. The UI split navigation path was verified separately with Maestro screenshots.