### PR TITLE
[codex] Unify dog registration UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,10 @@ scripts/harness/score-quality.sh
   enabled. App clients must not include `ALLOW_REFRESH_TOKEN_AUTH`; API must
   reject Cognito refresh responses that omit access or refresh tokens.
 - Keep Mobile UI aligned with Expo/React Native rules in `apps/mobile/CLAUDE.md`.
+- For user-facing UI changes, create or present an HTML mockup, visual companion
+  screen, or equivalent visual artifact before producing the implementation plan.
+  Record the mockup artifact and user feedback outcome in the final plan. If the
+  user explicitly opts out, record that opt-out instead.
 - When a bug, review comment, stale doc, or confusing pattern appears, promote the
   learning into docs, a harness validator, a journey, or a project skill.
 

--- a/apps/api/schema.graphql
+++ b/apps/api/schema.graphql
@@ -4,6 +4,7 @@ input AddDogInput {
 	gender: Gender!
 	avatar: Upload
 	birthday: BirthdayInput
+	walkGoal: WalkAmountInput
 }
 
 input AddEventInput {

--- a/apps/api/src/graphql/mutation/dog.rs
+++ b/apps/api/src/graphql/mutation/dog.rs
@@ -33,6 +33,7 @@ impl DogMutation {
             gender,
             avatar,
             birthday,
+            walk_goal,
         } = input;
         let avatar = match avatar {
             Some(file) => Some(upload_dog_avatar(ctx, file).await?),
@@ -47,7 +48,9 @@ impl DogMutation {
                 gender: gender_to_type(gender),
                 avatar,
                 birthday: birthday.map(Into::into),
+                walk_goal: walk_goal.map(Into::into),
             },
+            chrono::Utc::now().date_naive(),
         )
         .await
         .map_err(AppError::from)?;
@@ -130,6 +133,7 @@ struct AddDogInput {
     gender: Gender,
     avatar: Option<Upload>,
     birthday: Option<BirthdayInput>,
+    walk_goal: Option<WalkAmountInput>,
 }
 
 #[derive(Debug, Clone, InputObject)]

--- a/apps/api/src/service/dog.rs
+++ b/apps/api/src/service/dog.rs
@@ -27,6 +27,7 @@ pub struct AddDogCommand {
     pub gender: GenderType,
     pub avatar: Option<String>,
     pub birthday: Option<birthday::Model>,
+    pub walk_goal: Option<walk_amount::Model>,
 }
 
 #[derive(Clone, Debug)]
@@ -45,10 +46,12 @@ pub async fn add_dog(
     db: &DatabaseConnection,
     user_id: Uuid,
     command: AddDogCommand,
+    today: chrono::NaiveDate,
 ) -> ServiceResult<dog::Model> {
     db.transaction::<_, dog::Model, ServiceError>(|txn| {
         let command = command.clone();
         Box::pin(async move {
+            let walk_goal = command.walk_goal.clone();
             let dog = command.into_active_model().insert(txn).await?;
             user_dog::ActiveModel {
                 user_id: Set(user_id),
@@ -57,6 +60,9 @@ pub async fn add_dog(
             }
             .insert(txn)
             .await?;
+            if let Some(walk_goal) = walk_goal {
+                dog_walk_goal::upsert_goal(txn, dog.id, walk_goal, today).await?;
+            }
 
             Ok(dog)
         })

--- a/apps/api/tests/schema_auth_reset.rs
+++ b/apps/api/tests/schema_auth_reset.rs
@@ -60,3 +60,18 @@ fn schema_exposes_email_change_without_legacy_success_flags() {
     assert!(!sdl.contains("type ChangeEmailOutput {\n\tsuccess: Boolean!"));
     assert!(!sdl.contains("type ConfirmEmailChangeOutput {\n\tsuccess: Boolean!"));
 }
+
+#[test]
+fn schema_allows_initial_walk_goal_when_adding_dog() {
+    let schema =
+        async_graphql::Schema::build(Query::default(), Mutation::default(), EmptySubscription)
+            .finish();
+    let sdl = schema.sdl();
+    let add_dog_input = sdl
+        .split("input AddDogInput {")
+        .nth(1)
+        .and_then(|tail| tail.split("\n}").next())
+        .expect("AddDogInput should be present in the GraphQL schema");
+
+    assert!(add_dog_input.contains("walkGoal: WalkAmountInput"));
+}

--- a/apps/mobile/__tests__/app/dogs/layout.test.tsx
+++ b/apps/mobile/__tests__/app/dogs/layout.test.tsx
@@ -1,0 +1,26 @@
+import { render } from '@testing-library/react-native';
+import DogsLayout from '../../../app/dogs/_layout';
+
+const mockScreen = jest.fn((_props: unknown) => null);
+
+jest.mock('expo-router', () => {
+  const { View } = jest.requireActual('react-native');
+  const Stack = ({ children }: { children: React.ReactNode }) => <View>{children}</View>;
+  Stack.Screen = (props: unknown) => mockScreen(props);
+  return { Stack };
+});
+
+describe('DogsLayout', () => {
+  beforeEach(() => {
+    mockScreen.mockClear();
+  });
+
+  it('presents the new dog screen quickly from the bottom', () => {
+    render(<DogsLayout />);
+
+    expect(mockScreen).toHaveBeenCalledWith({
+      name: 'new',
+      options: { headerShown: false, animation: 'slide_from_bottom', animationDuration: 220 },
+    });
+  });
+});

--- a/apps/mobile/__tests__/app/dogs/new.test.tsx
+++ b/apps/mobile/__tests__/app/dogs/new.test.tsx
@@ -1,4 +1,6 @@
-import { fireEvent, render, screen } from '@testing-library/react-native';
+import { ActionSheetIOS } from 'react-native';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import * as ImagePicker from 'expo-image-picker';
 import NewDogScreen from '../../../app/dogs/new';
 
 const mockBack = jest.fn();
@@ -8,6 +10,51 @@ const mockCreateDog = jest.fn();
 
 jest.mock('@/hooks/use-color-scheme', () => ({
   useColorScheme: () => 'light',
+}));
+
+jest.mock('expo-image', () => ({
+  Image: 'Image',
+}));
+
+jest.mock('expo-blur', () => {
+  const { View } = jest.requireActual('react-native');
+  return {
+    BlurView: ({ children, ...props }: { children: React.ReactNode }) => (
+      <View {...props}>{children}</View>
+    ),
+  };
+});
+
+jest.mock('expo-image-picker', () => ({
+  PermissionStatus: { GRANTED: 'granted' },
+  requestMediaLibraryPermissionsAsync: jest.fn(),
+  launchImageLibraryAsync: jest.fn(),
+}));
+
+jest.mock('@/components/ui/icon-symbol', () => {
+  const { Text } = jest.requireActual<typeof import('react-native')>('react-native');
+
+  return {
+    IconSymbol: ({ name }: { name: string }) => <Text>{name}</Text>,
+  };
+});
+
+jest.mock('@expo/ui/swift-ui', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+  const { View } = jest.requireActual('react-native');
+  return {
+    Host: ({ children, ...props }: { children: React.ReactNode }) => (
+      <View {...props}>{children}</View>
+    ),
+    Slider: ({ onValueChange, ...props }: { onValueChange?: (value: number) => void }) => (
+      <View {...props} accessibilityRole="adjustable" onValueChange={onValueChange} />
+    ),
+  };
+});
+
+jest.mock('@expo/ui/swift-ui/modifiers', () => ({
+  clipped: (clipped = true) => ({ $type: 'clipped', clipped }),
+  frame: (params: Record<string, unknown>) => ({ $type: 'frame', ...params }),
 }));
 
 jest.mock('expo-router', () => ({
@@ -22,20 +69,53 @@ jest.mock('@/hooks/use-dog-mutations', () => ({
   useCreateDog: () => ({ mutateAsync: mockCreateDog }),
 }));
 
+const mockRequestMediaLibraryPermissionsAsync =
+  ImagePicker.requestMediaLibraryPermissionsAsync as jest.MockedFunction<
+    typeof ImagePicker.requestMediaLibraryPermissionsAsync
+  >;
+const mockLaunchImageLibraryAsync =
+  ImagePicker.launchImageLibraryAsync as jest.MockedFunction<
+    typeof ImagePicker.launchImageLibraryAsync
+  >;
+
 describe('NewDogScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.spyOn(ActionSheetIOS, 'showActionSheetWithOptions').mockImplementation(
+      (_config, cb) => cb(1),
+    );
+    mockCreateDog.mockResolvedValue({ id: 'dog-1' });
+    mockRequestMediaLibraryPermissionsAsync.mockResolvedValue({
+      granted: true,
+      status: ImagePicker.PermissionStatus.GRANTED,
+      canAskAgain: true,
+      expires: 'never',
+    });
+    mockLaunchImageLibraryAsync.mockResolvedValue({
+      canceled: true,
+      assets: null,
+    });
   });
 
-  it('renders the inline ScreenHeader title and common actions', () => {
+  it('renders the edit-style chrome, photo editor, form, and goal without a remove action', () => {
     render(<NewDogScreen />);
 
-    expect(screen.getByRole('header', { name: 'Register dog' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Cancel' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Save' })).toBeTruthy();
+    expect(screen.queryByRole('header', { name: 'Register dog' })).toBeNull();
+    expect(screen.queryByText('Cancel')).toBeNull();
+    expect(screen.queryByText('Save')).toBeNull();
+    expect(screen.getByText('xmark')).toBeTruthy();
+    expect(screen.getByText('checkmark')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Change photo' })).toBeTruthy();
+    expect(screen.getByText('🐩')).toBeTruthy();
+    expect(screen.getByText('GOAL')).toBeTruthy();
+    expect(screen.getByText('Cycle')).toBeTruthy();
+    expect(screen.getByText('Time')).toBeTruthy();
+    expect(screen.queryByText(/Remove /)).toBeNull();
   });
 
-  it('uses the ScreenHeader cancel action to go back', () => {
+  it('uses the chrome cancel action to go back', () => {
     render(<NewDogScreen />);
 
     fireEvent.press(screen.getByRole('button', { name: 'Cancel' }));
@@ -49,5 +129,49 @@ describe('NewDogScreen', () => {
     const save = screen.getByRole('button', { name: 'Save' });
 
     expect(save.props.accessibilityState?.disabled).toBe(true);
+  });
+
+  it('saves profile, avatar, and goal values from the unified registration screen', async () => {
+    mockLaunchImageLibraryAsync.mockResolvedValue({
+      canceled: false,
+      assets: [
+        {
+          uri: 'file:///buddy.png',
+          width: 100,
+          height: 100,
+          fileName: 'buddy.png',
+          mimeType: 'image/png',
+        },
+      ],
+    });
+    render(<NewDogScreen />);
+
+    fireEvent.press(screen.getByRole('button', { name: 'Change photo' }));
+    await waitFor(() => {
+      expect(mockLaunchImageLibraryAsync).toHaveBeenCalled();
+    });
+    fireEvent.changeText(screen.getByLabelText('Name'), 'Buddy');
+    fireEvent.changeText(screen.getByLabelText('Breed'), 'Golden Retriever');
+    fireEvent.press(screen.getByRole('button', { name: 'Gender' }));
+    fireEvent.press(screen.getByRole('button', { name: 'WEEKLY' }));
+    fireEvent(screen.getByTestId('dog-goal-slider'), 'valueChange', 60);
+    fireEvent.press(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(mockCreateDog).toHaveBeenCalledWith({
+        name: 'Buddy',
+        breed: 'Golden Retriever',
+        gender: 'FEMALE',
+        birthday: null,
+        walkGoal: { minutes: 60, cycleDays: 7 },
+        avatarFile: {
+          uri: 'file:///buddy.png',
+          name: 'buddy.png',
+          type: 'image/png',
+        },
+      });
+    });
+    expect(mockDismiss).toHaveBeenCalledTimes(1);
+    expect(mockPush).toHaveBeenCalledWith('/dogs/dog-1');
   });
 });

--- a/apps/mobile/__tests__/app/root-layout.test.tsx
+++ b/apps/mobile/__tests__/app/root-layout.test.tsx
@@ -78,4 +78,23 @@ describe('RootLayout', () => {
       options: { headerShown: false, animation: 'none' },
     });
   });
+
+  it('presents /dogs/new quickly from the bottom at the root stack boundary', () => {
+    render(<RootLayout />);
+
+    const dogsScreen = mockScreen.mock.calls
+      .map(([props]) => props as { name: string; options: unknown })
+      .find((props) => props.name === 'dogs');
+
+    expect(typeof dogsScreen?.options).toBe('function');
+    const options = dogsScreen?.options as (args: { route: unknown }) => unknown;
+    expect(options({ route: { params: { screen: 'new' } } })).toEqual({
+      headerShown: false,
+      animation: 'slide_from_bottom',
+      animationDuration: 220,
+    });
+    expect(options({ route: { params: { screen: '[id]' } } })).toEqual({
+      headerShown: false,
+    });
+  });
 });

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,4 +1,5 @@
 import { DarkTheme, DefaultTheme, Stack, ThemeProvider, useRouter, useSegments } from 'expo-router';
+import { getFocusedRouteNameFromRoute } from 'expo-router/build/react-navigation/core';
 import { StatusBar } from 'expo-status-bar';
 import { useEffect } from 'react';
 import 'react-native-reanimated';
@@ -12,6 +13,23 @@ import { useAuthStore } from '@/stores/auth-store';
 import { useSettingsStore } from '@/stores/settings-store';
 import { LoadingScreen } from '@/components/ui/LoadingScreen';
 import { ErrorScreen } from '@/components/ui/ErrorScreen';
+
+const ROOT_SCREEN_OPTIONS = { headerShown: false } as const;
+const DOG_NEW_ROOT_SCREEN_OPTIONS = {
+  ...ROOT_SCREEN_OPTIONS,
+  animation: 'slide_from_bottom',
+  animationDuration: 220,
+} as const;
+
+function dogsRootScreenOptions({
+  route,
+}: {
+  route: Parameters<typeof getFocusedRouteNameFromRoute>[0];
+}) {
+  return getFocusedRouteNameFromRoute(route) === 'new'
+    ? DOG_NEW_ROOT_SCREEN_OPTIONS
+    : ROOT_SCREEN_OPTIONS;
+}
 
 // 認証状態と現在の route group を見て、ログイン画面とアプリ本体の行き先を制御します。
 function NavigationGuard() {
@@ -68,7 +86,7 @@ function RootLayout() {
         <Stack>
           <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
           <Stack.Screen name="(auth)" options={{ headerShown: false }} />
-          <Stack.Screen name="dogs" options={{ headerShown: false }} />
+          <Stack.Screen name="dogs" options={dogsRootScreenOptions} />
           <Stack.Screen name="settings" options={{ headerShown: false }} />
           <Stack.Screen name="user" options={{ headerShown: false, animation: 'none' }} />
           <Stack.Screen name="walks" options={{ headerShown: false }} />

--- a/apps/mobile/app/dogs/_layout.tsx
+++ b/apps/mobile/app/dogs/_layout.tsx
@@ -6,7 +6,10 @@ import { Stack } from 'expo-router';
 export default function DogsLayout() {
   return (
     <Stack>
-      <Stack.Screen name="new" options={{ headerShown: false }} />
+      <Stack.Screen
+        name="new"
+        options={{ headerShown: false, animation: 'slide_from_bottom', animationDuration: 220 }}
+      />
       <Stack.Screen name="[id]" options={{ headerShown: false }} />
     </Stack>
   );

--- a/apps/mobile/app/dogs/new.tsx
+++ b/apps/mobile/app/dogs/new.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { ScrollView, StyleSheet } from 'react-native';
+import { ScrollView, StyleSheet, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
@@ -7,15 +7,18 @@ import { useCreateDog } from '@/hooks/use-dog-mutations';
 import {
   DogForm,
   birthdayValuesToInput,
+  clampGoalMinutes,
   isDogFormValid,
   type DogFormValues,
 } from '@/components/dogs/DogForm';
-import { ScreenHeader } from '@/components/ui/ScreenHeader';
+import { DogAvatarEditor } from '@/components/dogs/DogAvatarEditor';
+import { DogContactChromeButton } from '@/components/dogs/DogContactChromeButton';
 import { DAILY_GOAL_CYCLE_DAYS, DEFAULT_DAILY_GOAL_MINUTES } from '@/constants/walk';
 import { useColors } from '@/hooks/use-colors';
-import { spacing } from '@/theme/tokens';
+import { dogContactChrome, spacing } from '@/theme/tokens';
+import type { UploadFile } from '@/lib/graphql/client';
 
-// 新規犬登録画面 — inline ScreenHeader でフォームの Cancel/Save を提供します。
+// 新規犬登録画面 — 編集画面と同じ Contacts 風 chrome で Cancel/Save を提供します。
 export default function NewDogScreen() {
   const { t } = useTranslation();
   const router = useRouter();
@@ -32,6 +35,7 @@ export default function NewDogScreen() {
     goalMinutes: DEFAULT_DAILY_GOAL_MINUTES,
     goalCycleDays: DAILY_GOAL_CYCLE_DAYS,
   });
+  const [avatarFile, setAvatarFile] = useState<UploadFile | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
   const canSave = isDogFormValid(values) && !submitting;
@@ -45,6 +49,11 @@ export default function NewDogScreen() {
         breed: values.breed.trim() || undefined,
         gender: values.gender.trim() || undefined,
         birthday: birthdayValuesToInput(values),
+        walkGoal: {
+          minutes: clampGoalMinutes(values.goalMinutes, values.goalCycleDays),
+          cycleDays: values.goalCycleDays,
+        },
+        ...(avatarFile ? { avatarFile } : {}),
       });
 
       router.dismiss();
@@ -56,22 +65,35 @@ export default function NewDogScreen() {
 
   return (
     <SafeAreaView edges={['top']} style={[styles.safeArea, { backgroundColor: theme.background }]}>
-      <ScreenHeader
-        variant="inline"
-        title={t('dogs.new.title')}
-        leftAction={{ label: t('common.action.cancel'), onPress: () => router.back() }}
-        rightAction={{
-          label: t('common.action.save'),
-          onPress: handleSave,
-          strong: true,
-          disabled: !canSave,
-        }}
-      />
+      <View testID="dog-new-header" style={styles.header}>
+        <DogContactChromeButton
+          shape="circle"
+          label={t('common.action.cancel')}
+          accessibilityLabel={t('common.action.cancel')}
+          iconName="xmark"
+          onPress={() => router.back()}
+          testID="dog-new-cancel-button"
+        />
+        <DogContactChromeButton
+          shape="circle"
+          label={t('common.action.save')}
+          accessibilityLabel={t('common.action.save')}
+          iconName="checkmark"
+          onPress={handleSave}
+          disabled={!canSave}
+          testID="dog-new-save-button"
+        />
+      </View>
       <ScrollView
         contentContainerStyle={styles.scrollContent}
         keyboardShouldPersistTaps="handled"
       >
-        <DogForm values={values} onChange={setValues} showDailyGoal={false} />
+        <DogAvatarEditor
+          value={null}
+          onChange={setAvatarFile}
+          dogName={values.name.trim() || undefined}
+        />
+        <DogForm values={values} onChange={setValues} />
       </ScrollView>
     </SafeAreaView>
   );
@@ -79,5 +101,12 @@ export default function NewDogScreen() {
 
 const styles = StyleSheet.create({
   safeArea: { flex: 1 },
+  header: {
+    height: dogContactChrome.circleSize,
+    paddingHorizontal: spacing.md,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
   scrollContent: { flexGrow: 1, padding: spacing.lg },
 });

--- a/apps/mobile/hooks/use-dog-mutations.test.ts
+++ b/apps/mobile/hooks/use-dog-mutations.test.ts
@@ -2,7 +2,7 @@ import { act, renderHook, waitFor } from '@testing-library/react-native';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { createElement, type ReactNode } from 'react';
 import type * as ClientModule from '@/lib/graphql/client';
-import { useUpdateDog } from './use-dog-mutations';
+import { useCreateDog, useUpdateDog } from './use-dog-mutations';
 
 jest.mock('@/lib/graphql/client', () => ({
   authenticatedRequest: jest.fn(),
@@ -135,6 +135,84 @@ describe('useUpdateDog', () => {
           gender: 'FEMALE',
           birthday: null,
           walkGoal: { minutes: 420, cycleDays: 7 },
+          avatar: null,
+        },
+      },
+      { 'variables.input.avatar': avatarFile },
+    );
+    expect(mockAuthenticatedRequest).not.toHaveBeenCalled();
+    unmount();
+  });
+});
+
+describe('useCreateDog', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAuthenticatedRequest.mockResolvedValue({ addDog: apiDog });
+    mockAuthenticatedMultipartRequest.mockResolvedValue({ addDog: apiDog });
+    mockInvalidateUserQueries.mockResolvedValue(undefined);
+  });
+
+  it('uses the JSON GraphQL request path with the initial walk goal when avatarFile is omitted', async () => {
+    const { result, unmount } = renderHook(() => useCreateDog(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        name: 'Buddy',
+        breed: 'Golden Retriever',
+        gender: 'female',
+        birthday: null,
+        walkGoal: { minutes: 60, cycleDays: 7 },
+      });
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockAuthenticatedRequest).toHaveBeenCalledWith(expect.any(String), {
+      input: {
+        name: 'Buddy',
+        breed: 'Golden Retriever',
+        gender: 'FEMALE',
+        birthday: null,
+        walkGoal: { minutes: 60, cycleDays: 7 },
+      },
+    });
+    expect(mockAuthenticatedMultipartRequest).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it('uses the multipart GraphQL request path when avatarFile is provided', async () => {
+    const avatarFile = {
+      uri: 'file:///avatar.png',
+      name: 'avatar.png',
+      type: 'image/png',
+    };
+    const { result, unmount } = renderHook(() => useCreateDog(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        name: 'Buddy',
+        breed: 'Golden Retriever',
+        gender: 'male',
+        birthday: null,
+        walkGoal: { minutes: 30, cycleDays: 1 },
+        avatarFile,
+      });
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockAuthenticatedMultipartRequest).toHaveBeenCalledWith(
+      expect.any(String),
+      {
+        input: {
+          name: 'Buddy',
+          breed: 'Golden Retriever',
+          gender: 'MALE',
+          birthday: null,
+          walkGoal: { minutes: 30, cycleDays: 1 },
           avatar: null,
         },
       },

--- a/apps/mobile/hooks/use-dog-mutations.ts
+++ b/apps/mobile/hooks/use-dog-mutations.ts
@@ -32,10 +32,37 @@ type UpdateDogMutationInput = UpdateDogInput & {
   avatarFile?: UploadFile;
 };
 
+type CreateDogMutationInput = CreateDogInput & {
+  avatarFile?: UploadFile;
+};
+
 type UpdateDogMutationVariables = {
   id: string;
   input: UpdateDogMutationInput;
 };
+
+function toCreateDogRequestInput(input: CreateDogMutationInput): {
+  name: string;
+  breed: string | undefined;
+  gender: 'MALE' | 'FEMALE' | 'OTHER';
+  birthday: CreateDogInput['birthday'];
+  walkGoal?: CreateDogInput['walkGoal'];
+} {
+  const requestInput: {
+    name: string;
+    breed: string | undefined;
+    gender: 'MALE' | 'FEMALE' | 'OTHER';
+    birthday: CreateDogInput['birthday'];
+    walkGoal?: CreateDogInput['walkGoal'];
+  } = {
+    name: input.name,
+    breed: input.breed,
+    gender: toApiGender(input.gender),
+    birthday: input.birthday,
+  };
+  if (input.walkGoal !== undefined) requestInput.walkGoal = input.walkGoal;
+  return requestInput;
+}
 
 function toUpdateDogRequestInput(
   id: string,
@@ -74,16 +101,23 @@ function toUpdateDogRequestInput(
 // 犬の作成後、ユーザー関連キャッシュを更新して一覧へ反映します。
 export function useCreateDog() {
   const invalidateUserQueries = useInvalidateUserQueries();
-  return useMutation<Dog, Error, CreateDogInput>({
+  return useMutation<Dog, Error, CreateDogMutationInput>({
     mutationFn: async (input) => {
-      const data = await authenticatedRequest<CreateDogResponse>(ADD_DOG_MUTATION, {
-        input: {
-          name: input.name,
-          breed: input.breed,
-          gender: toApiGender(input.gender),
-          birthday: input.birthday,
-        },
-      });
+      const requestInput = toCreateDogRequestInput(input);
+      const data = input.avatarFile
+        ? await authenticatedMultipartRequest<CreateDogResponse>(
+            ADD_DOG_MUTATION,
+            {
+              input: {
+                ...requestInput,
+                avatar: null,
+              },
+            },
+            { 'variables.input.avatar': input.avatarFile },
+          )
+        : await authenticatedRequest<CreateDogResponse>(ADD_DOG_MUTATION, {
+            input: requestInput,
+          });
       return mapApiDog(data.addDog);
     },
     onSuccess: invalidateUserQueries,

--- a/apps/mobile/types/graphql.ts
+++ b/apps/mobile/types/graphql.ts
@@ -176,6 +176,7 @@ export interface CreateDogInput {
   breed?: string;
   gender?: string;
   birthday?: BirthdayInput | null;
+  walkGoal?: WalkAmount;
 }
 
 export interface UpdateDogInput {

--- a/docs/superpowers/mockups/2026-07-05-dog-register-edit-unified.html
+++ b/docs/superpowers/mockups/2026-07-05-dog-register-edit-unified.html
@@ -1,0 +1,621 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Dog Register/Edit Unified UI Mockup</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --page: #0b0b0d;
+      --panel: #151519;
+      --phone-border: #3e3f45;
+      --screen: #f3f3f8;
+      --surface: #ffffff;
+      --line: #e6e6eb;
+      --text: #101014;
+      --muted: #8f8f98;
+      --placeholder: #a0a0a8;
+      --blue: #1687ff;
+      --red: #ff4e4e;
+      --disabled: #b9b9c2;
+      --shadow: 0 18px 56px rgba(0, 0, 0, 0.35);
+      font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Helvetica Neue", Arial, sans-serif;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background:
+        radial-gradient(circle at 50% -10%, rgba(82, 83, 92, 0.48), transparent 42%),
+        var(--page);
+      color: #f8f8fb;
+      display: grid;
+      place-items: center;
+      padding: 28px;
+    }
+
+    .mockup-shell {
+      width: min(1180px, 100%);
+      display: grid;
+      gap: 22px;
+    }
+
+    .summary {
+      display: grid;
+      gap: 6px;
+      text-align: center;
+    }
+
+    .summary h1 {
+      margin: 0;
+      font-size: 22px;
+      line-height: 1.2;
+      font-weight: 800;
+    }
+
+    .summary p {
+      margin: 0;
+      color: #b9b9c1;
+      font-size: 14px;
+    }
+
+    .comparison {
+      display: flex;
+      justify-content: center;
+      align-items: flex-start;
+      gap: 42px;
+      flex-wrap: wrap;
+    }
+
+    .panel {
+      width: 430px;
+      display: grid;
+      justify-items: center;
+      gap: 12px;
+    }
+
+    .panel-title {
+      display: grid;
+      gap: 3px;
+      text-align: center;
+    }
+
+    .panel-title strong {
+      font-size: 18px;
+    }
+
+    .panel-title span {
+      color: #b9b9c1;
+      font-size: 13px;
+    }
+
+    .phone {
+      width: 393px;
+      height: 852px;
+      border-radius: 62px;
+      padding: 12px;
+      background: #050506;
+      box-shadow: var(--shadow), inset 0 0 0 2px var(--phone-border);
+    }
+
+    .screen {
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
+      position: relative;
+      border-radius: 50px;
+      background: var(--screen);
+      color: var(--text);
+      padding: 58px 24px 26px;
+    }
+
+    .status {
+      position: absolute;
+      top: 22px;
+      left: 0;
+      right: 0;
+      display: flex;
+      justify-content: space-between;
+      padding: 0 36px;
+      font-size: 17px;
+      font-weight: 800;
+      letter-spacing: 0;
+      pointer-events: none;
+    }
+
+    .island {
+      position: absolute;
+      top: 24px;
+      left: 50%;
+      width: 118px;
+      height: 35px;
+      margin-left: -59px;
+      background: #000;
+      border-radius: 22px;
+      pointer-events: none;
+    }
+
+    .header {
+      height: 58px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .chrome-button {
+      width: 52px;
+      height: 52px;
+      border-radius: 50%;
+      border: 1px solid #e2e2e7;
+      background: rgba(255, 255, 255, 0.74);
+      color: #050506;
+      display: grid;
+      place-items: center;
+      box-shadow: 0 1px 1px rgba(0, 0, 0, 0.03);
+      cursor: default;
+    }
+
+    .chrome-button svg {
+      width: 31px;
+      height: 31px;
+      stroke: currentColor;
+      stroke-width: 4.4;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      fill: none;
+    }
+
+    .chrome-button[disabled] {
+      opacity: 0.42;
+    }
+
+    .avatar-area {
+      margin: 36px 0 44px;
+      text-align: center;
+    }
+
+    .avatar {
+      width: 100px;
+      height: 100px;
+      border-radius: 50%;
+      margin: 0 auto 12px;
+      overflow: hidden;
+      display: grid;
+      place-items: center;
+      background: linear-gradient(145deg, #fafafa, #dde0e8);
+    }
+
+    .avatar.new-dog svg {
+      width: 62px;
+      height: 62px;
+      fill: #a0a5b2;
+    }
+
+    .avatar.photo {
+      background:
+        radial-gradient(circle at 55% 34%, rgba(235, 226, 255, 0.96) 0 20%, transparent 21%),
+        radial-gradient(circle at 54% 58%, rgba(239, 241, 255, 0.86) 0 10%, transparent 11%),
+        linear-gradient(132deg, #c7bced 0 33%, #6e9654 34% 48%, #e9eefc 49% 54%, #9dadb9 55% 60%, #3d6a40 61% 100%);
+    }
+
+    .link-button {
+      border: 0;
+      padding: 0;
+      background: transparent;
+      color: var(--blue);
+      font-size: 20px;
+      line-height: 24px;
+      cursor: default;
+    }
+
+    .grouped-card {
+      background: var(--surface);
+      border-radius: 24px;
+      overflow: hidden;
+      box-shadow: 0 12px 28px rgba(0, 0, 0, 0.025);
+    }
+
+    .row {
+      min-height: 58px;
+      display: grid;
+      grid-template-columns: 132px 1fr;
+      align-items: center;
+      padding: 0 18px 0 16px;
+      font-size: 20px;
+    }
+
+    .row.tall {
+      min-height: 78px;
+    }
+
+    .row + .row {
+      border-top: 1px solid var(--line);
+    }
+
+    .label {
+      color: var(--muted);
+    }
+
+    .value {
+      min-width: 0;
+      color: var(--text);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .placeholder {
+      color: var(--placeholder);
+    }
+
+    input.mock-input,
+    select.mock-select {
+      width: 100%;
+      border: 0;
+      outline: 0;
+      background: transparent;
+      color: var(--text);
+      font: inherit;
+      padding: 0;
+      appearance: none;
+    }
+
+    input.mock-input::placeholder {
+      color: var(--placeholder);
+      opacity: 1;
+    }
+
+    select.mock-select:invalid {
+      color: var(--placeholder);
+    }
+
+    .goal-section {
+      margin-top: 28px;
+    }
+
+    .section-title {
+      margin: 0 0 12px 8px;
+      color: #8d8d96;
+      font-size: 14px;
+      font-weight: 800;
+      letter-spacing: 0.08em;
+    }
+
+    .goal-card {
+      padding: 14px 16px 18px;
+    }
+
+    .goal-top {
+      display: grid;
+      grid-template-columns: 84px 1fr;
+      align-items: center;
+      margin-bottom: 14px;
+    }
+
+    .goal-label {
+      font-size: 20px;
+    }
+
+    .segment {
+      height: 32px;
+      border-radius: 10px;
+      background: #eeeef1;
+      padding: 2px;
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 2px;
+    }
+
+    .segment button {
+      border: 0;
+      border-radius: 8px;
+      background: transparent;
+      color: #96969d;
+      font-size: 15px;
+      font-weight: 800;
+      cursor: default;
+    }
+
+    .segment button.active {
+      background: #fff;
+      color: #111;
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+    }
+
+    .goal-mid {
+      border-top: 1px solid var(--line);
+      padding-top: 18px;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      font-size: 20px;
+    }
+
+    .goal-minutes {
+      font-size: 24px;
+      font-weight: 800;
+      font-variant-numeric: tabular-nums;
+    }
+
+    .range-wrap {
+      position: relative;
+      height: 34px;
+      margin: 18px 0 0;
+    }
+
+    .range-track {
+      position: absolute;
+      left: 0;
+      right: 0;
+      top: 15px;
+      height: 5px;
+      border-radius: 8px;
+      background: #dedee3;
+    }
+
+    .range-fill {
+      position: absolute;
+      left: 0;
+      top: 15px;
+      height: 5px;
+      width: 12%;
+      border-radius: 8px;
+      background: var(--blue);
+    }
+
+    .range-thumb {
+      position: absolute;
+      left: 9%;
+      top: 3px;
+      width: 58px;
+      height: 34px;
+      border-radius: 18px;
+      background: #fff;
+      box-shadow: 0 5px 14px rgba(0, 0, 0, 0.16);
+    }
+
+    .limits {
+      display: flex;
+      justify-content: space-between;
+      color: #c4c4ca;
+      font-size: 16px;
+    }
+
+    .remove-button {
+      width: 100%;
+      height: 58px;
+      margin-top: 28px;
+      border: 0;
+      border-radius: 24px;
+      background: #fff;
+      color: var(--red);
+      font-size: 20px;
+      font-weight: 800;
+      cursor: default;
+    }
+
+    .decision-notes {
+      display: grid;
+      gap: 8px;
+      max-width: 860px;
+      justify-self: center;
+      color: #d7d7dc;
+      font-size: 14px;
+      line-height: 1.55;
+      background: rgba(255, 255, 255, 0.06);
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      border-radius: 14px;
+      padding: 14px 16px;
+    }
+
+    .decision-notes p {
+      margin: 0;
+    }
+
+    @media (max-width: 940px) {
+      body {
+        align-items: start;
+        padding: 18px;
+      }
+
+      .panel {
+        width: min(430px, 100%);
+      }
+
+      .phone {
+        transform: scale(0.9);
+        transform-origin: center top;
+        margin-bottom: -74px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main class="mockup-shell">
+    <section class="summary" aria-label="Mockup summary">
+      <h1>Dog Registration UI Unified With Edit Screen</h1>
+      <p>Static HTML mockup for deciding the React Native implementation direction.</p>
+    </section>
+
+    <section class="comparison" aria-label="Screen comparison">
+      <article class="panel">
+        <div class="panel-title">
+          <strong>New dog after unification</strong>
+          <span>Edit-style chrome, photo, grouped form, and goal. No remove action.</span>
+        </div>
+        <div class="phone" aria-label="New dog mock phone">
+          <div class="screen">
+            <div class="status"><span>15:02</span><span>LTE</span></div>
+            <div class="island"></div>
+            <header class="header">
+              <button class="chrome-button" aria-label="Cancel">
+                <svg viewBox="0 0 32 32" aria-hidden="true"><path d="M7 7l18 18M25 7L7 25" /></svg>
+              </button>
+              <button class="chrome-button" aria-label="Save" id="new-save" disabled>
+                <svg viewBox="0 0 32 32" aria-hidden="true"><path d="M7 17l7 7L26 8" /></svg>
+              </button>
+            </header>
+
+            <section class="avatar-area" aria-label="Photo editor">
+              <div class="avatar new-dog" aria-label="Dog photo placeholder">
+                <svg viewBox="0 0 80 80" aria-hidden="true">
+                  <path d="M25 34c-5 0-9-4-9-9 0-4 2-8 6-10 3-1 6 1 7 4 2-1 5-2 8-2h6c3 0 6 1 8 2 1-3 4-5 7-4 4 2 6 6 6 10 0 5-4 9-9 9h-1c1 3 2 6 2 10 0 13-8 23-22 23S18 57 18 44c0-4 1-7 2-10h5Zm9 9c0 2 2 4 4 4s4-2 4-4-2-4-4-4-4 2-4 4Zm-8-8c2 0 4-2 4-4s-2-4-4-4-4 2-4 4 2 4 4 4Zm28 0c2 0 4-2 4-4s-2-4-4-4-4 2-4 4 2 4 4 4Zm-22 21c2 2 5 3 8 3s6-1 8-3c1-1 1-3 0-4s-3-1-4 0c-1 1-2 1-4 1s-3 0-4-1c-1-1-3-1-4 0s-1 3 0 4Z" />
+                </svg>
+              </div>
+              <button class="link-button">Change photo</button>
+            </section>
+
+            <section class="grouped-card" aria-label="Dog profile form">
+              <label class="row">
+                <span class="label">Name</span>
+                <input id="new-name" class="mock-input" placeholder="e.g. Buddy" />
+              </label>
+              <label class="row">
+                <span class="label">Breed</span>
+                <input class="mock-input" placeholder="e.g. Golden Retriever" />
+              </label>
+              <label class="row tall">
+                <span class="label">Gender</span>
+                <select id="new-gender" class="mock-select" required>
+                  <option value="" selected>Select gender</option>
+                  <option>Male</option>
+                  <option>Female</option>
+                  <option>Other</option>
+                </select>
+              </label>
+              <div class="row">
+                <span class="label">Birthday</span>
+                <span class="value placeholder">Add birthday</span>
+              </div>
+            </section>
+
+            <section class="goal-section" aria-label="Goal form">
+              <h2 class="section-title">GOAL</h2>
+              <div class="grouped-card goal-card">
+                <div class="goal-top">
+                  <div class="goal-label">Cycle</div>
+                  <div class="segment" aria-label="Goal cycle">
+                    <button type="button" data-cycle="daily">DAILY</button>
+                    <button type="button" class="active" data-cycle="weekly">WEEKLY</button>
+                  </div>
+                </div>
+                <div class="goal-mid">
+                  <div>Time</div>
+                  <div class="goal-minutes" data-minutes>60 min</div>
+                </div>
+                <div class="range-wrap" aria-hidden="true">
+                  <div class="range-track"></div>
+                  <div class="range-fill" data-fill></div>
+                  <div class="range-thumb" data-thumb></div>
+                </div>
+                <div class="limits">
+                  <span data-min>0 min</span>
+                  <span data-max>840 min</span>
+                </div>
+              </div>
+            </section>
+          </div>
+        </div>
+      </article>
+
+      <article class="panel">
+        <div class="panel-title">
+          <strong>Existing edit reference</strong>
+          <span>Reference surface. Remove remains edit-only.</span>
+        </div>
+        <div class="phone" aria-label="Edit dog mock phone">
+          <div class="screen">
+            <div class="status"><span>15:02</span><span>LTE</span></div>
+            <div class="island"></div>
+            <header class="header">
+              <button class="chrome-button" aria-label="Cancel">
+                <svg viewBox="0 0 32 32" aria-hidden="true"><path d="M7 7l18 18M25 7L7 25" /></svg>
+              </button>
+              <button class="chrome-button" aria-label="Save">
+                <svg viewBox="0 0 32 32" aria-hidden="true"><path d="M7 17l7 7L26 8" /></svg>
+              </button>
+            </header>
+
+            <section class="avatar-area" aria-label="Photo editor">
+              <div class="avatar photo" aria-label="Mint photo"></div>
+              <button class="link-button">Change photo</button>
+            </section>
+
+            <section class="grouped-card" aria-label="Dog profile form">
+              <div class="row"><span class="label">Name</span><span class="value">Mint</span></div>
+              <div class="row"><span class="label">Breed</span><span class="value placeholder">e.g. Golden Retriever</span></div>
+              <div class="row tall"><span class="label">Gender</span><span class="value">Female</span></div>
+              <div class="row"><span class="label">Birthday</span><span class="value">Oct 2015</span></div>
+            </section>
+
+            <section class="goal-section" aria-label="Goal form">
+              <h2 class="section-title">GOAL</h2>
+              <div class="grouped-card goal-card">
+                <div class="goal-top">
+                  <div class="goal-label">Cycle</div>
+                  <div class="segment" aria-label="Goal cycle">
+                    <button type="button">DAILY</button>
+                    <button type="button" class="active">WEEKLY</button>
+                  </div>
+                </div>
+                <div class="goal-mid">
+                  <div>Time</div>
+                  <div class="goal-minutes">60 min</div>
+                </div>
+                <div class="range-wrap" aria-hidden="true">
+                  <div class="range-track"></div>
+                  <div class="range-fill"></div>
+                  <div class="range-thumb"></div>
+                </div>
+                <div class="limits"><span>0 min</span><span>840 min</span></div>
+              </div>
+            </section>
+
+            <button class="remove-button">Remove Mint</button>
+          </div>
+        </div>
+      </article>
+    </section>
+
+    <section class="decision-notes" aria-label="Decision notes">
+      <p><strong>Decision focus:</strong> the new registration screen keeps the edit screen's visual hierarchy and control placement, while omitting the destructive remove action.</p>
+      <p><strong>Implementation implication:</strong> if this direction is accepted, new registration should also save photo and goal values so the visible controls do not become decorative.</p>
+    </section>
+  </main>
+
+  <script>
+    const nameInput = document.querySelector("#new-name");
+    const genderSelect = document.querySelector("#new-gender");
+    const saveButton = document.querySelector("#new-save");
+    const cycleButtons = document.querySelectorAll("[data-cycle]");
+    const minutes = document.querySelector("[data-minutes]");
+    const fill = document.querySelector("[data-fill]");
+    const thumb = document.querySelector("[data-thumb]");
+    const minLabel = document.querySelector("[data-min]");
+    const maxLabel = document.querySelector("[data-max]");
+
+    function updateSave() {
+      saveButton.disabled = !(nameInput.value.trim() && genderSelect.value);
+    }
+
+    function setGoal(cycle) {
+      const isWeekly = cycle === "weekly";
+      cycleButtons.forEach((button) => button.classList.toggle("active", button.dataset.cycle === cycle));
+      minutes.textContent = isWeekly ? "60 min" : "30 min";
+      minLabel.textContent = "0 min";
+      maxLabel.textContent = isWeekly ? "840 min" : "120 min";
+      fill.style.width = isWeekly ? "12%" : "25%";
+      thumb.style.left = isWeekly ? "9%" : "21%";
+    }
+
+    nameInput.addEventListener("input", updateSave);
+    genderSelect.addEventListener("change", updateSave);
+    cycleButtons.forEach((button) => button.addEventListener("click", () => setGoal(button.dataset.cycle)));
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Align dog registration with the edit-screen UI, including avatar editing and goal controls.
- Send avatar uploads and initial walk goals through the create-dog mutation and API service.
- Configure the new-dog route with a faster bottom transition and add navigation regression tests.
- Add the reviewed HTML mockup artifact and record the UI mockup workflow.

## Test Plan
- scripts/harness/validate-all.sh
- from apps/mobile: npm run typecheck
- from apps/mobile: npm run lint (passes with existing .expo/types/router.d.ts unused-disable warning)
- from apps/mobile: npm run knip
- from apps/mobile: npm test -- --cacheDirectory .jest-cache --runInBand --forceExit
- API Docker cargo test: docker run --rm -v "$PWD":/walking-dog -v apps_cargo_cache:/usr/local/cargo -v apps_api_target_harness:/tmp/walking-dog-target -w /walking-dog/apps/api apps-api cargo test --target-dir /tmp/walking-dog-target -j 1
