### PR TITLE
[codex] Add Cloudflare DNS Terraform module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ apps/api/.env.production
 *.tfstate
 *.tfstate.backup
 .terraform.lock.hcl
+!infra/cloudflare/.terraform.lock.hcl
+infra/cloudflare/.env.local
+infra/cloudflare/terraform.tfvars
 infra/**/lambda/*.zip
 infra/sakura/.env
 

--- a/infra/cloudflare/.env.example
+++ b/infra/cloudflare/.env.example
@@ -1,0 +1,1 @@
+CLOUDFLARE_API_TOKEN=replace-with-cloudflare-api-token

--- a/infra/cloudflare/.terraform.lock.hcl
+++ b/infra/cloudflare/.terraform.lock.hcl
@@ -1,0 +1,19 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/cloudflare/cloudflare" {
+  version     = "5.21.1"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:iWJb0lHfVWmCJQSyroXOT8zQlFOT8k1caHcfaooG5wk=",
+    "zh:049719425b8be43d9d4f0c208217aca0baa22374f061d7ff92f02563490f649c",
+    "zh:0a8a3c1b26680b437fe9e7910ca81e532d36f8efacfb14f45690b6a779856993",
+    "zh:32b61f80892243f7ab8e453fa038c1f3e2aac733ccb98307c2cfe798b2793b32",
+    "zh:42c27f3cd62979e70716c51f682a3d131d51ad76d86dff83d8cdbfffcebac841",
+    "zh:4c8cd464f9b6ecde5cd4430bbba4be3b810826105e51ef6328b6a2b69f821443",
+    "zh:586ea42ef74d6c5bc4c9b89da6b1f8618a19f4e80272fe8d615e7d5b11c491af",
+    "zh:b09b86c7cac7085e01c9b7a828f09d13c44589d3e3cd42f0b694ca3e4cd3ed0a",
+    "zh:eac80665e60c701b37a6318f4e405d67f1720f8da5f93135c6256049282d3367",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+  ]
+}

--- a/infra/cloudflare/README.md
+++ b/infra/cloudflare/README.md
@@ -1,103 +1,181 @@
-# Cloudflare DNS setup for Amazon SES and Cognito
+# Cloudflare DNS for cacheandbuffer.com
 
-このディレクトリは、Cloudflare Dashboard で行う手動DNS設定の運用メモです。
+This Terraform root module manages Cloudflare DNS records for
+`cacheandbuffer.com`.
 
-対象:
+Managed records:
 
-- SES identity domain: `walking-dog.cacheandbuffer.com`
-- Cognito sender: `Walking Dog <no-reply@walking-dog.cacheandbuffer.com>`
-- SES custom MAIL FROM: `ses-bounce.walking-dog.cacheandbuffer.com`
-- Runtime caller: Cognito user pool email configuration with `email_sending_account = "DEVELOPER"`
+- `walking-dog.cacheandbuffer.com` `A` record for the Sakura VPS API endpoint.
+- Amazon SES domain verification `TXT` record for Cognito email delivery.
+- Amazon SES Easy DKIM `CNAME` records.
+- Amazon SES custom MAIL FROM `MX` and SPF `TXT` records.
+- DMARC starter `TXT` record.
 
-Cloudflare Email Routing / Email Sending は使いません。CloudflareはDNS管理だけを担当し、メール送信はAmazon SES、確認コード送信はCognito標準メール機能が担当します。
+Cloudflare Email Routing / Email Sending is not used. Cognito sends
+confirmation and OTP emails through Amazon SES; Cloudflare owns the DNS records
+that verify and authenticate that sender domain.
 
 ## Terraform command note
 
-このrepoでは `.claude/skills/terraform/SKILL.md` に従い、TerraformはhostではなくDocker `hashicorp/terraform:1.14` で実行します。本文中の `terraform ...` はTerraform CLI引数の簡略表記です。実行時はrepo rootから以下の形式に置き換えます。
+Run Terraform through Docker from the repository root. This module stores state
+in the existing S3 backend, so the command needs AWS credentials for the backend
+and a Cloudflare API token for the provider.
 
 ```bash
 docker run --rm \
-  -v "$(pwd)/infra/aws:/workspace" \
+  -v "$PWD/infra/cloudflare:/workspace" \
   -v "$HOME/.aws:/root/.aws:ro" \
   -e AWS_PROFILE=personal \
+  --env-file "$PWD/infra/cloudflare/.env.local" \
   -w /workspace \
   hashicorp/terraform:1.14 <command>
 ```
 
-## Setup flow
+Use a Cloudflare API token scoped to the `cacheandbuffer.com` zone with:
 
-SES domain verificationはDNS反映を挟むため、初回は2段階で進めます。
+- `Zone:Read`
+- `DNS:Edit`
 
-1. TerraformでSES identityを作り、Cloudflareに入れるDNS recordを出力する。
-2. Cloudflare DNSにSES verification / DKIM / MAIL FROM / DMARC recordsを追加する。
-3. SES consoleでdomain identityとDKIMがverified/successfulになったことを確認する。
-4. TerraformでCognitoをSES送信へ切り替える。
-5. Cognito sign-up emailをE2E確認する。
+## Initial setup
 
-## Bootstrap Terraform apply
-
-SES identityを初めて作る時点ではDNSがまだ存在しないため、CognitoをSESへ切り替える前にDNS recordを取得します。
+Create a local `terraform.tfvars` from the example:
 
 ```bash
-cd infra/aws
-
-terraform apply \
-  -var cognito_use_ses_email=false
+cp infra/cloudflare/terraform.tfvars.example infra/cloudflare/terraform.tfvars
 ```
 
-Apply後、Cloudflareへ追加するDNS recordsを取得します。
+Create a local environment file for the Cloudflare API token:
 
 ```bash
-terraform output -json ses_cloudflare_dns_records
+cp infra/cloudflare/.env.example infra/cloudflare/.env.local
 ```
 
-`cognito_use_ses_email=false` はbootstrap用です。DNS検証後は既定値の `true` で運用します。
+Edit `infra/cloudflare/.env.local` and replace the placeholder value. This file
+is gitignored and must not be committed.
 
-## Add records in Cloudflare
+Fill in:
 
-1. Cloudflare Dashboardにログインする。
-2. `cacheandbuffer.com` または `walking-dog.cacheandbuffer.com` のDNS管理画面を開く。
-3. `terraform output -json ses_cloudflare_dns_records` の各recordを追加する。
-4. CNAME/MX/TXTはいずれも `DNS only` にする。
-   - TXT/MXはproxy対象外です。
-   - CNAMEもSES/DKIM検証用なのでproxyしないでください。
+- `cloudflare_zone_id`: Cloudflare zone ID for `cacheandbuffer.com`.
+- `ses_domain_verification_token`: Amazon SES verification token.
+- `ses_dkim_tokens`: the three Amazon SES DKIM tokens.
 
-Terraform outputのrecordは同じshapeです。
+The SES values come from the AWS root module:
 
-```json
-{
-  "type": "TXT",
-  "name": "_amazonses.walking-dog.cacheandbuffer.com",
-  "value": "example-token",
-  "priority": "",
-  "proxy_status": "DNS only",
-  "purpose": "SES domain ownership verification"
-}
+```bash
+docker run --rm \
+  -v "$PWD/infra/aws:/workspace" \
+  -v "$HOME/.aws:/root/.aws:ro" \
+  -e AWS_PROFILE=personal \
+  -w /workspace \
+  hashicorp/terraform:1.14 output -json ses_cloudflare_dns_records
 ```
 
-Cloudflare UIでの入力:
+From that output:
 
-- `type`: DNS record type。
-- `name`: Cloudflare zoneが `cacheandbuffer.com` の場合はFQDNのまま、またはUIが補完する場合はzone suffixを除いた名前で入力する。
-- `value`: Terraform outputの値をそのまま入れる。
-- `priority`: MX recordのみ `10` を入れる。
-- `Proxy status`: `DNS only`。
+- Use the `value` from the `SES domain ownership verification` record as
+  `ses_domain_verification_token`.
+- For each `SES Easy DKIM` record, take the token before
+  `._domainkey.walking-dog.cacheandbuffer.com` and put it in
+  `ses_dkim_tokens`.
+
+## Import existing DNS records
+
+The records already exist in Cloudflare. Do not run `apply` until every existing
+record has been imported into this module's state; otherwise Terraform will try
+to create duplicate DNS records.
+
+Initialize the module first:
+
+```bash
+docker run --rm \
+  -v "$PWD/infra/cloudflare:/workspace" \
+  -v "$HOME/.aws:/root/.aws:ro" \
+  -e AWS_PROFILE=personal \
+  --env-file "$PWD/infra/cloudflare/.env.local" \
+  -w /workspace \
+  hashicorp/terraform:1.14 init
+```
+
+Find each Cloudflare DNS record ID in the dashboard or through the Cloudflare
+API, then import it with the matching resource address:
+
+```bash
+docker run --rm \
+  -v "$PWD/infra/cloudflare:/workspace" \
+  -v "$HOME/.aws:/root/.aws:ro" \
+  -e AWS_PROFILE=personal \
+  --env-file "$PWD/infra/cloudflare/.env.local" \
+  -w /workspace \
+  hashicorp/terraform:1.14 import \
+  cloudflare_dns_record.walking_dog_api \
+  "$CLOUDFLARE_ZONE_ID/<walking-dog-a-record-id>"
+```
+
+Import addresses:
+
+```text
+cloudflare_dns_record.walking_dog_api
+cloudflare_dns_record.ses_domain_verification
+cloudflare_dns_record.ses_dkim["<first-dkim-token>"]
+cloudflare_dns_record.ses_dkim["<second-dkim-token>"]
+cloudflare_dns_record.ses_dkim["<third-dkim-token>"]
+cloudflare_dns_record.ses_mail_from_mx
+cloudflare_dns_record.ses_mail_from_spf
+cloudflare_dns_record.ses_dmarc
+```
+
+Use the same import ID shape for every DNS record:
+
+```text
+<cloudflare-zone-id>/<dns-record-id>
+```
+
+After importing all records, verify that Terraform sees no drift:
+
+```bash
+docker run --rm \
+  -v "$PWD/infra/cloudflare:/workspace" \
+  -v "$HOME/.aws:/root/.aws:ro" \
+  -e AWS_PROFILE=personal \
+  --env-file "$PWD/infra/cloudflare/.env.local" \
+  -w /workspace \
+  hashicorp/terraform:1.14 plan
+```
+
+`plan` should report no changes. If it wants to create a record, that record has
+not been imported. If it wants to update a record, compare the Terraform value
+with Cloudflare before applying.
 
 ## Expected DNS records
 
-値は必ずTerraform outputまたはSES consoleの値を優先してください。特にDKIM tokenは環境ごとに変わります。
-
 | Purpose | Type | Name | Value |
 | --- | --- | --- | --- |
+| Walking Dog API | `A` | `walking-dog.cacheandbuffer.com` | `133.167.103.109` |
 | SES domain verification | `TXT` | `_amazonses.walking-dog.cacheandbuffer.com` | SES verification token |
 | SES Easy DKIM | `CNAME` x 3 | `<token>._domainkey.walking-dog.cacheandbuffer.com` | `<token>.dkim.amazonses.com` |
 | SES custom MAIL FROM MX | `MX` | `ses-bounce.walking-dog.cacheandbuffer.com` | priority `10`, `feedback-smtp.ap-northeast-1.amazonses.com` |
 | SES custom MAIL FROM SPF | `TXT` | `ses-bounce.walking-dog.cacheandbuffer.com` | `v=spf1 include:amazonses.com ~all` |
 | DMARC starter policy | `TXT` | `_dmarc.walking-dog.cacheandbuffer.com` | `v=DMARC1; p=none;` |
 
-DMARCは既存recordがある場合、重複作成せず既存recordを更新します。`p=none` は監視開始用です。配送が安定し、DMARC reportを確認できるようになってから `quarantine` / `reject` を検討します。
+All records stay DNS-only. Do not proxy the SES/DKIM/MX/TXT records. Keep
+`walking-dog.cacheandbuffer.com` DNS-only while the Sakura VPS Caddy setup owns
+TLS issuance directly.
 
-## DNS verification commands
+## SES verification flow
+
+When bootstrapping a new SES identity:
+
+1. Run the AWS module with `cognito_use_ses_email=false` to create the SES
+   identity without switching Cognito to SES.
+2. Copy the SES verification token and DKIM tokens into
+   `infra/cloudflare/terraform.tfvars`.
+3. Apply this Cloudflare module.
+4. Wait for SES identity, DKIM, and custom MAIL FROM verification to succeed.
+5. Run the AWS module again with the default `cognito_use_ses_email=true`.
+
+## Verification
+
+DNS checks:
 
 ```bash
 dig TXT _amazonses.walking-dog.cacheandbuffer.com
@@ -105,135 +183,13 @@ dig CNAME '<dkim-token>._domainkey.walking-dog.cacheandbuffer.com'
 dig MX ses-bounce.walking-dog.cacheandbuffer.com
 dig TXT ses-bounce.walking-dog.cacheandbuffer.com
 dig TXT _dmarc.walking-dog.cacheandbuffer.com
+dig A walking-dog.cacheandbuffer.com
 ```
 
-DKIM tokenは `terraform output -json ses_cloudflare_dns_records` またはSES consoleで確認します。
+AWS checks:
 
-## Verify SES status
-
-AWS Console:
-
-1. Amazon SES consoleを開く。
-2. Regionを `ap-northeast-1` にする。
-3. `Verified identities` で `walking-dog.cacheandbuffer.com` を開く。
-4. Identity statusが `Verified` になっていることを確認する。
-5. DKIM statusが `Successful` になっていることを確認する。
-6. Custom MAIL FROM domainが `Successful` になっていることを確認する。
-
-SESはDNS反映に最大72時間かかる場合があります。Cloudflare DNSなら通常はもっと早く反映されます。
-
-## Verify recipient email addresses for SES sandbox
-
-SES sandbox中は、送信元domainがverifiedでも、送信先email addressもverifiedである必要があります。リリース前の検証では、受信に使うテスト用email addressをTerraform変数で指定します。
-
-```bash
-cd infra/aws
-
-terraform apply \
-  -var 'ses_sandbox_recipient_email_addresses=["you@example.com"]'
-```
-
-Terraformは各email addressにSES verification emailを送ります。受信者がメール内のverification linkをクリックすると、そのaddressがSESでverifiedになります。Terraformだけでリンククリック後の検証完了まではできません。
-
-複数addressを指定する場合:
-
-```bash
-terraform apply \
-  -var 'ses_sandbox_recipient_email_addresses=["you@example.com","another@example.com"]'
-```
-
-状態確認:
-
-```bash
-aws ses get-identity-verification-attributes \
-  --region ap-northeast-1 \
-  --profile personal \
-  --identities you@example.com
-```
-
-実email addressはソースに固定せず、CLIの `-var` かローカル専用のtfvarsで渡します。指定したaddressはTerraform stateには保存されます。
-
-## Move SES out of sandbox
-
-Cognitoから実ユーザー宛に送るには、SES accountがsandbox外である必要があります。
-
-AWS Console:
-
-1. Amazon SES consoleを開く。
-2. Regionを `ap-northeast-1` にする。
-3. `Account dashboard` を開く。
-4. Sending statusがsandboxの場合、production accessを申請する。
-
-申請では、この用途がCognitoの認証・確認コード・パスワードリセットなどのtransactional emailであり、marketing emailではないことを明記します。
-
-## Switch Cognito to SES
-
-SES identity / DKIM / MAIL FROMが検証済みになったら、通常applyでCognitoをSESへ切り替えます。SES sandbox中でも、送信先email addressがverifiedなら検証用途で送信できます。本番リリース前にはsandbox解除が必要です。
-
-```bash
-cd infra/aws
-
-terraform apply
-```
-
-`cognito_use_ses_email` の既定値は `true` です。明示する場合:
-
-```bash
-terraform apply \
-  -var cognito_use_ses_email=true
-```
-
-このapplyでCognitoは以下の設定になります。
-
-- `email_sending_account = "DEVELOPER"`
-- `source_arn = arn:aws:ses:ap-northeast-1:<account-id>:identity/walking-dog.cacheandbuffer.com`
-- `from_email_address = "Walking Dog <no-reply@walking-dog.cacheandbuffer.com>"`
-
-Apply実行principalには、CognitoがSES用service-linked roleを作成するための `iam:CreateServiceLinkedRole` が必要です。すでに `AWSServiceRoleForAmazonCognitoIdpEmailService` が存在する場合は再作成されません。
-
-## Test send
-
-SES consoleから直接test emailを送ります。
-
-1. SES consoleで `walking-dog.cacheandbuffer.com` identityを開く。
-2. `Send test email` を選ぶ。
-3. From local partに `no-reply` を指定する。
-4. 宛先へ届くことを確認する。
-
-次にCognito経由で確認します。
-
-1. GraphQL `requestOneTimePassword` mutationを実行する。
-2. `no-reply@walking-dog.cacheandbuffer.com` から確認コードメールが届くことを確認する。
-3. 受信したcodeと返却されたsessionで `verifyOneTimePassword` を実行する。
-4. `changeEmail` / `confirmEmailChange` も確認する。
-
-## Troubleshooting
-
-- SES identityがverifiedにならない:
-  - `_amazonses` TXTが正しいか確認する。
-  - Cloudflare UIでzone suffixを二重入力していないか確認する。
-  - TXT valueに余計な引用符や空白が入っていないか確認する。
-- DKIMがsuccessfulにならない:
-  - 3つのCNAMEがすべて `DNS only` になっているか確認する。
-  - CNAMEのname/valueをSES consoleまたはTerraform outputと照合する。
-- MAIL FROMがsuccessfulにならない:
-  - MX priorityが `10` になっているか確認する。
-  - MX valueが `feedback-smtp.ap-northeast-1.amazonses.com` になっているか確認する。
-  - TXT valueが `v=spf1 include:amazonses.com ~all` になっているか確認する。
-- Cognito applyがSES identity未検証で失敗する:
-  - `terraform apply -var cognito_use_ses_email=false` でbootstrap applyを行う。
-  - DNS追加とSES verification完了後に `terraform apply` を再実行する。
-- Cognito applyが `iam:CreateServiceLinkedRole` で失敗する:
-  - apply実行role/userに `iam:CreateServiceLinkedRole` を付与する。
-- Cognito sign-up emailが外部宛に届かない:
-  - SESがsandbox外か確認する。
-  - SES account-level suppression listを確認する。
-  - SES bounce/complaint metricsを確認する。
-
-## References
-
-- [Amazon Cognito email settings](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-email.html)
-- [Amazon Cognito service-linked roles](https://docs.aws.amazon.com/cognito/latest/developerguide/using-service-linked-roles.html)
-- [Amazon SES domain identity verification](https://docs.aws.amazon.com/ses/latest/dg/creating-identities.html#just-verify-domain-proc)
-- [Amazon SES custom MAIL FROM](https://docs.aws.amazon.com/ses/latest/dg/mail-from.html)
-- [Cloudflare vendor-specific DNS records](https://developers.cloudflare.com/dns/manage-dns-records/reference/vendor-specific-records/)
+1. In the Amazon SES console, confirm that the
+   `walking-dog.cacheandbuffer.com` identity is verified.
+2. Confirm DKIM is successful.
+3. Confirm custom MAIL FROM is successful.
+4. Run the Cognito email OTP flow through GraphQL.

--- a/infra/cloudflare/dns.tf
+++ b/infra/cloudflare/dns.tf
@@ -1,0 +1,52 @@
+resource "cloudflare_dns_record" "walking_dog_api" {
+  zone_id = var.cloudflare_zone_id
+  name    = "walking-dog.${var.root_domain}"
+  type    = "A"
+  content = var.walking_dog_api_ipv4
+  proxied = false
+  ttl     = 1
+}
+
+resource "cloudflare_dns_record" "ses_domain_verification" {
+  zone_id = var.cloudflare_zone_id
+  name    = "_amazonses.${var.cognito_email_domain}"
+  type    = "TXT"
+  content = "\"${var.ses_domain_verification_token}\""
+  ttl     = 1
+}
+
+resource "cloudflare_dns_record" "ses_dkim" {
+  for_each = var.ses_dkim_tokens
+
+  zone_id = var.cloudflare_zone_id
+  name    = "${each.key}._domainkey.${var.cognito_email_domain}"
+  type    = "CNAME"
+  content = "${each.key}.dkim.amazonses.com"
+  proxied = false
+  ttl     = 1
+}
+
+resource "cloudflare_dns_record" "ses_mail_from_mx" {
+  zone_id  = var.cloudflare_zone_id
+  name     = var.ses_mail_from_domain
+  type     = "MX"
+  content  = "feedback-smtp.${var.aws_region}.amazonses.com"
+  priority = 10
+  ttl      = 1
+}
+
+resource "cloudflare_dns_record" "ses_mail_from_spf" {
+  zone_id = var.cloudflare_zone_id
+  name    = var.ses_mail_from_domain
+  type    = "TXT"
+  content = "\"v=spf1 include:amazonses.com ~all\""
+  ttl     = 1
+}
+
+resource "cloudflare_dns_record" "ses_dmarc" {
+  zone_id = var.cloudflare_zone_id
+  name    = "_dmarc.${var.cognito_email_domain}"
+  type    = "TXT"
+  content = "\"${var.dmarc_policy}\""
+  ttl     = 1
+}

--- a/infra/cloudflare/main.tf
+++ b/infra/cloudflare/main.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.5"
+
+  backend "s3" {
+    bucket = "walking-dog-tfstate-967026628831"
+    key    = "cloudflare/cacheandbuffer.com/terraform.tfstate"
+    region = "ap-northeast-1"
+  }
+
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "cloudflare" {}

--- a/infra/cloudflare/outputs.tf
+++ b/infra/cloudflare/outputs.tf
@@ -1,0 +1,50 @@
+output "managed_dns_records" {
+  description = "Cloudflare DNS records managed by this root module."
+  value = {
+    walking_dog_api = {
+      name    = cloudflare_dns_record.walking_dog_api.name
+      type    = cloudflare_dns_record.walking_dog_api.type
+      content = cloudflare_dns_record.walking_dog_api.content
+    }
+    ses_domain_verification = {
+      name    = cloudflare_dns_record.ses_domain_verification.name
+      type    = cloudflare_dns_record.ses_domain_verification.type
+      content = cloudflare_dns_record.ses_domain_verification.content
+    }
+    ses_dkim = {
+      for token, record in cloudflare_dns_record.ses_dkim : token => {
+        name    = record.name
+        type    = record.type
+        content = record.content
+      }
+    }
+    ses_mail_from_mx = {
+      name     = cloudflare_dns_record.ses_mail_from_mx.name
+      type     = cloudflare_dns_record.ses_mail_from_mx.type
+      content  = cloudflare_dns_record.ses_mail_from_mx.content
+      priority = cloudflare_dns_record.ses_mail_from_mx.priority
+    }
+    ses_mail_from_spf = {
+      name    = cloudflare_dns_record.ses_mail_from_spf.name
+      type    = cloudflare_dns_record.ses_mail_from_spf.type
+      content = cloudflare_dns_record.ses_mail_from_spf.content
+    }
+    ses_dmarc = {
+      name    = cloudflare_dns_record.ses_dmarc.name
+      type    = cloudflare_dns_record.ses_dmarc.type
+      content = cloudflare_dns_record.ses_dmarc.content
+    }
+  }
+}
+
+output "terraform_import_addresses" {
+  description = "Terraform resource addresses to use when importing existing Cloudflare DNS records."
+  value = {
+    walking_dog_api         = "cloudflare_dns_record.walking_dog_api"
+    ses_domain_verification = "cloudflare_dns_record.ses_domain_verification"
+    ses_dkim                = { for token in var.ses_dkim_tokens : token => "cloudflare_dns_record.ses_dkim[\"${token}\"]" }
+    ses_mail_from_mx        = "cloudflare_dns_record.ses_mail_from_mx"
+    ses_mail_from_spf       = "cloudflare_dns_record.ses_mail_from_spf"
+    ses_dmarc               = "cloudflare_dns_record.ses_dmarc"
+  }
+}

--- a/infra/cloudflare/terraform.tfvars.example
+++ b/infra/cloudflare/terraform.tfvars.example
@@ -1,0 +1,9 @@
+cloudflare_zone_id = "replace-with-cacheandbuffer-zone-id"
+
+ses_domain_verification_token = "replace-with-amazon-ses-domain-verification-token"
+
+ses_dkim_tokens = [
+  "replace-with-first-dkim-token",
+  "replace-with-second-dkim-token",
+  "replace-with-third-dkim-token",
+]

--- a/infra/cloudflare/variables.tf
+++ b/infra/cloudflare/variables.tf
@@ -1,0 +1,55 @@
+variable "cloudflare_zone_id" {
+  type        = string
+  description = "Cloudflare zone ID for cacheandbuffer.com."
+}
+
+variable "root_domain" {
+  type        = string
+  description = "Cloudflare DNS zone name."
+  default     = "cacheandbuffer.com"
+}
+
+variable "walking_dog_api_ipv4" {
+  type        = string
+  description = "IPv4 address for walking-dog.cacheandbuffer.com."
+  default     = "133.167.103.109"
+}
+
+variable "cognito_email_domain" {
+  type        = string
+  description = "Amazon SES identity domain used by Cognito email delivery."
+  default     = "walking-dog.cacheandbuffer.com"
+}
+
+variable "aws_region" {
+  type        = string
+  description = "AWS region used by Amazon SES."
+  default     = "ap-northeast-1"
+}
+
+variable "ses_domain_verification_token" {
+  type        = string
+  description = "Amazon SES domain verification token for cognito_email_domain."
+}
+
+variable "ses_dkim_tokens" {
+  type        = set(string)
+  description = "Amazon SES DKIM tokens for cognito_email_domain."
+
+  validation {
+    condition     = length(var.ses_dkim_tokens) == 3
+    error_message = "Amazon SES Easy DKIM must provide exactly three DKIM tokens."
+  }
+}
+
+variable "ses_mail_from_domain" {
+  type        = string
+  description = "Amazon SES custom MAIL FROM domain."
+  default     = "ses-bounce.walking-dog.cacheandbuffer.com"
+}
+
+variable "dmarc_policy" {
+  type        = string
+  description = "DMARC DNS TXT policy for the Cognito email domain."
+  default     = "v=DMARC1; p=none;"
+}


### PR DESCRIPTION
## Summary

- Add a Terraform root module for the Cloudflare `cacheandbuffer.com` DNS zone.
- Manage the existing Walking Dog API, SES verification, DKIM, MAIL FROM, SPF, and DMARC records.
- Document local token/tfvars handling and the import workflow.

## Validation

- `node scripts/harness/validate-all.mjs`
- `docker run --rm -v "$PWD/infra/cloudflare:/workspace" -w /workspace hashicorp/terraform:1.14 fmt -recursive`
- `docker run --rm -v "$PWD/infra/cloudflare:/workspace" -v "$HOME/.aws:/root/.aws:ro" -e AWS_PROFILE=personal --env-file "$PWD/infra/cloudflare/.env.local" -w /workspace hashicorp/terraform:1.14 validate`
- `docker run --rm -v "$PWD/infra/cloudflare:/workspace" -v "$HOME/.aws:/root/.aws:ro" -e AWS_PROFILE=personal --env-file "$PWD/infra/cloudflare/.env.local" -w /workspace hashicorp/terraform:1.14 plan -input=false`

`terraform plan` reports no changes after importing the eight existing Cloudflare DNS records into the S3 backend state.
