### PR TITLE
[codex] Fix End Walk swipe navigation

### DIFF
--- a/apps/mobile/__tests__/app/root-layout.test.tsx
+++ b/apps/mobile/__tests__/app/root-layout.test.tsx
@@ -79,6 +79,15 @@ describe('RootLayout', () => {
     });
   });
 
+  it('disables the root tabs stack gesture so map-overlay sliders do not drag the screen', () => {
+    render(<RootLayout />);
+
+    expect(mockScreen).toHaveBeenCalledWith({
+      name: '(tabs)',
+      options: { headerShown: false, gestureEnabled: false },
+    });
+  });
+
   it('presents /dogs/new quickly from the bottom at the root stack boundary', () => {
     render(<RootLayout />);
 

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -15,6 +15,7 @@ import { LoadingScreen } from '@/components/ui/LoadingScreen';
 import { ErrorScreen } from '@/components/ui/ErrorScreen';
 
 const ROOT_SCREEN_OPTIONS = { headerShown: false } as const;
+const TABS_ROOT_SCREEN_OPTIONS = { headerShown: false, gestureEnabled: false } as const;
 const DOG_NEW_ROOT_SCREEN_OPTIONS = {
   ...ROOT_SCREEN_OPTIONS,
   animation: 'slide_from_bottom',
@@ -84,7 +85,7 @@ function RootLayout() {
       <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
         <NavigationGuard />
         <Stack>
-          <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+          <Stack.Screen name="(tabs)" options={TABS_ROOT_SCREEN_OPTIONS} />
           <Stack.Screen name="(auth)" options={{ headerShown: false }} />
           <Stack.Screen name="dogs" options={dogsRootScreenOptions} />
           <Stack.Screen name="settings" options={{ headerShown: false }} />

--- a/apps/mobile/components/walk/WalkControls.test.tsx
+++ b/apps/mobile/components/walk/WalkControls.test.tsx
@@ -1,7 +1,6 @@
 import { act, fireEvent, render, screen } from '@testing-library/react-native';
 import { StyleSheet } from 'react-native';
 import { WalkControls } from './WalkControls';
-import { components } from '@/theme/tokens';
 import type { Dog } from '@/types/graphql';
 
 jest.mock('@/hooks/use-color-scheme', () => ({
@@ -9,28 +8,6 @@ jest.mock('@/hooks/use-color-scheme', () => ({
 }));
 
 jest.mock('expo-image', () => ({ Image: 'Image' }));
-
-jest.mock('@react-native-community/slider', () => {
-  const { View } = jest.requireActual('react-native');
-  return {
-    __esModule: true,
-    default: ({
-      onValueChange,
-      onSlidingComplete,
-      ...props
-    }: {
-      onValueChange?: (value: number) => void;
-      onSlidingComplete?: (value: number) => void;
-    }) => (
-      <View
-        {...props}
-        accessibilityRole="adjustable"
-        onValueChange={onValueChange}
-        onSlidingComplete={onSlidingComplete}
-      />
-    ),
-  };
-});
 
 const mockWalkStoreState = {
   startedAt: null as Date | null,
@@ -93,9 +70,9 @@ describe('WalkControls', () => {
     expect(screen.getByText('LIVE')).toBeTruthy();
   });
 
-  it('renders native slide-to-end control without the Pause button', () => {
+  it('renders slide-to-end control without the Pause button', () => {
     render(<WalkControls dogs={[coco]} onStop={jest.fn()} isStopping={false} />);
-    expect(screen.getByTestId('walk-end-rn-slider')).toBeTruthy();
+    expect(screen.getByTestId('walk-end-slide-responder')).toBeTruthy();
     expect(screen.getByTestId('walk-end-slider-knob')).toBeTruthy();
     expect(screen.getByText('End Walk')).toBeTruthy();
     expect(screen.queryByRole('button', { name: 'Pause' })).toBeNull();
@@ -120,27 +97,21 @@ describe('WalkControls', () => {
 
   it('disables End Walk when isStopping', () => {
     render(<WalkControls dogs={[coco]} onStop={jest.fn()} isStopping={true} />);
-    const slider = screen.getByTestId('walk-end-rn-slider');
-    expect(slider.props.disabled).toBe(true);
+    const slideResponder = screen.getByTestId('walk-end-slide-responder');
+    expect(slideResponder.props.accessibilityState.disabled).toBe(true);
   });
 
-  it('uses a transparent RN slider thumb so the custom circular knob owns the visuals', () => {
+  it('does not render a hidden native slider behind the custom circular knob', () => {
     render(<WalkControls dogs={[coco]} onStop={jest.fn()} isStopping={false} />);
-    const slider = screen.getByTestId('walk-end-rn-slider');
-    expect(slider.props.thumbSize).toBe(components.walkControls.endSlideKnobSize);
-    expect(slider.props.thumbTintColor).toBe('#00000000');
-    expect(slider.props.minimumTrackTintColor).toBe('#00000000');
-    expect(slider.props.maximumTrackTintColor).toBe('#00000000');
+    expect(screen.queryByTestId('walk-end-rn-slider')).toBeNull();
   });
 
-  it('aligns the native slider thumb with the visible circular knob', () => {
+  it('keeps the slide gesture on the End Walk control instead of releasing it to the map', () => {
     render(<WalkControls dogs={[coco]} onStop={jest.fn()} isStopping={false} />);
-    const sliderStyle = StyleSheet.flatten(screen.getByTestId('walk-end-rn-slider').props.style);
-    const thumbCenter =
-      components.walkControls.endSlideKnobInset +
-      components.walkControls.endSlideKnobSize / 2;
-    expect(sliderStyle.left).toBe(thumbCenter);
-    expect(sliderStyle.right).toBe(thumbCenter);
+    const slideResponder = screen.getByTestId('walk-end-slide-responder');
+    expect(slideResponder.props.onStartShouldSetResponder()).toBe(true);
+    expect(slideResponder.props.onMoveShouldSetResponder()).toBe(true);
+    expect(slideResponder.props.onResponderTerminationRequest()).toBe(false);
   });
 
   it('renders single-dog identity with dog name and contextual walk label', () => {
@@ -163,13 +134,37 @@ describe('WalkControls', () => {
     const onStop = jest.fn();
     render(<WalkControls dogs={[coco]} onStop={onStop} isStopping={false} />);
 
-    const slider = screen.getByTestId('walk-end-rn-slider');
-    fireEvent(slider, 'onValueChange', 1);
+    const slideResponder = screen.getByTestId('walk-end-slide-responder');
+    fireEvent(slideResponder, 'onLayout', {
+      nativeEvent: { layout: { width: 320 } },
+    });
+    fireEvent(slideResponder, 'onResponderGrant', {
+      nativeEvent: { locationX: 32 },
+    });
+    fireEvent(slideResponder, 'onResponderMove', {
+      nativeEvent: { locationX: 288 },
+    });
     expect(onStop).not.toHaveBeenCalled();
 
-    fireEvent(slider, 'onSlidingComplete', 1);
+    fireEvent(slideResponder, 'onResponderRelease');
 
     expect(onStop).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not end the walk from a right-edge tap without a drag', () => {
+    const onStop = jest.fn();
+    render(<WalkControls dogs={[coco]} onStop={onStop} isStopping={false} />);
+
+    const slideResponder = screen.getByTestId('walk-end-slide-responder');
+    fireEvent(slideResponder, 'onLayout', {
+      nativeEvent: { layout: { width: 320 } },
+    });
+    fireEvent(slideResponder, 'onResponderGrant', {
+      nativeEvent: { locationX: 288 },
+    });
+    fireEvent(slideResponder, 'onResponderRelease');
+
+    expect(onStop).not.toHaveBeenCalled();
   });
 
   it('resets the end slider when a stop attempt returns to idle', () => {
@@ -178,12 +173,22 @@ describe('WalkControls', () => {
       <WalkControls dogs={[coco]} onStop={onStop} isStopping={false} />,
     );
 
-    fireEvent(screen.getByTestId('walk-end-rn-slider'), 'onValueChange', 1);
-    fireEvent(screen.getByTestId('walk-end-rn-slider'), 'onSlidingComplete', 1);
+    const slideResponder = screen.getByTestId('walk-end-slide-responder');
+    fireEvent(slideResponder, 'onLayout', {
+      nativeEvent: { layout: { width: 320 } },
+    });
+    fireEvent(slideResponder, 'onResponderGrant', {
+      nativeEvent: { locationX: 32 },
+    });
+    fireEvent(slideResponder, 'onResponderMove', {
+      nativeEvent: { locationX: 288 },
+    });
+    fireEvent(slideResponder, 'onResponderRelease');
     rerender(<WalkControls dogs={[coco]} onStop={onStop} isStopping={true} />);
     rerender(<WalkControls dogs={[coco]} onStop={onStop} isStopping={false} />);
 
-    expect(screen.getByTestId('walk-end-rn-slider').props.value).toBe(0);
+    const knobStyle = StyleSheet.flatten(screen.getByTestId('walk-end-slider-knob').props.style);
+    expect(knobStyle.transform).toEqual([{ translateX: 0 }]);
   });
 
   it('updates the elapsed metric while the walk is active', () => {

--- a/apps/mobile/components/walk/WalkControlsActions.tsx
+++ b/apps/mobile/components/walk/WalkControlsActions.tsx
@@ -1,6 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { StyleSheet, Text, View, type LayoutChangeEvent } from 'react-native';
-import Slider from '@react-native-community/slider';
+import {
+  StyleSheet,
+  Text,
+  View,
+  type GestureResponderEvent,
+  type LayoutChangeEvent,
+} from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColors } from '@/hooks/use-colors';
 import { components, typography } from '@/theme/tokens';
@@ -12,18 +17,22 @@ interface WalkControlsActionsProps {
 
 const SLIDE_MIN = 0;
 const SLIDE_MAX = 1;
-const SLIDE_STEP = 0.01;
 const SLIDE_COMPLETE_THRESHOLD = 0.95;
-const TRANSPARENT_CONTROL_COLOR = '#00000000';
-const SLIDE_THUMB_CENTER_OFFSET =
-  components.walkControls.endSlideKnobInset +
-  components.walkControls.endSlideKnobSize / 2;
 
 function clampSlideValue(value: number) {
   return Math.min(SLIDE_MAX, Math.max(SLIDE_MIN, value));
 }
 
-// 記録中パネル下部の終了操作を、RN Slider の native gesture で扱います。
+function slideValueFromDrag(startX: number, locationX: number, width: number) {
+  const knobTravel =
+    width -
+    components.walkControls.endSlideKnobSize -
+    components.walkControls.endSlideKnobInset * 2;
+  if (knobTravel <= 0) return SLIDE_MIN;
+  return clampSlideValue((locationX - startX) / knobTravel);
+}
+
+// 記録中パネル下部の終了操作を、専用 responder で親マップへ横ドラッグを渡さず扱います。
 export function WalkControlsActions({
   isStopping,
   onStop,
@@ -34,6 +43,7 @@ export function WalkControlsActions({
   const [sliderWidth, setSliderWidth] = useState(0);
   const slideValueRef = useRef(SLIDE_MIN);
   const hasCompletedRef = useRef(false);
+  const dragStartXRef = useRef<number | null>(null);
   const wasStoppingRef = useRef(isStopping);
 
   const setSlidePosition = useCallback((value: number) => {
@@ -49,14 +59,6 @@ export function WalkControlsActions({
     onStop();
   }, [isStopping, onStop, setSlidePosition]);
 
-  const handleSlideChange = useCallback(
-    (value: number) => {
-      if (isStopping || hasCompletedRef.current) return;
-      setSlidePosition(value);
-    },
-    [isStopping, setSlidePosition],
-  );
-
   const handleSlidingComplete = useCallback(
     (value: number) => {
       if (isStopping) return;
@@ -69,6 +71,50 @@ export function WalkControlsActions({
       setSlidePosition(SLIDE_MIN);
     },
     [completeSlide, isStopping, setSlidePosition],
+  );
+
+  const setSlidePositionFromEvent = useCallback(
+    (event: GestureResponderEvent) => {
+      if (isStopping || hasCompletedRef.current) return;
+      const dragStartX = dragStartXRef.current;
+      if (dragStartX === null) return;
+      setSlidePosition(slideValueFromDrag(dragStartX, event.nativeEvent.locationX, sliderWidth));
+    },
+    [isStopping, setSlidePosition, sliderWidth],
+  );
+
+  const shouldSetSlideResponder = useCallback(
+    () => !isStopping && !hasCompletedRef.current,
+    [isStopping],
+  );
+
+  const handleResponderGrant = useCallback(
+    (event: GestureResponderEvent) => {
+      if (isStopping || hasCompletedRef.current) return;
+      dragStartXRef.current = event.nativeEvent.locationX;
+      setSlidePosition(SLIDE_MIN);
+    },
+    [isStopping, setSlidePosition],
+  );
+
+  const handleResponderRelease = useCallback(() => {
+    if (isStopping) return;
+    dragStartXRef.current = null;
+    handleSlidingComplete(slideValueRef.current);
+  }, [handleSlidingComplete, isStopping]);
+
+  const handleResponderTerminate = useCallback(() => {
+    dragStartXRef.current = null;
+    if (hasCompletedRef.current) return;
+    setSlidePosition(SLIDE_MIN);
+  }, [setSlidePosition]);
+
+  const handleAccessibilityAction = useCallback(
+    (event: { nativeEvent: { actionName: string } }) => {
+      if (event.nativeEvent.actionName !== 'activate') return;
+      completeSlide();
+    },
+    [completeSlide],
   );
 
   useEffect(() => {
@@ -93,7 +139,24 @@ export function WalkControlsActions({
 
   return (
     <View style={styles.actionRow}>
-      <View style={styles.endSliderWrap} onLayout={handleSliderLayout}>
+      <View
+        accessible
+        accessibilityActions={[{ name: 'activate', label: t('walk.recording.endWalk') }]}
+        accessibilityLabel={t('walk.recording.endWalk')}
+        accessibilityRole="button"
+        accessibilityState={{ disabled: isStopping }}
+        onAccessibilityAction={handleAccessibilityAction}
+        onLayout={handleSliderLayout}
+        onMoveShouldSetResponder={shouldSetSlideResponder}
+        onResponderGrant={handleResponderGrant}
+        onResponderMove={setSlidePositionFromEvent}
+        onResponderRelease={handleResponderRelease}
+        onResponderTerminate={handleResponderTerminate}
+        onResponderTerminationRequest={() => false}
+        onStartShouldSetResponder={shouldSetSlideResponder}
+        style={styles.endSliderWrap}
+        testID="walk-end-slide-responder"
+      >
         <View
           pointerEvents="none"
           style={[
@@ -129,28 +192,6 @@ export function WalkControlsActions({
             <Text style={[styles.knobIcon, { color: theme.error }]}>⏻</Text>
           </View>
         </View>
-        <Slider
-          accessibilityLabel={t('walk.recording.endWalk')}
-          disabled={isStopping}
-          maximumTrackTintColor={TRANSPARENT_CONTROL_COLOR}
-          maximumValue={SLIDE_MAX}
-          minimumTrackTintColor={TRANSPARENT_CONTROL_COLOR}
-          minimumValue={SLIDE_MIN}
-          hitSlop={{
-            top: 0,
-            right: SLIDE_THUMB_CENTER_OFFSET,
-            bottom: 0,
-            left: SLIDE_THUMB_CENTER_OFFSET,
-          }}
-          onSlidingComplete={handleSlidingComplete}
-          onValueChange={handleSlideChange}
-          step={SLIDE_STEP}
-          style={styles.endSlider}
-          testID="walk-end-rn-slider"
-          thumbSize={components.walkControls.endSlideKnobSize}
-          thumbTintColor={TRANSPARENT_CONTROL_COLOR}
-          value={slideValue}
-        />
       </View>
     </View>
   );
@@ -164,14 +205,6 @@ const styles = StyleSheet.create({
     width: '100%',
     height: components.walkControls.endSlideHeight,
     position: 'relative',
-  },
-  endSlider: {
-    position: 'absolute',
-    top: 0,
-    right: SLIDE_THUMB_CENTER_OFFSET,
-    bottom: 0,
-    left: SLIDE_THUMB_CENTER_OFFSET,
-    height: components.walkControls.endSlideHeight,
   },
   visualLayer: {
     position: 'absolute',

--- a/apps/mobile/package-lock.json
+++ b/apps/mobile/package-lock.json
@@ -12,7 +12,6 @@
         "@expo/ui": "~56.0.13",
         "@expo/vector-icons": "^15.0.3",
         "@react-native-async-storage/async-storage": "2.2.0",
-        "@react-native-community/slider": "5.2.0",
         "@tanstack/react-query": "^5.91.3",
         "effect": "3.21.2",
         "expo": "^56.0.0",
@@ -4633,12 +4632,6 @@
       "peerDependencies": {
         "react-native": "^0.0.0-0 || >=0.65 <1.0"
       }
-    },
-    "node_modules/@react-native-community/slider": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/slider/-/slider-5.2.0.tgz",
-      "integrity": "sha512-484sH8aWEaSjxaZ7HT3YZ8CKDcNes2synko1vdEz5DFEdvKAduxKJTj22L/qBMD7rtIkfbX69DMzWDAGbOAV6w==",
-      "license": "MIT"
     },
     "node_modules/@react-native-masked-view/masked-view": {
       "version": "0.3.2",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -31,7 +31,6 @@
     "@expo/ui": "~56.0.13",
     "@expo/vector-icons": "^15.0.3",
     "@react-native-async-storage/async-storage": "2.2.0",
-    "@react-native-community/slider": "5.2.0",
     "@tanstack/react-query": "^5.91.3",
     "effect": "3.21.2",
     "expo": "^56.0.0",

--- a/docs/harness/lessons-learned.md
+++ b/docs/harness/lessons-learned.md
@@ -12,6 +12,11 @@ Date: 2026-06-13.
   boundary is probably the right home.
 - Harness flows need stable selectors. Current skeletons can run against visible
   English labels, but durable CI needs explicit `testID` or accessibility labels.
+- Map-overlay slide controls should not hide native value controls behind custom
+  visuals. Keep the visible knob and touch responder in one component so drag
+  ownership cannot leak to the map or leave native thumb artifacts visible. Also
+  check the actual route that owns the UI: active walk controls live in `(tabs)/walk`,
+  so `/walk-recording` stack gesture settings do not protect the in-tab overlay.
 - Local API verification should bind-mount the current worktree and isolate Cargo
   target cache when multiple worktrees use `apps/compose.yml`.
 - Legal URL behavior belongs to the Sakura/Caddy hosting path. App behavior should

--- a/docs/superpowers/mockups/2026-07-06-end-walk-slider-fix.html
+++ b/docs/superpowers/mockups/2026-07-06-end-walk-slider-fix.html
@@ -1,0 +1,78 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>End Walk Slider Fix Mockup</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --surface-container: rgba(229, 229, 231, 0.92);
+      --surface: #ffffff;
+      --label: #1f1f22;
+      --error: #ff453a;
+      --shadow: rgba(0, 0, 0, 0.14);
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      background:
+        linear-gradient(rgba(255, 255, 255, 0.72), rgba(255, 255, 255, 0.72)),
+        repeating-linear-gradient(0deg, #e8efe8 0 1px, transparent 1px 48px),
+        repeating-linear-gradient(90deg, #e8efe8 0 1px, transparent 1px 64px);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    .frame {
+      width: min(92vw, 620px);
+      padding: 16px 24px;
+    }
+
+    .slider {
+      position: relative;
+      height: 64px;
+      border-radius: 32px;
+      background: var(--surface-container);
+      overflow: hidden;
+    }
+
+    .label {
+      position: absolute;
+      inset: 0;
+      display: grid;
+      place-items: center;
+      color: var(--label);
+      font-size: 24px;
+      font-weight: 700;
+      opacity: 0.82;
+    }
+
+    .knob {
+      position: absolute;
+      top: 4px;
+      left: 4px;
+      width: 56px;
+      height: 56px;
+      border-radius: 50%;
+      display: grid;
+      place-items: center;
+      background: var(--surface);
+      color: var(--error);
+      font-size: 34px;
+      line-height: 1;
+      box-shadow: 0 2px 14px var(--shadow);
+    }
+  </style>
+</head>
+<body>
+  <main class="frame" aria-label="Corrected End Walk slider visual">
+    <section class="slider">
+      <div class="label">End Walk</div>
+      <div class="knob" aria-hidden="true">&#9211;</div>
+    </section>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Replace the hidden native End Walk slider layer with a single visible responder-owned control so the stray circular artifact is gone.
- Disable the root tabs stack gesture so swiping the End Walk control in the in-tab recording overlay does not move the screen.
- Add regression tests, a visual mockup artifact, and a harness lesson for map-overlay slide controls.

## Root Cause
The active recording UI lives inside (tabs)/walk, not the /walk-recording bridge route. The prior route-level gesture setting did not protect the in-tab overlay, so the iOS root stack swipe could still respond when the End Walk control started near the left edge.

## Test Plan
- npm test -- --runInBand --forceExit
- npm run typecheck
- npm run lint (exit 0; existing generated .expo/types/router.d.ts warning remains)
- npm run knip
- scripts/harness/validate-all.sh

## Journey Evidence
- Maestro walk-lifecycle was attempted earlier but stopped before End Walk because the harness seed precondition dog Harness Walker was missing. Existing harness docs already track deterministic seed/GPS fixtures as a gap.