### PR TITLE
[codex] Clear high severity Sonar findings

### DIFF
--- a/apps/mobile/components/ui/ScreenHeader.tsx
+++ b/apps/mobile/components/ui/ScreenHeader.tsx
@@ -2,7 +2,7 @@ import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useColors } from '@/hooks/use-colors';
-import { layout, spacing, typography } from '@/theme/tokens';
+import { layout, spacing, typography, type ColorTokens } from '@/theme/tokens';
 import { BackButton } from './BackButton';
 
 export interface ScreenHeaderProps {
@@ -53,13 +53,13 @@ interface ResolvedScreenHeaderAction extends ScreenHeaderAction {
 
 type ActionSide = 'left' | 'right';
 
-export function ScreenHeader({
+export const ScreenHeader = ({
   title,
   variant = 'largeTitle',
   leftAction,
   rightAction,
   testID,
-}: ScreenHeaderProps) {
+}: ScreenHeaderProps) => {
   const router = useRouter();
   const { t } = useTranslation();
   const theme = useColors();
@@ -73,76 +73,17 @@ export function ScreenHeader({
       : leftAction;
   const resolvedRightAction = rightAction;
 
-  const renderActionSlot = (
-    action: ResolvedScreenHeaderAction | undefined,
-    side: ActionSide,
-    inline: boolean,
-    slotTestID?: string,
-  ) => {
-    const isDisabled = action?.disabled === true;
-    const isStrong = action?.strong === true && !isDisabled;
-    const actionColor = isDisabled ? theme.textDisabled : theme.interactive;
-
-    return (
-      <View
-        testID={slotTestID}
-        style={[
-          styles.actionSlot,
-          inline ? styles.inlineActionSlot : null,
-          side === 'left' ? styles.leftSlot : styles.rightSlot,
-        ]}
-      >
-        {action ? (
-          action.icon === 'chevron.backward' ? (
-            <BackButton
-              label={action.label}
-              onPress={action.onPress}
-              color={actionColor}
-              disabled={isDisabled}
-              style={[
-                styles.actionButton,
-                side === 'left' ? styles.leftActionButton : styles.rightActionButton,
-              ]}
-            />
-          ) : (
-            <Pressable
-              accessibilityRole="button"
-              accessibilityLabel={action.label}
-              accessibilityState={{ disabled: isDisabled }}
-              disabled={isDisabled}
-              hitSlop={spacing.step12}
-              onPress={action.onPress}
-              style={[
-                styles.actionButton,
-                side === 'left' ? styles.leftActionButton : styles.rightActionButton,
-              ]}
-            >
-              <Text
-                style={[
-                  styles.actionLabel,
-                  isStrong ? styles.strongActionLabel : null,
-                  { color: actionColor },
-                ]}
-              >
-                {action.label}
-              </Text>
-            </Pressable>
-          )
-        ) : null}
-      </View>
-    );
-  };
-
   if (variant === 'inline') {
     return (
       <View testID={testID}>
         <View testID={derivedTestID(testID, 'action-row')} style={styles.inlineRow}>
-          {renderActionSlot(
-            resolvedLeftAction,
-            'left',
-            true,
-            slotTestID(testID, 'left'),
-          )}
+          <ScreenHeaderActionSlot
+            action={resolvedLeftAction}
+            inline
+            side="left"
+            slotTestID={slotTestID(testID, 'left')}
+            theme={theme}
+          />
           <Text
             accessibilityRole="header"
             numberOfLines={1}
@@ -150,12 +91,13 @@ export function ScreenHeader({
           >
             {title}
           </Text>
-          {renderActionSlot(
-            resolvedRightAction,
-            'right',
-            true,
-            slotTestID(testID, 'right'),
-          )}
+          <ScreenHeaderActionSlot
+            action={resolvedRightAction}
+            inline
+            side="right"
+            slotTestID={slotTestID(testID, 'right')}
+            theme={theme}
+          />
         </View>
       </View>
     );
@@ -167,18 +109,20 @@ export function ScreenHeader({
         testID={derivedTestID(testID, 'action-row')}
         style={styles.largeTitleActionRow}
       >
-        {renderActionSlot(
-          resolvedLeftAction,
-          'left',
-          false,
-          slotTestID(testID, 'left'),
-        )}
-        {renderActionSlot(
-          resolvedRightAction,
-          'right',
-          false,
-          slotTestID(testID, 'right'),
-        )}
+        <ScreenHeaderActionSlot
+          action={resolvedLeftAction}
+          inline={false}
+          side="left"
+          slotTestID={slotTestID(testID, 'left')}
+          theme={theme}
+        />
+        <ScreenHeaderActionSlot
+          action={resolvedRightAction}
+          inline={false}
+          side="right"
+          slotTestID={slotTestID(testID, 'right')}
+          theme={theme}
+        />
       </View>
       <View
         testID={derivedTestID(testID, 'large-title-row')}
@@ -194,6 +138,94 @@ export function ScreenHeader({
       </View>
     </View>
   );
+};
+
+interface ScreenHeaderActionSlotProps {
+  action: ResolvedScreenHeaderAction | undefined;
+  side: ActionSide;
+  inline: boolean;
+  slotTestID?: string;
+  theme: ColorTokens;
+}
+
+const ScreenHeaderActionSlot = ({
+  action,
+  side,
+  inline,
+  slotTestID,
+  theme,
+}: ScreenHeaderActionSlotProps) => (
+  <View
+    testID={slotTestID}
+    style={[
+      styles.actionSlot,
+      inline ? styles.inlineActionSlot : null,
+      actionSlotAlignmentStyle(side),
+    ]}
+  >
+    {action ? (
+      <ScreenHeaderActionButton action={action} side={side} theme={theme} />
+    ) : null}
+  </View>
+);
+
+interface ScreenHeaderActionButtonProps {
+  action: ResolvedScreenHeaderAction;
+  side: ActionSide;
+  theme: ColorTokens;
+}
+
+const ScreenHeaderActionButton = ({
+  action,
+  side,
+  theme,
+}: ScreenHeaderActionButtonProps) => {
+  const isDisabled = action.disabled === true;
+  const isStrong = action.strong === true && !isDisabled;
+  const actionColor = isDisabled ? theme.textDisabled : theme.interactive;
+  const buttonStyle = [styles.actionButton, actionButtonAlignmentStyle(side)];
+
+  if (action.icon === 'chevron.backward') {
+    return (
+      <BackButton
+        label={action.label}
+        onPress={action.onPress}
+        color={actionColor}
+        disabled={isDisabled}
+        style={buttonStyle}
+      />
+    );
+  }
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={action.label}
+      accessibilityState={{ disabled: isDisabled }}
+      disabled={isDisabled}
+      hitSlop={spacing.step12}
+      onPress={action.onPress}
+      style={buttonStyle}
+    >
+      <Text
+        style={[
+          styles.actionLabel,
+          isStrong ? styles.strongActionLabel : null,
+          { color: actionColor },
+        ]}
+      >
+        {action.label}
+      </Text>
+    </Pressable>
+  );
+};
+
+function actionSlotAlignmentStyle(side: ActionSide) {
+  return side === 'left' ? styles.leftSlot : styles.rightSlot;
+}
+
+function actionButtonAlignmentStyle(side: ActionSide) {
+  return side === 'left' ? styles.leftActionButton : styles.rightActionButton;
 }
 
 function slotTestID(testID: string | undefined, side: ActionSide): string | undefined {

--- a/apps/mobile/components/ui/TextInput.test.tsx
+++ b/apps/mobile/components/ui/TextInput.test.tsx
@@ -60,6 +60,28 @@ describe('TextInput', () => {
     expect(rowStyle.borderColor).not.toBe('transparent');
   });
 
+  it('forwards focus and blur events while updating focused state', () => {
+    const onFocus = jest.fn();
+    const onBlur = jest.fn();
+    render(
+      <TextInput
+        label="Email"
+        labelPosition="inline"
+        testID="email-row"
+        onBlur={onBlur}
+        onFocus={onFocus}
+      />,
+    );
+
+    const input = screen.getByLabelText('Email');
+
+    fireEvent(input, 'focus');
+    fireEvent(input, 'blur');
+
+    expect(onFocus).toHaveBeenCalledTimes(1);
+    expect(onBlur).toHaveBeenCalledTimes(1);
+  });
+
   it('inline variant does not render separator when separator prop is false', () => {
     render(
       <TextInput label="Password" labelPosition="inline" testID="pwd-row" />,

--- a/apps/mobile/components/ui/TextInput.tsx
+++ b/apps/mobile/components/ui/TextInput.tsx
@@ -9,7 +9,7 @@ import {
   type TextStyle,
 } from 'react-native';
 import { useColors } from '@/hooks/use-colors';
-import { components, spacing, radius, typography } from '@/theme/tokens';
+import { components, spacing, radius, typography, type ColorTokens } from '@/theme/tokens';
 
 type LabelPosition = 'top' | 'inline';
 
@@ -27,7 +27,10 @@ interface TextInputProps extends Omit<RNTextInputProps, 'style'> {
   separator?: boolean;
 }
 
-export function TextInput({
+type TextInputFocusEvent = Parameters<NonNullable<RNTextInputProps['onFocus']>>[0];
+type TextInputBlurEvent = Parameters<NonNullable<RNTextInputProps['onBlur']>>[0];
+
+export const TextInput = ({
   label,
   error,
   style,
@@ -37,89 +40,183 @@ export function TextInput({
   onBlur,
   onFocus,
   ...props
-}: TextInputProps) {
+}: TextInputProps) => {
   const theme = useColors();
+  const { isFocused, handleBlur, handleFocus } = useTextInputFocusHandlers({
+    onBlur,
+    onFocus,
+  });
+
+  return labelPosition === 'inline' ? (
+    <InlineTextInput
+      error={error}
+      inputProps={props}
+      isFocused={isFocused}
+      label={label}
+      onBlur={handleBlur}
+      onFocus={handleFocus}
+      separator={separator}
+      style={style}
+      testID={testID}
+      theme={theme}
+    />
+  ) : (
+    <TopTextInput
+      error={error}
+      inputProps={props}
+      isFocused={isFocused}
+      label={label}
+      onBlur={handleBlur}
+      onFocus={handleFocus}
+      style={style}
+      testID={testID}
+      theme={theme}
+    />
+  );
+};
+
+interface UseTextInputFocusHandlersProps {
+  onBlur?: RNTextInputProps['onBlur'];
+  onFocus?: RNTextInputProps['onFocus'];
+}
+
+function useTextInputFocusHandlers({
+  onBlur,
+  onFocus,
+}: UseTextInputFocusHandlersProps) {
   const [isFocused, setIsFocused] = useState(false);
 
-  function handleFocus(event: Parameters<NonNullable<RNTextInputProps['onFocus']>>[0]) {
+  function handleFocus(event: TextInputFocusEvent) {
     setIsFocused(true);
     onFocus?.(event);
   }
 
-  function handleBlur(event: Parameters<NonNullable<RNTextInputProps['onBlur']>>[0]) {
+  function handleBlur(event: TextInputBlurEvent) {
     setIsFocused(false);
     onBlur?.(event);
   }
 
-  if (labelPosition === 'inline') {
-    return (
-      <>
-        <View
-          testID={testID ? `${testID}-container` : undefined}
-          style={[
-            inlineStyles.row,
-            {
-              backgroundColor: isFocused ? theme.surfaceContainer : 'transparent',
-              borderColor: isFocused ? theme.interactive : 'transparent',
-            },
-          ]}
-        >
-          <Text style={[inlineStyles.label, { color: theme.onSurfaceVariant }]}>
-            {label}
-          </Text>
-          <RNTextInput
-            style={[inlineStyles.input, { color: theme.onSurface }, style]}
-            placeholderTextColor={theme.onSurfaceVariant}
-            accessibilityLabel={label}
-            testID={testID}
-            onBlur={handleBlur}
-            onFocus={handleFocus}
-            {...props}
-          />
-        </View>
-        {separator ? (
-          <View
-            testID={testID ? `${testID}-separator` : undefined}
-            style={[inlineStyles.separator, { backgroundColor: theme.border }]}
-          />
-        ) : null}
-        {error ? (
-          <Text style={[inlineStyles.error, { color: theme.error }]}>{error}</Text>
-        ) : null}
-      </>
-    );
-  }
+  return { isFocused, handleBlur, handleFocus };
+}
 
-  return (
-    <View style={styles.container}>
-      <Text
-        style={[styles.label, { color: theme.onSurface }]}
-        accessibilityRole="none"
-      >
+interface TextInputVariantProps {
+  error?: string;
+  inputProps: RNTextInputProps;
+  isFocused: boolean;
+  label: string;
+  onBlur: NonNullable<RNTextInputProps['onBlur']>;
+  onFocus: NonNullable<RNTextInputProps['onFocus']>;
+  style?: StyleProp<TextStyle>;
+  testID?: string;
+  theme: ColorTokens;
+}
+
+interface InlineTextInputProps extends TextInputVariantProps {
+  separator: boolean;
+}
+
+const InlineTextInput = ({
+  error,
+  inputProps,
+  isFocused,
+  label,
+  onBlur,
+  onFocus,
+  separator,
+  style,
+  testID,
+  theme,
+}: InlineTextInputProps) => (
+  <>
+    <View
+      testID={testID ? `${testID}-container` : undefined}
+      style={[
+        inlineStyles.row,
+        {
+          backgroundColor: isFocused ? theme.surfaceContainer : 'transparent',
+          borderColor: isFocused ? theme.interactive : 'transparent',
+        },
+      ]}
+    >
+      <Text style={[inlineStyles.label, { color: theme.onSurfaceVariant }]}>
         {label}
       </Text>
       <RNTextInput
-        style={[
-          styles.input,
-          {
-            backgroundColor: theme.surface,
-            color: theme.onSurface,
-            borderColor: error ? theme.error : isFocused ? theme.interactive : theme.border,
-          },
-          style,
-        ]}
+        style={[inlineStyles.input, { color: theme.onSurface }, style]}
         placeholderTextColor={theme.onSurfaceVariant}
         accessibilityLabel={label}
         testID={testID}
-        onBlur={handleBlur}
-        onFocus={handleFocus}
-        {...props}
+        onBlur={onBlur}
+        onFocus={onFocus}
+        {...inputProps}
       />
-      {error ? (
-        <Text style={[styles.error, { color: theme.error }]}>{error}</Text>
-      ) : null}
     </View>
-  );
+    {separator ? (
+      <View
+        testID={testID ? `${testID}-separator` : undefined}
+        style={[inlineStyles.separator, { backgroundColor: theme.border }]}
+      />
+    ) : null}
+    {error ? (
+      <Text style={[inlineStyles.error, { color: theme.error }]}>{error}</Text>
+    ) : null}
+  </>
+);
+
+const TopTextInput = ({
+  error,
+  inputProps,
+  isFocused,
+  label,
+  onBlur,
+  onFocus,
+  style,
+  testID,
+  theme,
+}: TextInputVariantProps) => (
+  <View style={styles.container}>
+    <Text
+      style={[styles.label, { color: theme.onSurface }]}
+      accessibilityRole="none"
+    >
+      {label}
+    </Text>
+    <RNTextInput
+      style={[
+        styles.input,
+        {
+          backgroundColor: theme.surface,
+          color: theme.onSurface,
+          borderColor: inputBorderColor({ error, isFocused, theme }),
+        },
+        style,
+      ]}
+      placeholderTextColor={theme.onSurfaceVariant}
+      accessibilityLabel={label}
+      testID={testID}
+      onBlur={onBlur}
+      onFocus={onFocus}
+      {...inputProps}
+    />
+    {error ? (
+      <Text style={[styles.error, { color: theme.error }]}>{error}</Text>
+    ) : null}
+  </View>
+);
+
+function inputBorderColor({
+  error,
+  isFocused,
+  theme,
+}: {
+  error?: string;
+  isFocused: boolean;
+  theme: ColorTokens;
+}) {
+  if (error) {
+    return theme.error;
+  }
+  return isFocused ? theme.interactive : theme.border;
 }
 
 const styles = StyleSheet.create({

--- a/apps/mobile/hooks/use-pack-progress.test.ts
+++ b/apps/mobile/hooks/use-pack-progress.test.ts
@@ -165,6 +165,22 @@ describe('aggregatePackProgress', () => {
     expect(result.perDog['old-dog']).toBeUndefined();
   });
 
+  it('uses walk dogs with default goals when no current pack dogs are loaded', () => {
+    const walks: Walk[] = [
+      makeWalk('w1', ['coco'], new Date(2026, 3, 19, 8, 0).toISOString(), 1000, 25 * 60),
+    ];
+
+    const result = aggregatePackProgress(walks, [], now);
+
+    expect(result.todayKm).toBeCloseTo(1, 5);
+    expect(result.todayMinutes).toBe(25);
+    expect(result.goalProgressMinutes).toBe(25);
+    expect(result.goalMinutes).toBe(30);
+    expect(result.progressPct).toBe(83);
+    expect(result.perDog.coco.goalMinutes).toBe(30);
+    expect(result.perDog.coco.totalWalks).toBe(1);
+  });
+
   it('streak counts consecutive days ending today', () => {
     const walks: Walk[] = [
       makeWalk('w1', ['coco'], new Date(2026, 3, 19, 8).toISOString(), 500),

--- a/apps/mobile/hooks/use-pack-progress.ts
+++ b/apps/mobile/hooks/use-pack-progress.ts
@@ -20,6 +20,24 @@ interface DogProgress {
   streakDays: number;
 }
 
+type DogGoal = { minutes: number; cycleDays: GoalCycleDays };
+
+interface PackProgressAccumulator {
+  dogDays: Map<string, Set<string>>;
+  dogGoalProgressMinutes: Map<string, number>;
+  dogGoals: Map<string, DogGoal>;
+  dogTodayM: Map<string, number>;
+  dogTodayMinutes: Map<string, number>;
+  dogTotalWalks: Map<string, number>;
+  currentDogIds: Set<string>;
+  hasCurrentDogs: boolean;
+  now: Date;
+  packDays: Set<string>;
+  packTodayM: number;
+  packTodayMinutes: number;
+  todayKey: string;
+}
+
 // パック全体と犬ごとの散歩進捗を、ホームや犬一覧で使う形にまとめた値です。
 export interface PackProgress {
   todayKm: number;
@@ -75,104 +93,233 @@ export function aggregatePackProgress(
   dogs: Dog[] = [],
   now: Date = new Date(),
 ): Omit<PackProgress, 'isLoading'> {
-  const todayKey = localDayKey(now);
+  const progress = createPackProgressAccumulator(dogs, now);
 
-  let packTodayM = 0;
-  let packTodayMinutes = 0;
-  const packDays = new Set<string>();
-  const dogDays = new Map<string, Set<string>>();
-  const dogTodayM = new Map<string, number>();
-  const dogTodayMinutes = new Map<string, number>();
-  const dogGoalProgressMinutes = new Map<string, number>();
-  const dogTotalWalks = new Map<string, number>();
-  const dogGoals = new Map<string, { minutes: number; cycleDays: GoalCycleDays }>();
+  // 散歩単位の距離をパック全体へ、参加中の犬ごとには個別進捗へ積み上げます。
+  for (const walk of walks) {
+    applyWalkProgress(progress, walk);
+  }
 
+  return buildPackProgress(progress);
+}
+
+function createPackProgressAccumulator(
+  dogs: Dog[],
+  now: Date,
+): PackProgressAccumulator {
+  const dogGoals = new Map<string, DogGoal>();
   for (const dog of dogs) {
     dogGoals.set(dog.id, getGoal(dog));
   }
   const currentDogIds = new Set(dogGoals.keys());
-  const hasCurrentDogs = currentDogIds.size > 0;
 
-  // 散歩単位の距離をパック全体へ、参加中の犬ごとには個別進捗へ積み上げます。
-  for (const walk of walks) {
-    const dayKey = toLocalDayKey(walk.startedAt);
-    const distanceM = walk.distanceM ?? 0;
-    const durationMinutes = durationSecToMinutes(walk.durationSec ?? null);
-    let includesCurrentDog = false;
+  return {
+    dogDays: new Map(),
+    dogGoalProgressMinutes: new Map(),
+    dogGoals,
+    dogTodayM: new Map(),
+    dogTodayMinutes: new Map(),
+    dogTotalWalks: new Map(),
+    currentDogIds,
+    hasCurrentDogs: currentDogIds.size > 0,
+    now,
+    packDays: new Set(),
+    packTodayM: 0,
+    packTodayMinutes: 0,
+    todayKey: localDayKey(now),
+  };
+}
 
-    for (const dog of walk.dogs ?? []) {
-      if (!dog?.id) continue;
-      if (hasCurrentDogs && !currentDogIds.has(dog.id)) continue;
-      includesCurrentDog = true;
-      let set = dogDays.get(dog.id);
-      if (!set) {
-        set = new Set();
-        dogDays.set(dog.id, set);
-      }
-      if (dayKey) set.add(dayKey);
-
-      dogTotalWalks.set(dog.id, (dogTotalWalks.get(dog.id) ?? 0) + 1);
-      if (dayKey === todayKey) {
-        dogTodayM.set(dog.id, (dogTodayM.get(dog.id) ?? 0) + distanceM);
-        dogTodayMinutes.set(
-          dog.id,
-          (dogTodayMinutes.get(dog.id) ?? 0) + durationMinutes,
-        );
-        packTodayMinutes += durationMinutes;
-      }
-      const goal = dogGoals.get(dog.id) ?? defaultGoal();
-      if (isInGoalWindow(dayKey, goal.cycleDays, now)) {
-        dogGoalProgressMinutes.set(
-          dog.id,
-          (dogGoalProgressMinutes.get(dog.id) ?? 0) + durationMinutes,
-        );
-      }
-    }
-
-    if (includesCurrentDog) {
-      if (dayKey === todayKey) packTodayM += distanceM;
-      if (dayKey) packDays.add(dayKey);
-    }
+function applyWalkProgress(progress: PackProgressAccumulator, walk: Walk) {
+  const dogIds = currentWalkDogIds(progress, walk);
+  if (dogIds.length === 0) {
+    return;
   }
 
-  const perDog: Record<string, DogProgress> = {};
-  const dogIds = new Set([...dogGoals.keys(), ...dogDays.keys()]);
+  const dayKey = toLocalDayKey(walk.startedAt);
+  const distanceM = walk.distanceM ?? 0;
+  const durationMinutes = durationSecToMinutes(walk.durationSec ?? null);
+
   for (const dogId of dogIds) {
-    const days = dogDays.get(dogId) ?? new Set<string>();
-    const goal = dogGoals.get(dogId) ?? defaultGoal();
-    perDog[dogId] = {
-      todayKm: (dogTodayM.get(dogId) ?? 0) / 1000,
-      todayMinutes: dogTodayMinutes.get(dogId) ?? 0,
-      goalProgressMinutes: dogGoalProgressMinutes.get(dogId) ?? 0,
-      goalMinutes: goal.minutes,
-      goalCycleDays: goal.cycleDays,
-      totalWalks: dogTotalWalks.get(dogId) ?? 0,
-      streakDays: computeStreak(days, now),
-    };
+    applyDogWalkProgress(progress, {
+      dayKey,
+      distanceM,
+      dogId,
+      durationMinutes,
+    });
   }
 
-  const todayKm = packTodayM / 1000;
-  const goalProgressMinutes = Array.from(dogIds).reduce(
-    (total, dogId) => total + (dogGoalProgressMinutes.get(dogId) ?? 0),
-    0,
-  );
-  const goalMinutes = Array.from(dogIds).reduce(
-    (total, dogId) => total + (dogGoals.get(dogId)?.minutes ?? DEFAULT_DAILY_GOAL_MINUTES),
-    0,
-  );
-  const progressPct =
-    goalMinutes > 0 ? Math.min(100, Math.round((goalProgressMinutes / goalMinutes) * 100)) : 0;
-  const packStreakDays = computeStreak(packDays, now);
+  if (dayKey === progress.todayKey) {
+    progress.packTodayM += distanceM;
+  }
+  if (dayKey) {
+    progress.packDays.add(dayKey);
+  }
+}
+
+function currentWalkDogIds(progress: PackProgressAccumulator, walk: Walk): string[] {
+  const dogIds: string[] = [];
+  for (const dog of walk.dogs ?? []) {
+    if (isIncludedWalkDog(progress, dog?.id)) {
+      dogIds.push(dog.id);
+    }
+  }
+  return dogIds;
+}
+
+function isIncludedWalkDog(
+  progress: PackProgressAccumulator,
+  dogId: string | undefined,
+) {
+  if (!dogId) {
+    return false;
+  }
+  return !progress.hasCurrentDogs || progress.currentDogIds.has(dogId);
+}
+
+function applyDogWalkProgress(
+  progress: PackProgressAccumulator,
+  walk: {
+    dayKey: string;
+    distanceM: number;
+    dogId: string;
+    durationMinutes: number;
+  },
+) {
+  addDogWalkDay(progress, walk.dogId, walk.dayKey);
+  incrementMap(progress.dogTotalWalks, walk.dogId, 1);
+  addTodayDogProgress(progress, walk);
+  addGoalProgress(progress, walk);
+}
+
+function addDogWalkDay(
+  progress: PackProgressAccumulator,
+  dogId: string,
+  dayKey: string,
+) {
+  if (dayKey) {
+    getDogDays(progress, dogId).add(dayKey);
+  } else {
+    getDogDays(progress, dogId);
+  }
+}
+
+function getDogDays(progress: PackProgressAccumulator, dogId: string) {
+  const existing = progress.dogDays.get(dogId);
+  if (existing) {
+    return existing;
+  }
+  const days = new Set<string>();
+  progress.dogDays.set(dogId, days);
+  return days;
+}
+
+function addTodayDogProgress(
+  progress: PackProgressAccumulator,
+  walk: {
+    dayKey: string;
+    distanceM: number;
+    dogId: string;
+    durationMinutes: number;
+  },
+) {
+  if (walk.dayKey !== progress.todayKey) {
+    return;
+  }
+  incrementMap(progress.dogTodayM, walk.dogId, walk.distanceM);
+  incrementMap(progress.dogTodayMinutes, walk.dogId, walk.durationMinutes);
+  progress.packTodayMinutes += walk.durationMinutes;
+}
+
+function addGoalProgress(
+  progress: PackProgressAccumulator,
+  walk: {
+    dayKey: string;
+    dogId: string;
+    durationMinutes: number;
+  },
+) {
+  const goal = progress.dogGoals.get(walk.dogId) ?? defaultGoal();
+  if (isInGoalWindow(walk.dayKey, goal.cycleDays, progress.now)) {
+    incrementMap(progress.dogGoalProgressMinutes, walk.dogId, walk.durationMinutes);
+  }
+}
+
+function incrementMap(values: Map<string, number>, key: string, amount: number) {
+  values.set(key, (values.get(key) ?? 0) + amount);
+}
+
+function buildPackProgress(
+  progress: PackProgressAccumulator,
+): Omit<PackProgress, 'isLoading'> {
+  const dogIds = progressDogIds(progress);
+  const perDog: Record<string, DogProgress> = {};
+  for (const dogId of dogIds) {
+    perDog[dogId] = buildDogProgress(progress, dogId);
+  }
+
+  const todayKm = progress.packTodayM / 1000;
+  const goalProgressMinutes = sumGoalProgressMinutes(progress, dogIds);
+  const goalMinutes = sumGoalMinutes(progress, dogIds);
+  const progressPct = progressPercentage(goalProgressMinutes, goalMinutes);
+  const packStreakDays = computeStreak(progress.packDays, progress.now);
 
   return {
     todayKm,
-    todayMinutes: packTodayMinutes,
+    todayMinutes: progress.packTodayMinutes,
     goalProgressMinutes,
     goalMinutes,
     progressPct,
     packStreakDays,
     perDog,
   };
+}
+
+function progressDogIds(progress: PackProgressAccumulator) {
+  return new Set([...progress.dogGoals.keys(), ...progress.dogDays.keys()]);
+}
+
+function buildDogProgress(
+  progress: PackProgressAccumulator,
+  dogId: string,
+): DogProgress {
+  const days = progress.dogDays.get(dogId) ?? new Set<string>();
+  const goal = progress.dogGoals.get(dogId) ?? defaultGoal();
+
+  return {
+    todayKm: (progress.dogTodayM.get(dogId) ?? 0) / 1000,
+    todayMinutes: progress.dogTodayMinutes.get(dogId) ?? 0,
+    goalProgressMinutes: progress.dogGoalProgressMinutes.get(dogId) ?? 0,
+    goalMinutes: goal.minutes,
+    goalCycleDays: goal.cycleDays,
+    totalWalks: progress.dogTotalWalks.get(dogId) ?? 0,
+    streakDays: computeStreak(days, progress.now),
+  };
+}
+
+function sumGoalProgressMinutes(
+  progress: PackProgressAccumulator,
+  dogIds: Set<string>,
+) {
+  return Array.from(dogIds).reduce(
+    (total, dogId) => total + (progress.dogGoalProgressMinutes.get(dogId) ?? 0),
+    0,
+  );
+}
+
+function sumGoalMinutes(progress: PackProgressAccumulator, dogIds: Set<string>) {
+  return Array.from(dogIds).reduce(
+    (total, dogId) =>
+      total + (progress.dogGoals.get(dogId)?.minutes ?? DEFAULT_DAILY_GOAL_MINUTES),
+    0,
+  );
+}
+
+function progressPercentage(goalProgressMinutes: number, goalMinutes: number) {
+  if (goalMinutes <= 0) {
+    return 0;
+  }
+  return Math.min(100, Math.round((goalProgressMinutes / goalMinutes) * 100));
 }
 
 // 最新の散歩履歴をもとに、パック進捗をメモ化して返します。


### PR DESCRIPTION
## Summary
- Refactor `ScreenHeader` action rendering into focused slot/button helpers to clear Sonar cognitive complexity.
- Split `TextInput` top/inline rendering and focus handling while preserving the public props and behavior.
- Break pack progress aggregation into smaller helpers without changing walk goal, group walk, streak, or current-pack semantics.

## Product impact
- Dog experience: no user-visible behavior change.
- Walk data: preserves existing pack and per-dog progress semantics while making the aggregation easier to maintain.
- Owner contribution: preserves the screens and stats owners use to understand walking progress.

## Validation
- `npm test -- components/ui/ScreenHeader.test.tsx components/ui/TextInput.test.tsx hooks/use-pack-progress.test.ts --runInBand` -> 39 passed.
- `npm run typecheck` -> passed.
- `npm run lint` -> passed.
- `npm test -- --runInBand --forceExit` -> 123 suites / 742 tests passed.
- `node scripts/harness/validate-all.mjs` -> passed.
- `scripts/sonar/run-analysis.sh` -> Sonar scanner execution successful.
- Sonar API `impactSeverities=HIGH,BLOCKER` -> `total: 0`.
- Sonar API `severities=BLOCKER,CRITICAL` -> `total: 0`.

## Notes
- The PR branch was created from `origin/main` to avoid unrelated local changes and the existing `clean` branch commit from entering this PR.