### PR TITLE
[codex] Make harness down remove volumes

### DIFF
--- a/.codex/skills/maestro-e2e/SKILL.md
+++ b/.codex/skills/maestro-e2e/SKILL.md
@@ -24,6 +24,7 @@ sed -n '1,100p' apps/mobile/e2e/maestro/<flow>.yaml
 2. Verify prerequisites that affect selectors and connectivity:
 
 - Maestro CLI is installed.
+- `jq` is installed for harness scripts and reading `.harness-runs/dev-stack/env.json`.
 - Xcode Simulator can start `iPhone 17 Pro`.
 - Simulator language is English because selectors use English UI text.
 - `apps/mobile` dependencies are installed.
@@ -41,13 +42,13 @@ cd ../..
 4. Start the harness dev stack when it is not already running:
 
 ```bash
-node scripts/harness/dev-stack.mjs up
+scripts/harness/dev-stack.sh up
 ```
 
 5. Read the worktree-specific API port:
 
 ```bash
-node -p "require('./.harness-runs/dev-stack/env.json').ports.api"
+jq -r '.ports.api' .harness-runs/dev-stack/env.json
 ```
 
 6. Install a Release build on the simulator with the working directory set to `apps/mobile`, substituting the literal API port from step 5. Codex shell calls do not preserve exports between separate commands, so do not rely on `WD_API_PORT` from a previous command unless using the same shell session:
@@ -99,10 +100,11 @@ Read each YAML's `Harness preconditions` comments before running it. Current flo
 
 ## Cleanup
 
-Stop the Expo/Metro terminal with `Ctrl-C`. Stop the harness dev stack if it is no longer needed:
+Stop the Expo/Metro terminal with `Ctrl-C`. Stop and remove the harness dev
+stack, including its named volumes, if it is no longer needed:
 
 ```bash
-node scripts/harness/dev-stack.mjs down
+scripts/harness/dev-stack.sh down
 ```
 
 ## Changing Flows

--- a/docs/runbooks/local-harness.md
+++ b/docs/runbooks/local-harness.md
@@ -13,6 +13,16 @@ scripts/harness/dev-stack.sh up
 The script writes `.harness-runs/dev-stack/env.json` with the compose project name
 and per-worktree ports.
 
+Stop and remove the current worktree's harness containers, networks, and named
+volumes:
+
+```bash
+scripts/harness/dev-stack.sh down
+```
+
+This removes local Postgres, DynamoDB, MinIO, Cargo, and target-cache volumes for
+the harness Compose project.
+
 ## Local API Authentication
 
 Local API auth uses a dedicated real AWS Cognito user pool for the local

--- a/scripts/harness/dev-stack.sh
+++ b/scripts/harness/dev-stack.sh
@@ -41,6 +41,9 @@ Usage:
 
 Project: $project_name
 Ports: $(printf '%s' "$ports_json" | jq -c '.')
+
+Note: down removes the harness containers, networks, and named volumes for this
+worktree.
 EOF
 }
 
@@ -68,7 +71,7 @@ main() {
       compose_args=(up -d postgres dynamodb-local minio minio-init elasticmq api track-point-worker)
       ;;
     down)
-      compose_args=(down)
+      compose_args=(down --volumes --remove-orphans)
       ;;
     status)
       compose_args=(ps)

--- a/scripts/harness/harness.test.sh
+++ b/scripts/harness/harness.test.sh
@@ -177,6 +177,13 @@ test_dev_stack_does_not_use_compose_override_files() {
   assert_not_contains "$source" "compose.override.yaml" "dev-stack should not use compose override yaml"
 }
 
+test_dev_stack_down_removes_named_volumes() {
+  local source
+  source="$(cat "$repo_root/scripts/harness/dev-stack.sh")"
+
+  assert_contains "$source" "compose_args=(down --volumes --remove-orphans)" "dev-stack down should remove harness volumes"
+}
+
 test_run_api_journey_uses_current_user_query() {
   local source
   source="$(cat "$repo_root/scripts/harness/run-api-journey.sh")"
@@ -255,7 +262,7 @@ test_harness_has_no_node_scripts_or_invocations() {
   [[ -z "$matches" ]] || fail "expected no harness .mjs files; found $matches"
 
   pattern="node scripts/"'harness|node --test scripts/'"harness|scripts/"'harness/[a-z-]+\.mjs|node -'"p"
-  matches="$(cd "$repo_root" && rg -n "$pattern" .github AGENTS.md CLAUDE.md docs scripts infra apps/mobile/e2e/maestro || true)"
+  matches="$(cd "$repo_root" && rg --hidden --no-ignore -n "$pattern" .codex .github AGENTS.md CLAUDE.md docs scripts infra apps/mobile/e2e/maestro || true)"
   [[ -z "$matches" ]] || fail "expected no Node harness references; found $matches"
 }
 

--- a/scripts/harness/reset-local-data.sh
+++ b/scripts/harness/reset-local-data.sh
@@ -18,7 +18,7 @@ main() {
 
   "$script_dir/dev-stack.sh" down
 
-  echo "Harness local data reset. Seed fixture: $seed_path"
+  echo "Harness local data reset. Dev stack containers and volumes removed. Seed fixture: $seed_path"
 }
 
 main "$@"


### PR DESCRIPTION
## Summary
- Make `scripts/harness/dev-stack.sh down` remove the harness Compose project's named volumes and orphans.
- Update reset output, the local harness runbook, and the Maestro E2E skill to match the current shell-based dev stack flow.
- Extend harness tests to require volume cleanup and catch stale Node-based harness references under `.codex`.

## Validation
- `bash scripts/harness/harness.test.sh`
- `scripts/harness/validate-all.sh`

## Notes
- `apps/api/.env.local` has unrelated local modifications and is intentionally not included in this PR.