### PR TITLE
[codex] Add contacts-style dog screens

### DIFF
--- a/apps/mobile/__tests__/app/dogs/dog-detail-layout.test.tsx
+++ b/apps/mobile/__tests__/app/dogs/dog-detail-layout.test.tsx
@@ -1,0 +1,26 @@
+import { render } from '@testing-library/react-native';
+import DogDetailLayout from '../../../app/dogs/[id]/_layout';
+
+const mockScreen = jest.fn((_props: unknown) => null);
+
+jest.mock('expo-router', () => {
+  const { View } = jest.requireActual('react-native');
+  const Stack = ({ children }: { children: React.ReactNode }) => <View>{children}</View>;
+  Stack.Screen = (props: unknown) => mockScreen(props);
+  return { Stack };
+});
+
+describe('DogDetailLayout', () => {
+  beforeEach(() => {
+    mockScreen.mockClear();
+  });
+
+  it('switches to edit without a stack transition animation', () => {
+    render(<DogDetailLayout />);
+
+    expect(mockScreen).toHaveBeenCalledWith({
+      name: 'edit',
+      options: { headerShown: false, animation: 'none' },
+    });
+  });
+});

--- a/apps/mobile/__tests__/app/dogs/dog-detail.test.tsx
+++ b/apps/mobile/__tests__/app/dogs/dog-detail.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render, screen } from '@testing-library/react-native';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import DogDetailScreen from '../../../app/dogs/[id]/index';
 import type { DogWithStats, Walk } from '@/types/graphql';
-import { spacing } from '@/theme/tokens';
+import { colors, dogContactChrome, spacing } from '@/theme/tokens';
 
 const mockPush = jest.fn();
 const mockReplace = jest.fn();
@@ -20,9 +20,30 @@ jest.mock('expo-router', () => ({
   }),
 }));
 
+jest.mock('@/hooks/use-color-scheme', () => ({
+  useColorScheme: () => 'light',
+}));
+
 jest.mock('expo-image', () => ({
   Image: 'Image',
 }));
+
+jest.mock('expo-blur', () => {
+  const { View } = jest.requireActual('react-native');
+  return {
+    BlurView: ({ children, ...props }: { children: React.ReactNode }) => (
+      <View {...props}>{children}</View>
+    ),
+  };
+});
+
+jest.mock('@/components/ui/icon-symbol', () => {
+  const { Text } = jest.requireActual<typeof import('react-native')>('react-native');
+
+  return {
+    IconSymbol: ({ name }: { name: string }) => <Text>{name}</Text>,
+  };
+});
 
 jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 44, bottom: 34, left: 0, right: 0 }),
@@ -105,7 +126,7 @@ describe('DogDetailScreen', () => {
     mockWalks = [];
   });
 
