### PR TITLE
[codex] Use icon add action on Dogs screen

### DIFF
--- a/apps/mobile/__tests__/app/tabs/dogs.test.tsx
+++ b/apps/mobile/__tests__/app/tabs/dogs.test.tsx
@@ -5,6 +5,14 @@ jest.mock('@/hooks/use-color-scheme', () => ({
   useColorScheme: () => 'light',
 }));
 
+jest.mock('@/components/ui/icon-symbol', () => {
+  const { Text } = jest.requireActual<typeof import('react-native')>('react-native');
+
+  return {
+    IconSymbol: ({ name }: { name: string }) => <Text>{name}</Text>,
+  };
+});
+
 jest.mock('expo-router', () => ({
   useRouter: () => ({ push: jest.fn() }),
 }));
@@ -74,8 +82,11 @@ describe('DogsScreen', () => {
     expect(screen.queryByText('Goal progress')).toBeNull();
   });
 
-  it('renders header + Add CTA', () => {
+  it('renders the header add action as an icon-only circular button', () => {
     render(<DogsScreen />);
-    expect(screen.getByRole('button', { name: '+ Add' })).toBeTruthy();
+
+    expect(screen.getByRole('button', { name: 'Add Dog' })).toBeTruthy();
+    expect(screen.getByText('plus')).toBeTruthy();
+    expect(screen.queryByText('+ Add')).toBeNull();
   });
 });

