### PR TITLE
chore: resolve mobile Knip ignored issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,13 @@ npm run lint
 npm run knip
 ```
 
+Mobile changes must also include Maestro journey evidence, or explicitly state
+why no user journey is affected. User-facing UI, navigation, auth, walk, dog,
+profile, API contract, persistence, or permission changes require the matching
+Maestro flow from `apps/mobile/e2e/maestro/`. Broad journey-impacting changes
+require running all current Maestro flows. Static tooling, type-only, or
+unused-code cleanup may record "no affected journey" instead of running Maestro.
+
 ## Harness Commands
 
 ```bash

--- a/apps/mobile/app/walks/[id].tsx
+++ b/apps/mobile/app/walks/[id].tsx
@@ -10,7 +10,7 @@ import { components, radius, spacing, typography } from '@/theme/tokens';
 import { useWalk } from '@/hooks/use-walks';
 import { useWalkDetailViewModel } from '@/hooks/use-walk-detail-view-model';
 import { WalkEventTimeline } from '@/components/walk/WalkEventTimeline';
-import { MAP_EVENT_EMOJIS } from '@/lib/walk/events';
+import { WALK_EVENT_EMOJIS } from '@/lib/walk/events';
 import { useWalkStore } from '@/stores/walk-store';
 
 // 散歩詳細画面は保存済み散歩のルート、メトリクス、担当者、イベント履歴を表示します。
@@ -81,10 +81,10 @@ export default function WalkDetailScreen() {
                   key={e.id}
                   coordinate={{ latitude: e.lat!, longitude: e.lng! }}
                   accessibilityLabel={t('walk.detail.eventMarker', {
-                    emoji: MAP_EVENT_EMOJIS[e.eventType],
+                    emoji: WALK_EVENT_EMOJIS[e.eventType],
                   })}
                 >
-                  <Text style={styles.eventMarker}>{MAP_EVENT_EMOJIS[e.eventType]}</Text>
+                  <Text style={styles.eventMarker}>{WALK_EVENT_EMOJIS[e.eventType]}</Text>
                 </Marker>
               ))}
           </MapView>

--- a/apps/mobile/components/dogs/DogForm.tsx
+++ b/apps/mobile/components/dogs/DogForm.tsx
@@ -497,10 +497,6 @@ export function isDogFormValid(values: DogFormValues): boolean {
   return values.name.trim().length > 0 && values.gender.trim().length > 0;
 }
 
