### PR TITLE
[codex] Improve Watch device install script

### DIFF
--- a/apps/mobile/scripts/install-watch-device.cjs
+++ b/apps/mobile/scripts/install-watch-device.cjs
@@ -6,6 +6,8 @@ const path = require('node:path');
 const WATCH_BUNDLE_ID = 'com.walkingdog.app.watch';
 const WATCH_SCHEME = 'WalkingDogWatch';
 const WATCH_APP_NAME = 'WalkingDogWatch.app';
+const WATCH_DEVICE_INSTALL_ATTEMPTS = 3;
+const WATCH_DEVICE_INSTALL_RETRY_DELAY_MS = 5000;
 
 function parseWatchDeviceIdFromXctrace(output) {
   let inDevicesSection = false;
@@ -30,6 +32,28 @@ function parseWatchDeviceIdFromXctrace(output) {
     const match = trimmed.match(/\(([0-9A-Fa-f]{8}-[0-9A-Fa-f]{16})\)$/);
     if (match) {
       return match[1];
+    }
+  }
+
+  return null;
+}
+
+function parseWatchDeviceIdFromXcodebuildDestinations(output) {
+  for (const line of output.split(/\r?\n/)) {
+    const trimmed = line.trim();
+
+    if (!/platform\s*:\s*watchOS\s*,/.test(trimmed)) {
+      continue;
+    }
+
+    const match = trimmed.match(/\bid\s*:\s*([^,}]+)/);
+    if (!match) {
+      continue;
+    }
+
+    const id = match[1].trim();
+    if (id && !id.startsWith('dvtdevice-')) {
+      return id;
     }
   }
 
@@ -67,11 +91,104 @@ function run(command, args, options = {}) {
   }
 }
 