--- a/apps/mobile/app/(tabs)/dogs.tsx
+++ b/apps/mobile/app/(tabs)/dogs.tsx
@@ -36,7 +36,11 @@ export default function DogsScreen() {
       <ScreenHeader
         title={t('dogs.list.title')}
         testID="dogs-header"
-        rightAction={{ label: t('dogs.list.addCta'), onPress: vm.handleAddDog }}
+        rightAction={{
+          label: t('dogs.list.addDog'),
+          onPress: vm.handleAddDog,
+          icon: 'plus',
+        }}
       />
       <FlatList
         data={vm.dogs}

--- a/apps/mobile/components/ui/ScreenHeader.test.tsx
+++ b/apps/mobile/components/ui/ScreenHeader.test.tsx
@@ -1,7 +1,7 @@
 import { StyleSheet } from 'react-native';
 import { fireEvent, render, screen } from '@testing-library/react-native';
 import { changeLanguage } from 'i18next';
-import { colors, layout, spacing, typography } from '@/theme/tokens';
+import { colors, components, layout, spacing, typography } from '@/theme/tokens';
 import { ScreenHeader } from './ScreenHeader';
 
 const mockBack = jest.fn();
@@ -131,6 +131,29 @@ describe('ScreenHeader', () => {
     expect(flattenStyle(label.props.style).fontWeight).toBe(
       typography.headline.fontWeight,
     );
+  });
+
+  it('renders an icon-only right action as a circular header button', () => {
+    const onPress = jest.fn();
+    render(
+      <ScreenHeader
+        title="Dogs"
+        rightAction={{ label: 'Add Dog', onPress, icon: 'plus' }}
+      />,
+    );
+
+    const button = screen.getByRole('button', { name: 'Add Dog' });
+    const buttonStyle = flattenStyle(button.props.style);
+
+    expect(screen.getByText('plus')).toBeTruthy();
+    expect(screen.queryByText('Add Dog')).toBeNull();
+    expect(buttonStyle.width).toBe(components.headerIconButton.size);
+    expect(buttonStyle.height).toBe(components.headerIconButton.size);
+    expect(buttonStyle.borderRadius).toBe(components.headerIconButton.radius);
+
+    fireEvent.press(button);
+
+    expect(onPress).toHaveBeenCalledTimes(1);
   });
 
   it('disables a disabled right action visually and semantically', () => {

--- a/apps/mobile/components/ui/ScreenHeader.tsx
+++ b/apps/mobile/components/ui/ScreenHeader.tsx
@@ -1,9 +1,18 @@
+import type { ComponentProps } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useColors } from '@/hooks/use-colors';
-import { layout, spacing, typography, type ColorTokens } from '@/theme/tokens';
+import {
+  components,
+  elevation,
+  layout,
+  spacing,
+  typography,
+  type ColorTokens,
+} from '@/theme/tokens';
 import { BackButton } from './BackButton';
+import { IconSymbol } from './icon-symbol';
 
 export interface ScreenHeaderProps {
   /** 表示タイトル。i18n 済みの文字列を渡す。 */
@@ -29,8 +38,9 @@ export interface ScreenHeaderProps {
 
   /**
    * - undefined / omitted: no button, frame still rendered.
-   * - object: explicit label and onPress. `strong: true` applies
-   *   `typography.headline.fontWeight`.
+   * - object: explicit label and onPress. `icon` renders an icon-only
+   *   circular action while preserving the label for accessibility.
+   *   `strong: true` applies `typography.headline.fontWeight`.
    */
   rightAction?: ScreenHeaderAction;
 
@@ -41,14 +51,18 @@ export interface ScreenHeaderProps {
 export interface ScreenHeaderAction {
   label: string;
   onPress: () => void;
+  /** Icon-only SF Symbol action. The label remains the accessibility label. */
+  icon?: ScreenHeaderActionIconName;
   /** Emphasized font weight for primary CTAs like Save. default: false */
   strong?: boolean;
   /** Disabled visual + accessibilityState.disabled. onPress is not called. */
   disabled?: boolean;
 }
 
+type ScreenHeaderActionIconName = ComponentProps<typeof IconSymbol>['name'];
+
 interface ResolvedScreenHeaderAction extends ScreenHeaderAction {
-  icon?: 'chevron.backward';
+  icon?: ScreenHeaderActionIconName;
 }
 
 type ActionSide = 'left' | 'right';
@@ -182,8 +196,20 @@ const ScreenHeaderActionButton = ({
 }: ScreenHeaderActionButtonProps) => {
   const isDisabled = action.disabled === true;
   const isStrong = action.strong === true && !isDisabled;
-  const actionColor = isDisabled ? theme.textDisabled : theme.interactive;
-  const buttonStyle = [styles.actionButton, actionButtonAlignmentStyle(side)];
+  const iconOnlyName = action.icon !== 'chevron.backward' ? action.icon : undefined;
+  const isIconOnly = iconOnlyName !== undefined;
+  const actionColor = isDisabled
+    ? theme.textDisabled
+    : isIconOnly
+      ? theme.onSurface
+      : theme.interactive;
+  const buttonStyle = [
+    styles.actionButton,
+    actionButtonAlignmentStyle(side),
+    isIconOnly ? styles.iconActionButton : null,
+    isIconOnly ? { backgroundColor: theme.surfaceContainer, borderColor: theme.border } : null,
+    isIconOnly && isDisabled ? styles.disabledIconActionButton : null,
+  ];
 
   if (action.icon === 'chevron.backward') {
     return (
@@ -194,6 +220,27 @@ const ScreenHeaderActionButton = ({
         disabled={isDisabled}
         style={buttonStyle}
       />
+    );
+  }
+
+  if (isIconOnly) {
+    return (
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={action.label}
+        accessibilityState={{ disabled: isDisabled }}
+        disabled={isDisabled}
+        hitSlop={spacing.step12}
+        onPress={action.onPress}
+        style={buttonStyle}
+      >
+        <IconSymbol
+          name={iconOnlyName}
+          size={components.headerIconButton.iconSize}
+          color={actionColor}
+          weight="regular"
+        />
+      </Pressable>
     );
   }
 
@@ -290,6 +337,19 @@ const styles = StyleSheet.create({
   },
   rightActionButton: {
     justifyContent: 'flex-end',
+  },
+  iconActionButton: {
+    width: components.headerIconButton.size,
+    height: components.headerIconButton.size,
+    minWidth: components.headerIconButton.size,
+    minHeight: components.headerIconButton.size,
+    borderRadius: components.headerIconButton.radius,
+    borderWidth: StyleSheet.hairlineWidth,
+    justifyContent: 'center',
+    ...elevation.low,
+  },
+  disabledIconActionButton: {
+    opacity: components.headerIconButton.disabledOpacity,
   },
   actionLabel: {
     ...typography.body,

--- a/apps/mobile/components/ui/icon-symbol.tsx
+++ b/apps/mobile/components/ui/icon-symbol.tsx
@@ -30,6 +30,7 @@ const MAPPING = {
   'info.circle': 'info',
   xmark: 'close',
   checkmark: 'check',
+  plus: 'add',
   'camera.fill': 'photo-camera',
 } satisfies Record<string, ComponentProps<typeof MaterialIcons>['name']>;
 

--- a/apps/mobile/theme/tokens.ts
+++ b/apps/mobile/theme/tokens.ts
@@ -260,6 +260,12 @@ export const components = {
     strokeWidth: 1.8,
     viewBox: 26,
   },
+  headerIconButton: {
+    size: 50,
+    radius: 25,
+    iconSize: 28,
+    disabledOpacity: 0.45,
+  },
   walkControls: {
     minimizeButtonSize: 32,
     minimizeIconSize: 18,


### PR DESCRIPTION
## Summary
- Replaces the Dogs screen `+ Add` text action with an icon-only circular plus action.
- Extends `ScreenHeader` with token-driven icon-only action rendering while keeping existing text actions unchanged.
- Adds regression coverage for the Dogs header and shared header behavior.

## Product impact
- Dog experience: no domain behavior change.
- Walk data: no data model or walk recording change.
- Owner contribution: the add-dog action is easier to scan and closer to native iOS header affordances.

## Validation
- `npm test -- --runInBand --forceExit`
- `npm run typecheck`
- `npm run lint`
- `npm run knip`
- `scripts/harness/validate-all.sh`