### PR TITLE
[codex] Use Expo native text fields

### DIFF
--- a/apps/mobile/__tests__/app/auth/signup.test.tsx
+++ b/apps/mobile/__tests__/app/auth/signup.test.tsx
@@ -24,7 +24,7 @@ describe('SignUpScreen', () => {
 
     expect(screen.getByText("Let's meet your dog.")).toBeTruthy();
     expect(screen.getByText("Create your account and you'll be walking in a minute.")).toBeTruthy();
-    expect(screen.getByLabelText('Email')).toBeTruthy();
+    expect(screen.getByPlaceholderText('Email')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Continue' })).toBeTruthy();
     expect(screen.getByText('Terms')).toBeTruthy();
     expect(screen.getByText('Privacy Policy')).toBeTruthy();

--- a/apps/mobile/__tests__/app/settings/email.test.tsx
+++ b/apps/mobile/__tests__/app/settings/email.test.tsx
@@ -62,7 +62,7 @@ describe('EmailSettingsScreen', () => {
     expect(screen.getByText('mio@walk.app')).toBeTruthy();
     expect(screen.queryByRole('button', { name: 'Change password' })).toBeNull();
 
-    fireEvent.changeText(screen.getByLabelText('New email'), 'mio@walk.app');
+    fireEvent.changeText(screen.getByPlaceholderText('New email'), 'mio@walk.app');
     expect(screen.getByRole('button', { name: 'Send code' }).props.accessibilityState).toEqual({
       disabled: true,
     });
@@ -80,7 +80,7 @@ describe('EmailSettingsScreen', () => {
 
     render(<EmailSettingsScreen />);
 
-    fireEvent.changeText(screen.getByLabelText('New email'), 'new-mio@walk.app');
+    fireEvent.changeText(screen.getByPlaceholderText('New email'), 'new-mio@walk.app');
     fireEvent.press(screen.getByRole('button', { name: 'Send code' }));
 
     await waitFor(() => {
@@ -109,7 +109,7 @@ describe('EmailSettingsScreen', () => {
 
     render(<EmailSettingsScreen />);
 
-    fireEvent.changeText(screen.getByLabelText('New email'), 'new-mio@walk.app');
+    fireEvent.changeText(screen.getByPlaceholderText('New email'), 'new-mio@walk.app');
     fireEvent.press(screen.getByRole('button', { name: 'Send code' }));
     await screen.findByLabelText('One-time password');
 
@@ -133,7 +133,7 @@ describe('EmailSettingsScreen', () => {
 
     render(<EmailSettingsScreen />);
 
-    fireEvent.changeText(screen.getByLabelText('New email'), 'new-mio@walk.app');
+    fireEvent.changeText(screen.getByPlaceholderText('New email'), 'new-mio@walk.app');
     fireEvent.press(screen.getByRole('button', { name: 'Send code' }));
     await screen.findByLabelText('One-time password');
 
@@ -147,7 +147,7 @@ describe('EmailSettingsScreen', () => {
     mockChangeEmail.mockRejectedValue({ kind: 'network' });
 
     render(<EmailSettingsScreen />);
-    fireEvent.changeText(screen.getByLabelText('New email'), 'other@walk.app');
+    fireEvent.changeText(screen.getByPlaceholderText('New email'), 'other@walk.app');
     fireEvent.press(screen.getByRole('button', { name: 'Send code' }));
 
     await waitFor(() => {

--- a/apps/mobile/__tests__/app/tabs/user.test.tsx
+++ b/apps/mobile/__tests__/app/tabs/user.test.tsx
@@ -104,10 +104,10 @@ describe('UserScreen', () => {
     fireEvent.press(screen.getByRole('button', { name: 'Edit' }));
     expect(mockPush).toHaveBeenCalledWith('/user/edit');
 
-    fireEvent.press(screen.getByRole('button', { name: 'Settings' }));
+    fireEvent.press(screen.getByText('Settings'));
     expect(mockPush).toHaveBeenCalledWith('/settings');
 
-    fireEvent.press(screen.getByRole('button', { name: 'Change email' }));
+    fireEvent.press(screen.getByText('Change email'));
     expect(mockPush).toHaveBeenCalledWith('/settings/email');
 
     expect(screen.queryByRole('button', { name: 'Change password' })).toBeNull();

--- a/apps/mobile/__tests__/app/user/edit.test.tsx
+++ b/apps/mobile/__tests__/app/user/edit.test.tsx
@@ -89,7 +89,7 @@ describe('UserEditScreen', () => {
   it('saves the edited user name and returns to the user screen', async () => {
     render(<UserEditScreen />);
 
-    fireEvent.changeText(screen.getByLabelText('Name'), 'Mio Updated');
+    fireEvent.changeText(screen.getByPlaceholderText('Name'), 'Mio Updated');
     fireEvent.press(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() => {

--- a/apps/mobile/app/(tabs)/user.tsx
+++ b/apps/mobile/app/(tabs)/user.tsx
@@ -2,9 +2,7 @@ import { ScrollView, StyleSheet } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
-import { GroupedCard } from '@/components/ui/GroupedCard';
-import { GroupedRow } from '@/components/ui/GroupedRow';
-import { IconSymbol } from '@/components/ui/icon-symbol';
+import { NativeFieldRow, NativeFieldSection } from '@/components/ui/NativeFieldGroup';
 import { useColors } from '@/hooks/use-colors';
 import { spacing } from '@/theme/tokens';
 import { useUserScreenViewModel } from '@/hooks/use-user-screen-view-model';
@@ -40,23 +38,23 @@ export default function UserScreen() {
           user={vm}
           footer={
             <>
-              <GroupedCard elevated={false} style={styles.accountActionsCard}>
-                <GroupedRow
-                  leading={<IconSymbol name="envelope.fill" size={18} color={theme.interactive} />}
+              <NativeFieldSection style={styles.accountActionsCard}>
+                <NativeFieldRow
+                  icon="email"
+                  iconColor={theme.interactive}
                   label={t('user.account.changeEmail')}
                   testID="account-change-email"
                   onPress={() => router.push('/settings/email')}
-                  separator={false}
                 />
-              </GroupedCard>
-              <GroupedCard elevated={false} style={styles.settingsLinkCard}>
-                <GroupedRow
-                  leading={<IconSymbol name="gearshape.fill" size={18} color={theme.interactive} />}
+              </NativeFieldSection>
+              <NativeFieldSection style={styles.settingsLinkCard}>
+                <NativeFieldRow
+                  icon="settings"
+                  iconColor={theme.interactive}
                   label={t('settings.openSettings')}
                   onPress={() => router.push('/settings')}
-                  separator={false}
                 />
-              </GroupedCard>
+              </NativeFieldSection>
             </>
           }
         />

--- a/apps/mobile/app/dogs/[id]/edit.tsx
+++ b/apps/mobile/app/dogs/[id]/edit.tsx
@@ -22,6 +22,7 @@ import { DAILY_GOAL_CYCLE_DAYS, DEFAULT_DAILY_GOAL_MINUTES } from '@/constants/w
 import { useColors } from '@/hooks/use-colors';
 import { components, spacing } from '@/theme/tokens';
 import type { UploadFile } from '@/lib/graphql/client';
+import { runDetached } from '@/lib/run-detached';
 
 // 犬編集画面 — inline ScreenHeader でフォームの Cancel/Save を提供します。
 // dog データのロード待ちは外側、form state 初期化は内側コンポーネントに分離して
@@ -117,7 +118,7 @@ function EditDogContent({ id, dogName, initialValues, currentAvatar }: EditDogCo
           text: t('dogs.edit.removeAction'),
           style: 'destructive',
           onPress: () => {
-            void handleRemove();
+            runDetached(handleRemove(), 'dogs.edit.remove');
           },
         },
       ],

--- a/apps/mobile/app/settings/email.tsx
+++ b/apps/mobile/app/settings/email.tsx
@@ -16,6 +16,7 @@ import { useColors } from '@/hooks/use-colors';
 import { useInvalidateUserQueries } from '@/hooks/use-invalidate-user-queries';
 import { useMe } from '@/hooks/use-me';
 import { toAuthError } from '@/lib/auth/errors';
+import { runDetached } from '@/lib/run-detached';
 import { spacing, typography } from '@/theme/tokens';
 import type { EmailChangeChallenge } from '@/lib/auth/api';
 
@@ -29,7 +30,7 @@ export default function EmailSettingsScreen() {
       <ErrorScreen
         message={t('user.loadError')}
         onRetry={() => {
-          void refetch();
+          runDetached(refetch(), 'settings.email.refetch');
         }}
       />
     );

--- a/apps/mobile/app/settings/email.tsx
+++ b/apps/mobile/app/settings/email.tsx
@@ -7,9 +7,8 @@ import { OneTimePasswordInput } from '@/components/auth/OneTimePasswordInput';
 import { emailKeyboardType } from '@/components/auth/emailKeyboard';
 import { Button } from '@/components/ui/Button';
 import { ErrorScreen } from '@/components/ui/ErrorScreen';
-import { GroupedCard } from '@/components/ui/GroupedCard';
-import { GroupedRow } from '@/components/ui/GroupedRow';
 import { LoadingScreen } from '@/components/ui/LoadingScreen';
+import { NativeFieldRow, NativeFieldSection } from '@/components/ui/NativeFieldGroup';
 import { ScreenHeader } from '@/components/ui/ScreenHeader';
 import { TextInput } from '@/components/ui/TextInput';
 import { useAuth } from '@/hooks/use-auth';
@@ -138,14 +137,13 @@ function EmailSettingsContent({ currentEmail }: { currentEmail: string }) {
         contentContainerStyle={styles.content}
         keyboardShouldPersistTaps="handled"
       >
-        <GroupedCard elevated={false}>
-          <GroupedRow
+        <NativeFieldSection>
+          <NativeFieldRow
             label={t('settings.emailChange.currentEmail')}
             value={currentEmail}
-            separator={false}
             showChevron={false}
           />
-        </GroupedCard>
+        </NativeFieldSection>
 
         {challenge ? (
           <View style={styles.otpSection}>
@@ -170,7 +168,7 @@ function EmailSettingsContent({ currentEmail }: { currentEmail: string }) {
           </View>
         ) : (
           <>
-            <GroupedCard elevated={false}>
+            <NativeFieldSection>
               <TextInput
                 label={t('settings.emailChange.newEmail')}
                 labelPosition="inline"
@@ -180,13 +178,11 @@ function EmailSettingsContent({ currentEmail }: { currentEmail: string }) {
                 keyboardType={emailKeyboardType}
                 autoCapitalize="none"
                 autoCorrect={false}
-                spellCheck={false}
                 autoComplete="email"
-                textContentType="emailAddress"
                 returnKeyType="send"
                 onSubmitEditing={handleSubmit}
               />
-            </GroupedCard>
+            </NativeFieldSection>
             <Button
               label={t('settings.emailChange.sendCode')}
               testID="email-change-send-code"

--- a/apps/mobile/app/user/edit.tsx
+++ b/apps/mobile/app/user/edit.tsx
@@ -3,7 +3,7 @@ import { ScrollView, StyleSheet } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
-import { GroupedCard } from '@/components/ui/GroupedCard';
+import { NativeFieldSection } from '@/components/ui/NativeFieldGroup';
 import { TextInput } from '@/components/ui/TextInput';
 import { ScreenHeader } from '@/components/ui/ScreenHeader';
 import { LoadingScreen } from '@/components/ui/LoadingScreen';
@@ -91,17 +91,17 @@ function UserEditContent({ me }: { me: User }) {
           displayName={name}
           onChange={setAvatarFile}
         />
-        <GroupedCard elevated={false}>
+        <NativeFieldSection>
           <TextInput
             label={t('userEdit.name')}
             labelPosition="inline"
             value={name}
             onChangeText={setName}
             autoCapitalize="words"
-            textContentType="name"
+            autoComplete="name"
             returnKeyType="done"
           />
-        </GroupedCard>
+        </NativeFieldSection>
       </ScrollView>
     </SafeAreaView>
   );

--- a/apps/mobile/app/user/edit.tsx
+++ b/apps/mobile/app/user/edit.tsx
@@ -13,6 +13,7 @@ import { useMe } from '@/hooks/use-me';
 import { useUpdateUser } from '@/hooks/use-user-mutations';
 import { useMutationWithAlert } from '@/hooks/use-mutation-with-alert';
 import { useColors } from '@/hooks/use-colors';
+import { runDetached } from '@/lib/run-detached';
 import { spacing } from '@/theme/tokens';
 import type { UploadFile } from '@/lib/graphql/client';
 import type { User } from '@/types/graphql';
@@ -27,7 +28,7 @@ export default function UserEditScreen() {
       <ErrorScreen
         message={t('user.loadError')}
         onRetry={() => {
-          void refetch();
+          runDetached(refetch(), 'user.edit.refetch');
         }}
       />
     );

--- a/apps/mobile/components/auth/EmailAuthForm.test.tsx
+++ b/apps/mobile/components/auth/EmailAuthForm.test.tsx
@@ -19,11 +19,10 @@ describe('EmailAuthForm', () => {
   it('renders one email field before requesting a code', () => {
     render(<EmailAuthForm onSuccess={jest.fn()} />);
 
-    const emailInput = screen.getByLabelText('Email');
+    const emailInput = screen.getByPlaceholderText('Email');
     expect(emailInput).toBeTruthy();
     expect(emailInput.props.keyboardType).toBe(emailKeyboardType);
     expect(emailInput.props.autoCorrect).toBe(false);
-    expect(emailInput.props.spellCheck).toBe(false);
     expect(screen.queryByLabelText('Your name')).toBeNull();
     expect(screen.queryByLabelText('Password')).toBeNull();
     expect(screen.queryByText('Create an account')).toBeNull();
@@ -38,7 +37,7 @@ describe('EmailAuthForm', () => {
     });
     render(<EmailAuthForm onSuccess={jest.fn()} />);
 
-    fireEvent.changeText(screen.getByLabelText('Email'), 'test@example.com');
+    fireEvent.changeText(screen.getByPlaceholderText('Email'), 'test@example.com');
     fireEvent.press(screen.getByRole('button', { name: 'Continue with email' }));
 
     await waitFor(() => {
@@ -55,7 +54,7 @@ describe('EmailAuthForm', () => {
     });
     render(<EmailAuthForm onSuccess={jest.fn()} submitLabel="Sign in" />);
 
-    fireEvent.changeText(screen.getByLabelText('Email'), ' test@example.com ');
+    fireEvent.changeText(screen.getByPlaceholderText('Email'), ' test@example.com ');
     fireEvent.press(screen.getByRole('button', { name: 'Sign in' }));
 
     await waitFor(() => {
@@ -74,7 +73,7 @@ describe('EmailAuthForm', () => {
     mockVerifyOneTimePassword.mockResolvedValue(undefined);
     render(<EmailAuthForm onSuccess={onSuccess} />);
 
-    fireEvent.changeText(screen.getByLabelText('Email'), 'test@example.com');
+    fireEvent.changeText(screen.getByPlaceholderText('Email'), 'test@example.com');
     fireEvent.press(screen.getByRole('button', { name: 'Continue with email' }));
     await screen.findByLabelText('One-time password');
 
@@ -101,7 +100,7 @@ describe('EmailAuthForm', () => {
     mockVerifyOneTimePassword.mockResolvedValue(undefined);
     render(<EmailAuthForm onSuccess={jest.fn()} />);
 
-    fireEvent.changeText(screen.getByLabelText('Email'), 'test@example.com');
+    fireEvent.changeText(screen.getByPlaceholderText('Email'), 'test@example.com');
     fireEvent.press(screen.getByRole('button', { name: 'Continue with email' }));
     await screen.findByLabelText('One-time password');
 
@@ -129,7 +128,7 @@ describe('EmailAuthForm', () => {
       .mockResolvedValueOnce(undefined);
     render(<EmailAuthForm onSuccess={jest.fn()} />);
 
-    fireEvent.changeText(screen.getByLabelText('Email'), 'test@example.com');
+    fireEvent.changeText(screen.getByPlaceholderText('Email'), 'test@example.com');
     fireEvent.press(screen.getByRole('button', { name: 'Continue with email' }));
     await screen.findByLabelText('One-time password');
 

--- a/apps/mobile/components/auth/EmailAuthForm.tsx
+++ b/apps/mobile/components/auth/EmailAuthForm.tsx
@@ -3,7 +3,7 @@ import { Linking, StyleSheet, Text, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '@/hooks/use-auth';
 import { Button } from '@/components/ui/Button';
-import { GroupedCard } from '@/components/ui/GroupedCard';
+import { NativeFieldSection } from '@/components/ui/NativeFieldGroup';
 import { OneTimePasswordInput } from '@/components/auth/OneTimePasswordInput';
 import { TextInput } from '@/components/ui/TextInput';
 import { emailKeyboardType } from '@/components/auth/emailKeyboard';
@@ -124,7 +124,7 @@ export function EmailAuthForm({
           />
         </>
       ) : (
-        <GroupedCard>
+        <NativeFieldSection>
           <TextInput
             label={t('auth.login.email')}
             labelPosition="inline"
@@ -134,11 +134,9 @@ export function EmailAuthForm({
             keyboardType={emailKeyboardType}
             autoCapitalize="none"
             autoCorrect={false}
-            spellCheck={false}
             autoComplete="email"
-            textContentType="emailAddress"
           />
-        </GroupedCard>
+        </NativeFieldSection>
       )}
 
       {!challenge && supportingText ? (

--- a/apps/mobile/components/auth/EmailAuthForm.tsx
+++ b/apps/mobile/components/auth/EmailAuthForm.tsx
@@ -11,6 +11,7 @@ import { useColors } from '@/hooks/use-colors';
 import { toAuthError } from '@/lib/auth/errors';
 import type { OneTimePasswordChallenge } from '@/lib/auth/api';
 import { PRIVACY_POLICY_URL, TERMS_URL } from '@/lib/legal-urls';
+import { runDetached } from '@/lib/run-detached';
 import { spacing, typography } from '@/theme/tokens';
 
 interface EmailAuthFormProps {
@@ -102,7 +103,7 @@ export function EmailAuthForm({
   }
 
   function openLegalUrl(url: string) {
-    void Linking.openURL(url);
+    runDetached(Linking.openURL(url), 'auth.legal.openUrl');
   }
 
   return (

--- a/apps/mobile/components/dogs/DogForm.test.tsx
+++ b/apps/mobile/components/dogs/DogForm.test.tsx
@@ -7,7 +7,7 @@ import {
   isDogFormValid,
   type DogFormValues,
 } from './DogForm';
-import { spacing } from '@/theme/tokens';
+import { components, spacing } from '@/theme/tokens';
 
 jest.mock('@/components/ui/icon-symbol', () => ({
   IconSymbol: () => null,
@@ -69,11 +69,23 @@ describe('DogForm', () => {
 
   it('renders name/breed fields and the selected gender value', () => {
     setup();
-    expect(screen.getByLabelText('Name')).toBeTruthy();
-    expect(screen.getByLabelText('Breed')).toBeTruthy();
+    expect(screen.getByPlaceholderText('Name')).toBeTruthy();
+    expect(screen.getByPlaceholderText('Breed')).toBeTruthy();
     expect(screen.getByText('Gender')).toBeTruthy();
     expect(screen.getByText('Select gender')).toBeTruthy();
     expect(screen.queryByTestId('dog-gender-segmented-control')).toBeNull();
+  });
+
+  it('sizes the native profile field section so all rows are initially visible', () => {
+    setup();
+    expect(screen.getByTestId('dog-profile-fields-host').props.style).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ height: expect.any(Number) }),
+        expect.objectContaining({
+          height: components.textInput.height * 2 + components.row.minHeight * 2 + spacing.step60 * 2,
+        }),
+      ]),
+    );
   });
 
   it('renders the goal section with the default daily time goal', () => {
@@ -173,7 +185,7 @@ describe('DogForm', () => {
 
   it('renders birthday in the profile group without an empty-state value', () => {
     setup();
-    expect(screen.getByRole('button', { name: 'Birthday' })).toBeTruthy();
+    expect(screen.getByText('Birthday')).toBeTruthy();
     expect(screen.queryByText('Add birthday')).toBeNull();
   });
 
@@ -184,19 +196,19 @@ describe('DogForm', () => {
 
   it('calls onChange with patched values when name changes', () => {
     const { onChange } = setup(makeValues({ breed: 'Poodle', gender: 'male' }));
-    fireEvent.changeText(screen.getByLabelText('Name'), 'Hana');
+    fireEvent.changeText(screen.getByPlaceholderText('Name'), 'Hana');
     expect(onChange).toHaveBeenCalledWith(makeValues({ name: 'Hana', breed: 'Poodle', gender: 'male' }));
   });
 
   it('calls onChange with patched values when breed changes', () => {
     const { onChange } = setup(makeValues({ name: 'Hana', gender: 'male' }));
-    fireEvent.changeText(screen.getByLabelText('Breed'), 'Poodle');
+    fireEvent.changeText(screen.getByPlaceholderText('Breed'), 'Poodle');
     expect(onChange).toHaveBeenCalledWith(makeValues({ name: 'Hana', breed: 'Poodle', gender: 'male' }));
   });
 
   it('opens the gender ActionSheet and calls onChange with patched values', () => {
     const { onChange } = setup(makeValues({ name: 'Hana', breed: 'Poodle' }));
-    fireEvent.press(screen.getByRole('button', { name: 'Gender' }));
+    fireEvent.press(screen.getByText('Gender'));
     expect(ActionSheetIOS.showActionSheetWithOptions).toHaveBeenCalledWith(
       {
         options: ['Male', 'Female', 'Other', 'Cancel'],
@@ -209,7 +221,7 @@ describe('DogForm', () => {
 
   it('opens the birthday picker modal from the birthday row', () => {
     setup();
-    fireEvent.press(screen.getByRole('button', { name: 'Birthday' }));
+    fireEvent.press(screen.getByText('Birthday'));
     expect(screen.getByText('Year')).toBeTruthy();
     expect(screen.getByText('Month')).toBeTruthy();
     expect(screen.getByText('Day')).toBeTruthy();
@@ -222,7 +234,7 @@ describe('DogForm', () => {
 
   it('stages birthday changes until Save is pressed', () => {
     const { onChange } = setup(makeValues({ name: 'Hana', gender: 'male' }));
-    fireEvent.press(screen.getByRole('button', { name: 'Birthday' }));
+    fireEvent.press(screen.getByText('Birthday'));
     fireEvent.press(screen.getByTestId('birthday-year-2021'));
     expect(onChange).not.toHaveBeenCalled();
     fireEvent.press(screen.getByRole('button', { name: 'Save' }));
@@ -231,7 +243,7 @@ describe('DogForm', () => {
 
   it('discards staged birthday changes when Cancel is pressed', () => {
     const { onChange } = setup(makeValues({ name: 'Hana', gender: 'male' }));
-    fireEvent.press(screen.getByRole('button', { name: 'Birthday' }));
+    fireEvent.press(screen.getByText('Birthday'));
     fireEvent.press(screen.getByTestId('birthday-year-2021'));
     fireEvent.press(screen.getByRole('button', { name: 'Cancel' }));
     expect(onChange).not.toHaveBeenCalled();
@@ -241,7 +253,7 @@ describe('DogForm', () => {
     const { onChange } = setup(
       makeValues({ name: 'Hana', gender: 'male', birthdayYear: '2021', birthdayMonth: '6', birthdayDay: '15' }),
     );
-    fireEvent.press(screen.getByRole('button', { name: 'Birthday' }));
+    fireEvent.press(screen.getByText('Birthday'));
     fireEvent.press(screen.getByTestId('birthday-year-unknown'));
     expect(onChange).not.toHaveBeenCalled();
     fireEvent.press(screen.getByRole('button', { name: 'Save' }));
@@ -252,7 +264,7 @@ describe('DogForm', () => {
     const { onChange } = setup(
       makeValues({ name: 'Hana', gender: 'male', birthdayYear: '2021', birthdayMonth: '6', birthdayDay: '15' }),
     );
-    fireEvent.press(screen.getByRole('button', { name: 'Birthday' }));
+    fireEvent.press(screen.getByText('Birthday'));
     fireEvent.press(screen.getByTestId('birthday-month-unknown'));
     fireEvent.press(screen.getByRole('button', { name: 'Save' }));
     expect(onChange).toHaveBeenCalledWith(makeValues({ name: 'Hana', gender: 'male', birthdayYear: '2021' }));
@@ -260,7 +272,7 @@ describe('DogForm', () => {
 
   it('requires year before month and month before day can be selected', () => {
     setup();
-    fireEvent.press(screen.getByRole('button', { name: 'Birthday' }));
+    fireEvent.press(screen.getByText('Birthday'));
     expect(screen.getByTestId('birthday-month-1').props.accessibilityState.disabled).toBe(true);
     expect(screen.getByTestId('birthday-day-1').props.accessibilityState.disabled).toBe(true);
     fireEvent.press(screen.getByTestId('birthday-year-2021'));

--- a/apps/mobile/components/dogs/DogForm.test.tsx
+++ b/apps/mobile/components/dogs/DogForm.test.tsx
@@ -7,7 +7,7 @@ import {
   isDogFormValid,
   type DogFormValues,
 } from './DogForm';
-import { components, spacing } from '@/theme/tokens';
+import { spacing } from '@/theme/tokens';
 
 jest.mock('@/components/ui/icon-symbol', () => ({
   IconSymbol: () => null,
@@ -76,16 +76,10 @@ describe('DogForm', () => {
     expect(screen.queryByTestId('dog-gender-segmented-control')).toBeNull();
   });
 
-  it('sizes the native profile field section so all rows are initially visible', () => {
+  it('keeps the profile fields in the screen scroll flow instead of a nested host', () => {
     setup();
-    expect(screen.getByTestId('dog-profile-fields-host').props.style).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ height: expect.any(Number) }),
-        expect.objectContaining({
-          height: components.textInput.height * 2 + components.row.minHeight * 2 + spacing.step60 * 2,
-        }),
-      ]),
-    );
+    expect(screen.getByTestId('dog-profile-fields')).toBeTruthy();
+    expect(screen.queryByTestId('dog-profile-fields-host')).toBeNull();
   });
 
   it('renders the goal section with the default daily time goal', () => {

--- a/apps/mobile/components/dogs/DogForm.tsx
+++ b/apps/mobile/components/dogs/DogForm.tsx
@@ -174,10 +174,7 @@ export function DogForm({ values, onChange, showDailyGoal = true }: DogFormProps
 
   return (
     <View style={styles.container}>
-      <NativeFieldSection
-        style={styles.profileFieldSection}
-        testID="dog-profile-fields"
-      >
+      <NativeFieldSection testID="dog-profile-fields">
         <TextInput
           label={t('dogs.form.name')}
           labelPosition="inline"
@@ -639,9 +636,6 @@ const styles = StyleSheet.create({
   goalSliderHost: {
     height: GOAL_SLIDER_HEIGHT,
     width: '100%',
-  },
-  profileFieldSection: {
-    height: components.textInput.height * 2 + components.row.minHeight * 2 + spacing.step60 * 2,
   },
   goalLimits: {
     flexDirection: 'row',

--- a/apps/mobile/components/dogs/DogForm.tsx
+++ b/apps/mobile/components/dogs/DogForm.tsx
@@ -13,6 +13,7 @@ import { useTranslation } from 'react-i18next';
 import { Host, Slider as SwiftUISlider } from '@expo/ui/swift-ui';
 import { clipped, frame } from '@expo/ui/swift-ui/modifiers';
 import { GroupedCard } from '@/components/ui/GroupedCard';
+import { NativeFieldRow, NativeFieldSection } from '@/components/ui/NativeFieldGroup';
 import { SegmentedControl } from '@/components/ui/SegmentedControl';
 import { IconSymbol } from '@/components/ui/icon-symbol';
 import { TextInput } from '@/components/ui/TextInput';
@@ -173,67 +174,35 @@ export function DogForm({ values, onChange, showDailyGoal = true }: DogFormProps
 
   return (
     <View style={styles.container}>
-      <GroupedCard>
+      <NativeFieldSection
+        style={styles.profileFieldSection}
+        testID="dog-profile-fields"
+      >
         <TextInput
           label={t('dogs.form.name')}
           labelPosition="inline"
-          separator
           value={values.name}
           onChangeText={(name) => set({ name })}
-          placeholder={t('dogs.form.namePlaceholder')}
         />
         <TextInput
           label={t('dogs.form.breed')}
           labelPosition="inline"
-          separator
           value={values.breed}
           onChangeText={(breed) => set({ breed })}
-          placeholder={t('dogs.form.breedPlaceholder')}
         />
-        <View style={styles.inlineRow}>
-          <Text style={[styles.inlineLabel, { color: theme.onSurfaceVariant }]}>
-            {t('dogs.form.gender')}
-          </Text>
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel={t('dogs.form.gender')}
-            onPress={presentGenderSheet}
-            style={styles.genderValueWrap}
-          >
-            <Text
-              style={[
-                styles.genderValue,
-                { color: genderValue ? theme.onSurface : theme.onSurfaceVariant },
-              ]}
-              numberOfLines={1}
-            >
-              {genderLabel}
-            </Text>
-          </Pressable>
-        </View>
-        <View style={[styles.separator, { backgroundColor: theme.border }]} />
-        <Pressable
-          accessibilityRole="button"
-          accessibilityLabel={t('dogs.form.birthday')}
+        <NativeFieldRow
+          label={t('dogs.form.gender')}
+          labelColor={theme.onSurfaceVariant}
+          value={genderLabel}
+          onPress={presentGenderSheet}
+        />
+        <NativeFieldRow
+          label={t('dogs.form.birthday')}
+          labelColor={theme.onSurfaceVariant}
+          value={birthdayDisplay.isPlaceholder ? undefined : birthdayDisplay.text}
           onPress={openBirthdayPicker}
-          style={styles.inlineRow}
-        >
-          <Text style={[styles.inlineLabel, { color: theme.onSurfaceVariant }]}>
-            {t('dogs.form.birthday')}
-          </Text>
-          {birthdayDisplay.isPlaceholder ? null : (
-            <Text
-              style={[
-                styles.birthdayValue,
-                { color: theme.onSurface },
-              ]}
-              numberOfLines={1}
-            >
-              {birthdayDisplay.text}
-            </Text>
-          )}
-        </Pressable>
-      </GroupedCard>
+        />
+      </NativeFieldSection>
       {showDailyGoal ? (
         <GoalSection
           minutes={values.goalMinutes}
@@ -671,6 +640,9 @@ const styles = StyleSheet.create({
     height: GOAL_SLIDER_HEIGHT,
     width: '100%',
   },
+  profileFieldSection: {
+    height: components.textInput.height * 2 + components.row.minHeight * 2 + spacing.step60 * 2,
+  },
   goalLimits: {
     flexDirection: 'row',
     justifyContent: 'space-between',
@@ -678,31 +650,6 @@ const styles = StyleSheet.create({
   },
   goalLimitText: {
     ...typography.caption,
-  },
-  inlineRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: components.row.gap,
-    paddingHorizontal: spacing.md,
-    paddingVertical: spacing.step14,
-    minHeight: components.row.minHeight,
-  },
-  inlineLabel: {
-    ...typography.subheadline,
-    width: components.textInput.inlineLabelWidth,
-  },
-  birthdayValue: {
-    ...typography.body,
-    flex: 1,
-  },
-  genderValueWrap: {
-    flex: 1,
-    minHeight: components.row.minHeight,
-    justifyContent: 'center',
-  },
-  genderValue: {
-    ...typography.body,
-    textAlign: 'left',
   },
   modalBackdrop: {
     flex: 1,
@@ -758,9 +705,5 @@ const styles = StyleSheet.create({
   },
   pickerOptionText: {
     ...typography.subheadline,
-  },
-  separator: {
-    height: StyleSheet.hairlineWidth,
-    marginLeft: spacing.lg,
   },
 });

--- a/apps/mobile/components/settings/LegalSection.test.tsx
+++ b/apps/mobile/components/settings/LegalSection.test.tsx
@@ -40,7 +40,7 @@ describe('LegalSection', () => {
 
   it('opens the terms URL when tapped', () => {
     render(<LegalSection />);
-    fireEvent.press(screen.getByRole('button', { name: 'Terms of Service' }));
+    fireEvent.press(screen.getByText('Terms of Service'));
     expect(Linking.openURL).toHaveBeenCalledWith(
       'https://walking-dog.cacheandbuffer.com/terms',
     );
@@ -48,7 +48,7 @@ describe('LegalSection', () => {
 
   it('opens the privacy URL when tapped', () => {
     render(<LegalSection />);
-    fireEvent.press(screen.getByRole('button', { name: 'Privacy Policy' }));
+    fireEvent.press(screen.getByText('Privacy Policy'));
     expect(Linking.openURL).toHaveBeenCalledWith(
       'https://walking-dog.cacheandbuffer.com/policy',
     );

--- a/apps/mobile/components/settings/LegalSection.tsx
+++ b/apps/mobile/components/settings/LegalSection.tsx
@@ -1,10 +1,7 @@
 import Constants from 'expo-constants';
 import { Linking, StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
-import { GroupedCard } from '@/components/ui/GroupedCard';
-import { GroupedRow } from '@/components/ui/GroupedRow';
-import { IconSymbol } from '@/components/ui/icon-symbol';
-import { SectionHeader } from '@/components/ui/SectionHeader';
+import { NativeFieldRow, NativeFieldSection } from '@/components/ui/NativeFieldGroup';
 import { useColors } from '@/hooks/use-colors';
 import { PRIVACY_POLICY_URL, TERMS_URL } from '@/lib/legal-urls';
 import { spacing } from '@/theme/tokens';
@@ -24,32 +21,27 @@ export function LegalSection() {
 
   return (
     <View style={styles.wrapper}>
-      <SectionHeader label={t('settings.sectionLabel.legal')} />
-      <GroupedCard elevated={false}>
-        <GroupedRow
-          leading={
-            <IconSymbol name="doc.text" size={18} color={theme.onSurfaceVariant} />
-          }
+      <NativeFieldSection title={t('settings.sectionLabel.legal')}>
+        <NativeFieldRow
+          icon="terms"
+          iconColor={theme.onSurfaceVariant}
           label={t('settings.terms')}
           onPress={openTerms}
         />
-        <GroupedRow
-          leading={
-            <IconSymbol name="lock.fill" size={18} color={theme.onSurfaceVariant} />
-          }
+        <NativeFieldRow
+          icon="privacy"
+          iconColor={theme.onSurfaceVariant}
           label={t('settings.privacy')}
           onPress={openPrivacy}
         />
-        <GroupedRow
-          leading={
-            <IconSymbol name="info.circle" size={18} color={theme.onSurfaceVariant} />
-          }
+        <NativeFieldRow
+          icon="about"
+          iconColor={theme.onSurfaceVariant}
           label={t('settings.about')}
           value={`v${version}`}
           showChevron
-          separator={false}
         />
-      </GroupedCard>
+      </NativeFieldSection>
     </View>
   );
 }

--- a/apps/mobile/components/settings/LegalSection.tsx
+++ b/apps/mobile/components/settings/LegalSection.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { NativeFieldRow, NativeFieldSection } from '@/components/ui/NativeFieldGroup';
 import { useColors } from '@/hooks/use-colors';
 import { PRIVACY_POLICY_URL, TERMS_URL } from '@/lib/legal-urls';
+import { runDetached } from '@/lib/run-detached';
 import { spacing } from '@/theme/tokens';
 
 export function LegalSection() {
@@ -12,11 +13,11 @@ export function LegalSection() {
   const version = Constants.expoConfig?.version ?? '1.0.0';
 
   function openTerms() {
-    void Linking.openURL(TERMS_URL);
+    runDetached(Linking.openURL(TERMS_URL), 'settings.legal.openTerms');
   }
 
   function openPrivacy() {
-    void Linking.openURL(PRIVACY_POLICY_URL);
+    runDetached(Linking.openURL(PRIVACY_POLICY_URL), 'settings.legal.openPrivacy');
   }
 
   return (

--- a/apps/mobile/components/settings/PreferencesSection.test.tsx
+++ b/apps/mobile/components/settings/PreferencesSection.test.tsx
@@ -72,20 +72,20 @@ describe('PreferencesSection', () => {
 
   it('opens the language ActionSheet and applies the selection', () => {
     render(<PreferencesSection />);
-    fireEvent.press(screen.getByRole('button', { name: 'Language' }));
+    fireEvent.press(screen.getByText('Language'));
     expect(ActionSheetIOS.showActionSheetWithOptions).toHaveBeenCalled();
     expect(mockSetLanguage).toHaveBeenCalledWith('en');
   });
 
   it('opens the units ActionSheet and applies mile', () => {
     render(<PreferencesSection />);
-    fireEvent.press(screen.getByRole('button', { name: 'Units' }));
+    fireEvent.press(screen.getByText('Units'));
     expect(mockSetUnits).toHaveBeenCalledWith('mile');
   });
 
   it('opens the appearance ActionSheet and applies the theme', () => {
     render(<PreferencesSection />);
-    fireEvent.press(screen.getByRole('button', { name: 'Appearance' }));
+    fireEvent.press(screen.getByText('Appearance'));
     expect(mockSetTheme).toHaveBeenCalledWith('dark');
   });
 });

--- a/apps/mobile/components/settings/PreferencesSection.tsx
+++ b/apps/mobile/components/settings/PreferencesSection.tsx
@@ -1,9 +1,6 @@
 import { ActionSheetIOS, Platform, StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
-import { GroupedCard } from '@/components/ui/GroupedCard';
-import { GroupedRow } from '@/components/ui/GroupedRow';
-import { IconSymbol } from '@/components/ui/icon-symbol';
-import { SectionHeader } from '@/components/ui/SectionHeader';
+import { NativeFieldRow, NativeFieldSection } from '@/components/ui/NativeFieldGroup';
 import { useColors } from '@/hooks/use-colors';
 import { spacing } from '@/theme/tokens';
 import { useSettingsStore } from '@/stores/settings-store';
@@ -69,10 +66,10 @@ export function PreferencesSection() {
 
   return (
     <View style={styles.wrapper}>
-      <SectionHeader label={t('settings.sectionLabel.preferences')} />
-      <GroupedCard elevated={false}>
-        <GroupedRow
-          leading={<IconSymbol name="globe" size={18} color={theme.interactive} />}
+      <NativeFieldSection title={t('settings.sectionLabel.preferences')}>
+        <NativeFieldRow
+          icon="globe"
+          iconColor={theme.interactive}
           label={t('settings.language')}
           value={languageLabel}
           onPress={() =>
@@ -87,26 +84,28 @@ export function PreferencesSection() {
             )
           }
         />
-        <GroupedRow
-          leading={<IconSymbol name="ruler" size={18} color={theme.interactive} />}
+        <NativeFieldRow
+          icon="ruler"
+          iconColor={theme.interactive}
           label={t('settings.units')}
           value={unitsLabels[units]}
           onPress={() => presentSheet(UNITS, unitsLabels, units, setUnits)}
         />
-        <GroupedRow
-          leading={<IconSymbol name="bell.fill" size={18} color={theme.warning} />}
+        <NativeFieldRow
+          icon="notifications"
+          iconColor={theme.warning}
           label={t('settings.notifications')}
           value={t('settings.notificationsValue')}
           showChevron
         />
-        <GroupedRow
-          leading={<IconSymbol name="moon.fill" size={18} color={theme.warning} />}
+        <NativeFieldRow
+          icon="appearance"
+          iconColor={theme.warning}
           label={t('settings.appearance')}
           value={themeLabels[themeMode]}
           onPress={() => presentSheet(THEMES, themeLabels, themeMode, setTheme)}
-          separator={false}
         />
-      </GroupedCard>
+      </NativeFieldSection>
     </View>
   );
 }

--- a/apps/mobile/components/settings/SignOutRow.test.tsx
+++ b/apps/mobile/components/settings/SignOutRow.test.tsx
@@ -31,7 +31,7 @@ describe('SignOutRow', () => {
   it('calls signOut after confirming the dialog', async () => {
     render(<SignOutRow />);
 
-    fireEvent.press(screen.getAllByRole('button', { name: 'Sign Out' })[0]);
+    fireEvent.press(screen.getByText('Sign Out'));
 
     const confirmButtons = await screen.findAllByRole('button', { name: 'Sign Out' });
     fireEvent.press(confirmButtons[confirmButtons.length - 1]);

--- a/apps/mobile/components/settings/SignOutRow.tsx
+++ b/apps/mobile/components/settings/SignOutRow.tsx
@@ -1,11 +1,11 @@
 import { useState } from 'react';
-import { Pressable, StyleSheet, Text } from 'react-native';
+import { StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
-import { GroupedCard } from '@/components/ui/GroupedCard';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
+import { NativeFieldRow, NativeFieldSection } from '@/components/ui/NativeFieldGroup';
 import { useColors } from '@/hooks/use-colors';
 import { useAuth } from '@/hooks/use-auth';
-import { components, spacing, typography } from '@/theme/tokens';
+import { spacing } from '@/theme/tokens';
 
 export function SignOutRow() {
   const { t } = useTranslation();
@@ -26,19 +26,14 @@ export function SignOutRow() {
 
   return (
     <>
-      <GroupedCard elevated={false} style={styles.card}>
-        <Pressable
-          accessibilityRole="button"
-          accessibilityLabel={t('settings.signOut')}
-          onPress={() => setShowConfirm(true)}
+      <NativeFieldSection style={styles.card}>
+        <NativeFieldRow
           disabled={loading}
-          style={styles.row}
-        >
-          <Text style={[styles.label, { color: theme.error }]}>
-            {t('settings.signOut')}
-          </Text>
-        </Pressable>
-      </GroupedCard>
+          label={t('settings.signOut')}
+          labelColor={theme.error}
+          onPress={() => setShowConfirm(true)}
+        />
+      </NativeFieldSection>
       <ConfirmDialog
         visible={showConfirm}
         title={t('settings.signOut')}
@@ -56,15 +51,5 @@ export function SignOutRow() {
 const styles = StyleSheet.create({
   card: {
     marginBottom: spacing.lg,
-  },
-  row: {
-    paddingVertical: spacing.step12,
-    paddingHorizontal: spacing.md,
-    alignItems: 'center',
-    justifyContent: 'center',
-    minHeight: components.row.minHeight,
-  },
-  label: {
-    ...typography.body,
   },
 });

--- a/apps/mobile/components/ui/NativeFieldGroup.test.tsx
+++ b/apps/mobile/components/ui/NativeFieldGroup.test.tsx
@@ -1,0 +1,58 @@
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { NativeFieldSection, NativeFieldRow } from './NativeFieldGroup';
+
+describe('NativeFieldGroup', () => {
+  it('wraps rows in a hosted field section', () => {
+    render(
+      <NativeFieldSection testID="profile-section">
+        <NativeFieldRow label="Name" value="Mio" />
+      </NativeFieldSection>,
+    );
+
+    expect(screen.getByTestId('profile-section-host')).toBeTruthy();
+    expect(screen.getByTestId('profile-section')).toBeTruthy();
+    expect(screen.getByText('Name')).toBeTruthy();
+    expect(screen.getByText('Mio')).toBeTruthy();
+  });
+
+  it('gives the native field group a viewport height based on row count', () => {
+    render(
+      <NativeFieldSection testID="profile-section" title="Profile">
+        <NativeFieldRow label="Name" />
+        <NativeFieldRow label="Breed" />
+      </NativeFieldSection>,
+    );
+
+    const hostStyle = screen.getByTestId('profile-section-host').props.style;
+    expect(hostStyle).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ width: '100%' }),
+        expect.objectContaining({ height: expect.any(Number) }),
+      ]),
+    );
+  });
+
+  it('hosts the native field group with viewport measurement instead of content matching', () => {
+    render(
+      <NativeFieldSection testID="profile-section">
+        <NativeFieldRow label="Name" />
+      </NativeFieldSection>,
+    );
+
+    const hostProps = screen.getByTestId('profile-section-host').props;
+    expect(hostProps.useViewportSizeMeasurement).toBe(true);
+    expect(hostProps.matchContents).toBeUndefined();
+  });
+
+  it('fires row actions from the native row surface', () => {
+    const onPress = jest.fn();
+    render(
+      <NativeFieldSection>
+        <NativeFieldRow label="Language" value="English" onPress={onPress} testID="language-row" />
+      </NativeFieldSection>,
+    );
+
+    fireEvent.press(screen.getByTestId('language-row'));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/mobile/components/ui/NativeFieldGroup.test.tsx
+++ b/apps/mobile/components/ui/NativeFieldGroup.test.tsx
@@ -2,20 +2,20 @@ import { fireEvent, render, screen } from '@testing-library/react-native';
 import { NativeFieldSection, NativeFieldRow } from './NativeFieldGroup';
 
 describe('NativeFieldGroup', () => {
-  it('wraps rows in a hosted field section', () => {
+  it('renders rows in a static field section without a hosted scroll container', () => {
     render(
       <NativeFieldSection testID="profile-section">
         <NativeFieldRow label="Name" value="Mio" />
       </NativeFieldSection>,
     );
 
-    expect(screen.getByTestId('profile-section-host')).toBeTruthy();
+    expect(screen.queryByTestId('profile-section-host')).toBeNull();
     expect(screen.getByTestId('profile-section')).toBeTruthy();
     expect(screen.getByText('Name')).toBeTruthy();
     expect(screen.getByText('Mio')).toBeTruthy();
   });
 
-  it('gives the native field group a viewport height based on row count', () => {
+  it('renders the section title and separators in the static field section', () => {
     render(
       <NativeFieldSection testID="profile-section" title="Profile">
         <NativeFieldRow label="Name" />
@@ -23,25 +23,20 @@ describe('NativeFieldGroup', () => {
       </NativeFieldSection>,
     );
 
-    const hostStyle = screen.getByTestId('profile-section-host').props.style;
-    expect(hostStyle).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ width: '100%' }),
-        expect.objectContaining({ height: expect.any(Number) }),
-      ]),
-    );
+    expect(screen.getByText('Profile')).toBeTruthy();
+    expect(screen.getByTestId('profile-section-separator-0')).toBeTruthy();
   });
 
-  it('hosts the native field group with viewport measurement instead of content matching', () => {
+  it('hosts each native row with content matching instead of viewport measurement', () => {
     render(
       <NativeFieldSection testID="profile-section">
-        <NativeFieldRow label="Name" />
+        <NativeFieldRow label="Name" testID="name-row" />
       </NativeFieldSection>,
     );
 
-    const hostProps = screen.getByTestId('profile-section-host').props;
-    expect(hostProps.useViewportSizeMeasurement).toBe(true);
-    expect(hostProps.matchContents).toBeUndefined();
+    const rowHostProps = screen.getByTestId('name-row-host').props;
+    expect(rowHostProps.matchContents).toEqual({ vertical: true });
+    expect(rowHostProps.useViewportSizeMeasurement).toBeUndefined();
   });
 
   it('fires row actions from the native row surface', () => {

--- a/apps/mobile/components/ui/NativeFieldGroup.tsx
+++ b/apps/mobile/components/ui/NativeFieldGroup.tsx
@@ -1,7 +1,12 @@
-import { Children, createContext, type ReactNode } from 'react';
-import type { StyleProp, ViewStyle } from 'react-native';
+import { Children, createContext, Fragment, isValidElement, type ReactNode } from 'react';
 import {
-  FieldGroup,
+  StyleSheet,
+  Text as RNText,
+  View,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native';
+import {
   Host,
   Icon,
   Row,
@@ -11,7 +16,7 @@ import {
 } from '@expo/ui';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { useColors } from '@/hooks/use-colors';
-import { components, spacing, typography } from '@/theme/tokens';
+import { components, elevation, radius, spacing, typography } from '@/theme/tokens';
 
 export const NativeFieldGroupContext = createContext(false);
 
@@ -80,36 +85,45 @@ interface NativeFieldRowProps {
 }
 
 export function NativeFieldSection({ children, style, testID, title }: NativeFieldSectionProps) {
-  const colorScheme = useColorScheme();
   const theme = useColors();
-  const estimatedHeight = getFieldSectionHeight(children, title);
+  const rows = Children.toArray(children).filter(Boolean);
 
   return (
-    <NativeFieldGroupContext.Provider value>
-      <Host
-        colorScheme={colorScheme}
-        style={[styles.host, { height: estimatedHeight }, style]}
-        testID={testID ? `${testID}-host` : undefined}
-        useViewportSizeMeasurement
+    <View style={[styles.section, style]}>
+      {title ? (
+        <RNText style={[styles.title, { color: theme.onSurfaceVariant }]}>
+          {title}
+        </RNText>
+      ) : null}
+      <View
+        style={[
+          styles.card,
+          { backgroundColor: theme.surface },
+          elevation.low,
+        ]}
+        testID={testID}
       >
-        <FieldGroup
-          testID={testID}
-          style={{ backgroundColor: theme.background }}
-        >
-          <FieldGroup.Section title={title}>{children}</FieldGroup.Section>
-        </FieldGroup>
-      </Host>
-    </NativeFieldGroupContext.Provider>
+        {rows.map((child, index) => (
+          <Fragment key={getRowKey(child, index)}>
+            {child}
+            {index < rows.length - 1 ? (
+              <View
+                style={[styles.separator, { backgroundColor: theme.border }]}
+                testID={testID ? `${testID}-separator-${index}` : undefined}
+              />
+            ) : null}
+          </Fragment>
+        ))}
+      </View>
+    </View>
   );
 }
 
-function getFieldSectionHeight(children: ReactNode, title?: string): number {
-  const rowCount = Children.toArray(children).filter(Boolean).length;
-  const headerHeight = title ? spacing.xl : spacing.md;
-  return Math.max(
-    components.row.minHeight,
-    rowCount * components.row.minHeight + headerHeight + spacing.md,
-  );
+function getRowKey(child: ReactNode, index: number): string {
+  if (isValidElement(child) && child.key != null) {
+    return String(child.key);
+  }
+  return `row-${index}`;
 }
 
 export function NativeFieldRow({
@@ -123,63 +137,90 @@ export function NativeFieldRow({
   testID,
   value,
 }: NativeFieldRowProps) {
+  const colorScheme = useColorScheme();
   const theme = useColors();
   const renderChevron = showChevron ?? typeof onPress === 'function';
 
   return (
-    <Row
-      alignment="center"
-      disabled={disabled}
-      onPress={disabled ? undefined : onPress}
-      spacing={components.row.gap}
-      style={styles.row}
-      testID={testID}
+    <Host
+      colorScheme={colorScheme}
+      matchContents={{ vertical: true }}
+      style={styles.rowHost}
+      testID={testID ? `${testID}-host` : undefined}
     >
-      {icon ? (
-        <Icon
-          name={NATIVE_FIELD_ICONS[icon]}
-          size={typography.body.fontSize}
-          color={iconColor ?? theme.interactive}
-        />
-      ) : null}
-      <Text
-        numberOfLines={1}
-        textStyle={{
-          ...typography.body,
-          color: labelColor ?? theme.onSurface,
-        }}
+      <Row
+        alignment="center"
+        disabled={disabled}
+        onPress={disabled ? undefined : onPress}
+        spacing={components.row.gap}
+        style={styles.row}
+        testID={testID}
       >
-        {label}
-      </Text>
-      <Spacer flexible />
-      {value ? (
+        {icon ? (
+          <Icon
+            name={NATIVE_FIELD_ICONS[icon]}
+            size={typography.body.fontSize}
+            color={iconColor ?? theme.interactive}
+          />
+        ) : null}
         <Text
           numberOfLines={1}
           textStyle={{
-            ...typography.subheadline,
-            color: theme.onSurfaceVariant,
+            ...typography.body,
+            color: labelColor ?? theme.onSurface,
           }}
         >
-          {value}
+          {label}
         </Text>
-      ) : null}
-      {renderChevron ? (
-        <Icon
-          name={NATIVE_FIELD_ICONS.chevronRight}
-          size={typography.body.fontSize}
-          color={theme.textDisabled}
-        />
-      ) : null}
-    </Row>
+        <Spacer flexible />
+        {value ? (
+          <Text
+            numberOfLines={1}
+            textStyle={{
+              ...typography.subheadline,
+              color: theme.onSurfaceVariant,
+            }}
+          >
+            {value}
+          </Text>
+        ) : null}
+        {renderChevron ? (
+          <Icon
+            name={NATIVE_FIELD_ICONS.chevronRight}
+            size={typography.body.fontSize}
+            color={theme.textDisabled}
+          />
+        ) : null}
+      </Row>
+    </Host>
   );
 }
 
-const styles = {
-  host: {
+const styles = StyleSheet.create({
+  section: {
     width: '100%' as const,
   },
+  title: {
+    ...typography.metricLabel,
+    fontWeight: typography.headline.fontWeight,
+    paddingHorizontal: spacing.xs,
+    marginBottom: spacing.step10,
+  },
+  card: {
+    width: '100%',
+    borderRadius: radius.xl,
+    overflow: 'hidden',
+  },
+  separator: {
+    height: StyleSheet.hairlineWidth,
+    marginLeft: components.row.paddingH,
+  },
+  rowHost: {
+    width: '100%',
+  },
   row: {
+    minHeight: components.row.minHeight,
     paddingHorizontal: components.row.paddingH,
     paddingVertical: components.row.paddingV,
   },
-};
+});

--- a/apps/mobile/components/ui/NativeFieldGroup.tsx
+++ b/apps/mobile/components/ui/NativeFieldGroup.tsx
@@ -1,0 +1,185 @@
+import { Children, createContext, type ReactNode } from 'react';
+import type { StyleProp, ViewStyle } from 'react-native';
+import {
+  FieldGroup,
+  Host,
+  Icon,
+  Row,
+  Spacer,
+  Text,
+  type IconName,
+} from '@expo/ui';
+import { useColorScheme } from '@/hooks/use-color-scheme';
+import { useColors } from '@/hooks/use-colors';
+import { components, spacing, typography } from '@/theme/tokens';
+
+export const NativeFieldGroupContext = createContext(false);
+
+const NATIVE_FIELD_ICONS = {
+  chevronRight: Icon.select({
+    ios: 'chevron.right',
+    android: import('@expo/material-symbols/chevron_right.xml'),
+  }),
+  globe: Icon.select({
+    ios: 'globe',
+    android: import('@expo/material-symbols/language.xml'),
+  }),
+  ruler: Icon.select({
+    ios: 'ruler',
+    android: import('@expo/material-symbols/straighten.xml'),
+  }),
+  notifications: Icon.select({
+    ios: 'bell.fill',
+    android: import('@expo/material-symbols/notifications.xml'),
+  }),
+  appearance: Icon.select({
+    ios: 'moon.fill',
+    android: import('@expo/material-symbols/dark_mode.xml'),
+  }),
+  settings: Icon.select({
+    ios: 'gearshape.fill',
+    android: import('@expo/material-symbols/settings.xml'),
+  }),
+  email: Icon.select({
+    ios: 'envelope.fill',
+    android: import('@expo/material-symbols/alternate_email.xml'),
+  }),
+  terms: Icon.select({
+    ios: 'doc.text',
+    android: import('@expo/material-symbols/description.xml'),
+  }),
+  privacy: Icon.select({
+    ios: 'lock.fill',
+    android: import('@expo/material-symbols/lock.xml'),
+  }),
+  about: Icon.select({
+    ios: 'info.circle',
+    android: import('@expo/material-symbols/info.xml'),
+  }),
+} satisfies Record<string, IconName>;
+
+export type NativeFieldIconName = Exclude<keyof typeof NATIVE_FIELD_ICONS, 'chevronRight'>;
+
+interface NativeFieldSectionProps {
+  children: ReactNode;
+  style?: StyleProp<ViewStyle>;
+  testID?: string;
+  title?: string;
+}
+
+interface NativeFieldRowProps {
+  disabled?: boolean;
+  icon?: NativeFieldIconName;
+  iconColor?: string;
+  label: string;
+  labelColor?: string;
+  onPress?: () => void;
+  showChevron?: boolean;
+  testID?: string;
+  value?: string;
+}
+
+export function NativeFieldSection({ children, style, testID, title }: NativeFieldSectionProps) {
+  const colorScheme = useColorScheme();
+  const theme = useColors();
+  const estimatedHeight = getFieldSectionHeight(children, title);
+
+  return (
+    <NativeFieldGroupContext.Provider value>
+      <Host
+        colorScheme={colorScheme}
+        style={[styles.host, { height: estimatedHeight }, style]}
+        testID={testID ? `${testID}-host` : undefined}
+        useViewportSizeMeasurement
+      >
+        <FieldGroup
+          testID={testID}
+          style={{ backgroundColor: theme.background }}
+        >
+          <FieldGroup.Section title={title}>{children}</FieldGroup.Section>
+        </FieldGroup>
+      </Host>
+    </NativeFieldGroupContext.Provider>
+  );
+}
+
+function getFieldSectionHeight(children: ReactNode, title?: string): number {
+  const rowCount = Children.toArray(children).filter(Boolean).length;
+  const headerHeight = title ? spacing.xl : spacing.md;
+  return Math.max(
+    components.row.minHeight,
+    rowCount * components.row.minHeight + headerHeight + spacing.md,
+  );
+}
+
+export function NativeFieldRow({
+  disabled,
+  icon,
+  iconColor,
+  label,
+  labelColor,
+  onPress,
+  showChevron,
+  testID,
+  value,
+}: NativeFieldRowProps) {
+  const theme = useColors();
+  const renderChevron = showChevron ?? typeof onPress === 'function';
+
+  return (
+    <Row
+      alignment="center"
+      disabled={disabled}
+      onPress={disabled ? undefined : onPress}
+      spacing={components.row.gap}
+      style={styles.row}
+      testID={testID}
+    >
+      {icon ? (
+        <Icon
+          name={NATIVE_FIELD_ICONS[icon]}
+          size={typography.body.fontSize}
+          color={iconColor ?? theme.interactive}
+        />
+      ) : null}
+      <Text
+        numberOfLines={1}
+        textStyle={{
+          ...typography.body,
+          color: labelColor ?? theme.onSurface,
+        }}
+      >
+        {label}
+      </Text>
+      <Spacer flexible />
+      {value ? (
+        <Text
+          numberOfLines={1}
+          textStyle={{
+            ...typography.subheadline,
+            color: theme.onSurfaceVariant,
+          }}
+        >
+          {value}
+        </Text>
+      ) : null}
+      {renderChevron ? (
+        <Icon
+          name={NATIVE_FIELD_ICONS.chevronRight}
+          size={typography.body.fontSize}
+          color={theme.textDisabled}
+        />
+      ) : null}
+    </Row>
+  );
+}
+
+const styles = {
+  host: {
+    width: '100%' as const,
+  },
+  row: {
+    paddingHorizontal: components.row.paddingH,
+    paddingVertical: components.row.paddingV,
+  },
+};

--- a/apps/mobile/components/ui/TextInput.test.tsx
+++ b/apps/mobile/components/ui/TextInput.test.tsx
@@ -7,15 +7,22 @@ jest.mock('@/hooks/use-color-scheme', () => ({
 }));
 
 describe('TextInput', () => {
-  it('renders the label', () => {
+  it('uses the label as the default placeholder without rendering visible label text', () => {
     render(<TextInput label="Email" />);
-    expect(screen.getByText('Email')).toBeTruthy();
+    expect(screen.getByPlaceholderText('Email')).toBeTruthy();
+    expect(screen.queryByText('Email')).toBeNull();
+  });
+
+  it('prefers an explicit placeholder over the label', () => {
+    render(<TextInput label="Email" placeholder="you@example.com" />);
+    expect(screen.getByPlaceholderText('you@example.com')).toBeTruthy();
+    expect(screen.queryByPlaceholderText('Email')).toBeNull();
   });
 
   it('calls onChangeText when the user types', () => {
     const onChangeText = jest.fn();
     render(<TextInput label="Email" onChangeText={onChangeText} />);
-    fireEvent.changeText(screen.getByLabelText('Email'), 'foo@example.com');
+    fireEvent.changeText(screen.getByPlaceholderText('Email'), 'foo@example.com');
     expect(onChangeText).toHaveBeenCalledWith('foo@example.com');
   });
 
@@ -31,22 +38,30 @@ describe('TextInput', () => {
 
   it('passes value prop through to the native input', () => {
     render(<TextInput label="Email" value="initial" />);
-    expect(screen.getByLabelText('Email').props.value).toBe('initial');
+    expect(screen.getByPlaceholderText('Email').props.value).toBe('initial');
   });
 
-  it('renders inline labelPosition with label and input accessible', () => {
+  it('re-seeds the native input when the parent value changes externally', () => {
+    const { rerender } = render(<TextInput label="Email" value="initial" />);
+
+    rerender(<TextInput label="Email" value="reset@example.com" />);
+
+    expect(screen.getByPlaceholderText('Email').props.value).toBe('reset@example.com');
+  });
+
+  it('renders inline labelPosition without a visible label and with an input placeholder', () => {
     render(
       <TextInput label="Email" labelPosition="inline" value="coco@walk.app" />,
     );
-    expect(screen.getByText('Email')).toBeTruthy();
-    expect(screen.getByLabelText('Email').props.value).toBe('coco@walk.app');
+    expect(screen.queryByText('Email')).toBeNull();
+    expect(screen.getByPlaceholderText('Email').props.value).toBe('coco@walk.app');
   });
 
-  it('inline variant renders separator when separator prop is true', () => {
+  it('does not render a manual separator when separator prop is true', () => {
     render(
       <TextInput label="Email" labelPosition="inline" separator testID="email-row" />,
     );
-    expect(screen.getByTestId('email-row-separator')).toBeTruthy();
+    expect(screen.queryByTestId('email-row-separator')).toBeNull();
   });
 
   it('inline variant highlights the row while focused', () => {
@@ -54,7 +69,7 @@ describe('TextInput', () => {
       <TextInput label="Email" labelPosition="inline" testID="email-row" />,
     );
 
-    fireEvent(screen.getByLabelText('Email'), 'focus');
+    fireEvent(screen.getByPlaceholderText('Email'), 'focus');
 
     const rowStyle = StyleSheet.flatten(screen.getByTestId('email-row-container').props.style);
     expect(rowStyle.borderColor).not.toBe('transparent');
@@ -73,7 +88,7 @@ describe('TextInput', () => {
       />,
     );
 
-    const input = screen.getByLabelText('Email');
+    const input = screen.getByPlaceholderText('Email');
 
     fireEvent(input, 'focus');
     fireEvent(input, 'blur');
@@ -82,7 +97,7 @@ describe('TextInput', () => {
     expect(onBlur).toHaveBeenCalledTimes(1);
   });
 
-  it('inline variant does not render separator when separator prop is false', () => {
+  it('does not render a manual separator when separator prop is false', () => {
     render(
       <TextInput label="Password" labelPosition="inline" testID="pwd-row" />,
     );

--- a/apps/mobile/components/ui/TextInput.tsx
+++ b/apps/mobile/components/ui/TextInput.tsx
@@ -1,208 +1,186 @@
-import { useState } from 'react';
+import { useContext, useEffect, useRef, useState } from 'react';
+import { StyleSheet, Text, type StyleProp, type TextStyle } from 'react-native';
 import {
-  StyleSheet,
-  Text,
-  TextInput as RNTextInput,
-  View,
-  type StyleProp,
-  type TextInputProps as RNTextInputProps,
-  type TextStyle,
-} from 'react-native';
+  Host,
+  TextInput as ExpoTextInput,
+  useNativeState,
+  type TextInputProps as ExpoTextInputProps,
+} from '@expo/ui';
+import { useColorScheme } from '@/hooks/use-color-scheme';
 import { useColors } from '@/hooks/use-colors';
-import { components, spacing, radius, typography, type ColorTokens } from '@/theme/tokens';
+import { components, radius, spacing, typography } from '@/theme/tokens';
+import { NativeFieldGroupContext } from './NativeFieldGroup';
 
 type LabelPosition = 'top' | 'inline';
+type ExpoFontWeight = NonNullable<ExpoTextInputProps['textStyle']>['fontWeight'];
 
-interface TextInputProps extends Omit<RNTextInputProps, 'style'> {
+const EXPO_FONT_WEIGHTS = new Set<ExpoFontWeight>([
+  'normal',
+  'bold',
+  '100',
+  '200',
+  '300',
+  '400',
+  '500',
+  '600',
+  '700',
+  '800',
+  '900',
+]);
+
+interface TextInputProps
+  extends Omit<
+    ExpoTextInputProps,
+    'onBlur' | 'onFocus' | 'placeholder' | 'style' | 'textStyle' | 'value'
+  > {
   label: string;
   error?: string;
-  style?: StyleProp<TextStyle>;
-  /**
-   * `top` (default) — UPPERCASE caption label above an outlined 52-px field.
-   * `inline` — iOS-settings-style row with label on the left and the field on
-   * the right, meant to sit inside a `GroupedCard`.
-   */
   labelPosition?: LabelPosition;
-  /** Inline-only: draw a hairline separator below the row (for stacked GroupedCard rows). */
+  placeholder?: string;
+  /** Native FieldGroup owns row separators; kept only for call-site compatibility. */
   separator?: boolean;
+  style?: StyleProp<TextStyle>;
+  textStyle?: ExpoTextInputProps['textStyle'];
+  value?: string;
+  onBlur?: () => void;
+  onFocus?: () => void;
 }
-
-type TextInputFocusEvent = Parameters<NonNullable<RNTextInputProps['onFocus']>>[0];
-type TextInputBlurEvent = Parameters<NonNullable<RNTextInputProps['onBlur']>>[0];
 
 export const TextInput = ({
   label,
   error,
-  style,
   labelPosition = 'top',
-  separator = false,
+  placeholder,
+  separator: _separator = false,
   testID,
   onBlur,
   onFocus,
+  onChangeText,
+  style,
+  textStyle,
+  value = '',
   ...props
 }: TextInputProps) => {
   const theme = useColors();
-  const { isFocused, handleBlur, handleFocus } = useTextInputFocusHandlers({
-    onBlur,
-    onFocus,
-  });
+  const colorScheme = useColorScheme();
+  const inNativeFieldGroup = useContext(NativeFieldGroupContext);
+  const [isFocused, setIsFocused] = useState(false);
+  const [nativeSeed, setNativeSeed] = useState({ value, version: 0 });
+  const lastInputValueRef = useRef(value);
+  const resolvedPlaceholder = placeholder ?? label;
 
-  return labelPosition === 'inline' ? (
-    <InlineTextInput
-      error={error}
-      inputProps={props}
-      isFocused={isFocused}
-      label={label}
-      onBlur={handleBlur}
+  useEffect(() => {
+    if (value !== lastInputValueRef.current) {
+      lastInputValueRef.current = value;
+      setNativeSeed((current) =>
+        current.value === value
+          ? current
+          : { value, version: current.version + 1 },
+      );
+    }
+  }, [value]);
+
+  function handleChangeText(nextValue: string) {
+    lastInputValueRef.current = nextValue;
+    onChangeText?.(nextValue);
+  }
+
+  function handleFocus() {
+    setIsFocused(true);
+    onFocus?.();
+  }
+
+  function handleBlur() {
+    setIsFocused(false);
+    onBlur?.();
+  }
+
+  const input = (
+    <NativeExpoTextInput
+      key={nativeSeed.version}
+      initialValue={nativeSeed.value}
+      onChangeText={handleChangeText}
+      placeholder={resolvedPlaceholder}
+      placeholderTextColor={theme.onSurfaceVariant}
       onFocus={handleFocus}
-      separator={separator}
-      style={style}
-      testID={testID}
-      theme={theme}
-    />
-  ) : (
-    <TopTextInput
-      error={error}
-      inputProps={props}
-      isFocused={isFocused}
-      label={label}
       onBlur={handleBlur}
-      onFocus={handleFocus}
-      style={style}
       testID={testID}
-      theme={theme}
+      style={{
+        ...nativeInputBoxStyle({ error, isFocused, labelPosition, theme }),
+      }}
+      textStyle={{
+        ...typography.body,
+        color: theme.onSurface,
+        ...(textStyle ?? {}),
+        ...flattenTextStyle(style),
+      }}
+      {...props}
     />
+  );
+
+  if (inNativeFieldGroup && !error) {
+    return input;
+  }
+
+  return (
+    <>
+      <Host
+        colorScheme={colorScheme}
+        matchContents={{ vertical: true }}
+        style={styles.host}
+        testID={testID ? `${testID}-container` : undefined}
+      >
+        {input}
+      </Host>
+      {error ? (
+        <Text style={[styles.error, { color: theme.error }]}>{error}</Text>
+      ) : null}
+    </>
   );
 };
 
-interface UseTextInputFocusHandlersProps {
-  onBlur?: RNTextInputProps['onBlur'];
-  onFocus?: RNTextInputProps['onFocus'];
+function NativeExpoTextInput({
+  initialValue,
+  ...props
+}: Omit<ExpoTextInputProps, 'value'> & { initialValue: string }) {
+  const nativeValue = useNativeState(initialValue);
+  return <ExpoTextInput value={nativeValue} {...props} />;
 }
 
-function useTextInputFocusHandlers({
-  onBlur,
-  onFocus,
-}: UseTextInputFocusHandlersProps) {
-  const [isFocused, setIsFocused] = useState(false);
-
-  function handleFocus(event: TextInputFocusEvent) {
-    setIsFocused(true);
-    onFocus?.(event);
-  }
-
-  function handleBlur(event: TextInputBlurEvent) {
-    setIsFocused(false);
-    onBlur?.(event);
-  }
-
-  return { isFocused, handleBlur, handleFocus };
-}
-
-interface TextInputVariantProps {
+function nativeInputBoxStyle({
+  error,
+  isFocused,
+  labelPosition,
+  theme,
+}: {
   error?: string;
-  inputProps: RNTextInputProps;
   isFocused: boolean;
-  label: string;
-  onBlur: NonNullable<RNTextInputProps['onBlur']>;
-  onFocus: NonNullable<RNTextInputProps['onFocus']>;
-  style?: StyleProp<TextStyle>;
-  testID?: string;
-  theme: ColorTokens;
+  labelPosition: LabelPosition;
+  theme: ReturnType<typeof useColors>;
+}): ExpoTextInputProps['style'] {
+  if (labelPosition === 'inline') {
+    return {
+      width: '100%',
+      height: components.row.minHeight,
+      paddingHorizontal: spacing.md,
+      paddingVertical: spacing.step14,
+      backgroundColor: isFocused ? theme.surfaceContainer : 'transparent',
+      borderWidth: components.textInput.borderWidth,
+      borderColor: isFocused ? theme.interactive : 'transparent',
+      borderRadius: radius.lg,
+    };
+  }
+
+  return {
+    width: '100%',
+    height: components.textInput.height,
+    paddingHorizontal: spacing.md,
+    backgroundColor: theme.surface,
+    borderWidth: components.textInput.borderWidth,
+    borderColor: inputBorderColor({ error, isFocused, theme }),
+    borderRadius: radius.lg,
+  };
 }
-
-interface InlineTextInputProps extends TextInputVariantProps {
-  separator: boolean;
-}
-
-const InlineTextInput = ({
-  error,
-  inputProps,
-  isFocused,
-  label,
-  onBlur,
-  onFocus,
-  separator,
-  style,
-  testID,
-  theme,
-}: InlineTextInputProps) => (
-  <>
-    <View
-      testID={testID ? `${testID}-container` : undefined}
-      style={[
-        inlineStyles.row,
-        {
-          backgroundColor: isFocused ? theme.surfaceContainer : 'transparent',
-          borderColor: isFocused ? theme.interactive : 'transparent',
-        },
-      ]}
-    >
-      <Text style={[inlineStyles.label, { color: theme.onSurfaceVariant }]}>
-        {label}
-      </Text>
-      <RNTextInput
-        style={[inlineStyles.input, { color: theme.onSurface }, style]}
-        placeholderTextColor={theme.onSurfaceVariant}
-        accessibilityLabel={label}
-        testID={testID}
-        onBlur={onBlur}
-        onFocus={onFocus}
-        {...inputProps}
-      />
-    </View>
-    {separator ? (
-      <View
-        testID={testID ? `${testID}-separator` : undefined}
-        style={[inlineStyles.separator, { backgroundColor: theme.border }]}
-      />
-    ) : null}
-    {error ? (
-      <Text style={[inlineStyles.error, { color: theme.error }]}>{error}</Text>
-    ) : null}
-  </>
-);
-
-const TopTextInput = ({
-  error,
-  inputProps,
-  isFocused,
-  label,
-  onBlur,
-  onFocus,
-  style,
-  testID,
-  theme,
-}: TextInputVariantProps) => (
-  <View style={styles.container}>
-    <Text
-      style={[styles.label, { color: theme.onSurface }]}
-      accessibilityRole="none"
-    >
-      {label}
-    </Text>
-    <RNTextInput
-      style={[
-        styles.input,
-        {
-          backgroundColor: theme.surface,
-          color: theme.onSurface,
-          borderColor: inputBorderColor({ error, isFocused, theme }),
-        },
-        style,
-      ]}
-      placeholderTextColor={theme.onSurfaceVariant}
-      accessibilityLabel={label}
-      testID={testID}
-      onBlur={onBlur}
-      onFocus={onFocus}
-      {...inputProps}
-    />
-    {error ? (
-      <Text style={[styles.error, { color: theme.error }]}>{error}</Text>
-    ) : null}
-  </View>
-);
 
 function inputBorderColor({
   error,
@@ -211,7 +189,7 @@ function inputBorderColor({
 }: {
   error?: string;
   isFocused: boolean;
-  theme: ColorTokens;
+  theme: ReturnType<typeof useColors>;
 }) {
   if (error) {
     return theme.error;
@@ -219,50 +197,32 @@ function inputBorderColor({
   return isFocused ? theme.interactive : theme.border;
 }
 
-const styles = StyleSheet.create({
-  container: {
-    marginBottom: spacing.md,
-  },
-  label: {
-    ...typography.metricLabel,
-    marginBottom: spacing.sm,
-  },
-  input: {
-    height: components.textInput.height,
-    borderWidth: components.textInput.borderWidth,
-    borderRadius: radius.lg,
-    paddingHorizontal: spacing.md,
-    ...typography.body,
-  },
-  error: {
-    ...typography.caption,
-    marginTop: spacing.xs,
-  },
-});
+function flattenTextStyle(style: StyleProp<TextStyle>): ExpoTextInputProps['textStyle'] {
+  const flat = StyleSheet.flatten(style);
+  if (!flat) return {};
+  return {
+    color: typeof flat.color === 'string' ? flat.color : undefined,
+    fontFamily: flat.fontFamily,
+    fontSize: flat.fontSize,
+    fontWeight: toExpoFontWeight(flat.fontWeight),
+    letterSpacing: flat.letterSpacing,
+    lineHeight: flat.lineHeight,
+    textAlign:
+      flat.textAlign === 'left' || flat.textAlign === 'right' || flat.textAlign === 'center'
+        ? flat.textAlign
+        : undefined,
+  };
+}
 
-const inlineStyles = StyleSheet.create({
-  row: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: components.row.gap,
-    paddingHorizontal: spacing.md,
-    paddingVertical: spacing.step14,
-    minHeight: components.row.minHeight,
-    borderWidth: components.textInput.borderWidth,
-    borderRadius: radius.lg,
-  },
-  label: {
-    ...typography.subheadline,
-    width: components.textInput.inlineLabelWidth,
-  },
-  input: {
-    flex: 1,
-    ...typography.body,
-    padding: components.textInput.inputPadding,
-  },
-  separator: {
-    height: StyleSheet.hairlineWidth,
-    marginLeft: spacing.md,
+function toExpoFontWeight(fontWeight: TextStyle['fontWeight']): ExpoFontWeight | undefined {
+  return typeof fontWeight === 'string' && EXPO_FONT_WEIGHTS.has(fontWeight as ExpoFontWeight)
+    ? (fontWeight as ExpoFontWeight)
+    : undefined;
+}
+
+const styles = StyleSheet.create({
+  host: {
+    width: '100%',
   },
   error: {
     ...typography.caption,

--- a/apps/mobile/components/walk/WalkEventActions.tsx
+++ b/apps/mobile/components/walk/WalkEventActions.tsx
@@ -7,6 +7,7 @@ import { useCameraEventTrigger } from '@/hooks/use-camera-event-trigger';
 import { useCommitWalkEvent } from '@/hooks/use-commit-walk-event';
 import { useMutationWithAlert } from '@/hooks/use-mutation-with-alert';
 import { useWalkEventRecorder } from '@/hooks/use-walk-event-recorder';
+import { runDetached } from '@/lib/run-detached';
 import { useWalkStore } from '@/stores/walk-store';
 import { spacing } from '@/theme/tokens';
 import { EVENT_ORDER, UI_EVENT_EMOJIS, countEventsByType } from '@/lib/walk/events';
@@ -105,11 +106,11 @@ export function WalkEventActions({ dogs }: WalkEventActionsProps) {
   const fire = useCallback(
     (type: WalkEventType, dogId?: string) => {
       if (type === 'photo') {
-        void handlePhoto(dogId);
+        runDetached(handlePhoto(dogId), 'walk.event.photo');
         return;
       }
 
-      void handleActivityEvent(type, dogId);
+      runDetached(handleActivityEvent(type, dogId), 'walk.event.activity');
     },
     [handlePhoto, handleActivityEvent],
   );

--- a/apps/mobile/components/walk/WalkMap.tsx
+++ b/apps/mobile/components/walk/WalkMap.tsx
@@ -6,6 +6,7 @@ import MapView, { Marker, Polyline, type Region } from 'react-native-maps';
 import { useTranslation } from 'react-i18next';
 import { useColors } from '@/hooks/use-colors';
 import { useWalkStore } from '@/stores/walk-store';
+import { runDetached } from '@/lib/run-detached';
 import { MAP_EVENT_EMOJIS } from '@/lib/walk/events';
 import { TOKYO_STATION_COORDINATE } from '@/lib/walk/constants';
 import { radius, spacing, typography } from '@/theme/tokens';
@@ -76,9 +77,7 @@ function usePreviewCurrentLocationRegion(enabled: boolean): Region | undefined {
       );
     }
 
-    void resolveCurrentLocationRegion().catch((error) => {
-      console.error('[walk.map.currentLocation] failed', error);
-    });
+    runDetached(resolveCurrentLocationRegion(), 'walk.map.currentLocation');
 
     return () => {
       isActive = false;

--- a/apps/mobile/components/walk/WalkQuickActions.tsx
+++ b/apps/mobile/components/walk/WalkQuickActions.tsx
@@ -7,6 +7,7 @@ import { elevation, radius, spacing, typography } from '@/theme/tokens';
 import { useWalkStore } from '@/stores/walk-store';
 import { useMutationWithAlert } from '@/hooks/use-mutation-with-alert';
 import { useRecordWalkEvent } from '@/hooks/use-walk-event-mutations';
+import { runDetached } from '@/lib/run-detached';
 import { UI_EVENT_EMOJIS } from '@/lib/walk/events';
 import type { Dog } from '@/types/graphql';
 
@@ -46,7 +47,7 @@ export function WalkQuickActions({ dogs }: WalkQuickActionsProps) {
       if (!event) return;
 
       addEvent(event);
-      void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+      runDetached(Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light), 'walk.haptics.impact');
     },
     [walkId, latestPoint, recordWalkEvent, addEvent, runWithAlert],
   );
@@ -131,7 +132,8 @@ function Pill({ label, onPress, disabled, bg, border, color, accessibilityLabel,
       accessibilityLabel={accessibilityLabel}
       accessibilityState={{ disabled }}
       onPress={() => {
-        void onPress();
+        const result = onPress();
+        if (result) runDetached(result, 'walk.quickAction.press');
       }}
       style={({ pressed }) => [
         styles.pill,

--- a/apps/mobile/hooks/use-active-walk-session-hydration.ts
+++ b/apps/mobile/hooks/use-active-walk-session-hydration.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect } from 'react';
 import { AppState } from 'react-native';
+import { runDetached } from '@/lib/run-detached';
 import { loadActiveWalkSession } from '@/lib/walk/active-walk-session';
 import { useWalkStore } from '@/stores/walk-store';
 
@@ -19,11 +20,11 @@ export function useActiveWalkSessionHydration() {
   }, []);
 
   useEffect(() => {
-    void hydrate();
+    runDetached(hydrate(), 'walk.activeSession.hydrate');
 
     const subscription = AppState.addEventListener('change', (status) => {
       if (status === 'active') {
-        void hydrate();
+        runDetached(hydrate(), 'walk.activeSession.hydrate');
       }
     });
 

--- a/apps/mobile/hooks/use-camera-event-trigger.ts
+++ b/apps/mobile/hooks/use-camera-event-trigger.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { AppState } from 'react-native';
+import { runDetached } from '@/lib/run-detached';
 
 interface UseCameraEventTriggerArgs {
   cameraRequestedAt: number | null;
@@ -37,7 +38,10 @@ export function useCameraEventTrigger({
 
       cameraTimerRef.current = setTimeout(() => {
         cameraTimerRef.current = null;
-        void triggerPhoto(dogId);
+        const result = triggerPhoto(dogId);
+        if (result) {
+          runDetached(result, 'walk.camera.triggerPhoto');
+        }
       }, 150);
     };
 

--- a/apps/mobile/hooks/use-commit-walk-event.ts
+++ b/apps/mobile/hooks/use-commit-walk-event.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import * as Haptics from 'expo-haptics';
+import { runDetached } from '@/lib/run-detached';
 import { useWalkStore } from '@/stores/walk-store';
 import type { WalkEvent } from '@/types/graphql';
 
@@ -14,7 +15,7 @@ export function useCommitWalkEvent() {
 
       // サーバー確定済みイベントだけをストアへ追加し、UI の件数表示と触覚反応を揃えます。
       addEvent(event);
-      void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+      runDetached(Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light), 'walk.haptics.impact');
       return event;
     },
     [addEvent],

--- a/apps/mobile/hooks/use-dog-detail-view-model.ts
+++ b/apps/mobile/hooks/use-dog-detail-view-model.ts
@@ -4,6 +4,7 @@ import { useDog } from '@/hooks/use-dog';
 import { aggregatePackProgress } from '@/hooks/use-pack-progress';
 import type { GoalCycleDays } from '@/constants/walk';
 import { useMyWalks } from '@/hooks/use-walks';
+import { runDetached } from '@/lib/run-detached';
 import type { Dog, DogWithStats, Walk } from '@/types/graphql';
 
 // 犬の誕生日から、詳細画面に出す短い年齢表示を作ります。
@@ -82,7 +83,9 @@ export function useDogDetailViewModel(): DogDetailViewModel {
   );
 
   const retryWalks = useCallback(() => {
-    void refetchWalks?.();
+    if (refetchWalks) {
+      runDetached(refetchWalks(), 'dog.detail.walks.refetch');
+    }
   }, [refetchWalks]);
 
   // 詳細表示に必要なデータが揃うまで、画面側へ loading として返します。

--- a/apps/mobile/hooks/use-dogs-screen-view-model.ts
+++ b/apps/mobile/hooks/use-dogs-screen-view-model.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import { useRouter } from 'expo-router';
 import { useMe } from '@/hooks/use-me';
 import { usePackProgress } from '@/hooks/use-pack-progress';
+import { runDetached } from '@/lib/run-detached';
 import type { Dog } from '@/types/graphql';
 
 // Dogs 画面へ渡す犬一覧、パック進捗、画面操作をまとめた ViewModel です。
@@ -32,7 +33,7 @@ export function useDogsScreenViewModel(): DogsScreenViewModel {
   );
 
   const handleRefresh = useCallback(() => {
-    void refetch();
+    runDetached(refetch(), 'dogs.screen.refetch');
   }, [refetch]);
 
   return {

--- a/apps/mobile/hooks/use-flush-walk-event-outbox.ts
+++ b/apps/mobile/hooks/use-flush-walk-event-outbox.ts
@@ -4,6 +4,7 @@ import {
   listPendingEvents,
   removePendingEvent,
 } from '@/lib/walk/event-outbox';
+import { runDetached } from '@/lib/run-detached';
 import { useWalkStore } from '@/stores/walk-store';
 import { useRecordWalkEvent } from './use-walk-event-mutations';
 
@@ -34,7 +35,7 @@ export function useFlushWalkEventOutbox() {
             : {}),
         });
         addEvent(event);
-        void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+        runDetached(Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light), 'walk.haptics.impact');
         await removePendingEvent(item.id);
         flushed += 1;
       } catch {

--- a/apps/mobile/hooks/use-settings-screen-view-model.ts
+++ b/apps/mobile/hooks/use-settings-screen-view-model.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import { useMe } from '@/hooks/use-me';
+import { runDetached } from '@/lib/run-detached';
 import type { User } from '@/types/graphql';
 
 type SettingsScreenStatus = 'loading' | 'error' | 'ready';
@@ -25,7 +26,7 @@ export function useSettingsScreenViewModel(): SettingsScreenViewModel {
   const { data: me, isLoading, error, refetch } = useMe();
 
   const handleRetry = useCallback(() => {
-    void refetch();
+    runDetached(refetch(), 'settings.screen.refetch');
   }, [refetch]);
 
   // 画面側がデータ有無を意識せず表示分岐できるよう、状態ごとに返却形を固定します。

--- a/apps/mobile/hooks/use-user-screen-view-model.ts
+++ b/apps/mobile/hooks/use-user-screen-view-model.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
+import { runDetached } from '@/lib/run-detached';
 import { formatDistance, formatDistanceParts, formatDuration } from '@/lib/walk/format';
 import { useUserProfile, type UserProfileData } from './use-user-profile';
 
@@ -55,7 +56,7 @@ export function useUserScreenViewModel(): UserViewModel {
   const { data, isLoading, error, refetch } = useUserProfile();
 
   const handleRetry = useCallback(() => {
-    void refetch();
+    runDetached(refetch(), 'user.screen.refetch');
   }, [refetch]);
 
   if (isLoading) return { status: 'loading', handleRetry };

--- a/apps/mobile/hooks/use-walk-event-recorder.ts
+++ b/apps/mobile/hooks/use-walk-event-recorder.ts
@@ -3,6 +3,7 @@ import { useMutationWithAlert } from '@/hooks/use-mutation-with-alert';
 import { usePhotoUpload, PhotoUploadError } from '@/hooks/use-photo-upload';
 import { useRecordWalkEvent } from '@/hooks/use-walk-event-mutations';
 import { useFlushWalkEventOutbox } from '@/hooks/use-flush-walk-event-outbox';
+import { runDetached } from '@/lib/run-detached';
 import { enqueuePendingEvent } from '@/lib/walk/event-outbox';
 import type { WalkActivityEventType, WalkEvent } from '@/types/graphql';
 
@@ -61,9 +62,7 @@ export function useWalkEventRecorder({
 
   // レコーダー起動時に、過去のオフライン操作で溜まったイベントを再送します。
   useEffect(() => {
-    void flushOutbox().catch(() => {
-      /* ベストエフォートのため、次回の記録成功時に再試行します。 */
-    });
+    runDetached(flushOutbox(), 'walk.outbox.flushOnRecorderStart');
   }, [flushOutbox]);
 
   // 通常イベントは失敗時に outbox へ積み、オンライン復帰後に再送できるようにします。
@@ -113,9 +112,7 @@ export function useWalkEventRecorder({
       }
 
       // 成功時に、以前の失敗で残っているイベントも可能な範囲で再送します。
-      void flushOutbox().catch(() => {
-        /* ベストエフォートのため握りつぶします。 */
-      });
+      runDetached(flushOutbox(), 'walk.outbox.flushAfterRecord');
       return result;
     },
     [walkId, latestPoint, recordWalkEvent, runWithAlert, source, flushOutbox],

--- a/apps/mobile/hooks/use-walk-live-activity-interactions.ts
+++ b/apps/mobile/hooks/use-walk-live-activity-interactions.ts
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { useCommitWalkEvent } from '@/hooks/use-commit-walk-event';
 import { useWalkEventRecorder } from '@/hooks/use-walk-event-recorder';
 import { useWalkSession } from '@/hooks/use-walk-session';
+import { runDetached } from '@/lib/run-detached';
 import { handleWalkActivityTarget } from '@/lib/walk/live-activity-interactions';
 import { useWalkStore } from '@/stores/walk-store';
 import type { WalkActivityEventType } from '@/types/graphql';
@@ -60,10 +61,13 @@ export function useWalkLiveActivityInteractions() {
 
   useEffect(() => {
     const subscription = addUserInteractionListener((event) => {
-      void handleWalkActivityTarget(event.target, {
-        recordEvent: recordActivityEvent,
-        finishWalk,
-      });
+      runDetached(
+        handleWalkActivityTarget(event.target, {
+          recordEvent: recordActivityEvent,
+          finishWalk,
+        }),
+        'walk.liveActivity.target',
+      );
     });
 
     return () => subscription.remove();

--- a/apps/mobile/hooks/use-walk-live-activity-sync.ts
+++ b/apps/mobile/hooks/use-walk-live-activity-sync.ts
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { runDetached } from '@/lib/run-detached';
 import { buildWalkActivityProps } from '@/lib/walk/live-activity';
 import { updateWalkLiveActivity } from '@/lib/walk/live-activity-controller';
 import { useWalkStore } from '@/stores/walk-store';
@@ -15,14 +16,17 @@ export function useWalkLiveActivitySync(dogs: Dog[]) {
   useEffect(() => {
     if (phase !== 'recording' || !walkId || !startedAt) return;
 
-    void updateWalkLiveActivity(
-      buildWalkActivityProps({
-        walkId,
-        startedAt,
-        distanceM,
-        dogs,
-        events,
-      }),
+    runDetached(
+      updateWalkLiveActivity(
+        buildWalkActivityProps({
+          walkId,
+          startedAt,
+          distanceM,
+          dogs,
+          events,
+        }),
+      ),
+      'walk.liveActivity.update',
     );
   }, [distanceM, dogs, events, phase, startedAt, walkId]);
 }

--- a/apps/mobile/hooks/use-watch-walk-command-processor.ts
+++ b/apps/mobile/hooks/use-watch-walk-command-processor.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo } from 'react';
 import { useCommitWalkEvent } from '@/hooks/use-commit-walk-event';
 import { useWalkEventRecorder } from '@/hooks/use-walk-event-recorder';
 import { useWalkSession } from '@/hooks/use-walk-session';
+import { runDetached } from '@/lib/run-detached';
 import { processWatchWalkCommand } from '@/lib/watch/commands';
 import { ackCommand, addCommandListener, getPendingCommands } from '@/lib/watch/bridge';
 import { useWalkStore } from '@/stores/walk-store';
@@ -69,23 +70,20 @@ export function useWatchWalkCommandProcessor() {
   useEffect(() => {
     let isMounted = true;
 
-    void getPendingCommands()
-      .then(async (commands) => {
+    runDetached(
+      getPendingCommands().then(async (commands) => {
         if (!isMounted) return;
 
         for (const command of commands) {
           if (!isMounted) return;
           await processCommand(command);
         }
-      })
-      .catch((error) => {
-        console.error('[watch.command] failed to drain pending commands', error);
-      });
+      }),
+      'watch.command.drainPending',
+    );
 
     const subscription = addCommandListener((command) => {
-      void processCommand(command).catch((error) => {
-        console.error('[watch.command] failed to process command', error);
-      });
+      runDetached(processCommand(command), 'watch.command.process');
     });
 
     return () => {

--- a/apps/mobile/hooks/use-watch-walk-snapshot-sync.ts
+++ b/apps/mobile/hooks/use-watch-walk-snapshot-sync.ts
@@ -1,4 +1,5 @@
 import { useEffect, useMemo } from 'react';
+import { runDetached } from '@/lib/run-detached';
 import { publishWalkSnapshot } from '@/lib/watch/bridge';
 import { buildWatchWalkSnapshot } from '@/lib/watch/snapshot';
 import { useWalkStore } from '@/stores/walk-store';
@@ -26,25 +27,24 @@ export function useWatchWalkSnapshotSync() {
   );
 
   useEffect(() => {
-    void publishWalkSnapshot(
-      buildWatchWalkSnapshot({
-        phase,
-        walkId,
-        startedAt,
-        dogs,
-        events,
-        distanceM,
-        latestPoint,
-      }),
-    )
-      .then((result) => {
+    runDetached(
+      publishWalkSnapshot(
+        buildWatchWalkSnapshot({
+          phase,
+          walkId,
+          startedAt,
+          dogs,
+          events,
+          distanceM,
+          latestPoint,
+        }),
+      ).then((result) => {
         if (result?.failureReason && !loggedPublishFailureReasons.has(result.failureReason)) {
           loggedPublishFailureReasons.add(result.failureReason);
           console.warn('[watch.snapshot] publish diagnostic', result);
         }
-      })
-      .catch((error) => {
-        console.error('[watch.snapshot] failed to publish walk snapshot', error);
-      });
+      }),
+      'watch.snapshot.publish',
+    );
   }, [distanceM, dogs, events, latestPoint, phase, startedAt, walkId]);
 }

--- a/apps/mobile/jest.setup.ts
+++ b/apps/mobile/jest.setup.ts
@@ -1,3 +1,5 @@
+import type { ReactNode } from 'react';
+
 jest.mock(
   '@react-native-async-storage/async-storage',
   () => ({
@@ -45,6 +47,141 @@ jest.mock('react-native-reanimated', () => {
     FadeIn: new AnimationBuilderMock(),
     FadeOut: new AnimationBuilderMock(),
     LinearTransition: new AnimationBuilderMock(),
+  };
+});
+
+jest.mock('@expo/ui', () => {
+  const React = require('react');
+  const {
+    Pressable,
+    Text: RNText,
+    TextInput: RNTextInput,
+    View,
+  } = require('react-native');
+
+  const Host = ({
+    children,
+    style,
+    testID,
+    ...props
+  }: {
+    children?: ReactNode;
+    style?: unknown;
+    testID?: string;
+    [key: string]: unknown;
+  }) => React.createElement(View, { style, testID, ...props }, children);
+
+  const RNHostView = ({
+    children,
+    style,
+    testID,
+  }: {
+    children?: ReactNode;
+    style?: unknown;
+    testID?: string;
+  }) => React.createElement(View, { style, testID }, children);
+
+  const FieldGroup = ({
+    children,
+    style,
+    testID,
+  }: {
+    children?: ReactNode;
+    style?: unknown;
+    testID?: string;
+  }) => React.createElement(View, { style, testID }, children);
+  FieldGroup.Section = ({ children, title }: { children?: ReactNode; title?: string }) => (
+    React.createElement(
+      View,
+      null,
+      title ? React.createElement(RNText, null, title) : null,
+      children,
+    )
+  );
+
+  const Row = ({
+    children,
+    disabled,
+    onPress,
+    style,
+    testID,
+  }: {
+    children?: ReactNode;
+    disabled?: boolean;
+    onPress?: () => void;
+    style?: unknown;
+    testID?: string;
+  }) => React.createElement(Pressable, { disabled, onPress, style, testID }, children);
+
+  const Spacer = () => React.createElement(View, { testID: 'native-spacer' });
+
+  const Text = ({
+    children,
+    numberOfLines,
+    textStyle,
+  }: {
+    children?: ReactNode;
+    numberOfLines?: number;
+    textStyle?: unknown;
+  }) => React.createElement(RNText, { numberOfLines, style: textStyle }, children);
+
+  const TextInput = ({
+    onBlur,
+    onChangeText,
+    onFocus,
+    placeholder,
+    placeholderTextColor,
+    style,
+    testID,
+    textStyle,
+    value,
+    ...props
+  }: {
+    onBlur?: () => void;
+    onChangeText?: (value: string) => void;
+    onFocus?: () => void;
+    placeholder?: string;
+    placeholderTextColor?: string;
+    style?: unknown;
+    testID?: string;
+    textStyle?: unknown;
+    value?: { value: string } | string;
+    [key: string]: unknown;
+  }) => {
+    const currentValue = typeof value === 'object' && value !== null ? value.value : value;
+    return React.createElement(RNTextInput, {
+      onBlur,
+      onChangeText: (nextValue: string) => {
+          if (typeof value === 'object' && value !== null) {
+            value.value = nextValue;
+          }
+          onChangeText?.(nextValue);
+        },
+      onFocus,
+      placeholder,
+      placeholderTextColor,
+      ...props,
+      style: [style, textStyle],
+      testID,
+      value: currentValue,
+    });
+  };
+
+  const Icon = ({ name, testID }: { name?: unknown; testID?: string }) => (
+    React.createElement(RNText, { testID }, typeof name === 'string' ? name : 'icon')
+  );
+  Icon.select = (spec: { ios: unknown }) => spec.ios;
+
+  return {
+    FieldGroup,
+    Host,
+    Icon,
+    RNHostView,
+    Row,
+    Spacer,
+    Text,
+    TextInput,
+    useNativeState: (initialValue: string) => ({ value: initialValue }),
   };
 });
 

--- a/apps/mobile/lib/run-detached.test.ts
+++ b/apps/mobile/lib/run-detached.test.ts
@@ -1,0 +1,26 @@
+import { runDetached } from './run-detached';
+
+describe('runDetached', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('logs rejected detached promises with context', async () => {
+    const error = new Error('boom');
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    runDetached(Promise.reject(error), 'walk.test');
+    await Promise.resolve();
+
+    expect(consoleError).toHaveBeenCalledWith('[walk.test] failed', error);
+  });
+
+  it('ignores missing tasks from maybe-async callbacks', async () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => runDetached(undefined, 'walk.test')).not.toThrow();
+    await Promise.resolve();
+
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/lib/run-detached.ts
+++ b/apps/mobile/lib/run-detached.ts
@@ -1,0 +1,10 @@
+export function runDetached(
+  task: PromiseLike<unknown> | null | undefined | void,
+  context: string,
+): void {
+  if (!task) return;
+
+  Promise.resolve(task).catch((error) => {
+    console.error(`[${context}] failed`, error);
+  });
+}

--- a/apps/mobile/lib/walk/tracking-manager.ts
+++ b/apps/mobile/lib/walk/tracking-manager.ts
@@ -1,5 +1,6 @@
 import { startTracking } from '@/lib/walk/gps-tracker';
 import { stopWalkBackgroundLocationUpdates } from '@/lib/walk/background-location-task';
+import { runDetached } from '@/lib/run-detached';
 import { useWalkStore } from '@/stores/walk-store';
 import type { WalkPoint, WalkPointInput } from '@/types/graphql';
 
@@ -59,7 +60,10 @@ export async function beginWalkTracking({
   );
 
   const flushTimer = setInterval(() => {
-    void flushPendingWalkPoints({ walkId, addWalkPoints }).catch(logPeriodicFlushError);
+    runDetached(
+      flushPendingWalkPoints({ walkId, addWalkPoints }).catch(logPeriodicFlushError),
+      'walk.tracking.periodicFlush',
+    );
   }, PERIODIC_FLUSH_INTERVAL_MS);
 
   const cleanup = async () => {
@@ -82,7 +86,7 @@ export async function stopWalkTracking() {
 
 export function resetWalkTrackingState() {
   useWalkStore.getState().resetTrackingSession();
-  void stopWalkBackgroundLocationUpdates();
+  runDetached(stopWalkBackgroundLocationUpdates(), 'walk.tracking.stopBackgroundLocation');
 }
 
 async function flushPendingWalkPointsNow({

--- a/apps/mobile/package-lock.json
+++ b/apps/mobile/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@effect/platform": "0.96.1",
+        "@expo/material-symbols": "0.1.1",
         "@expo/ui": "~56.0.13",
         "@expo/vector-icons": "^15.0.3",
         "@react-native-async-storage/async-storage": "2.2.0",
@@ -2202,6 +2203,15 @@
         "expo": "*",
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/@expo/material-symbols": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@expo/material-symbols/-/material-symbols-0.1.1.tgz",
+      "integrity": "sha512-ruA6hZATOPKxo1qSd1NE3HI9FrmEDwcMDhsvzTAdMkP9AapdHfJ/0tKmBMWFJir85voxs1twYxLVrGW9OLGaOg==",
+      "license": "MIT",
+      "bin": {
+        "add-material-symbols": "bin/add-material-symbols.mjs"
       }
     },
     "node_modules/@expo/metro": {

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@effect/platform": "0.96.1",
+    "@expo/material-symbols": "0.1.1",
     "@expo/ui": "~56.0.13",
     "@expo/vector-icons": "^15.0.3",
     "@react-native-async-storage/async-storage": "2.2.0",

--- a/docs/mobile/20260628-mobile-ui-screen-inventory.md
+++ b/docs/mobile/20260628-mobile-ui-screen-inventory.md
@@ -415,7 +415,7 @@ Expo Router の leaf route は 14 個あるが、以下 2 route は画面を描�
 | `ScreenHeader` | large title / inline header、戻る、保存、編集、追加など |
 | `BackButton` | 戻る導線 |
 | `GroupedCard` | 統計、地図、散歩履歴などの汎用カード surface |
-| `NativeFieldSection` | `@expo/ui` FieldGroup ベースのフォーム / 設定セクション |
+| `NativeFieldSection` | `@expo/ui` TextInput / Row を画面スクロール内に並べる静的フォーム / 設定セクション |
 | `NativeFieldRow` | `@expo/ui` Row + Icon ベースの設定行、アカウント導線、値付き行 |
 | `TextInput` | `@expo/ui` TextInput ベースの入力欄。label は visible label ではなく placeholder として表示する |
 | `Button` | primary / secondary / ghost / destructive などの汎用ボタン |
@@ -434,6 +434,7 @@ Expo Router の leaf route は 14 個あるが、以下 2 route は画面を描�
 - Me タブはプロフィールと散歩貢献を主表示し、表示設定や法務リンクは `/settings` に置く。
 - map 主役の画面は `ScreenHeader` で上を押し下げず、マップ全面 + overlay 構成を維持する。
 - 入力・設定 UI は grouped row 形式と `ActionSheetIOS` ベースの選択を第一候補にする。
+- 入力セクション内に独立したスクロール領域を作らず、画面単位の `ScrollView` にスクロール範囲を集約する。
 - スタイルを変更する場合は `apps/mobile/theme/tokens.ts` の token を使い、magic number を増やさない。
 - UI 整理の判断は product axes で説明する:
   - Dog experience: 犬同士の出会い、犬との関係性を深めるか

--- a/docs/mobile/20260628-mobile-ui-screen-inventory.md
+++ b/docs/mobile/20260628-mobile-ui-screen-inventory.md
@@ -190,7 +190,7 @@ Expo Router の leaf route は 14 個あるが、以下 2 route は画面を描�
 ### 5. マイページ画面
 
 - **route**: `apps/mobile/app/(tabs)/user.tsx`
-- **主要コンポーネント**: `ScreenHeader`, `ScrollView`, `UserSummary`, `UserAvatar`, `GroupedCard`, `GroupedRow`
+- **主要コンポーネント**: `ScreenHeader`, `ScrollView`, `UserSummary`, `UserAvatar`, `GroupedCard`, `NativeFieldSection`, `NativeFieldRow`
 - **役割**: ユーザー自身の散歩貢献とアカウント導線を表示する
 
 表示要素:
@@ -217,7 +217,7 @@ Expo Router の leaf route は 14 個あるが、以下 2 route は画面を描�
 ### 6. 犬登録画面
 
 - **route**: `apps/mobile/app/dogs/new.tsx`
-- **主要コンポーネント**: `ScreenHeader`, `ScrollView`, `DogForm`, `TextInput`
+- **主要コンポーネント**: `ScreenHeader`, `ScrollView`, `DogForm`, `NativeFieldSection`, `TextInput`
 - **役割**: 新しい犬の基本プロフィールを登録する
 
 表示要素:
@@ -275,7 +275,7 @@ Expo Router の leaf route は 14 個あるが、以下 2 route は画面を描�
 ### 8. 犬編集画面
 
 - **route**: `apps/mobile/app/dogs/[id]/edit.tsx`
-- **主要コンポーネント**: `ScreenHeader`, `DogAvatarEditor`, `DogForm`, `TextInput`, `SegmentedControl`, `@expo/ui/swift-ui` `Slider`
+- **主要コンポーネント**: `ScreenHeader`, `DogAvatarEditor`, `DogForm`, `NativeFieldSection`, `TextInput`, `SegmentedControl`, `@expo/ui/swift-ui` `Slider`
 - **役割**: 犬のプロフィール、写真、散歩目標を編集する
 
 表示要素:
@@ -307,7 +307,7 @@ Expo Router の leaf route は 14 個あるが、以下 2 route は画面を描�
 ### 9. ユーザー編集画面
 
 - **route**: `apps/mobile/app/user/edit.tsx`
-- **主要コンポーネント**: `ScreenHeader`, `UserAvatarEditor`, `UserAvatar`, `GroupedCard`, `TextInput`
+- **主要コンポーネント**: `ScreenHeader`, `UserAvatarEditor`, `UserAvatar`, `NativeFieldSection`, `TextInput`
 - **役割**: ユーザー表示名と写真を編集する
 
 表示要素:
@@ -328,7 +328,7 @@ Expo Router の leaf route は 14 個あるが、以下 2 route は画面を描�
 ### 10. 設定画面
 
 - **route**: `apps/mobile/app/settings/index.tsx`
-- **主要コンポーネント**: `ScreenHeader`, `PreferencesSection`, `LegalSection`, `SignOutRow`, `GroupedCard`, `GroupedRow`, `ConfirmDialog`
+- **主要コンポーネント**: `ScreenHeader`, `PreferencesSection`, `LegalSection`, `SignOutRow`, `NativeFieldSection`, `NativeFieldRow`, `ConfirmDialog`
 - **役割**: 表示設定、法的リンク、サインアウト導線をまとめる
 
 表示要素:
@@ -356,7 +356,7 @@ Expo Router の leaf route は 14 個あるが、以下 2 route は画面を描�
 ### 11. メール変更画面
 
 - **route**: `apps/mobile/app/settings/email.tsx`
-- **主要コンポーネント**: `ScreenHeader`, `GroupedCard`, `GroupedRow`, `TextInput`, `Button`, `OneTimePasswordInput`
+- **主要コンポーネント**: `ScreenHeader`, `NativeFieldSection`, `NativeFieldRow`, `TextInput`, `Button`, `OneTimePasswordInput`
 - **役割**: ログイン中ユーザーのメールアドレス変更
 
 表示要素:
@@ -414,9 +414,10 @@ Expo Router の leaf route は 14 個あるが、以下 2 route は画面を描�
 | --- | --- |
 | `ScreenHeader` | large title / inline header、戻る、保存、編集、追加など |
 | `BackButton` | 戻る導線 |
-| `GroupedCard` | iOS settings 風の grouped surface |
-| `GroupedRow` | 設定行、アカウント導線、値付き行 |
-| `TextInput` | top label / inline label の入力欄 |
+| `GroupedCard` | 統計、地図、散歩履歴などの汎用カード surface |
+| `NativeFieldSection` | `@expo/ui` FieldGroup ベースのフォーム / 設定セクション |
+| `NativeFieldRow` | `@expo/ui` Row + Icon ベースの設定行、アカウント導線、値付き行 |
+| `TextInput` | `@expo/ui` TextInput ベースの入力欄。label は visible label ではなく placeholder として表示する |
 | `Button` | primary / secondary / ghost / destructive などの汎用ボタン |
 | `EmptyState` | 空状態メッセージと CTA |
 | `LoadingScreen` | 読み込み状態 |


### PR DESCRIPTION
## Summary
- Replace the shared mobile text field wrapper with `@expo/ui` native `TextInput`, using the former label text as the placeholder.
- Replace scrollable `@expo/ui` `FieldGroup` sections with a static `NativeFieldSection` card so dog/user forms scroll with the whole screen.
- Keep native `@expo/ui` `Row`/`TextInput` controls hosted per row/input, add `@expo/material-symbols` icon support, and move auth/profile/settings rows onto the shared native field components.
- Add `runDetached` for intentionally detached async work and remove Sonar high-impact `void` operator findings.

## Product Impact
- Dog experience: dog profile entry/editing stays visible and native-feeling, reducing friction when owners maintain dog details.
- Walk data: dog profile and walk-goal fields remain easier to complete consistently, improving future walk context.
- Owner contribution: profile/settings workflows follow platform conventions and avoid confusing nested scroll regions.

## Validation
- `npm test -- --runInBand --forceExit` from `apps/mobile`: 125 suites / 755 tests passed.
- `npm run typecheck` from `apps/mobile`: passed.
- `npm run lint` from `apps/mobile`: exit 0, with existing `.expo/types/router.d.ts` unused eslint-disable warning.
- `node scripts/harness/validate-all.mjs`: passed.
- Maestro `apps/mobile/e2e/maestro/dog-profile.yaml`: passed on iPhone 17 Pro simulator after loading the PR Metro bundle against the logged-in `matsuokashuheiii@gmail.com` local state.
- SonarQube local analysis: scanner execution succeeded; unresolved High/Blocker impact issues: 0.