-function getWatchDeviceId() {
+function sleepSync(ms) {
+  if (ms <= 0) {
+    return;
+  }
+
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function getErrorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function buildWatchApp(projectRoot, watchDeviceIdOrOptions, maybeOptions) {
+  const options =
+    maybeOptions ??
+    (typeof watchDeviceIdOrOptions === 'object' && watchDeviceIdOrOptions !== null
+      ? watchDeviceIdOrOptions
+      : {});
+  const runCommand = options.run ?? run;
+  const { derivedDataPath, workspacePath } = getWatchInstallPaths(projectRoot);
+
+  runCommand('xcodebuild', [
+    '-workspace',
+    workspacePath,
+    '-scheme',
+    WATCH_SCHEME,
+    '-configuration',
+    'Release',
+    '-destination',
+    'generic/platform=watchOS',
+    '-derivedDataPath',
+    derivedDataPath,
+    '-allowProvisioningUpdates',
+    '-allowProvisioningDeviceRegistration',
+    'build',
+  ]);
+}
+
+function runDevicectlWithRetry(actionLabel, devicectlArgs, options = {}) {
+  const maxAttempts = options.maxAttempts ?? WATCH_DEVICE_INSTALL_ATTEMPTS;
+  const retryDelayMs = options.retryDelayMs ?? WATCH_DEVICE_INSTALL_RETRY_DELAY_MS;
+  const runCommand = options.run ?? run;
+  const sleep = options.sleep ?? sleepSync;
+  const warn = options.warn ?? console.warn;
+  let lastError;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      runCommand('xcrun', ['devicectl', ...devicectlArgs]);
+      return;
+    } catch (error) {
+      lastError = error;
+      if (attempt >= maxAttempts) {
+        throw error;
+      }
+
+      warn(`${actionLabel} failed on attempt ${attempt}/${maxAttempts}: ${getErrorMessage(error)}`);
+      warn(`Retrying ${actionLabel} in ${retryDelayMs}ms...`);
+      sleep(retryDelayMs);
+    }
+  }
+
+  throw lastError;
+}
+
+function installBuiltWatchApp(watchDeviceId, watchAppPath, options = {}) {
+  try {
+    runDevicectlWithRetry(
+      'Apple Watch install',
+      ['device', 'install', 'app', '--device', watchDeviceId, watchAppPath],
+      options,
+    );
+  } catch (error) {
+    throw new Error(
+      [
+        `Apple Watch install failed after ${options.maxAttempts ?? WATCH_DEVICE_INSTALL_ATTEMPTS} attempts.`,
+        'Build succeeded, so you can retry only the install step after unlocking the Watch and iPhone:',
+        `xcrun devicectl device install app --device ${watchDeviceId} ${watchAppPath}`,
+        `Last error: ${getErrorMessage(error)}`,
+      ].join('\n'),
+    );
+  }
+}
+
+function verifyBuiltWatchApp(watchDeviceId, options = {}) {
+  runDevicectlWithRetry(
+    'Apple Watch app verification',
+    ['device', 'info', 'apps', '--device', watchDeviceId, '--bundle-id', WATCH_BUNDLE_ID],
+    options,
+  );
+}
+
+function getWatchDeviceId(projectRoot = path.resolve(__dirname, '..')) {
   if (process.env.WATCH_DEVICE_ID) {
     return process.env.WATCH_DEVICE_ID;
   }
 
+  const { workspacePath } = getWatchInstallPaths(projectRoot);
   const result = spawnSync('xcrun', ['xctrace', 'list', 'devices'], {
     encoding: 'utf8',
   });
@@ -92,58 +209,55 @@ function getWatchDeviceId() {
   }
 
   const watchDeviceId = parseWatchDeviceIdFromXctrace(result.stdout);
-  if (!watchDeviceId) {
+  if (watchDeviceId) {
+    return watchDeviceId;
+  }
+
+  const destinationsResult = spawnSync(
+    'xcodebuild',
+    ['-workspace', workspacePath, '-scheme', WATCH_SCHEME, '-showdestinations'],
+    {
+      encoding: 'utf8',
+    },
+  );
+
+  if (destinationsResult.error) {
+    throw destinationsResult.error;
+  }
+
+  if (destinationsResult.status !== 0) {
     throw new Error(
       [
-        'No online Apple Watch device was found.',
+        'Failed to list watchOS destinations with xcodebuild.',
+        destinationsResult.stderr && destinationsResult.stderr.trim(),
+      ]
+        .filter(Boolean)
+        .join('\n'),
+    );
+  }
+
+  const destinationWatchDeviceId = parseWatchDeviceIdFromXcodebuildDestinations(
+    [destinationsResult.stdout, destinationsResult.stderr].filter(Boolean).join('\n'),
+  );
+  if (!destinationWatchDeviceId) {
+    throw new Error(
+      [
+        'No available Apple Watch device was found.',
         'Unlock the Apple Watch, keep it near the iPhone/Mac, then run `xcrun xctrace list devices`.',
       ].join('\n'),
     );
   }
 
-  return watchDeviceId;
+  return destinationWatchDeviceId;
 }
 
 function installWatchDevice(projectRoot = path.resolve(__dirname, '..')) {
-  const watchDeviceId = getWatchDeviceId();
-  const { derivedDataPath, watchAppPath, workspacePath } = getWatchInstallPaths(projectRoot);
+  const { watchAppPath } = getWatchInstallPaths(projectRoot);
 
-  run('xcodebuild', [
-    '-workspace',
-    workspacePath,
-    '-scheme',
-    WATCH_SCHEME,
-    '-configuration',
-    'Release',
-    '-destination',
-    `platform=watchOS,id=${watchDeviceId}`,
-    '-derivedDataPath',
-    derivedDataPath,
-    '-allowProvisioningUpdates',
-    '-allowProvisioningDeviceRegistration',
-    'build',
-  ]);
-
-  run('xcrun', [
-    'devicectl',
-    'device',
-    'install',
-    'app',
-    '--device',
-    watchDeviceId,
-    watchAppPath,
-  ]);
-
-  run('xcrun', [
-    'devicectl',
-    'device',
-    'info',
-    'apps',
-    '--device',
-    watchDeviceId,
-    '--bundle-id',
-    WATCH_BUNDLE_ID,
-  ]);
+  buildWatchApp(projectRoot);
+  const watchDeviceId = getWatchDeviceId(projectRoot);
+  installBuiltWatchApp(watchDeviceId, watchAppPath);
+  verifyBuiltWatchApp(watchDeviceId);
 }
 
 if (require.main === module) {
@@ -156,7 +270,12 @@ if (require.main === module) {
 }
 
 module.exports = {
+  buildWatchApp,
   getWatchInstallPaths,
+  installBuiltWatchApp,
   installWatchDevice,
+  parseWatchDeviceIdFromXcodebuildDestinations,
   parseWatchDeviceIdFromXctrace,
+  runDevicectlWithRetry,
+  verifyBuiltWatchApp,
 };

--- a/apps/mobile/scripts/install-watch-device.test.js
+++ b/apps/mobile/scripts/install-watch-device.test.js
@@ -1,5 +1,12 @@
 const { scripts } = require('../package.json');
-const { getWatchInstallPaths, parseWatchDeviceIdFromXctrace } = require('./install-watch-device.cjs');
+const {
+  buildWatchApp,
+  getWatchInstallPaths,
+  installBuiltWatchApp,
+  parseWatchDeviceIdFromXcodebuildDestinations,
+  parseWatchDeviceIdFromXctrace,
+  runDevicectlWithRetry,
+} = require('./install-watch-device.cjs');
 
 describe('Apple Watch device install script', () => {
   it('is exposed through an npm script', () => {
@@ -32,6 +39,19 @@ describe('Apple Watch device install script', () => {
     expect(parseWatchDeviceIdFromXctrace(output)).toBeNull();
   });
 
+  it('finds the physical Apple Watch UDID from xcodebuild destinations', () => {
+    const output = [
+      'Available destinations for the "WalkingDogWatch" scheme:',
+      '\t{ platform:watchOS, arch:arm64, id:00008310-000E5C613A00E01E, name:Shuhei’s Apple Watch }',
+      '\t{ platform:watchOS, id:dvtdevice-DVTiOSDevicePlaceholder-watchos:placeholder, name:Any watchOS Device }',
+      '\t{ platform:watchOS Simulator, arch:arm64, id:48D461D1-2F56-4F5F-8E01-07DE6CC34638, OS:26.5, name:Apple Watch SE 3 (40mm) }',
+    ].join('\n');
+
+    expect(parseWatchDeviceIdFromXcodebuildDestinations(output)).toBe(
+      '00008310-000E5C613A00E01E',
+    );
+  });
+
   it('uses a deterministic DerivedData path for the Watch app product', () => {
     const paths = getWatchInstallPaths('/repo/apps/mobile');
 
@@ -39,5 +59,66 @@ describe('Apple Watch device install script', () => {
     expect(paths.watchAppPath).toBe(
       '/repo/apps/mobile/ios/build/watch-device-derived-data/Build/Products/Release-watchos/WalkingDogWatch.app',
     );
+  });
+
+  it('retries transient devicectl failures before succeeding', () => {
+    const run = jest.fn(() => {
+      if (run.mock.calls.length < 3) {
+        throw new Error('Connection interrupted');
+      }
+    });
+    const sleep = jest.fn();
+
+    runDevicectlWithRetry('install Apple Watch app', ['device', 'install', 'app'], {
+      maxAttempts: 3,
+      retryDelayMs: 10,
+      run,
+      sleep,
+      warn: jest.fn(),
+    });
+
+    expect(run).toHaveBeenCalledTimes(3);
+    expect(run).toHaveBeenCalledWith('xcrun', ['devicectl', 'device', 'install', 'app']);
+    expect(sleep).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledWith(10);
+  });
+
+  it('reports the direct install command after repeated install failures', () => {
+    const run = jest.fn(() => {
+      throw new Error('tunnel handshake timed out');
+    });
+    const sleep = jest.fn();
+
+    expect(() =>
+      installBuiltWatchApp('00008310-000E5C613A00E01E', '/repo/WalkingDogWatch.app', {
+        maxAttempts: 2,
+        retryDelayMs: 10,
+        run,
+        sleep,
+        warn: jest.fn(),
+      }),
+    ).toThrow(
+      [
+        'Apple Watch install failed after 2 attempts.',
+        'Build succeeded, so you can retry only the install step after unlocking the Watch and iPhone:',
+        'xcrun devicectl device install app --device 00008310-000E5C613A00E01E /repo/WalkingDogWatch.app',
+        'Last error: tunnel handshake timed out',
+      ].join('\n'),
+    );
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledTimes(1);
+  });
+
+  it('builds with a generic watchOS destination instead of waiting for the physical Watch', () => {
+    const run = jest.fn();
+
+    buildWatchApp('/repo/apps/mobile', '00008310-000E5C613A00E01E', { run });
+
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(run.mock.calls[0][0]).toBe('xcodebuild');
+    expect(run.mock.calls[0][1]).toEqual(
+      expect.arrayContaining(['-destination', 'generic/platform=watchOS']),
+    );
+    expect(run.mock.calls[0][1]).not.toContain('platform=watchOS,id=00008310-000E5C613A00E01E');
   });
 });


### PR DESCRIPTION
## Summary
- Build the Watch app with the generic watchOS destination so `xcodebuild` does not block on physical Watch availability.
- Resolve the physical Watch only for install and verification, with `xcodebuild -showdestinations` as a fallback when `xctrace` reports the device offline.
- Add retry handling and focused tests for transient `devicectl` install/verification failures.

## Root Cause
`watch:dev` used the physical Apple Watch UDID as the `xcodebuild` build destination. Even when the Watch was unlocked and installable through `devicectl`, `xcodebuild` could time out while waiting for that destination to become available. The build does not need the physical device; only install and verification do.

## Validation
- `npm run watch:dev` installed and verified `com.walkingdog.app.watch` on the physical Watch.
- `npm run lint` exited 0 with one existing `.expo/types/router.d.ts` warning.
- `npm run typecheck`
- `npm test -- --runInBand --forceExit` (123 suites / 746 tests passed)
- `node scripts/harness/validate-all.mjs`

## Product Decision Axes
- Dog experience: no runtime product behavior change.
- Walk data: no data model or tracking behavior change.
- Owner contribution: no app UX behavior change; this improves local Watch development reliability.