### PR TITLE
[codex] Use slide control to end walks

### DIFF
--- a/apps/mobile/components/walk/WalkControls.test.tsx
+++ b/apps/mobile/components/walk/WalkControls.test.tsx
@@ -1,5 +1,7 @@
 import { act, fireEvent, render, screen } from '@testing-library/react-native';
+import { StyleSheet } from 'react-native';
 import { WalkControls } from './WalkControls';
+import { components } from '@/theme/tokens';
 import type { Dog } from '@/types/graphql';
 
 jest.mock('@/hooks/use-color-scheme', () => ({
@@ -7,6 +9,28 @@ jest.mock('@/hooks/use-color-scheme', () => ({
 }));
 
 jest.mock('expo-image', () => ({ Image: 'Image' }));
+
+jest.mock('@react-native-community/slider', () => {
+  const { View } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({
+      onValueChange,
+      onSlidingComplete,
+      ...props
+    }: {
+      onValueChange?: (value: number) => void;
+      onSlidingComplete?: (value: number) => void;
+    }) => (
+      <View
+        {...props}
+        accessibilityRole="adjustable"
+        onValueChange={onValueChange}
+        onSlidingComplete={onSlidingComplete}
+      />
+    ),
+  };
+});
 
 const mockWalkStoreState = {
   startedAt: null as Date | null,
@@ -69,9 +93,13 @@ describe('WalkControls', () => {
     expect(screen.getByText('LIVE')).toBeTruthy();
   });
 
-  it('renders the destructive End Walk button', () => {
+  it('renders native slide-to-end control without the Pause button', () => {
     render(<WalkControls dogs={[coco]} onStop={jest.fn()} isStopping={false} />);
-    expect(screen.getByRole('button', { name: 'End Walk' })).toBeTruthy();
+    expect(screen.getByTestId('walk-end-rn-slider')).toBeTruthy();
+    expect(screen.getByTestId('walk-end-slider-knob')).toBeTruthy();
+    expect(screen.getByText('End Walk')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Pause' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Resume' })).toBeNull();
   });
 
   it('renders a minimize button and calls onMinimize', () => {
@@ -92,8 +120,27 @@ describe('WalkControls', () => {
 
   it('disables End Walk when isStopping', () => {
     render(<WalkControls dogs={[coco]} onStop={jest.fn()} isStopping={true} />);
-    const button = screen.getByRole('button', { name: 'End Walk' });
-    expect(button.props.accessibilityState?.disabled).toBe(true);
+    const slider = screen.getByTestId('walk-end-rn-slider');
+    expect(slider.props.disabled).toBe(true);
+  });
+
+  it('uses a transparent RN slider thumb so the custom circular knob owns the visuals', () => {
+    render(<WalkControls dogs={[coco]} onStop={jest.fn()} isStopping={false} />);
+    const slider = screen.getByTestId('walk-end-rn-slider');
+    expect(slider.props.thumbSize).toBe(components.walkControls.endSlideKnobSize);
+    expect(slider.props.thumbTintColor).toBe('#00000000');
+    expect(slider.props.minimumTrackTintColor).toBe('#00000000');
+    expect(slider.props.maximumTrackTintColor).toBe('#00000000');
+  });
+
+  it('aligns the native slider thumb with the visible circular knob', () => {
+    render(<WalkControls dogs={[coco]} onStop={jest.fn()} isStopping={false} />);
+    const sliderStyle = StyleSheet.flatten(screen.getByTestId('walk-end-rn-slider').props.style);
+    const thumbCenter =
+      components.walkControls.endSlideKnobInset +
+      components.walkControls.endSlideKnobSize / 2;
+    expect(sliderStyle.left).toBe(thumbCenter);
+    expect(sliderStyle.right).toBe(thumbCenter);
   });
 
   it('renders single-dog identity with dog name and contextual walk label', () => {
@@ -112,11 +159,31 @@ describe('WalkControls', () => {
     expect(screen.getByText('Group walk · together')).toBeTruthy();
   });
 
-  it('Pause button toggles to Resume when pressed', () => {
-    render(<WalkControls dogs={[coco]} onStop={jest.fn()} isStopping={false} />);
-    const pause = screen.getByRole('button', { name: 'Pause' });
-    fireEvent.press(pause);
-    expect(screen.getByRole('button', { name: 'Resume' })).toBeTruthy();
+  it('ends the walk only after releasing the slide at the end', () => {
+    const onStop = jest.fn();
+    render(<WalkControls dogs={[coco]} onStop={onStop} isStopping={false} />);
+
+    const slider = screen.getByTestId('walk-end-rn-slider');
+    fireEvent(slider, 'onValueChange', 1);
+    expect(onStop).not.toHaveBeenCalled();
+
+    fireEvent(slider, 'onSlidingComplete', 1);
+
+    expect(onStop).toHaveBeenCalledTimes(1);
+  });
+
+  it('resets the end slider when a stop attempt returns to idle', () => {
+    const onStop = jest.fn();
+    const { rerender } = render(
+      <WalkControls dogs={[coco]} onStop={onStop} isStopping={false} />,
+    );
+
+    fireEvent(screen.getByTestId('walk-end-rn-slider'), 'onValueChange', 1);
+    fireEvent(screen.getByTestId('walk-end-rn-slider'), 'onSlidingComplete', 1);
+    rerender(<WalkControls dogs={[coco]} onStop={onStop} isStopping={true} />);
+    rerender(<WalkControls dogs={[coco]} onStop={onStop} isStopping={false} />);
+
+    expect(screen.getByTestId('walk-end-rn-slider').props.value).toBe(0);
   });
 
   it('updates the elapsed metric while the walk is active', () => {

--- a/apps/mobile/components/walk/WalkControls.tsx
+++ b/apps/mobile/components/walk/WalkControls.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import { Pressable, StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { IconSymbol } from '@/components/ui/icon-symbol';
@@ -22,22 +22,6 @@ interface WalkControlsProps {
   children?: ReactNode;
 }
 
-interface PauseState {
-  startedAtMs: number | null;
-  isPaused: boolean;
-  pausedAtMs: number | null;
-  totalPausedMs: number;
-}
-
-function initialPauseState(startedAtMs: number | null): PauseState {
-  return {
-    startedAtMs,
-    isPaused: false,
-    pausedAtMs: null,
-    totalPausedMs: 0,
-  };
-}
-
 // 記録中の下部パネルとして、犬の表示、メトリクス、イベント操作、停止操作をまとめます。
 export function WalkControls({
   dogs,
@@ -49,37 +33,9 @@ export function WalkControls({
   const { t } = useTranslation();
   const theme = useColors();
   const startedAt = useWalkStore((s) => s.startedAt);
-  const startedAtMs = startedAt?.getTime() ?? null;
   const totalDistanceM = useWalkStore((s) => s.totalDistanceM);
   const units = useSettingsStore((s) => s.units);
-
-  const [pauseState, setPauseState] = useState(() => initialPauseState(startedAtMs));
-  const activePauseState =
-    pauseState.startedAtMs === startedAtMs ? pauseState : initialPauseState(startedAtMs);
-  const { isPaused, totalPausedMs } = activePauseState;
-  const elapsedSec = useWalkElapsed({ startedAt, isPaused, totalPausedMs });
-
-  // 一時停止の開始時刻を state に残し、再開時に累計停止時間へ加算します。
-  const togglePause = () => {
-    const now = Date.now();
-    setPauseState((previous) => {
-      const current =
-        previous.startedAtMs === startedAtMs ? previous : initialPauseState(startedAtMs);
-      if (current.isPaused && current.pausedAtMs !== null) {
-        return {
-          ...current,
-          isPaused: false,
-          pausedAtMs: null,
-          totalPausedMs: current.totalPausedMs + (now - current.pausedAtMs),
-        };
-      }
-      return {
-        ...current,
-        isPaused: true,
-        pausedAtMs: now,
-      };
-    });
-  };
+  const elapsedSec = useWalkElapsed({ startedAt, isPaused: false, totalPausedMs: 0 });
 
   // 記録中パネルのメトリクスは、設定単位に合わせた表示文字列へ変換して渡します。
   const { value: distanceValue, unit: distanceUnit } = formatDistanceParts(totalDistanceM, units);
@@ -133,9 +89,7 @@ export function WalkControls({
       {children ? <View style={styles.slot}>{children}</View> : null}
 
       <WalkControlsActions
-        isPaused={isPaused}
         isStopping={isStopping}
-        onTogglePause={togglePause}
         onStop={onStop}
       />
     </View>

--- a/apps/mobile/components/walk/WalkControlsActions.tsx
+++ b/apps/mobile/components/walk/WalkControlsActions.tsx
@@ -1,58 +1,155 @@
-import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { StyleSheet, Text, View, type LayoutChangeEvent } from 'react-native';
+import Slider from '@react-native-community/slider';
 import { useTranslation } from 'react-i18next';
-import { Button } from '@/components/ui/Button';
 import { useColors } from '@/hooks/use-colors';
-import { radius, spacing, typography } from '@/theme/tokens';
+import { components, typography } from '@/theme/tokens';
 
 interface WalkControlsActionsProps {
-  isPaused: boolean;
   isStopping: boolean;
-  onTogglePause: () => void;
   onStop: () => void;
 }
 
-// 記録中パネル下部の一時停止/再開と終了操作を表示します。
+const SLIDE_MIN = 0;
+const SLIDE_MAX = 1;
+const SLIDE_STEP = 0.01;
+const SLIDE_COMPLETE_THRESHOLD = 0.95;
+const TRANSPARENT_CONTROL_COLOR = '#00000000';
+const SLIDE_THUMB_CENTER_OFFSET =
+  components.walkControls.endSlideKnobInset +
+  components.walkControls.endSlideKnobSize / 2;
+
+function clampSlideValue(value: number) {
+  return Math.min(SLIDE_MAX, Math.max(SLIDE_MIN, value));
+}
+
+// 記録中パネル下部の終了操作を、RN Slider の native gesture で扱います。
 export function WalkControlsActions({
-  isPaused,
   isStopping,
-  onTogglePause,
   onStop,
 }: WalkControlsActionsProps) {
   const { t } = useTranslation();
   const theme = useColors();
+  const [slideValue, setSlideValue] = useState(SLIDE_MIN);
+  const [sliderWidth, setSliderWidth] = useState(0);
+  const slideValueRef = useRef(SLIDE_MIN);
+  const hasCompletedRef = useRef(false);
+  const wasStoppingRef = useRef(isStopping);
+
+  const setSlidePosition = useCallback((value: number) => {
+    const nextValue = clampSlideValue(value);
+    slideValueRef.current = nextValue;
+    setSlideValue(nextValue);
+  }, []);
+
+  const completeSlide = useCallback(() => {
+    if (hasCompletedRef.current || isStopping) return;
+    hasCompletedRef.current = true;
+    setSlidePosition(SLIDE_MAX);
+    onStop();
+  }, [isStopping, onStop, setSlidePosition]);
+
+  const handleSlideChange = useCallback(
+    (value: number) => {
+      if (isStopping || hasCompletedRef.current) return;
+      setSlidePosition(value);
+    },
+    [isStopping, setSlidePosition],
+  );
+
+  const handleSlidingComplete = useCallback(
+    (value: number) => {
+      if (isStopping) return;
+      const nextValue = clampSlideValue(value);
+      if (nextValue >= SLIDE_COMPLETE_THRESHOLD) {
+        setSlidePosition(nextValue);
+        completeSlide();
+        return;
+      }
+      setSlidePosition(SLIDE_MIN);
+    },
+    [completeSlide, isStopping, setSlidePosition],
+  );
+
+  useEffect(() => {
+    if (wasStoppingRef.current && !isStopping) {
+      hasCompletedRef.current = false;
+      setSlidePosition(SLIDE_MIN);
+    }
+    wasStoppingRef.current = isStopping;
+  }, [isStopping, setSlidePosition]);
+
+  const handleSliderLayout = useCallback((event: LayoutChangeEvent) => {
+    setSliderWidth(event.nativeEvent.layout.width);
+  }, []);
+
+  const knobTravel =
+    sliderWidth > 0
+      ? sliderWidth -
+        components.walkControls.endSlideKnobSize -
+        components.walkControls.endSlideKnobInset * 2
+      : 0;
+  const knobOffset = slideValue * Math.max(knobTravel, 0);
 
   return (
     <View style={styles.actionRow}>
-      <Pressable
-        accessibilityRole="button"
-        accessibilityLabel={isPaused ? t('walk.recording.resume') : t('walk.recording.pause')}
-        accessibilityState={{ disabled: isStopping }}
-        disabled={isStopping}
-        onPress={onTogglePause}
-        style={({ pressed }) => [
-          styles.pauseButton,
-          {
-            backgroundColor: pressed
-              ? theme.surfaceContainer
-              : theme.surfaceContainer,
-          },
-          isStopping && styles.buttonDisabled,
-        ]}
-      >
-        <Text style={[styles.pauseEmoji, { color: theme.onSurface }]}>
-          {isPaused ? '▶' : '❚❚'}
-        </Text>
-        <Text style={[styles.pauseLabel, { color: theme.onSurface }]}>
-          {isPaused ? t('walk.recording.resume') : t('walk.recording.pause')}
-        </Text>
-      </Pressable>
-      <View style={styles.endButtonWrap}>
-        <Button
-          label={t('walk.recording.endWalk')}
-          variant="destructive"
-          onPress={onStop}
+      <View style={styles.endSliderWrap} onLayout={handleSliderLayout}>
+        <View
+          pointerEvents="none"
+          style={[
+            styles.visualLayer,
+            {
+              backgroundColor: theme.surfaceContainer,
+              opacity: isStopping ? components.walkControls.endSlideDisabledOpacity : 1,
+            },
+          ]}
+          testID="walk-end-slider-visual"
+        >
+          <Text
+            style={[
+              styles.endLabel,
+              {
+                color: theme.onSurface,
+                opacity: components.walkControls.endSlideLabelOpacity,
+              },
+            ]}
+          >
+            {t('walk.recording.endWalk')}
+          </Text>
+          <View
+            style={[
+              styles.knob,
+              {
+                backgroundColor: theme.surface,
+                transform: [{ translateX: knobOffset }],
+              },
+            ]}
+            testID="walk-end-slider-knob"
+          >
+            <Text style={[styles.knobIcon, { color: theme.error }]}>⏻</Text>
+          </View>
+        </View>
+        <Slider
+          accessibilityLabel={t('walk.recording.endWalk')}
           disabled={isStopping}
-          loading={isStopping}
+          maximumTrackTintColor={TRANSPARENT_CONTROL_COLOR}
+          maximumValue={SLIDE_MAX}
+          minimumTrackTintColor={TRANSPARENT_CONTROL_COLOR}
+          minimumValue={SLIDE_MIN}
+          hitSlop={{
+            top: 0,
+            right: SLIDE_THUMB_CENTER_OFFSET,
+            bottom: 0,
+            left: SLIDE_THUMB_CENTER_OFFSET,
+          }}
+          onSlidingComplete={handleSlidingComplete}
+          onValueChange={handleSlideChange}
+          step={SLIDE_STEP}
+          style={styles.endSlider}
+          testID="walk-end-rn-slider"
+          thumbSize={components.walkControls.endSlideKnobSize}
+          thumbTintColor={TRANSPARENT_CONTROL_COLOR}
+          value={slideValue}
         />
       </View>
     </View>
@@ -61,32 +158,52 @@ export function WalkControlsActions({
 
 const styles = StyleSheet.create({
   actionRow: {
-    flexDirection: 'row',
-    gap: spacing.xs,
-    alignItems: 'center',
+    width: '100%',
   },
-  pauseButton: {
-    flexDirection: 'row',
+  endSliderWrap: {
+    width: '100%',
+    height: components.walkControls.endSlideHeight,
+    position: 'relative',
+  },
+  endSlider: {
+    position: 'absolute',
+    top: 0,
+    right: SLIDE_THUMB_CENTER_OFFSET,
+    bottom: 0,
+    left: SLIDE_THUMB_CENTER_OFFSET,
+    height: components.walkControls.endSlideHeight,
+  },
+  visualLayer: {
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
+    borderRadius: components.walkControls.endSlideHeight / 2,
+    justifyContent: 'center',
+    overflow: 'hidden',
+  },
+  endLabel: {
+    ...typography.headline,
+    fontWeight: typography.headline.fontWeight,
+    textAlign: 'center',
+  },
+  knob: {
+    position: 'absolute',
+    left: components.walkControls.endSlideKnobInset,
+    width: components.walkControls.endSlideKnobSize,
+    height: components.walkControls.endSlideKnobSize,
+    borderRadius: components.walkControls.endSlideKnobSize / 2,
     alignItems: 'center',
     justifyContent: 'center',
-    paddingVertical: spacing.md,
-    paddingHorizontal: spacing.md,
-    borderRadius: radius.lg,
-    gap: spacing.step6,
-    flex: 1,
+    shadowColor: '#000000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.14,
+    shadowRadius: 7,
+    elevation: 3,
   },
-  pauseEmoji: {
-    ...typography.caption,
-    fontWeight: typography.largeTitle.fontWeight,
-  },
-  pauseLabel: {
-    ...typography.footnote,
-    fontWeight: typography.headline.fontWeight,
-  },
-  buttonDisabled: {
-    opacity: 0.4,
-  },
-  endButtonWrap: {
-    flex: 1.2,
+  knobIcon: {
+    fontSize: components.walkControls.endSlidePowerIconSize,
+    lineHeight: components.walkControls.endSlidePowerIconSize + 4,
   },
 });

--- a/apps/mobile/e2e/maestro/walk-events-photo.yaml
+++ b/apps/mobile/e2e/maestro/walk-events-photo.yaml
@@ -14,11 +14,19 @@ env:
 ---
 - launchApp:
     clearState: false
+- runFlow:
+    when:
+      visible: Goal progress
+    commands:
+      - tapOn:
+          point: 11%,9%
 - tapOn: Walk
+- assertVisible: Walk
 - assertVisible: ${DOG_NAME}
+- tapOn: ${DOG_NAME}
 - tapOn: START WALK
 - extendedWaitUntil:
-    visible: Recording
+    visible: LIVE
     timeout: 15000
 - tapOn: Pee
 - tapOn: Poop
@@ -28,7 +36,11 @@ env:
       visible: OK
     commands:
       - tapOn: OK
-- tapOn: End Walk
+- assertVisible: End Walk
+- swipe:
+    start: 13%,84%
+    end: 91%,84%
+    duration: 2500
 - extendedWaitUntil:
     visible: Walk Complete!
     timeout: 15000

--- a/apps/mobile/e2e/maestro/walk-lifecycle.yaml
+++ b/apps/mobile/e2e/maestro/walk-lifecycle.yaml
@@ -14,19 +14,27 @@ env:
 ---
 - launchApp:
     clearState: false
+- runFlow:
+    when:
+      visible: Goal progress
+    commands:
+      - tapOn:
+          point: 11%,9%
 - tapOn: Walk
 - assertVisible: Walk
 - assertVisible: ${DOG_NAME}
+- tapOn: ${DOG_NAME}
 - tapOn: START WALK
 - extendedWaitUntil:
-    visible: Recording
+    visible: LIVE
     timeout: 15000
 - assertVisible: Time
 - assertVisible: Distance
-- tapOn: Pause
-- assertVisible: Resume
-- tapOn: Resume
-- tapOn: End Walk
+- assertVisible: End Walk
+- swipe:
+    start: 13%,84%
+    end: 91%,84%
+    duration: 2500
 - extendedWaitUntil:
     visible: Walk Complete!
     timeout: 15000

--- a/apps/mobile/package-lock.json
+++ b/apps/mobile/package-lock.json
@@ -12,6 +12,7 @@
         "@expo/ui": "~56.0.13",
         "@expo/vector-icons": "^15.0.3",
         "@react-native-async-storage/async-storage": "2.2.0",
+        "@react-native-community/slider": "5.2.0",
         "@tanstack/react-query": "^5.91.3",
         "effect": "3.21.2",
         "expo": "^56.0.0",
@@ -4632,6 +4633,12 @@
       "peerDependencies": {
         "react-native": "^0.0.0-0 || >=0.65 <1.0"
       }
+    },
+    "node_modules/@react-native-community/slider": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/slider/-/slider-5.2.0.tgz",
+      "integrity": "sha512-484sH8aWEaSjxaZ7HT3YZ8CKDcNes2synko1vdEz5DFEdvKAduxKJTj22L/qBMD7rtIkfbX69DMzWDAGbOAV6w==",
+      "license": "MIT"
     },
     "node_modules/@react-native-masked-view/masked-view": {
       "version": "0.3.2",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -31,6 +31,7 @@
     "@expo/ui": "~56.0.13",
     "@expo/vector-icons": "^15.0.3",
     "@react-native-async-storage/async-storage": "2.2.0",
+    "@react-native-community/slider": "5.2.0",
     "@tanstack/react-query": "^5.91.3",
     "effect": "3.21.2",
     "expo": "^56.0.0",

--- a/apps/mobile/theme/tokens.ts
+++ b/apps/mobile/theme/tokens.ts
@@ -270,6 +270,12 @@ export const components = {
     minimizeButtonSize: 32,
     minimizeIconSize: 18,
     panelPaddingBottom: 24,
+    endSlideHeight: 64,
+    endSlideKnobSize: 56,
+    endSlideKnobInset: 4,
+    endSlidePowerIconSize: 28,
+    endSlideDisabledOpacity: 0.55,
+    endSlideLabelOpacity: 0.82,
   },
   walkMinimized: {
     avatarSize: 38,


### PR DESCRIPTION
## Summary
- Remove the recording Pause control and replace the End Walk button with a slide-to-end control.
- Use `@react-native-community/slider` for the native gesture surface, with a custom large circular knob visual.
- Update walk Maestro flows to slide the End Walk control instead of tapping a button.

## Why
The previous SwiftUI Slider approach could either show the iOS Liquid effect or lose reliable hit testing when hidden. The RN Slider keeps native sliding behavior while letting the UI own the visual treatment.

## Product Impact
- Dog experience: reduces accidental walk termination while the owner is handling a dog.
- Walk data: keeps completed-walk data cleaner by requiring an intentional release at the end of the slide.
- Owner contribution: makes ending a walk feel deliberate and less error-prone.

## Validation
- `npm test -- --runInBand --forceExit` passed: 124 suites / 751 tests.
- `npm run typecheck` passed.
- `npm run lint` passed with one existing generated `.expo/types/router.d.ts` warning and 0 errors.
- `npm run knip` passed.
- `git diff --check --cached` passed.
- Release iOS simulator build succeeded and installed on iPhone 17 Pro.

## Known Gap
- Maestro E2E could not be completed after the Release reinstall because the simulator returned to the login screen and the flows require saved Cognito auth state. Before that, the slider-only check reached the active walk screen but was superseded by the final alignment fix and rebuild.