-export function clampDailyGoalMinutes(minutes: number): number {
-  return clampGoalMinutes(minutes, DAILY_GOAL_CYCLE_DAYS);
-}
-
 export function clampGoalMinutes(minutes: number, cycleDays: GoalCycleDays): number {
   const finiteMinutes = Number.isFinite(minutes) ? minutes : DEFAULT_DAILY_GOAL_MINUTES;
   const rounded =

--- a/apps/mobile/components/dogs/DogWalkRow.tsx
+++ b/apps/mobile/components/dogs/DogWalkRow.tsx
@@ -3,7 +3,7 @@ import Svg, { Circle, Path } from 'react-native-svg';
 import { useTranslation } from 'react-i18next';
 import { useColors } from '@/hooks/use-colors';
 import { components, radius, spacing, typography } from '@/theme/tokens';
-import { UI_EVENT_EMOJIS, countWalkActivityEvents } from '@/lib/walk/events';
+import { WALK_EVENT_EMOJIS, countWalkActivityEvents } from '@/lib/walk/events';
 import {
   formatDistance,
   formatPaceString,
@@ -70,12 +70,12 @@ export function DogWalkRow({ walk, onPress, separator = true }: DogWalkRowProps)
           <View style={styles.eventCounts}>
             {pee > 0 ? (
               <Text style={[styles.eventText, { color: theme.onSurfaceVariant }]}>
-                {UI_EVENT_EMOJIS.pee}{pee}
+                {WALK_EVENT_EMOJIS.pee}{pee}
               </Text>
             ) : null}
             {poo > 0 ? (
               <Text style={[styles.eventText, { color: theme.onSurfaceVariant }]}>
-                {UI_EVENT_EMOJIS.poo}{poo}
+                {WALK_EVENT_EMOJIS.poo}{poo}
               </Text>
             ) : null}
           </View>

--- a/apps/mobile/components/ui/ScreenHeader.tsx
+++ b/apps/mobile/components/ui/ScreenHeader.tsx
@@ -38,7 +38,7 @@ export interface ScreenHeaderProps {
   testID?: string;
 }
 
-export interface ScreenHeaderAction {
+interface ScreenHeaderAction {
   label: string;
   onPress: () => void;
   /** Emphasized font weight for primary CTAs like Save. default: false */

--- a/apps/mobile/components/walk/DogEventActionRow.tsx
+++ b/apps/mobile/components/walk/DogEventActionRow.tsx
@@ -1,6 +1,6 @@
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { Image } from 'expo-image';
-import { EVENT_ORDER, UI_EVENT_EMOJIS } from '@/lib/walk/events';
+import { EVENT_ORDER, WALK_EVENT_EMOJIS } from '@/lib/walk/events';
 import { spacing, typography } from '@/theme/tokens';
 import type { Dog, WalkEventType } from '@/types/graphql';
 
@@ -54,7 +54,7 @@ export function DogEventActionRow({
           {dog.name}
         </Text>
         <Text style={[styles.counts, { color: secondaryTextColor }]}>
-          {`${UI_EVENT_EMOJIS.pee} ${counts.pee} · ${UI_EVENT_EMOJIS.poo} ${counts.poo}`}
+          {`${WALK_EVENT_EMOJIS.pee} ${counts.pee} · ${WALK_EVENT_EMOJIS.poo} ${counts.poo}`}
         </Text>
       </View>
       <View style={styles.buttons}>
@@ -75,7 +75,7 @@ export function DogEventActionRow({
               disabled && styles.buttonDisabled,
             ]}
           >
-            <Text style={styles.iconEmoji}>{UI_EVENT_EMOJIS[type]}</Text>
+            <Text style={styles.iconEmoji}>{WALK_EVENT_EMOJIS[type]}</Text>
           </Pressable>
         ))}
       </View>

--- a/apps/mobile/components/walk/PerDogSummaryCard.tsx
+++ b/apps/mobile/components/walk/PerDogSummaryCard.tsx
@@ -3,7 +3,7 @@ import { Image } from 'expo-image';
 import { useTranslation } from 'react-i18next';
 import { GroupedCard } from '@/components/ui/GroupedCard';
 import { useColors } from '@/hooks/use-colors';
-import { UI_EVENT_EMOJIS, countEventsByType } from '@/lib/walk/events';
+import { WALK_EVENT_EMOJIS, countEventsByType } from '@/lib/walk/events';
 import { components, radius, spacing, typography } from '@/theme/tokens';
 import type { Dog, WalkEvent } from '@/types/graphql';
 
@@ -76,7 +76,7 @@ export function PerDogSummaryCard({
                       photo: counts.photo,
                     })}
                   >
-                    {`${UI_EVENT_EMOJIS.pee} ${counts.pee}  ·  ${UI_EVENT_EMOJIS.poo} ${counts.poo}  ·  ${UI_EVENT_EMOJIS.photo} ${counts.photo}`}
+                    {`${WALK_EVENT_EMOJIS.pee} ${counts.pee}  ·  ${WALK_EVENT_EMOJIS.poo} ${counts.poo}  ·  ${WALK_EVENT_EMOJIS.photo} ${counts.photo}`}
                   </Text>
                 </View>
                 <Text style={[styles.chevron, { color: theme.textDisabled }]}>

--- a/apps/mobile/components/walk/WalkEventActions.tsx
+++ b/apps/mobile/components/walk/WalkEventActions.tsx
@@ -9,7 +9,7 @@ import { useMutationWithAlert } from '@/hooks/use-mutation-with-alert';
 import { useWalkEventRecorder } from '@/hooks/use-walk-event-recorder';
 import { useWalkStore } from '@/stores/walk-store';
 import { spacing } from '@/theme/tokens';
-import { EVENT_ORDER, UI_EVENT_EMOJIS, countEventsByType } from '@/lib/walk/events';
+import { EVENT_ORDER, WALK_EVENT_EMOJIS, countEventsByType } from '@/lib/walk/events';
 import { DogEventActionRow } from './DogEventActionRow';
 import { EventPill } from './EventPill';
 import type { Dog, WalkEventType } from '@/types/graphql';
@@ -126,7 +126,7 @@ export function WalkEventActions({ dogs }: WalkEventActionsProps) {
           <EventPill
             key={type}
             label={t(`walk.event.${type}`)}
-            emoji={UI_EVENT_EMOJIS[type]}
+            emoji={WALK_EVENT_EMOJIS[type]}
             count={counts[type]}
             disabled={isDisabled}
             onPress={() => fire(type, singleDogId)}

--- a/apps/mobile/components/walk/WalkMap.tsx
+++ b/apps/mobile/components/walk/WalkMap.tsx
@@ -6,7 +6,7 @@ import MapView, { Marker, Polyline, type Region } from 'react-native-maps';
 import { useTranslation } from 'react-i18next';
 import { useColors } from '@/hooks/use-colors';
 import { useWalkStore } from '@/stores/walk-store';
-import { MAP_EVENT_EMOJIS } from '@/lib/walk/events';
+import { WALK_EVENT_EMOJIS } from '@/lib/walk/events';
 import { TOKYO_STATION_COORDINATE } from '@/lib/walk/constants';
 import { radius, spacing, typography } from '@/theme/tokens';
 import type { Dog } from '@/types/graphql';
@@ -167,11 +167,11 @@ export function WalkMap({ mode = 'recording', dogs = [] }: WalkMapProps) {
                   testID={`event-marker-${e.id}`}
                   coordinate={{ latitude: e.lat!, longitude: e.lng! }}
                   accessibilityLabel={t('walk.map.eventAt', {
-                    emoji: MAP_EVENT_EMOJIS[e.eventType],
+                    emoji: WALK_EVENT_EMOJIS[e.eventType],
                     occurredAt: e.occurredAt,
                   })}
                 >
-                  <Text style={styles.eventMarker}>{MAP_EVENT_EMOJIS[e.eventType]}</Text>
+                  <Text style={styles.eventMarker}>{WALK_EVENT_EMOJIS[e.eventType]}</Text>
                 </Marker>
               ))
           : null}

--- a/apps/mobile/components/walk/WalkQuickActions.tsx
+++ b/apps/mobile/components/walk/WalkQuickActions.tsx
@@ -7,7 +7,7 @@ import { elevation, radius, spacing, typography } from '@/theme/tokens';
 import { useWalkStore } from '@/stores/walk-store';
 import { useMutationWithAlert } from '@/hooks/use-mutation-with-alert';
 import { useRecordWalkEvent } from '@/hooks/use-walk-event-mutations';
-import { UI_EVENT_EMOJIS } from '@/lib/walk/events';
+import { WALK_EVENT_EMOJIS } from '@/lib/walk/events';
 import type { Dog } from '@/types/graphql';
 
 interface WalkQuickActionsProps {
@@ -65,7 +65,7 @@ export function WalkQuickActions({ dogs }: WalkQuickActionsProps) {
       {isSingleDog ? (
         <>
           <Pill
-            label={`${UI_EVENT_EMOJIS.pee} ${t('walk.event.pee')}`}
+            label={`${WALK_EVENT_EMOJIS.pee} ${t('walk.event.pee')}`}
             onPress={() => handlePeeOrPoo('pee', dogs[0].id)}
             disabled={isDisabled}
             bg={theme.surface}
@@ -74,7 +74,7 @@ export function WalkQuickActions({ dogs }: WalkQuickActionsProps) {
             accessibilityLabel={`${dogs[0].name} ${t('walk.event.pee')}`}
           />
           <Pill
-            label={`${UI_EVENT_EMOJIS.poo} ${t('walk.event.poo')}`}
+            label={`${WALK_EVENT_EMOJIS.poo} ${t('walk.event.poo')}`}
             onPress={() => handlePeeOrPoo('poo', dogs[0].id)}
             disabled={isDisabled}
             bg={theme.surface}
@@ -87,7 +87,7 @@ export function WalkQuickActions({ dogs }: WalkQuickActionsProps) {
         dogs.flatMap((dog) => [
           <Pill
             key={`pee-${dog.id}`}
-            label={`${UI_EVENT_EMOJIS.pee} ${dog.name}`}
+            label={`${WALK_EVENT_EMOJIS.pee} ${dog.name}`}
             onPress={() => handlePeeOrPoo('pee', dog.id)}
             disabled={isDisabled}
             bg={theme.surface}
@@ -97,7 +97,7 @@ export function WalkQuickActions({ dogs }: WalkQuickActionsProps) {
           />,
           <Pill
             key={`poo-${dog.id}`}
-            label={`${UI_EVENT_EMOJIS.poo} ${dog.name}`}
+            label={`${WALK_EVENT_EMOJIS.poo} ${dog.name}`}
             onPress={() => handlePeeOrPoo('poo', dog.id)}
             disabled={isDisabled}
             bg={theme.surface}

--- a/apps/mobile/hooks/use-user-profile.ts
+++ b/apps/mobile/hooks/use-user-profile.ts
@@ -6,7 +6,7 @@ import { mapApiUser } from '@/lib/graphql/adapters';
 import { useIsAuthenticated } from './use-is-authenticated';
 import type { UserProfileResponse, User } from '@/types/graphql';
 
-export interface UserProfileWalkSummary {
+interface UserProfileWalkSummary {
   id: string;
   startedAt: string;
   distanceM: number;
@@ -20,7 +20,7 @@ export interface UserProfileData {
   recentWalks: UserProfileWalkSummary[];
 }
 
-export function mapUserProfileResponse(response: UserProfileResponse): UserProfileData {
+function mapUserProfileResponse(response: UserProfileResponse): UserProfileData {
   return {
     user: mapApiUser(response.user),
     totalWalks: response.user.walks.totalCount,

--- a/apps/mobile/hooks/use-user-screen-view-model.ts
+++ b/apps/mobile/hooks/use-user-screen-view-model.ts
@@ -6,13 +6,13 @@ import { useUserProfile, type UserProfileData } from './use-user-profile';
 type UserStatus = 'loading' | 'error' | 'ready';
 type Translate = (key: string, values?: Record<string, unknown>) => string;
 
-export interface UserMetricViewModel {
+interface UserMetricViewModel {
   key: 'walks' | 'distance' | 'totalTime' | 'dogs';
   value: string;
   label: string;
 }
 
-export interface UserWeekDayViewModel {
+interface UserWeekDayViewModel {
   key: string;
   label: string;
   distanceKm: number;
@@ -21,7 +21,7 @@ export interface UserWeekDayViewModel {
   isToday: boolean;
 }
 
-export interface UserWeekViewModel {
+interface UserWeekViewModel {
   title: string;
   totalLabel: string;
   days: UserWeekDayViewModel[];

--- a/apps/mobile/knip.jsonc
+++ b/apps/mobile/knip.jsonc
@@ -35,23 +35,5 @@
     // Knip's Expo plugin assumes OTA updates are enabled when app.config.ts
     // does not explicitly disable them.
     "expo-updates"
-  ],
-  "ignoreIssues": {
-    // Existing production-code export baseline. This PR wires Knip into the
-    // harness without changing app/runtime source.
-    "components/dogs/DogForm.tsx": ["exports"],
-    "components/ui/ScreenHeader.tsx": ["types"],
-    "hooks/use-user-profile.ts": ["exports", "types"],
-    "hooks/use-user-screen-view-model.ts": ["types"],
-    "lib/walk/live-activity-controller.ts": ["exports"],
-    "lib/walk/live-activity.ts": ["types"],
-    "lib/watch/types.ts": ["types"],
-    "scripts/expo-xcodebuild-provisioning-hook.cjs": ["exports"],
-    "theme/tokens.ts": ["types"],
-    "types/graphql.ts": ["types"],
-
-    // These aliases intentionally point at one emoji table so map markers and
-    // UI controls cannot drift.
-    "lib/walk/events.ts": ["duplicates"]
-  }
+  ]
 }

--- a/apps/mobile/lib/walk/events.test.ts
+++ b/apps/mobile/lib/walk/events.test.ts
@@ -1,7 +1,6 @@
 import {
   EVENT_ORDER,
-  MAP_EVENT_EMOJIS,
-  UI_EVENT_EMOJIS,
+  WALK_EVENT_EMOJIS,
   countEventsByType,
   countWalkActivityEvents,
   type CountableEvent,
@@ -13,31 +12,31 @@ describe('EVENT_ORDER', () => {
   });
 });
 
-describe('MAP_EVENT_EMOJIS (map markers)', () => {
+describe('WALK_EVENT_EMOJIS map marker values', () => {
   it('uses the droplet emoji for pee on map pins', () => {
-    expect(MAP_EVENT_EMOJIS.pee).toBe('💧');
+    expect(WALK_EVENT_EMOJIS.pee).toBe('💧');
   });
 
   it('maps poo to poop emoji', () => {
-    expect(MAP_EVENT_EMOJIS.poo).toBe('💩');
+    expect(WALK_EVENT_EMOJIS.poo).toBe('💩');
   });
 
   it('maps photo to camera emoji', () => {
-    expect(MAP_EVENT_EMOJIS.photo).toBe('📷');
+    expect(WALK_EVENT_EMOJIS.photo).toBe('📷');
   });
 });
 
-describe('UI_EVENT_EMOJIS (buttons, summary cards)', () => {
+describe('WALK_EVENT_EMOJIS UI values', () => {
   it('uses the droplet emoji for pee in UI surfaces', () => {
-    expect(UI_EVENT_EMOJIS.pee).toBe('💧');
+    expect(WALK_EVENT_EMOJIS.pee).toBe('💧');
   });
 
   it('maps poo to poop emoji', () => {
-    expect(UI_EVENT_EMOJIS.poo).toBe('💩');
+    expect(WALK_EVENT_EMOJIS.poo).toBe('💩');
   });
 
   it('maps photo to camera emoji', () => {
-    expect(UI_EVENT_EMOJIS.photo).toBe('📷');
+    expect(WALK_EVENT_EMOJIS.photo).toBe('📷');
   });
 });
 

--- a/apps/mobile/lib/walk/events.ts
+++ b/apps/mobile/lib/walk/events.ts
@@ -12,9 +12,6 @@ export const WALK_EVENT_EMOJIS: Record<WalkEventType, string> = {
   photo: '📷',
 };
 
-export const MAP_EVENT_EMOJIS = WALK_EVENT_EMOJIS;
-export const UI_EVENT_EMOJIS = WALK_EVENT_EMOJIS;
-
 export interface CountableEvent {
   eventType: WalkEventType;
   dogId?: string | null;

--- a/apps/mobile/lib/walk/live-activity-controller.ts
+++ b/apps/mobile/lib/walk/live-activity-controller.ts
@@ -33,7 +33,7 @@ function isMissingLiveActivityError(error: unknown): boolean {
   );
 }
 
-export function walkRecordingActivityUrl(walkId: string): string {
+function walkRecordingActivityUrl(walkId: string): string {
   return `walking-dog://walk-recording?walkId=${encodeURIComponent(walkId)}`;
 }
 

--- a/apps/mobile/lib/walk/live-activity.ts
+++ b/apps/mobile/lib/walk/live-activity.ts
@@ -5,7 +5,7 @@ export const WALK_ACTIVITY_NAME = 'WalkingDogWalkActivity';
 const WALK_ACTIVITY_TARGET_PREFIX = 'walk';
 export const WALK_ACTIVITY_FINISH_TARGET = `${WALK_ACTIVITY_TARGET_PREFIX}:finish`;
 
-export interface WalkActivityDogProps {
+interface WalkActivityDogProps {
   id: string;
   name: string;
   peeCount: number;
@@ -14,7 +14,7 @@ export interface WalkActivityDogProps {
   pooTarget: string;
 }
 
-export interface WalkActivityLabels {
+interface WalkActivityLabels {
   walking: string;
   distance: string;
   walk: string;

--- a/apps/mobile/lib/watch/types.ts
+++ b/apps/mobile/lib/watch/types.ts
@@ -5,14 +5,14 @@ export interface WatchCoordinate {
   lng: number;
 }
 
-export interface WatchWalkSnapshotDog {
+interface WatchWalkSnapshotDog {
   id: string;
   name: string;
   peeCount: number;
   pooCount: number;
 }
 
-export type WatchWalkSyncState = 'fresh' | 'stale' | 'offline';
+type WatchWalkSyncState = 'fresh' | 'stale' | 'offline';
 
 export interface WatchWalkSnapshot {
   isActive: boolean;

--- a/apps/mobile/scripts/expo-xcodebuild-provisioning-hook.cjs
+++ b/apps/mobile/scripts/expo-xcodebuild-provisioning-hook.cjs
@@ -54,6 +54,5 @@ if (process.env.NODE_ENV !== 'test') {
 
 module.exports = {
   REQUIRED_PROVISIONING_FLAGS,
-  patchSpawnForProvisioningUpdates,
   withRequiredProvisioningFlags,
 };

--- a/apps/mobile/theme/tokens.ts
+++ b/apps/mobile/theme/tokens.ts
@@ -358,5 +358,3 @@ export const dogContactChrome = {
   deleteButtonMinHeight: 58,
   deleteButtonRadius: 24,
 } as const;
-
-export type DogContactChromeTokens = typeof dogContactChrome;

--- a/apps/mobile/types/graphql.ts
+++ b/apps/mobile/types/graphql.ts
@@ -34,12 +34,12 @@ export interface WalkStats {
   totalDurationSec: number;
 }
 
-export interface WalkAmount {
+interface WalkAmount {
   minutes: number;
   cycleDays: number;
 }
 
-export interface DogWalkGoal {
+interface DogWalkGoal {
   id: string;
   dogId: string;
   walkAmount: WalkAmount;
@@ -283,14 +283,14 @@ export interface UserResponse {
   user: ApiUser;
 }
 
-export interface ApiUserProfileWalk {
+interface ApiUserProfileWalk {
   id: string;
   startedAt: string;
   endedAt: string | null;
   distance: number | null;
 }
 
-export interface ApiUserProfileWalkConnection {
+interface ApiUserProfileWalkConnection {
   totalCount: number;
   totalDistance: number;
   totalDuration: number;


### PR DESCRIPTION
## Summary

- Remove `ignoreIssues` from `apps/mobile/knip.jsonc` and make mobile Knip pass without suppressions.
- Collapse duplicate walk event emoji aliases into `WALK_EVENT_EMOJIS`.
- Internalize or remove unused mobile exports, and document the mobile Maestro evidence expectation in the repo agent instructions.

## Validation

- `cd apps/mobile && npm run knip`
- `cd apps/mobile && npm run typecheck`
- `cd apps/mobile && npm run lint` (exit 0; existing generated `.expo/types/router.d.ts` warning remains)
- `cd apps/mobile && npm test -- --runInBand` (all 124 suites / 747 tests passed; process stayed open on existing open handles)
- `cd apps/mobile && npm test -- --runInBand --forceExit`
- `scripts/harness/validate-all.sh`
- `git diff --check`
- `EXPO_PUBLIC_E2E=1 EXPO_PUBLIC_API_URL=http://127.0.0.1:5070 npx expo run:ios --configuration Release --device "iPhone 17 Pro"`
- `maestro test apps/mobile/e2e/maestro/auth-onboarding.yaml`
- `maestro test apps/mobile/e2e/maestro/*.yaml` (1/6 passed; remaining flows fail on documented missing seeded E2E fixture dogs such as `Harness Coco`, `Harness Event Dog`, `Harness Goal Dog`, `Harness History Dog`, and `Harness Walker`)

## Harness Note

Full Maestro coverage is still blocked by the fixture gaps already documented in `docs/harness/quality-score.md`. The passing smoke flow confirms the app launches and auth/onboarding path works in the release simulator build.