-  it('renders the large title screen header with dog title and back action', () => {
+  it('renders the contacts-style header with dog title and icon-only back action', () => {
     renderWithProviders(<DogDetailScreen />);
 
     expect(screen.getByTestId('dog-detail-header')).toBeTruthy();
@@ -113,6 +134,13 @@ describe('DogDetailScreen', () => {
     expect(screen.getByTestId('dog-detail-header-large-title-row')).toBeTruthy();
     expect(screen.getAllByText('Buddy')).toHaveLength(1);
     expect(screen.getByLabelText('Dogs')).toBeTruthy();
+    expect(screen.getByText('chevron.backward')).toBeTruthy();
+    expect(screen.queryByText('Dogs')).toBeNull();
+    const backStyle = StyleSheet.flatten(screen.getByTestId('dog-detail-back-button').props.style);
+    expect(backStyle.width).toBe(dogContactChrome.circleSize);
+    expect(backStyle.height).toBe(dogContactChrome.circleSize);
+    expect(backStyle.backgroundColor).toBe(colors.light.background);
+    expect(backStyle.borderColor).toBe(colors.light.border);
   });
 
   it('renders edit button exactly once in screen header for a loaded dog', () => {
@@ -120,6 +148,10 @@ describe('DogDetailScreen', () => {
     // Regression guard: Edit must appear exactly once (no duplicate from
     // a stray Stack header reintroduction).
     expect(screen.getAllByText('Edit')).toHaveLength(1);
+    const editStyle = StyleSheet.flatten(screen.getByTestId('dog-detail-edit-button').props.style);
+    expect(editStyle.minWidth).toBe(dogContactChrome.pillMinWidth);
+    expect(editStyle.borderRadius).toBe(dogContactChrome.pillRadius);
+    expect(editStyle.backgroundColor).toBe(colors.light.background);
   });
 
   it('navigates to edit screen when edit button is pressed', () => {

--- a/apps/mobile/__tests__/app/dogs/edit.test.tsx
+++ b/apps/mobile/__tests__/app/dogs/edit.test.tsx
@@ -1,8 +1,9 @@
-import { Alert } from 'react-native';
+import { Alert, StyleSheet } from 'react-native';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
 import * as ImagePicker from 'expo-image-picker';
 import EditDogScreen from '../../../app/dogs/[id]/edit';
 import type { DogWithStats } from '@/types/graphql';
+import { colors, dogContactChrome } from '@/theme/tokens';
 
 const mockBack = jest.fn();
 const mockReplace = jest.fn();
@@ -22,11 +23,28 @@ jest.mock('expo-image', () => ({
   Image: 'Image',
 }));
 
+jest.mock('expo-blur', () => {
+  const { View } = jest.requireActual('react-native');
+  return {
+    BlurView: ({ children, ...props }: { children: React.ReactNode }) => (
+      <View {...props}>{children}</View>
+    ),
+  };
+});
+
 jest.mock('expo-image-picker', () => ({
   PermissionStatus: { GRANTED: 'granted' },
   requestMediaLibraryPermissionsAsync: jest.fn(),
   launchImageLibraryAsync: jest.fn(),
 }));
+
+jest.mock('@/components/ui/icon-symbol', () => {
+  const { Text } = jest.requireActual<typeof import('react-native')>('react-native');
+
+  return {
+    IconSymbol: ({ name }: { name: string }) => <Text>{name}</Text>,
+  };
+});
 
 const mockRequestMediaLibraryPermissionsAsync =
   ImagePicker.requestMediaLibraryPermissionsAsync as jest.MockedFunction<
@@ -92,12 +110,24 @@ describe('EditDogScreen', () => {
     });
   });
 
-  it('renders the inline ScreenHeader title and common actions', () => {
+  it('renders contacts-style cancel and save icon buttons', () => {
     render(<EditDogScreen />);
 
-    expect(screen.getByRole('header', { name: 'Edit dog' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Cancel' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Save' })).toBeTruthy();
+    expect(screen.queryByRole('header', { name: 'Edit dog' })).toBeNull();
+    expect(screen.queryByText('Cancel')).toBeNull();
+    expect(screen.queryByText('Save')).toBeNull();
+    expect(screen.getByText('xmark')).toBeTruthy();
+    expect(screen.getByText('checkmark')).toBeTruthy();
+
+    const cancelStyle = StyleSheet.flatten(screen.getByTestId('dog-edit-cancel-button').props.style);
+    const saveStyle = StyleSheet.flatten(screen.getByTestId('dog-edit-save-button').props.style);
+    expect(cancelStyle.width).toBe(dogContactChrome.circleSize);
+    expect(cancelStyle.backgroundColor).toBe(colors.light.background);
+    expect(cancelStyle.borderColor).toBe(colors.light.border);
+    expect(saveStyle.height).toBe(dogContactChrome.circleSize);
+    expect(saveStyle.backgroundColor).toBe(colors.light.background);
   });
 
   it('uses the ScreenHeader cancel action to go back', () => {
@@ -169,7 +199,12 @@ describe('EditDogScreen', () => {
   it('renders a remove dog button for the current dog', () => {
     render(<EditDogScreen />);
 
-    expect(screen.getByRole('button', { name: 'Remove Buddy' })).toBeTruthy();
+    const remove = screen.getByRole('button', { name: 'Remove Buddy' });
+    const removeStyle = StyleSheet.flatten(remove.props.style);
+
+    expect(remove).toBeTruthy();
+    expect(removeStyle.borderRadius).toBe(dogContactChrome.deleteButtonRadius);
+    expect(removeStyle.backgroundColor).not.toBe('transparent');
   });
 
   it('shows a confirmation alert before removing the dog', () => {

--- a/apps/mobile/app/dogs/[id]/_layout.tsx
+++ b/apps/mobile/app/dogs/[id]/_layout.tsx
@@ -5,7 +5,7 @@ export default function DogDetailLayout() {
   return (
     <Stack>
       <Stack.Screen name="index" options={{ headerShown: false }} />
-      <Stack.Screen name="edit" options={{ headerShown: false }} />
+      <Stack.Screen name="edit" options={{ headerShown: false, animation: 'none' }} />
     </Stack>
   );
 }

--- a/apps/mobile/app/dogs/[id]/edit.tsx
+++ b/apps/mobile/app/dogs/[id]/edit.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Alert, Pressable, ScrollView, StyleSheet, Text } from 'react-native';
+import { Alert, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
@@ -16,14 +16,14 @@ import {
   type DogFormValues,
 } from '@/components/dogs/DogForm';
 import { DogAvatarEditor } from '@/components/dogs/DogAvatarEditor';
+import { DogContactChromeButton } from '@/components/dogs/DogContactChromeButton';
 import { LoadingScreen } from '@/components/ui/LoadingScreen';
-import { ScreenHeader } from '@/components/ui/ScreenHeader';
 import { DAILY_GOAL_CYCLE_DAYS, DEFAULT_DAILY_GOAL_MINUTES } from '@/constants/walk';
 import { useColors } from '@/hooks/use-colors';
-import { components, spacing } from '@/theme/tokens';
+import { components, dogContactChrome, spacing } from '@/theme/tokens';
 import type { UploadFile } from '@/lib/graphql/client';
 
-// 犬編集画面 — inline ScreenHeader でフォームの Cancel/Save を提供します。
+// 犬編集画面 — Contacts 風 chrome でフォームの Cancel/Save を提供します。
 // dog データのロード待ちは外側、form state 初期化は内側コンポーネントに分離して
 // React Hooks ルールを守りつつ initial values を一発で確定する。
 export default function EditDogScreen() {
@@ -126,17 +126,25 @@ function EditDogContent({ id, dogName, initialValues, currentAvatar }: EditDogCo
 
   return (
     <SafeAreaView edges={['top']} style={[styles.safeArea, { backgroundColor: theme.background }]}>
-      <ScreenHeader
-        variant="inline"
-        title={t('dogs.edit.title')}
-        leftAction={{ label: t('common.action.cancel'), onPress: () => router.back() }}
-        rightAction={{
-          label: t('common.action.save'),
-          onPress: handleSave,
-          strong: true,
-          disabled: !canSave,
-        }}
-      />
+      <View testID="dog-edit-header" style={styles.header}>
+        <DogContactChromeButton
+          shape="circle"
+          label={t('common.action.cancel')}
+          accessibilityLabel={t('common.action.cancel')}
+          iconName="xmark"
+          onPress={() => router.back()}
+          testID="dog-edit-cancel-button"
+        />
+        <DogContactChromeButton
+          shape="circle"
+          label={t('common.action.save')}
+          accessibilityLabel={t('common.action.save')}
+          iconName="checkmark"
+          onPress={handleSave}
+          disabled={!canSave}
+          testID="dog-edit-save-button"
+        />
+      </View>
       <ScrollView
         contentContainerStyle={styles.scrollContent}
         keyboardShouldPersistTaps="handled"
@@ -147,7 +155,7 @@ function EditDogContent({ id, dogName, initialValues, currentAvatar }: EditDogCo
           accessibilityRole="button"
           accessibilityLabel={t('dogs.edit.remove', { name: dogName })}
           onPress={openRemoveConfirm}
-          style={styles.removeButton}
+          style={[styles.removeButton, { backgroundColor: theme.surface }]}
         >
           <Text style={[styles.removeButtonText, { color: theme.error }]}>
             {t('dogs.edit.remove', { name: dogName })}
@@ -160,13 +168,20 @@ function EditDogContent({ id, dogName, initialValues, currentAvatar }: EditDogCo
 
 const styles = StyleSheet.create({
   safeArea: { flex: 1 },
+  header: {
+    height: dogContactChrome.circleSize,
+    paddingHorizontal: spacing.md,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
   scrollContent: { flexGrow: 1, padding: spacing.lg },
   removeButton: {
     alignItems: 'center',
     justifyContent: 'center',
-    minHeight: components.row.minHeight,
+    minHeight: dogContactChrome.deleteButtonMinHeight,
     marginTop: spacing.lg,
-    backgroundColor: 'transparent',
+    borderRadius: dogContactChrome.deleteButtonRadius,
   },
   removeButtonText: {
     ...components.button.fontGhost,

--- a/apps/mobile/app/dogs/[id]/index.tsx
+++ b/apps/mobile/app/dogs/[id]/index.tsx
@@ -1,28 +1,17 @@
-import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useDogDetailViewModel } from '@/hooks/use-dog-detail-view-model';
 import { WEEKLY_GOAL_CYCLE_DAYS } from '@/constants/walk';
 import { DogHero } from '@/components/dogs/DogHero';
+import { DogContactChromeButton } from '@/components/dogs/DogContactChromeButton';
 import { GoalProgressCard } from '@/components/dogs/GoalProgressCard';
 import { DogStatsCard } from '@/components/dogs/DogStatsCard';
 import { DogWalksList } from '@/components/dogs/DogWalksList';
-import { BackButton } from '@/components/ui/BackButton';
 import { LoadingScreen } from '@/components/ui/LoadingScreen';
 import { useColors } from '@/hooks/use-colors';
-import { layout, spacing, typography } from '@/theme/tokens';
-
-// Hardcoded for legibility over arbitrary user photos; this chrome must stay
-// pure white regardless of the active color scheme.
-const OVERLAY_TEXT = '#FFFFFF';
-const OVERLAY_SHADOW_OFFSET_X = 0;
-const OVERLAY_SHADOW_OFFSET_Y = 1;
-const OVERLAY_TEXT_SHADOW = {
-  textShadowColor: 'rgba(0,0,0,0.3)',
-  textShadowOffset: { width: OVERLAY_SHADOW_OFFSET_X, height: OVERLAY_SHADOW_OFFSET_Y },
-  textShadowRadius: spacing.xs,
-} as const;
+import { dogContactChrome, spacing, typography } from '@/theme/tokens';
 
 // Lifts the name block into the hero's 60pt bottom fade without changing DogHero.
 const NAME_OVERLAP = 50;
@@ -116,29 +105,27 @@ export default function DogDetailScreen() {
           testID="dog-detail-header-action-row"
           style={styles.headerActionRow}
         >
-          <BackButton
+          <DogContactChromeButton
+            shape="circle"
             accessibilityLabel={t('dogs.detail.back')}
             label={t('dogs.detail.back')}
             onPress={handleBack}
-            color={OVERLAY_TEXT}
-            labelStyle={styles.headerText}
-            style={styles.headerLeft}
+            iconName="chevron.backward"
+            testID="dog-detail-back-button"
           />
 
-          <Pressable
-            accessibilityRole="button"
+          <DogContactChromeButton
+            shape="pill"
             accessibilityLabel={t('dogs.detail.edit')}
-            hitSlop={spacing.step12}
+            label={t('dogs.detail.edit')}
             onPress={() =>
               router.push({
                 pathname: '/dogs/[id]/edit',
                 params: { id: vm.dog.id },
               })
             }
-            style={styles.headerRight}
-          >
-            <Text style={styles.headerText}>{t('dogs.detail.edit')}</Text>
-          </Pressable>
+            testID="dog-detail-edit-button"
+          />
         </View>
       </View>
     </View>
@@ -175,28 +162,13 @@ const styles = StyleSheet.create({
     position: 'absolute',
     left: SCREEN_EDGE,
     right: SCREEN_EDGE,
-    height: layout.navBar,
+    height: dogContactChrome.circleSize,
   },
   headerActionRow: {
-    height: layout.navBar,
+    height: dogContactChrome.circleSize,
     paddingHorizontal: spacing.md,
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
-  },
-  headerLeft: {
-    minHeight: layout.navBar,
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: spacing.step6,
-  },
-  headerRight: {
-    minHeight: layout.navBar,
-    justifyContent: 'center',
-  },
-  headerText: {
-    ...typography.body,
-    ...OVERLAY_TEXT_SHADOW,
-    color: OVERLAY_TEXT,
   },
 });

--- a/apps/mobile/components/dogs/DogContactChromeButton.tsx
+++ b/apps/mobile/components/dogs/DogContactChromeButton.tsx
@@ -1,0 +1,106 @@
+import type { ComponentProps } from 'react';
+import { Pressable, StyleSheet, Text, type StyleProp, type ViewStyle } from 'react-native';
+import { BlurView, type BlurTint } from 'expo-blur';
+import { IconSymbol } from '@/components/ui/icon-symbol';
+import { useColorScheme } from '@/hooks/use-color-scheme';
+import { useColors } from '@/hooks/use-colors';
+import { dogContactChrome, spacing } from '@/theme/tokens';
+
+type DogContactChromeButtonShape = 'circle' | 'pill';
+
+interface DogContactChromeButtonProps {
+  shape: DogContactChromeButtonShape;
+  label: string;
+  onPress: () => void;
+  iconName?: ComponentProps<typeof IconSymbol>['name'];
+  disabled?: boolean;
+  accessibilityLabel?: string;
+  testID?: string;
+  style?: StyleProp<ViewStyle>;
+}
+
+export function DogContactChromeButton({
+  shape,
+  label,
+  onPress,
+  iconName,
+  disabled = false,
+  accessibilityLabel,
+  testID,
+  style,
+}: DogContactChromeButtonProps) {
+  const isCircle = shape === 'circle';
+  const theme = useColors();
+  const colorScheme = useColorScheme();
+  const blurTint: BlurTint =
+    colorScheme === 'dark' ? 'systemChromeMaterialDark' : 'systemChromeMaterialLight';
+  const chromeColorStyle = {
+    backgroundColor: theme.background,
+    borderColor: theme.border,
+  };
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel ?? label}
+      accessibilityState={{ disabled }}
+      disabled={disabled}
+      hitSlop={spacing.step12}
+      onPress={onPress}
+      style={[
+        styles.base,
+        chromeColorStyle,
+        isCircle ? styles.circle : styles.pill,
+        disabled ? styles.disabled : null,
+        style,
+      ]}
+      testID={testID}
+    >
+      <BlurView
+        intensity={dogContactChrome.blurIntensity}
+        tint={blurTint}
+        style={[styles.blur, { backgroundColor: theme.background }]}
+      >
+        {iconName ? (
+          <IconSymbol
+            name={iconName}
+            size={dogContactChrome.iconSize}
+            color={theme.onSurface}
+            weight="semibold"
+          />
+        ) : (
+          <Text style={[styles.label, { color: theme.onSurface }]}>{label}</Text>
+        )}
+      </BlurView>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  base: {
+    overflow: 'hidden',
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  circle: {
+    width: dogContactChrome.circleSize,
+    height: dogContactChrome.circleSize,
+    borderRadius: dogContactChrome.circleRadius,
+  },
+  pill: {
+    minWidth: dogContactChrome.pillMinWidth,
+    height: dogContactChrome.pillHeight,
+    borderRadius: dogContactChrome.pillRadius,
+  },
+  blur: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: dogContactChrome.pillPaddingH,
+  },
+  label: {
+    ...dogContactChrome.labelFont,
+  },
+  disabled: {
+    opacity: dogContactChrome.disabledOpacity,
+  },
+});

--- a/apps/mobile/theme/tokens.ts
+++ b/apps/mobile/theme/tokens.ts
@@ -339,3 +339,24 @@ export const components = {
 } as const;
 
 export type ComponentTokens = typeof components;
+
+export const dogContactChrome = {
+  circleSize: 52,
+  circleRadius: 26,
+  pillMinWidth: 75,
+  pillHeight: 52,
+  pillRadius: 27,
+  pillPaddingH: 20,
+  iconSize: 28,
+  labelFont: {
+    fontSize: 20,
+    fontWeight: '700' as const,
+    lineHeight: 24,
+  },
+  blurIntensity: 72,
+  disabledOpacity: 0.45,
+  deleteButtonMinHeight: 58,
+  deleteButtonRadius: 24,
+} as const;
+
+export type DogContactChromeTokens = typeof dogContactChrome;


### PR DESCRIPTION
## Summary
- Updates the Dog detail top chrome to Contacts-style back and edit controls.
- Adds a reusable `DogContactChromeButton` and moves its geometry into mobile design tokens while using the existing `background`, `border`, and `onSurface` color tokens.
- Replaces the Dog edit header with icon-only Cancel/Save controls, disables edit transition animation, and styles remove as a full-width destructive button.

## Product Decision Axes
- Dog experience: Dog profiles feel more native and focused, making each dog identity screen easier to recognize and edit.
- Walk data: No API or data model changes; existing Dog profile fields and walk-goal data remain unchanged.
- Owner contribution: The edit flow is clearer and more familiar on iOS, reducing friction when owners maintain dog profile information.

## Test Plan
- `cd apps/mobile && npm test`
- `cd apps/mobile && npm run typecheck`
- `cd apps/mobile && npm run lint` (passes with existing `.expo/types/router.d.ts` unused eslint-disable warning)
- `node scripts/harness/validate-all.mjs`
- iOS Simulator visual check on iPhone 17 Pro via Dogs tab → Mint → Edit screenshots