### PR TITLE
docs: add API and mobile replacement roadmap

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,140 @@
+# Walking Dog
+
+Walking Dog describes the people, dogs, and walks that make better shared walk
+experiences possible.
+
+## Language
+
+**Account**:
+The login identity authenticated for Walking Dog. An Account owns its Email
+Address, authentication challenges, and Authenticated Sessions and corresponds
+to exactly one Owner. It does not replace the Owner as the subject of dog care,
+walks, or contribution.
+_Avoid_: User, Owner when discussing authentication
+
+**Owner**:
+A person who registers and cares for one or more Dogs in Walking Dog. An Owner's
+display name is trimmed before saving, contains 1–50 user-perceived characters,
+and contains no newline or control character; other Unicode characters are
+allowed. Each Owner corresponds to exactly one Account.
+_Avoid_: User when discussing dog ownership
+
+**Email Address**:
+The Account's normalized authentication identity. It is trimmed, lowercased, at
+most 254 characters, may contain a `+` alias, and contains neither control
+characters nor an invalid email structure.
+_Avoid_: Username, unnormalized email
+
+**Authenticated Session**:
+A rotating access-token and refresh-token relationship through which an Account
+may use Walking Dog. It is authentication state, not part of an Owner or Walk.
+_Avoid_: Owner session, Walk session
+
+**Dog**:
+A currently registered, non-archived dog cared for by an Owner. An Owner cannot
+have two Dogs whose names are the exact same sequence of characters; Archived
+Dogs do not reserve names, and case, whitespace, and Unicode-equivalent but
+non-identical sequences remain distinct names. A Dog name contains 1–50
+user-perceived characters, is not whitespace-only, and contains no newline or
+control character; other Unicode characters and surrounding whitespace are
+preserved.
+_Avoid_: Pet
+
+**Birthday**:
+An optional Dog birth value preserving year, year-month, or full-date precision.
+Known components must be valid, from 1900 through the API's present, and not
+future. Age calculation uses the full date, day 16 for year-month, or July 1 for
+year-only; inferred components are not persisted.
+_Avoid_: Birth timestamp, persisted approximate date
+
+**Gender**:
+A required Dog classification with exactly Male, Female, or Other domain values.
+Display labels are localized while API representation is a closed enum.
+_Avoid_: Free-form gender string, missing gender
+
+**Archived Dog**:
+A Dog removed from the Owner's current Dogs and future Walk selection while its
+past Walks, statistics, photos, and events remain part of history. A Dog taking
+part in an Active Walk cannot become an Archived Dog.
+_Avoid_: Deleted Dog, removed Dog
+
+**Walker**:
+The Owner who performs a Walk. Past Walks resolve the Walker's current profile
+through the Owner reference rather than preserving a profile snapshot. A missing
+or unavailable current profile image is represented by an initial derived from
+the current display name.
+_Avoid_: Historical walker profile
+
+**Walk**:
+An outing performed by one Walker with one or more Dogs, including its time,
+route, events, photos, and resulting statistics. Historical participants keep
+Dog references and resolve their current names rather than name snapshots;
+Archived Dogs therefore expose their final current names.
+_Avoid_: Session when referring to the recorded outing
+
+**Completed Walk**:
+A Walk the Owner ended successfully. It is the only Walk state eligible for
+Owner-visible history, statistics, Walk Goal progress, and Contribution.
+_Avoid_: Interrupted Walk, finalized Walk when state matters
+
+**Active Walk**:
+The single Walk an Owner is currently recording. While it exists, returning to
+its recording controls takes precedence over viewing any past Walk detail.
+_Avoid_: Recording session, current trip
+
+**Walk Recording**:
+The activity of starting an Active Walk, collecting Track Points and Walk Events,
+and finalizing it as Completed or Interrupted. It is not the Walk itself.
+_Avoid_: Walk, Authenticated Session
+
+**Track Point**:
+A time-stamped location observation accepted for a Walk after its coordinates,
+horizontal accuracy, ordering, and implied speed satisfy the Walk's quality
+rules. Unvalidated location-provider output is not a Track Point.
+_Avoid_: Raw GPS value, location update
+
+**Walk Event**:
+A time-stamped Pee, Poop, or Photo occurrence for one participating Dog within
+one Walk. Location is optional and, when present, refers to the latest accepted
+Track Point. One idempotency identity denotes the same occurrence across retries.
+_Avoid_: Track Point, aggregate event count
+
+**Pending Walk Event**:
+A Walk Event durably retained on an Owner's device whose API registration is not
+complete. For Photo, completion includes media upload.
+_Avoid_: Failed event, temporary event
+
+**Pending Photo Event**:
+A Pending Walk Event whose kind is Photo. It may remain pending after the Walk
+ends and is removed only after synchronization or explicit Owner discard.
+_Avoid_: Failed photo, temporary upload
+
+**Interrupted Walk**:
+A Walk ended automatically because required foreground location access was lost.
+It preserves data internally for diagnostics and pending-event synchronization,
+but is hidden from all Owner-facing history and does not count toward completed-
+Walk totals, statistics, charts, or Walk Goals.
+_Avoid_: Failed Walk, completed Walk
+
+**Walk Goal**:
+A time target for one Dog over either a Daily or Weekly cycle. Daily and Weekly
+values are independent preferences and are never converted into one another;
+zero means the Owner has no active target for that cycle.
+_Avoid_: Distance goal, converted daily average
+
+**Walk History**:
+The chronological collection of Completed Walks visible to an Owner, optionally
+filtered to one current or Archived Dog. It excludes Active and Interrupted
+Walks.
+_Avoid_: Active Walk list, all persisted Walks
+
+**Contribution**:
+An Owner's walking record derived from Completed Walks, including lifetime walk
+count, distance, duration, and current-week daily distance. It is not an
+independently maintained record.
+_Avoid_: Dog Walk Progress, persisted contribution
+
+**Dog Walk Progress**:
+Statistics and Walk Goal progress derived from Completed Walks for one Dog. It
+does not include the Walk Goal setting itself.
+_Avoid_: Contribution, Walk Goal

--- a/docs/adr/0001-archive-dogs-to-preserve-walk-history.md
+++ b/docs/adr/0001-archive-dogs-to-preserve-walk-history.md
@@ -1,0 +1,7 @@
+# Archive Dogs to Preserve Walk History
+
+Removing a Dog makes it an Archived Dog rather than physically deleting it so
+past Walks, statistics, photos, and events remain meaningful. A Dog in an Active
+Walk cannot be archived; once archived it is absent from current Dogs and future
+Walk selection, and its exact name may be reused by a new Dog because historical
+identity is retained by `dogId` and the recorded Walk data.

--- a/docs/adr/0002-use-testcontainers-as-the-single-development-and-test-harness.md
+++ b/docs/adr/0002-use-testcontainers-as-the-single-development-and-test-harness.md
@@ -1,0 +1,21 @@
+# Use Testcontainers as the single development and test harness
+
+Walking Dog uses a repository-owned Testcontainers runtime as the only source of
+truth for development services, adapter integration tests, GraphQL journeys, and
+Mobile/Maestro harness runs. We rejected preserving Docker Compose for API tests
+and rejected a Testcontainers/Compose hybrid because reproducibility, isolation,
+contract fidelity, diagnostics, and topology-drift prevention matter more than
+reusing the existing orchestration; production Compose remains solely a
+deployment artifact.
+
+Migration cost and the amount of existing code replaced were explicitly not
+constraints in this decision.
+
+## Consequences
+
+The harness must provide a resident runner, leases, typed connection manifests,
+health-based waits, stale-resource cleanup, and sanitized evidence bundles so
+Mobile and human-driven sessions can use the same runtime as automated tests.
+Testcontainers remains tools-only and is mechanically forbidden from production
+dependency graphs. Development `apps/compose.yml` and its shell wrappers are
+removed when the architecture kernel cuts over.

--- a/docs/roadmaps/2026-07-11-api-mobile-replacement-implementation-plan.md
+++ b/docs/roadmaps/2026-07-11-api-mobile-replacement-implementation-plan.md
@@ -1,0 +1,670 @@
+# API and Mobile Replacement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> `superpowers:subagent-driven-development` (recommended) or
+> `superpowers:executing-plans` to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `apps/api` and `apps/mobile` with the PR #366/#367 architecture
+and make every normalized `docs/tmp-testcases/` outcome executable through seven
+canonical iOS Journeys.
+
+**Architecture:** Three deployable foundation pull requests establish the API
+kernel, Mobile kernel, and deterministic contract/Harness. Seven vertical pull
+requests then deliver one canonical Journey each through API, GraphQL, Mobile,
+Harness, observability, and evidence. One final pull request deletes residue and
+proves the complete matrix.
+
+**Tech Stack:** Rust 1.96.0 edition 2024, Axum, async-graphql, SeaORM/PostgreSQL,
+AWS SDK adapters, Testcontainers, MinIO, ElasticMQ, DynamoDB Local, Toxiproxy,
+OpenTelemetry, Expo 56, React Native 0.85, TypeScript 6, Expo Router, XState,
+TanStack Query, SQLite, SecureStore, GraphQL Code Generator, Jest, Maestro, iOS
+18.3 and 26.5 Simulators.
+
+## Global Constraints
+
+- Initial Mobile acceptance is iOS only with deployment target 18.0.
+- Existing GraphQL, Mobile source/runtime, device data, and production data are
+  not preserved; there is no production data.
+- Migration cost, diff size, and reuse are not constraints.
+- Every merge builds, starts, and truthfully exposes only completed Journeys.
+- Domain decisions live in API domain/application modules, never resolvers or
+  adapters; storage details stay behind ports.
+- Mobile routes compose public Feature interfaces only; no deep imports, global
+  mutable store, handwritten GraphQL, or generated transport type outside
+  adapters.
+- Every product mutation is idempotent. Required values never become optional or
+  fallback values. Errors are never caught and ignored.
+- Required CI never calls live AWS. Production Cognito mapping is tested through
+  a deterministic compatible provider; real-provider contracts are separate.
+- Tokens, OTPs, challenges, Email Addresses, signed URLs, object keys,
+  idempotency keys, unnecessary PII, and precise location are forbidden from
+  logs/evidence.
+- Every user-facing route follows the approved artifact
+  `docs/wayfinder/artifacts/2026-07-11-mobile-journey-wireflow.html` until a later
+  reviewed design artifact supersedes it.
+- Each pull request uses one immutable intent under the relevant
+  `architecture/intents/` directory and closes without TODO/TBD, warning gates,
+  compatibility aliases, dual runtimes, or expired exceptions.
+
+## Sources of truth
+
+- Domain: `CONTEXT.md`
+- Normalized behavior:
+  `docs/wayfinder/2026-07-11-acceptance-spec-normalization.md`
+- Ownership: `docs/wayfinder/2026-07-11-domain-journey-ownership-map.md`
+- API kernel: `docs/wayfinder/2026-07-11-api-architecture-kernel.md`
+- Mobile kernel: `docs/wayfinder/2026-07-11-mobile-architecture-kernel.md`
+- GraphQL: `docs/wayfinder/2026-07-11-graphql-contract-and-generation.md`
+- Harness:
+  `docs/wayfinder/2026-07-11-deterministic-acceptance-observability-harness.md`
+- PR order:
+  `docs/wayfinder/2026-07-11-deployable-vertical-migration-sequence.md`
+
+## Exact Journey scenario ledger
+
+For each basename below, create both
+`apps/mobile/journeys/<journey>/fixtures/<basename>.yaml` and
+`apps/mobile/e2e/maestro/journeys/<journey>/<basename>.yaml`:
+
+| Journey directory | Required basenames |
+| --- | --- |
+| `access-account` | `success`, `validation`, `transport-recovery`, `persistence-recovery`, `privacy-evidence` |
+| `manage-owner-profile-and-preferences` | `success`, `validation`, `permission`, `transport-recovery`, `persistence-recovery`, `empty-loading-error`, `accessibility`, `language-theme-units`, `privacy-evidence` |
+| `manage-dogs-and-goals` | `success`, `validation`, `permission`, `transport-recovery`, `persistence-recovery`, `empty-loading-error`, `accessibility`, `language-theme-units`, `privacy-evidence` |
+| `record-a-walk` | `success`, `validation`, `permission`, `transport-recovery`, `persistence-recovery`, `empty-loading-error`, `accessibility`, `language-theme-units`, `privacy-evidence` |
+| `capture-walk-events` | `success`, `validation`, `permission`, `transport-recovery`, `persistence-recovery`, `accessibility`, `privacy-evidence` |
+| `review-walk-history` | `success`, `validation`, `transport-recovery`, `empty-loading-error`, `accessibility`, `language-theme-units`, `privacy-evidence` |
+| `review-owner-contribution` | `success`, `transport-recovery`, `empty-loading-error`, `accessibility`, `language-theme-units`, `privacy-evidence` |
+
+No other scenario basename is created without updating the canonical Journey,
+Feature manifest, selection fixtures, and this ledger in the same pull request.
+
+---
+
+## PR 1 — API architecture kernel
+
+### Task 1.1: Replace the Cargo root and legacy product crates
+
+**Files:**
+
+- Replace: `apps/api/Cargo.toml`
+- Regenerate: `apps/api/Cargo.lock`
+- Create: `apps/api/rust-toolchain.toml`
+- Create: `apps/api/crates/domain/{Cargo.toml,src/lib.rs}`
+- Create: `apps/api/crates/application/{Cargo.toml,src/lib.rs}`
+- Create: `apps/api/crates/adapter-graphql/{Cargo.toml,src/lib.rs}`
+- Create: `apps/api/crates/adapter-postgres/{Cargo.toml,src/lib.rs}`
+- Create: `apps/api/crates/adapter-aws-cognito/{Cargo.toml,src/lib.rs}`
+- Create: `apps/api/crates/adapter-aws-s3/{Cargo.toml,src/lib.rs}`
+- Create: `apps/api/crates/adapter-aws-sqs/{Cargo.toml,src/lib.rs}`
+- Create: `apps/api/crates/adapter-aws-dynamodb/{Cargo.toml,src/lib.rs}`
+- Create: `apps/api/crates/api-bootstrap/{Cargo.toml,src/lib.rs}`
+- Create: `apps/api/crates/api-bootstrap/src/bin/{api.rs,track-point-worker.rs,schema.rs,migrate.rs}`
+- Delete: `apps/api/src/`, `apps/api/migration/`, `apps/api/sqs-consumer/`
+
+**Interfaces:** Produces the exact workspace/crate names and dependency direction
+defined by the API kernel. No product type or field is produced.
+
+- [ ] Write a failing workspace test that asserts the exact member set, virtual
+  root, edition, pinned toolchain, and absence of the three legacy crates.
+- [ ] Run `cd apps/api && cargo metadata --locked --all-features`; expect failure
+  until the workspace and lockfile exist.
+- [ ] Create the virtual workspace and minimal compileable crates with only
+  policy-allowed dependencies.
+- [ ] Run `cd apps/api && cargo check --workspace --all-targets --all-features`;
+  expect success with no warning.
+- [ ] Delete the legacy directories and prove `rg -n 'migration|sqs-consumer|name =
+  "walking-dog"' apps/api/Cargo.toml` returns no match.
+
+### Task 1.2: Implement bootstrap, empty baseline, and architecture compiler
+
+**Files:**
+
+- Create: `apps/api/crates/api-bootstrap/src/{config.rs,health.rs,observability.rs,shutdown.rs,composition.rs}`
+- Create: `apps/api/crates/adapter-postgres/src/{lib.rs,migrations/mod.rs,migrations/m0001_empty_baseline.rs}`
+- Create: `apps/api/tools/architecture-validator/{Cargo.toml,src/main.rs,src/policy.rs,src/ast.rs,tests/fixtures.rs}`
+- Create: `apps/api/tools/{harness-runtime,integration-test-support,xtask}/Cargo.toml`
+- Create: `apps/api/tools/{harness-runtime,integration-test-support}/src/lib.rs`
+- Create: `apps/api/tools/xtask/src/{main.rs,architecture.rs,intent.rs}`
+- Create: `apps/api/tools/xtask/src/journey_generator.rs`
+- Create: `apps/api/tools/xtask/templates/journey/{use_case.rs,contract.rs,graphql.rs,manifest.toml,observability.rs}`
+- Create: `apps/api/tools/xtask/tests/journey_generator.rs`
+- Create: `apps/api/architecture/{dependency-policy.toml,exceptions.toml}`
+- Create: `apps/api/architecture/intents/20260711-api-kernel.toml`
+- Create: `apps/api/fixtures/{architecture,observability,providers}/`
+- Modify: `infra/sakura/compose.yml`, `.github/workflows/deploy-api.yml`
+- Delete: `apps/compose.yml`, `scripts/harness/dev-stack.sh`,
+  `scripts/docker-compose-up.sh`
+
+**Interfaces:** Produces `cargo xtask architecture check`, `api`,
+`track-point-worker`, `schema`, `migrate`, and `/health`.
+
+- [ ] Add failing positive/negative fixtures for all `API-ARCH-001` through
+  `API-ARCH-012`, resolved Cargo edges, exact exceptions, intents, secret logs,
+  unknown files, and parser failure.
+- [ ] Run `cd apps/api && cargo test -p architecture-validator`; expect failing
+  rule IDs before implementation.
+- [ ] Implement default-deny graph/AST validation and SARIF/human diagnostics;
+  make every fixture assert rule ID and location.
+- [ ] Add failing bootstrap tests for missing config, readiness, safe logs,
+  graceful shutdown, and twice-applied empty migration; implement the minimum
+  typed bootstrap that passes them.
+- [ ] Add failing generator tests for collision atomicity, closed registries,
+  production/in-memory adapter pairs, contract/GraphQL/observability/manifest
+  output, and `verify-generated`; implement `cargo xtask journey new` and
+  `cargo xtask journey verify-generated` until they pass.
+- [ ] Run `cd apps/api && cargo xtask architecture check`; expect success.
+- [ ] Run `cd apps/api && cargo test --workspace --all-targets --all-features`;
+  expect all tests pass.
+- [ ] Build API/worker images and run `/health`; expect HTTP 200 only after typed
+  readiness and no product GraphQL/queue behavior.
+- [ ] Record `no affected journey` in the PR evidence: this PR replaces only the
+  API architecture/bootstrap kernel, intentionally exposes no product operation,
+  and therefore has no user-observable Journey that Maestro can execute.
+
+**PR 1 required result:** API and worker deploy, empty migration applies, every
+API architecture negative fixture blocks, and no legacy/API compatibility source
+remains. Rollback redeploys the pre-PR API image.
+
+---
+
+## PR 2 — Mobile architecture kernel
+
+### Task 2.1: Replace source, package graph, and iOS configuration
+
+**Files:**
+
+- Replace: `apps/mobile/package.json`, `apps/mobile/package-lock.json`,
+  `apps/mobile/tsconfig.json`, `apps/mobile/eslint.config.js`,
+  `apps/mobile/app.config.ts`, `apps/mobile/jest.setup.ts`
+- Create: `apps/mobile/app/{_layout.tsx,index.tsx}`
+- Create: `apps/mobile/{features,platform,generated/graphql,design-system,journeys,architecture,tools/mobile-architecture,test-support}/`
+- Delete: `apps/mobile/{hooks,stores,components,lib,types,targets}`,
+  `apps/mobile/android/`, `apps/mobile/web/`
+- Delete obsolete Watch/Web/Android scripts under `apps/mobile/scripts/`
+- Modify: `apps/mobile/README.md`, `apps/mobile/CLAUDE.md`
+
+**Interfaces:** Produces an iOS 18.0 shell and removes Zustand, Effect, Graffle,
+AsyncStorage domain state, Watch, widgets, Android, and Web dependencies.
+The replacement dependency set includes pinned XState, TanStack Query, Expo
+SQLite, Expo SecureStore, GraphQL, GraphQL Code Generator plugins, and JSON Schema
+validation; it excludes every competing state/transport/persistence runtime.
+
+- [ ] Write a failing package/config test asserting deployment target 18.0,
+  allowed scripts/dependencies, and forbidden legacy roots/targets.
+- [ ] Replace package/config files and run `cd apps/mobile && npm ci`; expect a
+  reproducible install.
+- [ ] Build an honest localized shell with no product route and stable
+  accessibility identifiers.
+- [ ] Run `cd apps/mobile && npm run typecheck && npm run lint && npm run knip`;
+  expect success.
+- [ ] Run the pinned iOS 18.3 Release-equivalent install/launch smoke; expect the
+  development shell and no crash.
+- [ ] Record `no affected journey` in the PR evidence: this PR deliberately ships
+  only an honest non-product shell, so the Release-equivalent launch smoke is the
+  applicable executable evidence and no product Maestro flow is added or claimed.
+
+### Task 2.2: Implement manifests, compiler, state/error/persistence policies
+
+**Files:**
+
+- Create: `apps/mobile/architecture/{module.schema.json,dependency-policy.yaml,exceptions.yaml}`
+- Create: `apps/mobile/architecture/intents/20260711-mobile-kernel.yaml`
+- Create: `apps/mobile/tools/mobile-architecture/src/{cli.ts,discover.ts,graph.ts,exports.ts,manifest.ts,intent.ts,diagnostics.ts}`
+- Create: `apps/mobile/tools/mobile-architecture/src/review-input.ts`
+- Create: `apps/mobile/tools/mobile-architecture/tests/fixtures/`
+- Create: `apps/mobile/platform/result/{module.yaml,index.ts,result.ts,mobile-error.ts}`
+- Create: `apps/mobile/platform/query/{module.yaml,index.ts,query-client.ts}`
+- Create: one `module.yaml` and `index.ts` for each eight Feature directory and
+  each Platform directory named by the Mobile kernel
+- Modify: `.github/workflows/test-mobile.yml`,
+  `scripts/harness/validate-mobile-knip.sh`, `scripts/harness/validate-all.sh`
+
+**Interfaces:** Produces `npm run architecture`, exact manifest schema, closed
+error Result, and policy ownership; placeholder implementation layers remain
+absent.
+
+- [ ] Add failing fixtures for `MOB-ARCH-001` through `MOB-ARCH-014`, aliases,
+  re-exports, dynamic imports, type imports, cycles, route leaks, unowned files,
+  missing adapter contracts, and privacy violations.
+- [ ] Implement the compiler with TypeScript Compiler API and JSON Schema until
+  `cd apps/mobile && npm run architecture` passes every fixture.
+- [ ] Add Result/error exhaustiveness tests and query-client boundary tests; run
+  `npm test -- --runInBand`; expect pass.
+- [ ] Generate independent-review input highlighting new exports, dependencies,
+  fallbacks, optional domain values, mutable module state, locality, seam pairs,
+  and production/test interface parity; assert it contains no secret values.
+- [ ] Run `scripts/harness/validate-all.sh`; expect no output and exit 0.
+
+**PR 2 required result:** iOS shell builds/launches; all Mobile negative gates
+block; no legacy source, global store, handwritten GraphQL, or out-of-scope
+platform survives. Rollback installs the pre-PR Mobile build.
+
+---
+
+## PR 3 — GraphQL generation and deterministic Harness foundation
+
+### Task 3.1: Establish schema and Mobile code generation
+
+**Files:**
+
+- Create: `apps/api/crates/adapter-graphql/src/{lib.rs,system_query.rs}`
+- Modify: `apps/api/crates/api-bootstrap/src/bin/schema.rs`
+- Create: `apps/api/schema.graphql`
+- Create: `apps/mobile/codegen.ts`
+- Create: `apps/mobile/generated/graphql/{schema-types.ts,operations.ts}`
+- Create: `apps/mobile/platform/graphql/{module.yaml,index.ts,transport.ts,envelope.ts,scalar-parsers.ts}`
+- Create: `apps/mobile/platform/graphql/tests/{transport.contract.test.ts,scalar-parsers.test.ts}`
+- Modify: `apps/mobile/package.json`, `apps/mobile/package-lock.json`
+
+**Interfaces:** Produces deterministic local `schema.graphql`, pinned
+`typescript`/`typescript-operations`/`typed-document-node`, strict scalar mapping,
+and typed standard-fetch transport. Only bootstrap `schemaRevision` exists.
+
+- [ ] Add failing schema determinism, hand-edit, operation-location, strict
+  scalar, top-level envelope, and second-generation-clean tests.
+- [ ] Generate schema, run Mobile codegen twice, and assert `git diff --exit-code
+  -- apps/api/schema.graphql apps/mobile/generated/graphql` succeeds.
+- [ ] Run API GraphQL tests and Mobile transport contracts; expect pass.
+
+### Task 3.2: Implement the Testcontainers runtime and evidence system
+
+**Files:**
+
+- Create: `apps/api/tools/harness-runtime/src/{runtime.rs,resources.rs,lease.rs,control.rs,auth_provider.rs,clock.rs,faults.rs,evidence.rs,privacy.rs}`
+- Create: `apps/api/tools/integration-test-support/src/{environment.rs,fixtures.rs,projections.rs}`
+- Create: `apps/api/tools/xtask/src/{harness.rs,journey.rs,evidence.rs}`
+- Create: `apps/api/fixtures/providers/cognito/`
+- Create: `apps/mobile/journeys/schema.json`
+- Create: `apps/mobile/test-support/{environment.ts,simulator.ts,maestro.ts}`
+- Create: `.github/workflows/{api-architecture.yml,api-unit.yml,api-integration.yml,graphql-contract.yml,mobile-quality.yml,mobile-ai-review.yml,journey-pr.yml,journey-main.yml,journey-nightly.yml,provider-contract.yml}`
+- Delete: `.github/workflows/{test-api.yml,test-mobile.yml,harness.yml}`
+- Replace: `docs/runbooks/local-harness.md`, `docs/harness/README.md`
+
+**Interfaces:** Produces `cargo xtask harness verify`, `harness serve/down`,
+`journey select/run/run-all`, and `evidence verify` with the exact environment and
+evidence manifests in the Harness design.
+
+- [ ] Test two concurrent run namespaces and assert zero shared DB/auth/storage/
+  queue/DynamoDB/clock/fault/Simulator/SQLite state.
+- [ ] Test every control-plane/Toxiproxy fault reaches its declared seam and no
+  control symbol enters production images.
+- [ ] Test OTP retrieval redaction and malicious evidence fixtures; expect unsafe
+  bundles never upload.
+- [ ] Test setup failure, Journey failure, cleanup failure, exporter loss, lease
+  recovery, and resource leak produce distinct failed checks.
+- [ ] Test the advisory independent Mobile architecture review publishes evidence
+  and requires a linked durable human dismissal for P0/P1 findings while never
+  replacing deterministic merge gates.
+- [ ] Run `cargo xtask harness verify`; expect all container digests/resources,
+  iOS 18.3/26.5 shell runs, evidence hashes, and teardown pass without AWS
+  credentials.
+- [ ] Record `no affected product journey` in the PR evidence: this PR validates
+  the Journey runner, Maestro bridge, isolation, failure semantics, and evidence
+  pipeline themselves; canonical product flows begin in PR 4 after the first
+  complete vertical slice exists.
+
+**PR 3 required result:** one command proves the isolated system and clean
+schema/codegen; required CI is installed; no product Journey is claimed.
+
+---
+
+## PR 4 — Access Account vertical slice
+
+### Task 4.1: Identity contract and API
+
+**Files:**
+
+- Create: `apps/api/crates/domain/src/identity/{mod.rs,account.rs,email_address.rs,session.rs,challenge.rs}`
+- Create: `apps/api/crates/application/src/identity/{mod.rs,ports.rs,request_code.rs,verify_code.rs,refresh.rs,change_email.rs,sign_out.rs,contracts.rs}`
+- Create: `apps/api/crates/adapter-aws-cognito/src/{lib.rs,client.rs,mapping.rs}`
+- Create: `apps/api/crates/adapter-postgres/src/identity/{mod.rs,repository.rs,migrations.rs}`
+- Create: `apps/api/crates/adapter-graphql/src/identity/{mod.rs,mutation.rs,types.rs}`
+- Modify: API composition, migrations, policy/manifests, `apps/api/schema.graphql`
+
+**Produces:** all eight identity mutations, rotating session, shared 401 envelope,
+Owner provisioning port, Active-Walk Sign Out guard, and reusable contracts.
+
+- [ ] Write contract tests for every normalized OTP/rate/refresh/revocation/
+  idempotency/auth outcome; verify they fail against empty adapters.
+- [ ] Implement domain/application, then deterministic and Cognito adapters using
+  the same contract suite.
+- [ ] Add GraphQL unions and envelope tests; regenerate schema and Mobile output.
+
+### Task 4.2: Account-access Feature and Journey
+
+**Files:**
+
+- Create: `apps/mobile/features/account-access/{module.yaml,index.ts}`
+- Create: `apps/mobile/features/account-access/{domain,application,react,ui,adapters/graphql,adapters/secure-storage,tests}/`
+- Create: `apps/mobile/platform/secure-storage/{module.yaml,index.ts,expo-secure-store.ts,in-memory.ts,contract.ts}`
+- Create: `apps/mobile/app/{sign-in.tsx,sign-up.tsx,verify.tsx,settings/email.tsx,settings/email/verify.tsx}`
+- Create: `apps/mobile/app/(tabs)/{_layout.tsx,dogs.tsx,walk.tsx,me.tsx}`
+- Create: `docs/harness/journeys/access-account.md`
+- Create: `apps/mobile/journeys/access-account/journey.yaml` and the exact
+  Access Account fixture/flow pairs in the scenario ledger
+- Delete: `docs/harness/journeys/auth-onboarding.md`,
+  `apps/mobile/e2e/maestro/auth-onboarding.yaml` after replacement evidence passes
+
+- [ ] Test auth XState transitions, secure storage contract, refresh single-flight,
+  one replay, missing tokens, and Active Walk auth recovery port.
+- [ ] Implement UI/routes through the public Feature; unavailable tabs remain
+  honest shell states.
+- [ ] Run `cargo xtask journey run access-account --profile pr`; expect every
+  Sign Up/Login/Email Change scenario and privacy comparison passes.
+
+**PR 4 required result:** Access Account is executable end to end on both main
+runtimes; all prior foundation checks remain green.
+
+---
+
+## PR 5 — Manage Owner Profile and Preferences vertical slice
+
+### Task 5.1: Owner/media API
+
+**Files:**
+
+- Create: `apps/api/crates/domain/src/owner/{mod.rs,owner.rs,owner_name.rs,avatar.rs}`
+- Create: `apps/api/crates/application/src/owner/{mod.rs,ports.rs,current_owner.rs,update_owner.rs,prepare_avatar.rs,contracts.rs}`
+- Create: `apps/api/crates/adapter-postgres/src/owner/`
+- Implement: `apps/api/crates/adapter-aws-s3/src/`
+- Create: `apps/api/crates/adapter-graphql/src/owner/`
+- Modify: schema, migrations, manifests, codegen
+
+- [ ] Write failing name, last-write-wins, upload purpose/checksum/expiry,
+  replacement/removal/compensation, and read-image contract tests.
+- [ ] Implement application/adapters and run production/in-memory shared contracts.
+
+### Task 5.2: Owner-profile/preferences Features and Journey
+
+**Files:**
+
+- Implement: `apps/mobile/features/{owner-profile,preferences}/`
+- Implement: `apps/mobile/platform/{media,system-settings}/`
+- Create: `apps/mobile/app/{owner/edit.tsx,settings/index.tsx}`
+- Create: `docs/harness/journeys/manage-owner-profile-and-preferences.md`
+- Create: `apps/mobile/journeys/manage-owner-profile-and-preferences/journey.yaml`
+  and its exact fixture/flow pairs in the scenario ledger
+
+- [ ] Write failing form/media/dirty/no-change/settings persistence, notification,
+  legal/About, accessibility, language/theme/unit tests.
+- [ ] Implement public Features and route composition; run selected Jest/contracts.
+- [ ] Run the canonical Journey; expect API/resource/UI values and failure recovery
+  compare exactly.
+
+**PR 5 required result:** Owner and Settings outcomes pass; Contribution remains
+absent; prior Access Journey passes.
+
+---
+
+## PR 6 — Manage Dogs and Goals vertical slice
+
+### Task 6.1: Dog/Goal API and contract
+
+**Files:**
+
+- Create: `apps/api/crates/domain/src/dog/{mod.rs,dog.rs,dog_name.rs,gender.rs,birthday.rs,walk_goal.rs}`
+- Create: `apps/api/crates/application/src/dog/{mod.rs,ports.rs,list.rs,get.rs,create.rs,update.rs,archive.rs,prepare_avatar.rs,contracts.rs}`
+- Create: `apps/api/crates/adapter-postgres/src/dog/`
+- Create: `apps/api/crates/adapter-graphql/src/dog/`
+- Modify: media adapter, schema, migrations, manifests, codegen
+
+- [ ] Write failing tests for exact duplicate semantics, validation, partial
+  Birthday, Gender, Goal bounds/default/independence, Archive, Active participant,
+  media, and no Breed surface.
+- [ ] Implement and run the same application/adapter contracts.
+
+### Task 6.2: Dogs Feature and Journey
+
+**Files:**
+
+- Implement: `apps/mobile/features/dogs/`
+- Create: `apps/mobile/app/dogs/{new.tsx,[dogId]/index.tsx,[dogId]/edit.tsx}`
+- Create: `docs/harness/journeys/manage-dogs-and-goals.md`
+- Create: `apps/mobile/journeys/manage-dogs-and-goals/journey.yaml` and its exact
+  fixture/flow pairs in the scenario ledger
+- Delete: `docs/harness/journeys/{dog-profile.md,walk-goal.md}` and
+  `apps/mobile/e2e/maestro/{dog-profile.yaml,walk-goal.yaml}` after replacement
+  evidence passes
+
+- [ ] Write failing list/form/detail/archive/media/age/Goal/error/accessibility tests.
+- [ ] Implement Feature mapping and routes without History/Contribution internals.
+- [ ] Run the canonical Journey; expect every Dogs source section assigned to this
+  slice passes and Breed never appears in schema/UI/evidence.
+
+**PR 6 required result:** Dogs/Goals Journey and all prior Journeys pass.
+
+---
+
+## PR 7 — Record a Walk vertical slice
+
+### Task 7.1: Walk lifecycle, Track Points, worker, and GraphQL
+
+**Files:**
+
+- Create: `apps/api/crates/domain/src/walk/{mod.rs,walk.rs,participant.rs,track_point.rs,metrics.rs}`
+- Create: `apps/api/crates/application/src/walk_recording/{mod.rs,ports.rs,start.rs,append_track_points.rs,finish.rs,interrupt.rs,recover.rs,contracts.rs}`
+- Create: `apps/api/crates/adapter-postgres/src/walk_recording/`
+- Implement: `apps/api/crates/adapter-aws-{sqs,dynamodb}/src/`
+- Create: `apps/api/crates/adapter-graphql/src/walk_recording/`
+- Modify: worker composition, schema, migrations, manifests, codegen
+
+- [ ] Write failing lifecycle transaction, ownership, one-Active, future-time,
+  Track Point batch/order/quality/idempotency, distance/duration, interruption,
+  queue retry, and reconciliation contracts.
+- [ ] Implement domain/application then Postgres/SQS/DynamoDB/GraphQL/worker
+  adapters; run shared contracts and Testcontainers integration.
+
+### Task 7.2: Walk-recording Feature and Journey
+
+**Files:**
+
+- Implement: `apps/mobile/features/walk-recording/`
+- Implement: `apps/mobile/platform/{persistence,location,observability}/`
+- Replace: `apps/mobile/app/(tabs)/walk.tsx`
+- Create: `docs/harness/journeys/record-a-walk.md`
+- Create: `apps/mobile/journeys/record-a-walk/journey.yaml` and its exact
+  fixture/flow pairs in the scenario ledger
+- Delete: `docs/harness/journeys/walk-lifecycle.md`,
+  `apps/mobile/e2e/maestro/walk-lifecycle.yaml` after replacement evidence passes
+
+- [ ] Write failing XState transition/model, SQLite contract, permission,
+  foreground/background, route quality, restart/reconcile, auth recovery, stable
+  map, and interruption tests.
+- [ ] Implement without event controls; Finish confirms saved state and returns
+  Ready until PR 9 owns real detail navigation.
+- [ ] Run the canonical Journey including process kill, permission loss, 30-second
+  invalid feed, and API/local mismatch; expect exact hidden Interrupted evidence.
+
+**PR 7 required result:** Record a Walk and all prior Journeys pass; no placeholder
+detail or event UI exists.
+
+---
+
+## PR 8 — Capture Walk Events vertical slice
+
+### Task 8.1: Event/media API
+
+**Files:**
+
+- Extend: `apps/api/crates/domain/src/walk/` with Event/Photo values
+- Create: `apps/api/crates/application/src/walk_event/{mod.rs,ports.rs,record_pee.rs,record_poop.rs,prepare_photo.rs,record_photo.rs,contracts.rs}`
+- Create: `apps/api/crates/adapter-postgres/src/walk_event/`
+- Create: `apps/api/crates/adapter-graphql/src/walk_event/`
+- Modify: S3 adapter, schema, migrations, manifests, codegen
+
+- [ ] Write failing distinct-tap, participant, boundary, late sync, unknown write,
+  media policy/expiry/compensation, idempotency, Completed/Interrupted contracts.
+- [ ] Implement and pass production/in-memory adapter contracts.
+
+### Task 8.2: Walk-events Feature and Journey
+
+**Files:**
+
+- Implement: `apps/mobile/features/walk-events/`
+- Create: camera route/modal composition under `apps/mobile/app/(tabs)/walk.tsx`
+- Create: `docs/harness/journeys/capture-walk-events.md`
+- Create: `apps/mobile/journeys/capture-walk-events/journey.yaml` and its exact
+  fixture/flow pairs in the scenario ledger
+- Delete: `docs/harness/journeys/walk-events-photo.md`,
+  `apps/mobile/e2e/maestro/walk-events-photo.yaml` after replacement evidence
+  passes
+
+- [ ] Write failing per-Dog tap, durable intent, deep-link-once, Photo normalize/
+  upload/pending/retry/discard, post-Finish, unknown-read tests.
+- [ ] Implement using only `walk-recording` public `ActiveWalkContext`.
+- [ ] Run canonical Journey and verify UI/API/outbox/storage/queue/event evidence.
+
+**PR 8 required result:** Events Journey passes without map remount or Feature
+deep import; all prior Journeys pass.
+
+---
+
+## PR 9 — Review Walk History vertical slice
+
+### Task 9.1: History/detail read models and GraphQL
+
+**Files:**
+
+- Create: `apps/api/crates/application/src/walk_insight/{mod.rs,ports.rs,history.rs,detail.rs,contracts.rs}`
+- Create: `apps/api/crates/adapter-postgres/src/walk_insight/`
+- Create: `apps/api/crates/adapter-graphql/src/walk_insight/`
+- Modify: schema, manifests, codegen
+
+- [ ] Write failing Completed-only, fixed-20 cursor, tie order, filter binding,
+  Archived/current references, multi-Dog, bad-row isolation, event order/omission,
+  pending/broken Photo, Not Found indistinguishability contracts.
+- [ ] Implement and pass query-plan/integration tests that prove filtering occurs
+  before cursor math and no nested resolver issues queries.
+
+### Task 9.2: Walk-history Feature and Journey
+
+**Files:**
+
+- Implement: `apps/mobile/features/walk-history/`
+- Create: `apps/mobile/app/walks/{index.tsx,[walkId].tsx}`
+- Modify: Dog Detail and Me route composition, Walk Finish destination
+- Create: `docs/harness/journeys/review-walk-history.md`
+- Create: `apps/mobile/journeys/review-walk-history/journey.yaml` and its exact
+  fixture/flow pairs in the scenario ledger
+
+- [ ] Write failing page/refresh/filter/scroll, unavailable row, units, timeline,
+  photo modal, Active redirect, and no-loop tests.
+- [ ] Implement public Feature and route composition; replace PR 7 Ready
+  confirmation with direct real detail on successful Finish.
+- [ ] Run canonical Journey with >20 rows, cursor faults, Archived/renamed Dogs,
+  bad metrics/events/media, pending Photo, and Active redirect.
+
+**PR 9 required result:** History Journey and every prior Journey pass.
+
+---
+
+## PR 10 — Review Owner Contribution vertical slice
+
+### Task 10.1: Contribution/progress API read models
+
+**Files:**
+
+- Create: `apps/api/crates/application/src/walk_insight/{owner_contribution.rs,dog_progress.rs}`
+- Extend: `apps/api/crates/adapter-postgres/src/walk_insight/`
+- Extend: `apps/api/crates/adapter-graphql/src/walk_insight/`
+- Modify: schema, manifests, codegen
+
+- [ ] Write failing Completed-only, multi-Dog counting, complete-data, timezone,
+  Monday week, startedAt classification, DST/midnight, unrounded seconds, zero vs
+  malformed, and Walking Since contracts.
+- [ ] Implement authoritative queries and pass query-plan/boundary fixtures.
+
+### Task 10.2: Contribution Feature and Journey
+
+**Files:**
+
+- Implement: `apps/mobile/features/contribution/`
+- Modify: `apps/mobile/app/(tabs)/me.tsx`, Dog Detail composition
+- Create: `docs/harness/journeys/review-owner-contribution.md`
+- Create: `apps/mobile/journeys/review-owner-contribution/journey.yaml` and its
+  exact fixture/flow pairs in the scenario ledger
+- Delete: `docs/harness/journeys/walk-history-owner-contribution.md`,
+  `apps/mobile/e2e/maestro/walk-history-owner-contribution.yaml` after both
+  replacement Journeys pass
+
+- [ ] Write failing formatting/unit/locale/weekly graph/no-Walk/large-value/
+  unavailable/progress/accessibility tests.
+- [ ] Implement using API read models and injected DisplayPreferences only.
+- [ ] Run canonical Journey across timezone/unit/language/theme matrices and
+  compare unrounded API aggregates with displayed rounded values.
+
+**PR 10 required result:** all seven canonical Journeys pass end to end.
+
+---
+
+## PR 11 — Integrated hardening, deletion, and knowledge promotion
+
+### Task 11.1: Complete negative gates and full CI matrix
+
+**Files:**
+
+- Modify: all architecture fixture directories and required workflows
+- Modify: `scripts/harness/{validate-all.sh,validate-knowledge.sh,validate-architecture.sh,score-quality.sh}`
+- Modify: `docs/harness/{README.md,quality-score.md,lessons-learned.md}`
+- Modify: `docs/runbooks/local-harness.md`, `apps/api/README.md`,
+  `apps/mobile/README.md`, root `AGENTS.md`
+- Create/modify ADRs under `docs/adr/` only for durable questioned decisions
+
+- [ ] Add deletion/negative tests for every PR #366/#367 rule, GraphQL drift,
+  evidence privacy, setup/cleanup/leak/exporter failures, and AI-review absence.
+- [ ] Run all seven Journeys on iOS 18.3/26.5 and the full nightly pairwise
+  accessibility/presentation/fault/timezone matrix; expect zero unexplained retry.
+- [ ] Run provider contract separately and record `HUMAN_TIMEOUT` safely when
+  applicable; it does not alter deterministic merge status.
+
+### Task 11.2: Delete residue and prove repository closure
+
+**Files:**
+
+- Delete: all superseded source, flows, fixtures, schemas, generated types,
+  Compose/run scripts, old Journey documents, Watch/Live Activity/Android/Web,
+  Breed UI/API, unused dependencies, and expired exceptions identified by
+  `git ls-files`, Knip, Cargo metadata, and architecture ownership reports
+- Promote final terms/invariants to `CONTEXT.md`, canonical Journeys, ADRs, and
+  validators; keep `AGENTS.md` a map
+
+- [ ] Run `rg` checks for every forbidden legacy root/package/symbol and assert no
+  match outside migration history documents.
+- [ ] Run `cd apps/api && cargo fmt --check && cargo clippy --workspace
+  --all-targets --all-features -- -D warnings && cargo test --workspace
+  --all-targets --all-features`.
+- [ ] Run `cd apps/mobile && npm test -- --runInBand && npm run typecheck && npm
+  run lint && npm run knip && npm run architecture && npm run graphql:check`.
+- [ ] Run `cargo xtask journey run-all --profile main`, then nightly/release
+  profiles; expect every evidence/privacy/hash comparison passes.
+- [ ] Run `scripts/harness/validate-all.sh`; expect no output and exit 0.
+- [ ] Compare requirement ledger totals: zero unmapped, duplicate-owned,
+  contradictory, unverifiable, or placeholder requirements.
+
+**PR 11 required result:** no obsolete asset or exception remains, all required
+checks are enforced, seven Journeys satisfy every normalized outcome, and the
+input/output audit is ready for human review.
+
+## Rollback and merge discipline
+
+- Merge PRs strictly in numeric order; never cherry-pick a later Feature onto an
+  earlier foundation.
+- Tag the last green API image and Mobile build for each PR. Rollback selects the
+  pair and its empty/development database state; it never mixes schema clients.
+- A failed Journey merge is reverted as the whole PR. Do not disable the route,
+  optionalize the contract, suppress evidence, or add a compatibility adapter.
+- Because there is no production data, destructive schema correction resets the
+  development/Harness baseline instead of preserving invalid state.
+
+## Plan completion checks
+
+- Each of 11 PRs has exact owned paths, inputs, produced interfaces, failing-test
+  first actions, commands, and required result.
+- Every API module, Mobile Feature, GraphQL root area, Harness subsystem, and
+  canonical Journey appears in the PR that first needs it.
+- Every current top-level workflow/runbook slated for replacement is named.
+- The separate audit ticket must validate this plan against every line of PR
+  #366, PR #367, all design documents, and every numbered source-spec section
+  before review is requested from the user.

--- a/docs/wayfinder/2026-07-11-acceptance-spec-normalization.md
+++ b/docs/wayfinder/2026-07-11-acceptance-spec-normalization.md
@@ -1,0 +1,278 @@
+# Acceptance Specification Normalization
+
+## Purpose
+
+This document records product decisions that make every item under
+`docs/tmp-testcases/` observable and executable. The source files remain the
+acceptance inventory. When an inventory statement offers alternatives or asks
+to confirm behavior, the decision below is authoritative.
+
+## Global outcomes
+
+- Initial Mobile acceptance is iOS only.
+- Every migrated merge keeps main deployable; migrated journeys remain usable.
+- Current GraphQL, Mobile source, and runtime compatibility are not required.
+- There is no production-data migration.
+- Features absent from `docs/tmp-testcases/`, including Watch and Live Activity,
+  are not retained for compatibility.
+- A cached successful result remains visible when refresh fails. A localized,
+  non-blocking update error and Retry are shown. With no cached result, the same
+  failure uses a full error screen.
+- Invalid, nonexistent, and unauthorized Dog or Walk identifiers produce the
+  same localized Not Found screen with Back and no Retry. Transport and
+  temporary provider failures produce a separate Retryable error.
+- Normal GraphQL operations and foreground-location acquisition time out after
+  30 seconds. Image-upload operations time out after 60 seconds. Inputs remain
+  available for idempotent retry.
+- During an in-flight mutation, repeat submission and Cancel/Back are disabled.
+- If a create or edit form is dirty, Cancel/Back requires discard confirmation.
+  If a picker or modal is open, Back closes that surface first without losing
+  form state.
+- A permission that iOS can no longer request presents localized explanation,
+  Open Settings, and Cancel actions. A temporary denial presents explanation
+  without forcing Settings. This applies to photo library, camera, and location.
+- Duplicate identifiers, invalid required values, and response ordering that
+  violates the API contract are surfaced as contract errors and observability
+  evidence. Mobile does not silently repair provider or API contract violations.
+
+## Owner and authentication
+
+- Owner display names are trimmed before saving, contain 1–50 user-perceived
+  characters, and contain no newline or control character. Other Unicode,
+  including emoji and RTL text, is allowed. Empty display names cannot be saved.
+- An absent or invalid display name received while reading renders as localized
+  Unknown User and uses `?` as its avatar initial.
+- Authentication Email Addresses are trimmed, lowercased, at most 254
+  characters, allow `+` aliases, and reject controls or invalid email structure
+  in both Mobile and API.
+- OTP is valid for 10 minutes. Resend becomes available after 30 seconds, a
+  resend invalidates the earlier code, and one Email Address may request five
+  codes per hour. Rate-limit UI shows the next retry time.
+- Returning from OTP entry to email entry destroys the challenge/session.
+- OTP length is fixed by journey and returned by API: Sign In uses eight ASCII
+  digits; Sign Up and Email Change use six. Mobile strips nondigits, truncates
+  excess input, and auto-verifies exactly once on first reaching the expected
+  length. Failure clears input and permits the same code to be entered again.
+  Unexpected `codeLength` is a contract error; API rejects invalid shape before
+  invoking Cognito.
+- Human-assisted E2E OTP wait is 10 minutes and records `HUMAN_TIMEOUT` rather
+  than silently hanging or exposing OTP/session/token values.
+- Successful Email Address change makes the new address the only login identity,
+  rejects the old address, revokes every session on every device, and requires
+  the current device to sign in again with the new address.
+- Active Walk and Interrupted Walk finalization states block Sign Out. The Owner
+  is directed to the recording controls and must finish before signing out.
+- On access-token expiry, concurrent failures share one refresh operation and
+  retry once with the original idempotency identity. Invalid refresh state or a
+  response missing either required token invalidates the session. Without an
+  Active Walk, Mobile returns to Sign In. During an Active Walk, Mobile retains
+  local route/events, attempts Interrupted finalization, and stays in an
+  authentication-recovery state if that cannot be authorized. No new event may
+  be added there; after Sign In, finalization and retained-event sync resume.
+
+## Dog profile
+
+- An Owner cannot have two current Dogs with names that are exactly the same
+  character sequence. No case, whitespace, or Unicode normalization is applied
+  to uniqueness. Archived Dogs do not reserve names.
+- Dog names contain 1–50 user-perceived characters, are not whitespace-only, and
+  contain no newline or control character. Other Unicode and surrounding
+  whitespace are preserved.
+- Birthday is optional and preserves year, year-month, or full-date precision.
+  Year is 1900 through the API current year; known components must exist and the
+  represented precision cannot be future. Missing components are never stored
+  as guessed values. For age calculation only, year-month uses day 16 and
+  year-only uses July 1; full dates use their stored day.
+- Gender is required and is exactly `MALE`, `FEMALE`, or `OTHER` in the API.
+  Mobile localizes labels but sends the enum. Unknown, missing, differently
+  cased, or whitespace-padded values are rejected and never rounded to a default.
+- Breed is outside this acceptance scope. Its database column remains reserved,
+  but Mobile-facing GraphQL operations, domain models, registration, edit,
+  detail, list, and acceptance tests do not expose or display it.
+- Removing a current Dog archives it. Active Walk participants cannot be
+  archived. Archived Dogs leave current lists and future selection while past
+  Walks, statistics, events, and photos remain accessible.
+- A selected Dog/Owner Avatar makes create or update atomic from the Owner's
+  perspective. Upload or database failure leaves no created/changed record,
+  compensates orphaned new media, preserves the form and selected image for
+  retry, and deletes an old object only after the new reference commits.
+- With no changed field or image, Dog and Owner Save is disabled and no API call
+  is made. Reverting edits to the initial values disables Save again.
+- Dog and Owner edit allow an existing Avatar to be removed after confirmation.
+  A successful database update clears the reference before deleting the old
+  object. Failure retains the prior Avatar and permits idempotent retry.
+- Concurrent Dog and Owner edits use last-write-wins. After mutation, Mobile
+  refetches and converges to the server's final state; no merge/conflict UI is
+  provided.
+
+## Media boundaries
+
+- Dog and Owner Avatars are square-cropped, normalized to JPEG, no larger than
+  1024×1024 and 5 MiB.
+- Walk Photos are not cropped, are normalized to JPEG, have a maximum long edge
+  of 2048 pixels, and are no larger than 10 MiB.
+- Mobile resizes/compresses through temporary files and validates before upload;
+  API validates the same media-specific limits. Invalid, undecodable, non-image,
+  or oversized input is rejected explicitly.
+- Invalid, unavailable, or expired profile images fall back to an initial from
+  the current display name. Invalid Walk Photo thumbnails show an explicit
+  placeholder/error without exposing object keys or signed URLs.
+
+## Walk lifecycle and history
+
+- Foreground location is required to start and continue a Walk. Start is blocked
+  when it is unavailable. Background denial falls back to foreground tracking.
+- Losing foreground permission or disabling location services during recording
+  automatically ends the Active Walk as an Interrupted Walk.
+- An Interrupted Walk preserves time, route, events, and photos internally for
+  diagnostics and synchronization, but is absent from every Mobile history,
+  detail, Dog, and Me surface. API history pagination excludes it before cursor
+  calculation. It never contributes to counts, statistics, charts, Goals, or
+  event totals and cannot be resumed or changed to Completed.
+- Immediately after interruption, Mobile explains that location loss ended the
+  Walk and returns to Ready without opening detail. Pending events sync to the
+  hidden Interrupted Walk and are removed locally after success. Until then they
+  remain background retry state, not user-visible history.
+- While an Active Walk exists, opening any Walk detail route redirects to its
+  recording controls, even when the requested identifier names a past Walk.
+- A completed Walk requires `endedAt`, `startedAt <= endedAt`, and
+  `endedAt <= API clock now`. Duration is computed by API and cannot be negative.
+  Invalid read-model data fails rather than receiving a Mobile fallback.
+- API rejects any `startedAt`, `endedAt`, event `occurredAt`, or track-point
+  timestamp later than its receive-time clock, with no skew allowance. The
+  enclosing write fails validation. Future-dated read data is omitted from
+  aggregates and logged as a contract violation; a detail view that depends on
+  it fails rather than clamping or substituting the current time.
+- History is ordered by `startedAt` descending and `walkId` descending for ties.
+  Events are ordered by `occurredAt` ascending and `eventId` ascending for ties.
+  API guarantees order; Mobile preserves it.
+- Past Walks resolve the Walker's current display name and current image instead
+  of storing a profile snapshot. An unavailable image falls back to an initial
+  from the current display name.
+- Past Walks also resolve each participating Dog's current name by `dogId`, with
+  no Dog-name snapshot. Renaming changes past displays. Archived Dogs retain the
+  reference and expose their final current name; filters always use `dogId`.
+- Walk History is reachable from Me for all Dogs and from Dog detail with that
+  Dog preselected. Filters are All Dogs or one current/archived Dog; no date or
+  Walker filters are included.
+- Completed Walks appear; Active and Interrupted Walks do not. A multi-Dog Walk
+  appears once under All Dogs and in every participating Dog filter.
+- Returning to Walk History preserves filter and scroll position.
+- History uses fixed 20-item cursor pages. Mobile cannot choose another page
+  size. Repeated bottom events do not duplicate a request, and cyclic/invalid
+  cursors fail visibly rather than looping.
+- Completed Walk `distanceM` and `durationSec` are non-null, finite, and
+  nonnegative; duration is an integer. Null, negative, nonfinite, or malformed
+  values never become zero. A bad history row renders Walk data unavailable
+  while other rows remain; detail fails as a contract error; affected Owner/Dog
+  aggregates render Unavailable with Retry. Explicit zero remains valid.
+- A Pending Photo Event is persisted on device immediately, uses one idempotency
+  identity until upload and registration succeed, may outlive Walk completion,
+  remains visibly pending, and is removed only after sync or explicit discard.
+- Finishing a Walk does not wait for Pending Photo Events. They continue syncing
+  after completion and appear as pending in history/detail until success. A
+  permanent failure is retained for explicit Retry or confirmed discard.
+- Each intentional Pee or Poop tap creates a distinct event. Its button is
+  disabled while that submission is in flight; a retry reuses the same
+  idempotency identity. A tap after completion creates another event, with no
+  time-window deduplication.
+- API exposes Pee, Poop, and Photo event types. Unknown read events are ignored
+  by Mobile in timeline, map, counts, and aggregates; only a privacy-safe
+  contract-violation count is recorded. Unknown writes are impossible in Mobile
+  and rejected by API.
+- An event `occurredAt` must be within its Walk: at or after `startedAt`, and for
+  a finalized Walk at or before `endedAt`. New online events target only Active
+  Walks. An event durably created while offline may sync after completion with
+  its original time and idempotency identity, provided it remains within the
+  finalized boundary. Existing out-of-bound events are ignored in UI, map,
+  counts, and aggregates and recorded as privacy-safe contract violations.
+- A route point is accepted only when horizontal accuracy is at most 50 metres,
+  its timestamp is later than the previous accepted point, and its implied speed
+  is at most 12 m/s. Rejected points affect neither route nor distance. If no
+  acceptable point arrives for 30 seconds, the Walk ends as Interrupted.
+- On startup, sign-in, and foreground return, API Active Walk state is
+  authoritative. If API has an Active Walk and Mobile has no local state, Mobile
+  restores its Dogs, start time, submitted events, and route, enters recording,
+  and resumes location when permitted. Failure to regain valid location within
+  30 seconds ends it as Interrupted; device-only state that no longer exists
+  cannot be restored.
+- If Mobile has local Active Walk state but API does not, location recording
+  stops immediately. Mobile shows the API's Completed/Interrupted state when the
+  Walk exists. If it does not exist, Mobile discards the active shell and shows
+  an error. Unsubmitted events are retained: they retry only when the target Walk
+  exists, otherwise remain explicitly unrecoverable until confirmed discard.
+  Mobile never creates a Walk from orphaned local Active Walk state.
+
+## Settings
+
+- Language supports Japanese and English; Units supports kilometers and miles;
+  Appearance supports Light, Dark, and Auto. Selection applies immediately and
+  persists; failed persistence restores the prior visible value and reports an
+  error.
+- Units affect active distance/pace, history, Walk detail, Dog statistics, and Me
+  aggregates consistently. API returns canonical metric values; Mobile formats
+  the selected unit.
+- Notifications reflects iOS permission as Not Requested, On, or Off. Tapping
+  opens the Walking Dog notification settings; returning refreshes the value.
+  There is no separate in-app notification preference or notification-delivery
+  feature in this scope.
+- About is a read-only row displaying real app version and build number. It has
+  no chevron, tap action, or separate About screen.
+- Terms opens `/terms`; Privacy opens `/policy`. Open/offline failures produce a
+  localized error and leave Settings usable.
+
+## Goal and profile presentation
+
+- Walk Goals retain independent Daily and Weekly values. Switching cycles never
+  converts one value into the other and restores the last value set for the
+  selected cycle.
+- Defaults are Daily 30 minutes and Weekly 120 minutes. Daily permits 0–120 and
+  Weekly permits 0–840, both in five-minute steps. Zero means no goal.
+- A valid Owner `createdAt` renders Walking Since using the device locale and
+  local-timezone month. Missing, invalid, or future values render `Walking since
+  --`, record a contract violation, and do not fail the rest of the screen.
+- Daily and weekly boundaries use the device's current timezone at display time;
+  a week is Monday 00:00 through the next Monday. A completed Walk belongs wholly
+  to the local day/week of `startedAt`, even across midnight. Active and
+  Interrupted Walks do not contribute to lifetime totals, charts, or Goals.
+  Multi-Dog Walks count once for Owner totals and once for every participating
+  Dog. Goal comparisons use summed unrounded seconds; formatting rounds only
+  after aggregation. A timezone change may reclassify past Walks.
+
+## Human-visible evidence
+
+- Success, failure, retry, permission, empty, loading, accessibility, theme,
+  language, and unit outcomes named by each source file remain mandatory.
+- Evidence must not contain OTPs, challenge/session values, access/refresh
+  tokens, private storage keys, signed URLs, precise location beyond the minimum
+  deterministic fixture proof, or unnecessary personal data.
+- Product values, API fixtures, ordered identifiers, pageInfo/cursors, database
+  state, queue/storage effects, and UI output are compared rather than inferred
+  from screenshots alone.
+
+## Input coverage
+
+| Acceptance inventory | Normalized outcome areas |
+| --- | --- |
+| `signup-e2e-test-cases.md` | Email, OTP, legal links, timeout, evidence secrecy |
+| `login-screen-e2e-test-cases.md` | Email, OTP, refresh, authenticated destination |
+| `email-change-screen-e2e-test-cases.md` | Email identity replacement, OTP, global session revocation |
+| `user-screen-e2e-test-cases.md` | Current profile, Walking Since, totals, weekly boundaries, units |
+| `user-edit-screen-e2e-test-cases.md` | Name, Avatar atomicity/removal, dirty forms, last-write-wins |
+| `settings-screen-e2e-test-cases.md` | Language, units, appearance, notification permission, legal, About, Sign Out |
+| `dogs-list-e2e-test-cases.md` | Current Dogs, cache/error distinction, identity, images, archived exclusion |
+| `dog-registration-e2e-test-cases.md` | Name uniqueness, Gender, partial Birthday, independent Goals, media atomicity |
+| `dog-edit-screen-e2e-test-cases.md` | Not Found, no-change save, archive, partial Birthday, media removal |
+| `dog-detail-screen-e2e-test-cases.md` | Current Dog data, calculated age, Completed-only statistics/Goal/history |
+| `walk-screen-e2e-test-cases.md` | selection, location, route quality, events, offline media, recovery, finish |
+| `walk-history-list-e2e-test-cases.md` | Completed-only filtering, ordering, pagination, archived Dog references |
+| `walk-detail-screen-e2e-test-cases.md` | lifecycle precedence, route/event validation, current references, media |
+
+## Normalization status
+
+All identified decision points are resolved. Source acceptance statements that
+conflict with these outcomes are superseded and must be rewritten when promoted
+into executable journeys. In particular, this applies to Breed UI/API behavior,
+Daily/Weekly conversion, Interrupted Walk history visibility, Dog-name snapshots,
+null distance/duration becoming zero, unconfirmed dirty-form discard, unchanged
+Save submission, and current-implementation fallback behavior.

--- a/docs/wayfinder/2026-07-11-api-architecture-kernel.md
+++ b/docs/wayfinder/2026-07-11-api-architecture-kernel.md
@@ -1,0 +1,440 @@
+# API Architecture Kernel and Fail-Closed Gates
+
+## Purpose
+
+This document adapts the approved API architecture in PR #366 to an in-place,
+compatibility-breaking replacement of `apps/api`. It fixes the workspace,
+dependency policy, architecture validator, exceptions, change intents, journey
+generator, deterministic harness, and CI root of trust. Product behavior is not
+implemented by the kernel.
+
+Migration cost, diff size, and reuse of existing orchestration are not design
+constraints. When alternatives differ, choose the one with stronger
+reproducibility, isolation, correctness, diagnosability, maintainability, and
+mechanical enforcement even when it requires replacing more existing code.
+
+Inputs:
+
+- `docs/superpowers/specs/2026-07-11-greenfield-api-architecture-prevention-design.md`
+- `docs/wayfinder/2026-07-11-current-architecture-inventory.md`
+- `docs/wayfinder/2026-07-11-domain-journey-ownership-map.md`
+- `docs/wayfinder/2026-07-11-acceptance-spec-normalization.md`
+
+## Cutover decision
+
+The Architecture Kernel replaces the current product crate and GraphQL API in
+one deployable merge. It does not retain a legacy crate, feature flag, alternate
+port, or parallel schema. Existing GraphQL and Mobile compatibility is not a
+constraint and there is no production data to migrate.
+
+At kernel exit, `api-bootstrap` supplies typed configuration, observability,
+graceful shutdown, and `/health`. The API and track-point-worker binaries build
+and start, but expose no product GraphQL behavior and process no product queue
+message. Database migrations become a new empty baseline. Docker and deployment
+workflows build the new binaries. Rollback uses the previous deployable image,
+not a legacy branch in the new runtime.
+
+The following Walking Skeleton adds the first product slice: an authenticated
+Owner reads one of their Dogs through GraphQL, an application query, a repository
+port, and PostgreSQL.
+
+## Workspace layout
+
+```text
+apps/api/
+├── Cargo.toml                         # virtual workspace
+├── Cargo.lock
+├── rust-toolchain.toml                # exact 1.96.0 toolchain and components
+├── crates/
+│   ├── domain/
+│   ├── application/
+│   ├── adapter-graphql/
+│   ├── adapter-postgres/
+│   ├── adapter-aws-cognito/
+│   ├── adapter-aws-s3/
+│   ├── adapter-aws-sqs/
+│   ├── adapter-aws-dynamodb/
+│   └── api-bootstrap/
+├── tools/
+│   ├── architecture-validator/
+│   ├── harness-runtime/
+│   ├── integration-test-support/
+│   └── xtask/
+├── architecture/
+│   ├── dependency-policy.toml
+│   ├── exceptions.toml
+│   ├── intents/
+│   └── manifests/
+└── fixtures/
+    ├── architecture/
+    ├── observability/
+    └── providers/
+```
+
+The root package `walking-dog`, standalone `migration`, and standalone
+`sqs-consumer` members are removed. SeaORM models and migration definitions live
+inside `adapter-postgres`. Generic SQS consumption is internal to
+`adapter-aws-sqs`. `api-bootstrap` owns the `api`, `track-point-worker`, `schema`,
+and `migrate` binaries and is the only production composition root.
+
+The six application modules live under `application/src/{identity,owner,dog,
+walk_recording,walk_event,walk_insight}`. The four domain namespaces live under
+`domain/src/{identity,owner,dog,walk}`. No crate-per-use-case split is introduced.
+
+`harness-runtime`, `integration-test-support`, `architecture-validator`, and
+`xtask` are tools and cannot enter any production dependency graph. The Rust
+toolchain and build/test container images are version- and digest-pinned; an
+upgrade changes the policy and runs every validator fixture and contract suite.
+
+## Dependency policy
+
+`architecture/dependency-policy.toml` is versioned, default-deny, and validates
+the resolved `cargo metadata --locked --all-features` graph.
+
+```toml
+version = 1
+default = "deny"
+
+[workspace_edges.normal]
+domain = []
+application = ["domain"]
+adapter-graphql = ["application", "domain"]
+adapter-postgres = ["application", "domain"]
+adapter-aws-cognito = ["application", "domain"]
+adapter-aws-s3 = ["application", "domain"]
+adapter-aws-sqs = ["application", "domain"]
+adapter-aws-dynamodb = ["application", "domain"]
+api-bootstrap = [
+  "application",
+  "adapter-graphql",
+  "adapter-postgres",
+  "adapter-aws-cognito",
+  "adapter-aws-s3",
+  "adapter-aws-sqs",
+  "adapter-aws-dynamodb",
+]
+architecture-validator = []
+harness-runtime = []
+integration-test-support = ["harness-runtime"]
+xtask = ["architecture-validator", "harness-runtime"]
+
+[workspace_edges.dev]
+domain = []
+application = []
+adapter-graphql = ["integration-test-support"]
+adapter-postgres = ["integration-test-support"]
+adapter-aws-cognito = ["integration-test-support"]
+adapter-aws-s3 = ["integration-test-support"]
+adapter-aws-sqs = ["integration-test-support"]
+adapter-aws-dynamodb = ["integration-test-support"]
+api-bootstrap = ["integration-test-support"]
+```
+
+Every crate also has an explicit third-party package, feature, dependency-kind,
+target, registry, and source allowlist. Examples of permitted capabilities are:
+
+- `domain`: pure value dependencies such as `chrono`, `uuid`, `serde`, and
+  `thiserror`;
+- `application`: `domain`, async port support, `serde`, `thiserror`, and
+  provider-neutral tracing;
+- `adapter-graphql`: `async-graphql`, without Axum, SeaORM, or AWS SDKs;
+- `adapter-postgres`: SeaORM, PostgreSQL, and migration dependencies;
+- each AWS adapter: only its provider-family SDK and mapping dependencies;
+- `api-bootstrap`: Axum, Tokio, tracing subscriber, typed configuration, and
+  construction-time SDK/config dependencies;
+- tools: only their parser, metadata, Testcontainers, CLI, and fixture needs.
+
+Normal, build, dev, target-specific, optional, and feature-activated edges are
+checked against their separate allowlists. A dev edge never authorizes the same
+edge in a production/build graph. Unknown workspace edges, packages, features,
+registries, Git sources, workspace-external paths, and wildcard versions fail.
+Application contract suites are public test support within `application`:
+application tests run them with in-memory adapters, and adapter integration tests
+run the same suite through their existing normal dependency on `application`.
+The adapter's dev-only edge to `integration-test-support` supplies containers,
+typed endpoints, and fixtures but never adapter construction, avoiding a cycle.
+
+Policy changes require CODEOWNERS approval. Dependency automation cannot add a
+package or feature without a corresponding reviewed policy change.
+
+## Architecture validator
+
+`tools/architecture-validator` is a Rust binary using `cargo_metadata`, `syn`,
+and repository policy files. `cargo xtask architecture check` is the canonical
+entrypoint and performs dependency, AST, exception, intent, and generated-output
+validation.
+
+### Source discovery and failure behavior
+
+- Discover every workspace target through Cargo metadata and separately classify
+  libraries, binaries, build scripts, tests, examples, and benches.
+- Parse every `src/**/*.rs`, including currently unreachable files, so dead code
+  is not an escape hatch.
+- Exclude only `target/` and policy-declared generated outputs.
+- Track `use` trees, rename, glob, `extern crate`, type aliases, and public
+  re-exports sufficiently to prevent syntactic hiding of forbidden paths.
+- Fail on parse errors, unknown crates/files/targets, invalid policy, unused
+  exceptions, and rules that cannot complete.
+- Do not claim semantic coverage that `syn` cannot provide; assign those cases to
+  the Cargo graph, compiler/Clippy, or contract tests.
+
+### Initial rules
+
+| Rule | Fail-closed prohibition |
+| --- | --- |
+| `API-ARCH-001` | Process environment access outside `api-bootstrap` |
+| `API-ARCH-002` | SeaORM outside `adapter-postgres` and classified migration targets |
+| `API-ARCH-003` | AWS SDK outside the corresponding adapter and bootstrap wiring |
+| `API-ARCH-004` | GraphQL derives, Context, or Upload outside `adapter-graphql` |
+| `API-ARCH-005` | `unwrap`, `expect`, `panic!`, `todo!`, or `unimplemented!` in production targets |
+| `API-ARCH-006` | Adapter types in domain/application public signatures, aliases, or re-exports |
+| `API-ARCH-007` | HTTP, filesystem, environment, or provider clients in domain/application |
+| `API-ARCH-008` | Transactions, retries, clocks, repositories, storage, or providers in resolvers |
+| `API-ARCH-009` | Adapter construction outside `api-bootstrap` |
+| `API-ARCH-010` | Direct imports between the six application modules |
+| `API-ARCH-011` | Raw SQL outside classified `adapter-postgres` query/migration modules |
+| `API-ARCH-012` | Direct logging of tokens, OTP, Email Address, coordinates, or storage keys |
+
+Every rule has passing fixtures and multiple failing fixtures, including alias
+and re-export cases where relevant. Fixture tests assert rule ID and exact source
+location. Validator output includes rule ID, repository-relative location,
+symbol, permitted destination, and corrective guidance. Human-readable and SARIF
+formats are required; there is no warning mode. Validator unit tests and golden
+SARIF tests are part of the Architecture required check.
+
+## Time-limited exceptions
+
+There is no global bypass. `architecture/exceptions.toml` entries use the
+following shape:
+
+```toml
+version = 1
+
+[[exception]]
+id = "API-EXC-0001"
+rule = "API-ARCH-008"
+crate = "adapter-graphql"
+file = "crates/adapter-graphql/src/walk/query.rs"
+symbol = "WalkQuery::legacy_projection"
+fingerprint = "sha256:<validator-generated-ast-fingerprint>"
+owner = "github:matsuokashuhei"
+created_on = "2026-07-11"
+expires_on = "2026-08-10"
+removal_issue = "https://github.com/matsuokashuhei/walking-dog/issues/..."
+adr = "docs/adr/....md"
+justification = "..."
+```
+
+The maximum duration is 30 days. Exact crate, file, symbol, rule, AST
+fingerprint, valid Owner, open removal issue, and one-to-one ADR are mandatory.
+Globs, directories, multiple rules, indefinite/expired dates, missing targets,
+unused entries, and fingerprint drift fail CI. The removal issue must target a
+milestone before expiry. CI annotates seven days before expiry and fails on the
+expiry date.
+
+The entry and ADR require security/reliability CODEOWNERS approval. Extension
+requires a new ID, ADR, risk review, and approval. AI, environment variables,
+local flags, and CLI switches cannot create or extend exceptions. Fixtures,
+generated output, tests, and migration tooling use explicit target policy rather
+than exceptions.
+
+## Change Intent Manifest
+
+Before product editing, `cargo xtask intent new <id>` creates an immutable audit
+record under `architecture/intents/<YYYYMMDD>-<slug>.toml`.
+
+Required fields are version, unique ID, title, change kind, Owner, issue, product
+axes, canonical journeys, application modules, touched seams, schema impact,
+data-migration impact, expected failure modes, and required evidence. Values are
+closed registries. Schema impact is `none`, `compatible`, or `breaking`.
+
+CI derives actual changed crates, adapters, schema, migrations, and files from
+the merge base and compares declaration and diff in both directions. Every
+product file belongs to exactly one intent. Adapter changes require their seam
+and integration evidence. Application changes name one of the six modules.
+GraphQL-only work may omit an application module only for a justified
+`presentation` change. Architecture/tool/docs changes use `architecture` and do
+not invent a product journey. Required evidence names must resolve to successful
+CI artifacts.
+
+Unknown or empty values, duplicate IDs, overlapping ownership, missing artifacts,
+and secret-like values fail. Save-time feedback rejects the first product edit
+without an intent, while CI remains the root of trust for final diff consistency.
+Merged manifests remain as the agent feedback and change-reason corpus.
+
+## Journey generator
+
+`cargo xtask journey new <use-case>` creates one application use case associated
+with a canonical Owner journey and application module. It accepts interactive
+input or a reproducible `--spec <toml>` form. Inputs include command/query kind,
+GraphQL field contract, real external seams, and expected failure categories.
+It never creates a port solely for a mock.
+
+Generated outputs include:
+
+- application command/query, result, typed error, handler, and reusable contract
+  suite;
+- GraphQL conversion module;
+- selected adapter contract/integration skeletons;
+- canonical journey document creation or manifested use-case update;
+- observability field and forbidden-data fixtures;
+- architecture manifest with generator version and generated file ownership.
+
+Generation happens in a temporary directory, validates the complete result, and
+atomically places files only when formatting, architecture checks, and generated
+fixtures pass. Existing-file collisions leave the workspace unchanged. Generated
+files may be edited, but deleting required markers, contracts, ownership, or
+manifest data fails `cargo xtask journey verify-generated`.
+
+## Single Testcontainers harness
+
+Testcontainers is the only development and test service-orchestration source of
+truth. `apps/compose.yml` and `scripts/harness/dev-stack.sh` are removed when the
+kernel migration completes. `infra/sakura/compose.yml` remains a production
+deployment artifact and is never a test topology source.
+
+`tools/harness-runtime` defines digest-pinned PostgreSQL, MinIO, ElasticMQ,
+DynamoDB Local, deterministic Cognito/JWKS fixture, API, and worker containers.
+It owns typed wait strategies, resource provisioning, seed data, random ports,
+run identity, leases, cleanup, log collection, and typed connection manifests.
+`tools/integration-test-support` exposes service handles, typed endpoints,
+resource fixtures, and failure controls without constructing production adapters
+or leaking container control into contract suites. Each adapter integration test
+constructs its own adapter from those typed inputs.
+
+Adapter integration tests instantiate `harness-runtime` directly and start only
+required services. GraphQL journeys use the same runtime. Mobile and Maestro use
+`cargo xtask harness serve`, a resident runner that keeps containers alive and
+writes `.harness-runs/<run-id>/environment.json`; app builds read the API URL
+from that manifest. `cargo xtask harness down <run-id>` or runner shutdown cleans
+all resources. Labels and leases detect and reclaim stale runners and containers.
+
+Every suite uses isolated database/schema, bucket prefix, queue, and DynamoDB
+namespace. Image digests, typed initialization, health/resource wait conditions,
+and sanitized evidence collection are identical locally and in CI. Fixed sleeps
+are forbidden. Failure bundles correlate container logs, API spans, resource
+state, and test results by run ID before cleanup. Testcontainers dependencies are
+tools-only and are rejected from every production graph by policy.
+
+Required CI never calls live AWS. Provider-specific behavior that deterministic
+fixtures cannot prove runs in a separate scheduled/explicit provider-contract
+workflow against dedicated non-production resources. Its evidence may discover
+adapter drift but cannot weaken or replace the required local contracts.
+
+## Required CI checks
+
+Five stable checks run for pull requests, pushes to main, and merge queue events:
+
+1. `API / Architecture`
+   - format, all-target/all-feature Clippy with warnings denied, dependency
+     policy, every AST rule/fixture, exception, intent, and generated drift;
+2. `API / Domain and Application Contracts`
+   - domain/property tests and all module contracts using in-memory adapters;
+3. `API / Adapter Integration`
+   - every production adapter contract and emulator-specific failure,
+     concurrency, retry, partial-failure, and compensation test;
+4. `API / GraphQL Schema and Journeys`
+   - GraphQL adapter, schema artifact comparison, intent-selected journeys,
+     downstream state assertions, correlation, and log-safety evidence;
+5. `Repository / Harness Invariants`
+   - repository validators, PR metadata consistency, harness tests, and
+     validator self-tests.
+
+During kernel cutover, `scripts/harness/validate-all.sh` is updated atomically to
+delegate API architecture checks to `cargo xtask architecture check`; it must not
+retain references to removed `service/*`, Compose, or the legacy grep validator.
+Repository-level knowledge, quality, and Mobile checks remain composed through
+the same top-level command.
+
+Workflows create stable check names on every PR; non-API changes explicitly pass
+no-op jobs after change detection rather than skipping the workflow. Main branch
+protection requires all five, fresh base, stale approval dismissal, and no
+ordinary administrator bypass. Architecture policy, validators, workflows, and
+exception files require CODEOWNERS review.
+
+Local save feedback runs affected `cargo check`, affected AST rules, and intent
+presence. Pre-commit runs format, full Clippy, dependency/AST/exception/intent
+checks, and affected contracts. Hooks are never the root of trust.
+
+Service images are digest-pinned, waits use health/resource conditions, timeouts
+fail, and caches key on lockfile/toolchain/target without caching test outcomes.
+SARIF, schema, journey evidence, and sanitized failure logs are uploaded even on
+failure.
+
+## Policy documentation and promotion
+
+Root `AGENTS.md` remains a router. Kernel delivery creates the PR #366 policy
+documents for dependency, module, error, transaction, observability, and
+exception rules under `docs/architecture/`, and routes to domain rules, journeys,
+lessons, and the local Testcontainers runbook.
+
+A recurring or generalizable review finding must receive a minimal fixture and
+be classified for compiler, AST, contract, integration, or journey enforcement.
+The second occurrence cannot merge without deterministic promotion. Findings
+that cannot be deterministic become a load-bearing ADR or contextual lesson;
+AI never grants exceptions or blocks merge as the sole evidence.
+
+High-confidence AI findings require a human or independent validation-agent
+disposition. Accepted deterministic findings are promoted before the next
+representative use case; design-only findings are recorded as ADRs or lessons.
+
+## Permanent success invariants
+
+- Known architecture-violation fixture detection is 100% and known-rule CI
+  escapes are zero.
+- Indefinite, expired, unused, or silently broadened exceptions are zero.
+- GraphQL resolver use of SeaORM/AWS, provider types in application interfaces,
+  and environment reads outside bootstrap are zero.
+- Applicable application use cases with reusable contracts and production
+  adapters with deterministic integration coverage remain 100%.
+- Product changes with matching product-axis, canonical-journey, and evidence
+  manifests remain 100%.
+- A second occurrence of a known general failure without deterministic promotion
+  has zero permitted merges.
+
+## Kernel exit criteria
+
+- The virtual workspace and production dependency graph match the default-deny
+  policy.
+- All twelve initial architecture rules have passing and failing fixtures.
+- Alias, public re-export, unreachable-file, parse-error, invalid-policy, and
+  expired/unused-exception fixtures fail with exact rule evidence.
+- Intent/diff and generated-journey fixtures prove both acceptance and rejection.
+- Testcontainers starts each isolated service and the full resident Harness,
+  emits a typed connection manifest, captures sanitized failure evidence, and
+  cleans normal/stale resources.
+- API, worker, schema, and migration binaries build from `api-bootstrap`; API and
+  worker start, report health/readiness, and shut down gracefully.
+- The new empty database baseline applies from scratch.
+- All five stable required checks pass and remain required when local hooks are
+  disabled.
+- The old product crate, GraphQL schema, migration crate, SQS consumer crate,
+  development Compose topology, and legacy boundary shell validator are absent.
+- No product journey is claimed complete until the Walking Skeleton that follows
+  the kernel.
+
+## Self-review traceability
+
+| PR #366 input | Resolution in this document |
+| --- | --- |
+| Objective, fixed constraints, chosen approach | Purpose, cutover, default-deny policy, CI root of trust |
+| Workspace Architecture and Port Rule | Workspace layout, dependency policy, application contracts |
+| Gate 1: Cargo graph | Dependency policy including normal/dev/feature/target edges |
+| Gate 2: Rust AST | Twelve rules, source discovery, aliases, fixtures, SARIF |
+| Gate 3: Application contracts | Generator output and Domain/Application required check |
+| Gate 4: Infrastructure integration | Single Testcontainers harness and scheduled provider contracts |
+| Gate 5: Journey/schema/observability | GraphQL/Journey required check, intents, evidence, log safety |
+| Save-time, pre-commit, PR, merge timing | Required CI checks and local feedback |
+| Documentation routing | Policy documentation and runbook routing |
+| Change Intent Manifest | Versioned retained intent schema and diff validation |
+| Journey Generator | Atomic generator and generated-drift verification |
+| PR Architecture Agent and promotion loop | Human/independent disposition and deterministic promotion |
+| Exceptions | Fingerprinted 30-day maximum entries and one-to-one ADRs |
+| Delivery phases | Kernel cutover, Walking Skeleton handoff, kernel exit criteria |
+| Success measures and non-goals | Permanent success invariants and removal of legacy/AI bypasses |
+
+The review also compared the current inventory gaps: single-crate capability
+leakage, resolver persistence access, provider types, distributed environment
+reads, missing compiler/AST gates, missing contracts/integration coverage, and
+shell-only validation all receive explicit kernel destinations. No input is
+answered by preserving the old architecture merely because it already exists.

--- a/docs/wayfinder/2026-07-11-current-architecture-inventory.md
+++ b/docs/wayfinder/2026-07-11-current-architecture-inventory.md
@@ -1,0 +1,288 @@
+# Current API and Mobile Architecture Inventory
+
+## Purpose
+
+This research resolves the Wayfinder question “Inventory current architecture
+gaps and reusable assets.” It compares the current repository with the approved
+architecture designs from PR #366 and PR #367. It does not choose replacement
+tools or implement the migration.
+
+The evidence baseline is `origin/main` at `08e7e519`, together with the working
+tree at `8ef85528`. The two approved inputs are:
+
+- `docs/superpowers/specs/2026-07-11-greenfield-api-architecture-prevention-design.md`
+- `docs/superpowers/specs/2026-07-11-next-mobile-architecture-prevention-design.md`
+
+## Executive finding
+
+The repository has useful journey, service-contract, local-infrastructure, and
+unit-test assets, but neither target architecture exists yet. The API remains a
+single product crate in which GraphQL, SeaORM, AWS clients, configuration, and
+application behavior cross boundaries. Mobile remains organized primarily by
+technology-wide `app`, `hooks`, `components`, `lib`, and `stores` directories,
+with routes importing those details directly.
+
+The current harness detects a small set of known patterns. It does not enforce
+the dependency graphs, manifests, generated contracts, exception expiry,
+architecture fixtures, or affected-journey evidence required by the two designs.
+The migration must therefore establish deterministic architecture kernels before
+moving product journeys.
+
+## API inventory
+
+### Current shape
+
+`apps/api/Cargo.toml` defines one `walking-dog` product crate plus the existing
+`migration` and `sqs-consumer` workspace members. The product crate publicly
+exports `auth`, `entity`, `graphql`, `observability`, `queue`, `service`, and
+`util` modules from `apps/api/src/lib.rs`.
+
+There are no target crates for:
+
+- `domain`;
+- `application`;
+- `adapter-graphql`;
+- `adapter-postgres`;
+- provider-specific Cognito, S3, SQS, or DynamoDB adapters;
+- `api-bootstrap`;
+- a repository-owned architecture validator or `xtask` generator.
+
+### Mandatory-boundary gaps
+
+| Target rule | Current evidence | Gap |
+| --- | --- | --- |
+| Cargo enforces dependency direction | GraphQL, SeaORM, AWS SDKs, application logic, and bootstrap dependencies are declared by the same product crate | Cargo cannot prevent an inner layer from importing an adapter dependency |
+| GraphQL is a translation adapter | 16 files under `apps/api/src/graphql` reference SeaORM; resolver/object code queries entities directly | Resolvers and GraphQL objects own persistence access and read-model behavior |
+| Provider types stay in provider adapters | GraphQL contains AWS references; service and queue files expose Cognito, S3, SQS, or DynamoDB SDK types | Provider types and construction are not isolated by crates |
+| Environment reads occur only in bootstrap | Environment access appears in `graphql`, `auth`, `observability`, `service`, queue, and worker paths | Configuration is read at runtime across the product crate |
+| Application interfaces contain no adapter types | `service/error.rs` uses SeaORM error types and service modules accept `DatabaseConnection` or AWS clients | Application-visible contracts are coupled to adapters |
+| Production has no `unwrap` or `expect` | Source contains many `unwrap`/`expect` calls; some are tests, while production examples include schema/context access and startup | No AST rule distinguishes and rejects production occurrences |
+| Adapter construction occurs only in bootstrap | `apps/api/src/graphql/mod.rs`, `main.rs`, worker binaries, and service constructors build clients or read configuration | Composition is distributed rather than owned by one bootstrap crate |
+| Every journey exposes application contracts | Existing service tests cover selected behavior, but there is no journey-module contract suite convention | Authorization, idempotency, rollback, concurrency, clock, error, and log-safety coverage is not systematic |
+
+### Existing deterministic checks
+
+`scripts/harness/validate-architecture.sh` currently checks selected textual
+patterns:
+
+- AWS SDK, DynamoDB item shapes, environment access, and selected concrete
+  gateway names in GraphQL resolver directories;
+- React Navigation imports in Mobile;
+- shared API/Mobile walk-goal constants;
+- one track-point worker configuration pattern.
+
+These checks are useful promoted lessons, but they are grep-based, do not inspect
+the resolved Cargo feature graph or Rust AST, and cover only a subset of PR #366.
+There are no passing/failing architecture fixtures with rule identifiers and
+source locations. There is also no machine-readable exception registry or expiry
+validator.
+
+### Reusable API assets
+
+The following should be treated as behavior and test assets, not copied blindly
+as target-layer structure:
+
+- `service::track_point::TrackPointRepository` already expresses the intended
+  track-point storage seam.
+- `service::storage::StorageGateway` already expresses the intended upload seam.
+- `service::auth::AuthGateway` provides a starting seam for Cognito behavior.
+- `service::walk` and `service::walk_read_model` already concentrate portions of
+  walk lifecycle and aggregate behavior.
+- API integration tests cover passwordless authentication, goal boundaries,
+  observability, schema behavior, storage, walk lifecycle, and walk read models.
+- SeaORM migrations and entity definitions capture the existing relational
+  vocabulary and constraints.
+- `apps/compose.yml` provides PostgreSQL, DynamoDB Local, MinIO, ElasticMQ, API,
+  and worker services suitable for deterministic adapter tests.
+- The track-point worker and queue tests contain partial retry, batch, message,
+  and repository behavior that can seed future adapter contracts.
+
+### API removal or replacement candidates
+
+These artifacts conflict structurally with the target and should be removed only
+after replacement journeys are proven:
+
+- the root `walking-dog` crate as the owner of all product capabilities;
+- direct SeaORM imports from `graphql/**`;
+- SeaORM and AWS types in application/service public interfaces;
+- client construction and environment reads in `graphql`, services, and queue
+  modules;
+- hand-wired GraphQL context containing database/provider implementation types;
+- GraphQL object field resolvers that execute persistence queries;
+- grep-only architecture checks once equivalent AST/dependency rules and fixtures
+  are active.
+
+`migration` remains a valid adapter/tooling concern. `sqs-consumer` requires a
+separate ownership decision: retain it as generic infrastructure only if its
+public contract is provider- and domain-neutral; otherwise absorb the behavior
+into the SQS adapter or worker composition boundary.
+
+## Mobile inventory
+
+### Current shape
+
+Mobile is an Expo Router application with root-level technology directories:
+
+- `app` for routes;
+- `components` for shared and domain-grouped UI;
+- `hooks` for queries and workflows;
+- `lib` for GraphQL, authentication, storage, walk behavior, platform bridges,
+  and utilities;
+- `stores` for global Zustand state;
+- `types/graphql.ts` for handwritten transport and domain-shaped types.
+
+The baseline contains 22 route TSX files. Fifteen route files directly import
+from root `hooks`, `lib`, or `stores`. The repository contains approximately 65
+root hook files, 100 component TSX files, 74 `lib` TypeScript/TSX files, and six
+store files. These counts include tests and platform variants where applicable;
+they are inventory indicators, not quality metrics.
+
+There are no `features/*/module.yaml` manifests, feature public entrypoints,
+architecture directory, or `generated/graphql` output.
+
+### Mandatory-boundary gaps
+
+| Target rule | Current evidence | Gap |
+| --- | --- | --- |
+| Routes compose public feature interfaces only | Routes import hooks, stores, GraphQL-adjacent behavior, and shared implementation modules directly | Route callers know workflow and state implementation details |
+| Code that changes together lives in vertical modules | Authentication, dog, user, settings, and walk behavior is spread across routes, components, hooks, lib, stores, and types | Domain concepts lack one owner and one public entrypoint |
+| No application-wide mutable store | Zustand stores own auth, settings, and walk lifecycle state | Durable feature state and application coordination are globally reachable |
+| Lifecycle-heavy features use explicit state machines | `walk-store.ts` has a three-value phase and many imperative actions; `use-walk-session.ts` sequences API, persistence, tracking, Live Activity, and cleanup | Starting, finishing, failed, recovery, and compensation are implicit across hooks and stores |
+| React sends intents rather than orchestrating adapters | Provider and walk hooks coordinate hydration, tracking, Watch, Live Activity, persistence, API mutations, and cleanup | React lifecycle and hook ordering carry domain workflow knowledge |
+| Generated operation types are transport-only | Operations are handwritten strings and `types/graphql.ts` contains aliases such as `avatar`/`avatarUrl` and `distance`/`distanceM` | Schema drift and parallel domain vocabulary remain possible |
+| Manifests match imports, exports, adapters, journeys, and product axes | No `module.yaml` files or manifest validator exist | Ownership and affected-journey declarations cannot be checked |
+| Deep imports, cycles, generated drift, and route/platform imports fail CI | ESLint checks selected syntax/i18n rules and Knip checks unused code | Target dependency rules are not represented as code |
+| Tests use the same public interface as production | Jest tests generally exercise components, hooks, stores, and utilities separately | Tests can bypass the feature interface that production routes should use |
+
+### Current GraphQL contract state
+
+The API schema is checked in at `apps/api/schema.graphql`, and at least the walk
+query tests parse handwritten documents against it. This is a useful seed for a
+schema gate. It is not a generation workflow:
+
+- operation documents are handwritten under `lib/graphql`;
+- `types/graphql.ts` is handwritten and mixes transport types, UI aliases, and
+  domain-facing types;
+- no code-generation command or configuration is present;
+- no CI step regenerates schema/operations and rejects a dirty tree;
+- generated output is not isolated from route or UI imports.
+
+### Reusable Mobile assets
+
+- Expo Router routes and navigation tests capture the current screen inventory
+  and navigation intent.
+- Design-system-like primitives under `components/ui` and theme tokens under
+  `theme` provide reusable visual behavior, subject to public API cleanup.
+- Authentication uses Secure Store rather than AsyncStorage for sensitive
+  tokens, with tests around bootstrap, refresh, and storage.
+- TanStack Query already provides a server-state owner and query invalidation
+  behavior that aligns with PR #367.
+- Walk libraries contain reusable algorithms and native adapter behavior for
+  distance calculation, GPS tracking, background tasks, persistence, permissions,
+  and event outboxes.
+- Approximately 120 Jest test files provide behavior examples and regression
+  cases for routes, components, hooks, stores, GraphQL, storage, and walk logic.
+- Six Maestro flows and six corresponding harness journey documents establish an
+  initial journey vocabulary and selector/evidence skeleton.
+- ESLint i18n checks, typed-route safeguards, theme tests, and Knip are useful
+  deterministic gates to retain inside the new architecture gate set.
+
+### Mobile removal or replacement candidates
+
+- root-level domain workflow hooks, stores, and `lib/walk` ownership;
+- route deep imports into implementation details;
+- `types/graphql.ts` handwritten transport/domain hybrid types;
+- alias-preserving adapters that allow two names for the same domain value;
+- global provider bridges that start feature lifecycle orchestration from the
+  root layout;
+- Watch and Live Activity code, because those capabilities are outside the
+  accepted `docs/tmp-testcases/` scope for this migration;
+- Knip ignore entries and dependencies retained only for the removed Apple
+  extension features.
+
+Shared visual primitives should move to `design-system`; platform-neutral
+technical capabilities should move to `platform`; journey-specific UI and
+workflow code should move behind feature public entrypoints. Those moves must be
+behavior-driven rather than mechanical directory renames.
+
+## Harness, CI, and knowledge inventory
+
+### Reusable assets
+
+- Product principles explicitly define dog experience, data-maximized walks, and
+  owner contribution.
+- Domain rules cover walk goals, track points, walk lifecycle/read models,
+  storage, Cognito email, and legal hosting.
+- Six journey documents align with six Maestro skeletons.
+- The per-worktree dev stack isolates ports, Compose projects, volumes, and
+  evidence paths.
+- `validate-all.sh` composes knowledge, architecture, quality, and Mobile Knip
+  gates.
+- API and Mobile workflows already separate Rust and Jest verification.
+- Existing runbooks define API, Mobile, simulator, journey, and evidence commands.
+
+### Missing mandatory gates
+
+- Cargo resolved-dependency allowlist validation;
+- Rust AST policies with good/bad fixtures and stable rule identifiers;
+- exception registry and expiry enforcement;
+- API change-intent manifest and manifest-to-diff validation;
+- API journey generator;
+- application contract suites shared by in-memory and production adapters;
+- deterministic infrastructure contracts for every Postgres/AWS adapter;
+- GraphQL schema and Mobile operation generation with dirty-tree drift checks;
+- Mobile `module.yaml` schema and manifest-to-import/export/test validation;
+- Mobile deep-import, route-to-platform/generated, and cycle validation;
+- affected-module to affected-journey selection;
+- deterministic seed data, GPS replay, permission control, and camera/photo
+  fixtures;
+- deterministic local Cognito/JWKS/OTP behavior suitable for required CI;
+- cross-layer correlation identifiers and automated sensitive-log inspection;
+- standardized evidence manifests and CI artifact publication;
+- branch protection requiring all deterministic architecture and journey gates;
+- change-intent-driven independent AI architecture review with human disposition;
+- a versioned good-change/bad-fixture feedback corpus with false-positive and
+  false-negative tracking;
+- machine-readable promotion and time-limited exception workflows.
+
+Current GitHub workflows run API tests, Mobile Jest, and repository invariants.
+They do not run Mobile lint/typecheck/Knip in the Mobile test workflow, Maestro in
+pull requests, architecture fixtures, schema/code generation, or affected-journey
+selection.
+
+## Migration constraints exposed by the inventory
+
+1. **Architecture kernels must precede feature migration.** Without the target
+   crates, manifests, and validators, migrated code can immediately drift back.
+2. **A replacement GraphQL contract must be designed jointly.** The current
+   schema, handwritten operations, and handwritten aliases cannot be migrated
+   independently without recreating coupling.
+3. **Journeys are the safe replacement unit.** A layer-by-layer rewrite would
+   leave main deployable but behaviorally incoherent. Each slice needs route,
+   feature interface, generated operation, GraphQL adapter, application module,
+   adapters, and evidence.
+4. **The first slice should be simpler than Active Walk.** Authentication and a
+   read-only dog/profile slice can prove both architecture kernels before GPS,
+   queues, storage compensation, and background recovery are introduced.
+5. **Legacy removal needs explicit gates.** A legacy path may be deleted only
+   after its replacement journey passes public-interface contracts and end-to-end
+   evidence on main.
+6. **Test assets require re-homing, not wholesale deletion.** Existing tests are
+   valuable behavior evidence, but target contract tests must enter through the
+   same feature/application interfaces used in production.
+
+## Inputs for downstream Wayfinder tickets
+
+The inventory leaves these decisions to their dedicated tickets:
+
+- canonical domain terms and journey/module ownership;
+- the concrete Rust workspace, AST validator, manifest, generator, and exception
+  formats;
+- the concrete Mobile manifest, import validator, state-machine, and generation
+  tool choices;
+- the replacement GraphQL schema and typed error contract;
+- deterministic Cognito/OTP, GPS, permission, media, fixture, observability, and
+  CI strategy;
+- vertical-slice ordering and final file-level roadmap.
+
+No additional product decision was inferred during this research.

--- a/docs/wayfinder/2026-07-11-deployable-vertical-migration-sequence.md
+++ b/docs/wayfinder/2026-07-11-deployable-vertical-migration-sequence.md
@@ -1,0 +1,547 @@
+# Deployable Vertical Migration Sequence
+
+## Purpose
+
+This document fixes the dependency order and atomic pull-request boundaries for
+replacing `apps/api` and `apps/mobile`. It is the structural input to the later
+file-level implementation roadmap. It does not preserve the current API, Mobile,
+runtime, local device data, or production data.
+
+The sequence prioritizes whole-system consistency and quality over diff size or
+reuse. Foundation merges may temporarily expose no product Journey. Once a
+Journey is declared migrated, it remains executable end to end in every later
+merge.
+
+Inputs:
+
+- API architecture kernel and PR #366
+- Mobile architecture kernel and PR #367
+- replacement GraphQL contract
+- deterministic acceptance/observability Harness
+- canonical domain/Journey ownership map
+- normalized acceptance specification
+- approved visual artifact:
+  `docs/wayfinder/artifacts/2026-07-11-mobile-journey-wireflow.html`
+
+The visual artifact was reviewed and approved on 2026-07-11. It validates the
+three-tab shell, route/Feature/Journey ownership, lifecycle overrides, common
+states, and delivery-slice placement. It is structural, not final visual design.
+
+## Atomic merge policy
+
+The migration uses eleven sequential pull requests. Each is one reviewable,
+deployable unit. Journey pull requests are vertical: contract, API, GraphQL,
+Mobile, Harness, observability, and evidence merge together. They are never split
+into API-only, Mobile-only, or test-later pull requests.
+
+Within a pull request, commits follow:
+
+```text
+contract/negative fixture
+-> API/domain/application/adapters
+-> schema and generated Mobile transport
+-> Mobile public Feature and route composition
+-> Journey fixture/Maestro/observability
+-> deletion and full verification
+```
+
+Every commit passes format, architecture, generation, and type/build gates. The
+route remains unreachable until its complete Journey commit. The pull request
+merges only when its exit criteria pass; there are no follow-up TODOs, warning
+gates, temporary compatibility adapters, dual schemas, feature flags, or
+indefinite exceptions.
+
+Rollback always deploys the previous complete API image and Mobile build as a
+pair. It does not reactivate legacy code inside the new binaries. Database/device
+data migration and forward compatibility are unnecessary because there is no
+production data and the replacement Mobile starts with an empty device schema.
+
+## Dependency graph
+
+```text
+PR 1 API Kernel
+  -> PR 2 Mobile Kernel
+    -> PR 3 Contract + Harness Foundation
+      -> PR 4 Access Account
+        -> PR 5 Owner Profile + Preferences
+          -> PR 6 Dogs + Goals
+            -> PR 7 Record a Walk
+              -> PR 8 Capture Walk Events
+                -> PR 9 Review Walk History
+                  -> PR 10 Review Owner Contribution
+                    -> PR 11 Integrated Hardening
+```
+
+History depends on Events so its detail/timeline/media contract is complete when
+first exposed. Contribution follows History so the Completed-only projections,
+filtering, ordering, and bad-data policy are already proven. This is intentionally
+more sequential than parallel feature construction: it prevents callers from
+depending on incomplete read models or speculative seams.
+
+## PR 1 — Replace the API with the architecture kernel
+
+### Outcome
+
+Remove the current product crate and establish the virtual Rust workspace,
+default-deny dependency/AST compiler, typed bootstrap, empty database baseline,
+production API/worker binaries, `/health`, structured observability, graceful
+shutdown, Testcontainers tool crates, intents, exact exceptions, and generator
+fixtures. No product GraphQL field, queue message, or migration is retained.
+
+### Ownership and surfaces
+
+- Creates `domain`, `application`, all declared adapter crates, `api-bootstrap`,
+  architecture tools, Harness tools, and `xtask` with no speculative product
+  implementation.
+- Removes the current root product crate, standalone migration/consumer crates,
+  development Compose topology, and legacy migrations.
+- Keeps production Sakura Compose as deployment-only configuration pointing at
+  the replacement images.
+
+### Deployable state
+
+The API and worker build and start. `/health` reports process/config readiness;
+the worker processes no product message. Database migration creates the new empty
+baseline. Mobile is temporarily incompatible and is not a supported Journey.
+
+### Exit criteria
+
+- all API architecture rules and positive/negative fixtures pass;
+- `cargo metadata --locked --all-features` matches default-deny policy;
+- API/worker/schema/migrate binaries build from pinned toolchain/container;
+- empty migration applies twice safely to isolated PostgreSQL;
+- `/health`, startup failure, shutdown, and forbidden-log fixtures pass;
+- Docker/deployment build uses only new binaries;
+- legacy API source, migration history, dev Compose, and compatibility schema are
+  absent;
+- repository Harness validation passes.
+
+## PR 2 — Replace Mobile with the architecture kernel
+
+### Outcome
+
+Remove the current Expo source and introduce the iOS-only vertical modular
+monolith, module manifests, architecture compiler, intent protocol, Journey
+registry, design-system boundary, route-only composition shell, error Result
+algebra, XState/TanStack/SQLite/SecureStore policies, and Release-build gates.
+
+### Ownership and surfaces
+
+- Creates manifests for the eight Features and required Platform modules without
+  empty implementation layers.
+- Creates the localized accessible routing shell; product routes remain absent.
+- Removes root hooks/stores/components/lib/types, Zustand, handwritten GraphQL,
+  Android/Web/Watch/Live Activity code and config, and the old device schema.
+- Sets minimum iOS 18.0 and pinned simulator matrix policy.
+
+### Deployable state
+
+The iOS app builds, installs, and launches to an honest development shell. It
+does not claim authentication, Dog, Walk, History, or Contribution availability.
+The API remains health-only.
+
+### Exit criteria
+
+- all Mobile architecture fixtures fail/pass under their stable rule IDs;
+- every source file has exactly one manifest owner and the dependency graph is
+  acyclic;
+- route imports, deep imports, generated access, global mutable state, missing
+  adapter contracts, and out-of-scope targets are mechanically rejected;
+- iOS 18.3 Release-equivalent build installs and launches without crash;
+- localization, Dynamic Type, VoiceOver naming, and reduced-motion shell smoke
+  tests pass;
+- old Mobile source, dependencies, native targets, and device data are absent;
+- repository Harness validation passes.
+
+## PR 3 — Establish the shared contract and deterministic Harness
+
+### Outcome
+
+Integrate local schema generation, Feature-owned operation discovery, pinned
+Mobile codegen, deterministic Cognito-compatible provider, PostgreSQL/MinIO/
+ElasticMQ/DynamoDB Local/Toxiproxy/OTel runtime, run isolation, fixture compiler,
+failure control, iOS runner, evidence bundle, privacy scanner, and Journey
+selection. The system still exposes no product Journey.
+
+### Ownership and surfaces
+
+- API schema contains only a bootstrap-owned system/schema-revision query needed
+  to prove deterministic generation; no product aggregate exists.
+- Mobile generates transport output from the local schema but owns no product
+  operation.
+- Harness proves production binaries/adapters against deterministic external
+  services; it contains all fault controls outside production graphs.
+
+### Deployable state
+
+API health/system schema and Mobile development shell work against one Harness
+environment manifest. One command starts, verifies, and tears down the isolated
+stack. The shell does not expose a product route.
+
+### Exit criteria
+
+- schema generation and Mobile generation are deterministic with a clean second
+  pass;
+- two concurrent isolated runs cannot observe each other's database, auth,
+  storage, queue, DynamoDB, clock, faults, Simulator, keychain, or SQLite state;
+- each failure-control family proves it reaches its intended seam;
+- intentional token/OTP/signed-URL/object-key/coordinate evidence is blocked
+  before upload;
+- setup, cleanup, lease recovery, resource leak, and exporter failure each fail
+  the correct gate;
+- pinned iOS 18.3 and 26.5 shell runs produce valid evidence bundles;
+- every required foundation CI check is enforced.
+
+## PR 4 — Migrate Access Account
+
+### Outcome
+
+Deliver Sign In, Sign Up, OTP verification, token refresh rotation, Email Address
+change, global session revocation, Sign Out, legal links, session persistence, and
+authenticated entry into the Dogs/Walk/Me shell.
+
+### API and contract
+
+- Implements `identity`, its Cognito ports/adapters, idempotency, Owner
+  provisioning port, 401 envelope, and secret-safe telemetry.
+- Adds all identity mutations and typed outcomes from the replacement GraphQL
+  contract. Both access and refresh tokens are mandatory.
+- Creates the minimum Owner record required for account ownership, without Owner
+  profile-edit or contribution queries.
+
+### Mobile and Journey
+
+- Implements `account-access`, AuthenticatedClient capability, SecureStore
+  adapter plus in-memory adapter/contract, and auth XState machines.
+- Publishes authenticated tabs whose unavailable product destinations remain
+  honest shell states until their slices migrate.
+- Promotes `Access Account` Journey and all Sign Up/Login/Email Change source
+  sections into deterministic scenarios.
+
+### Exit criteria
+
+- eight/six-digit OTP, ten-minute expiry, 30-second resend, invalidation,
+  consumption, five-per-hour rate limit, and 10-minute human timeout pass;
+- concurrent 401s single-flight one refresh and replay mutations once with their
+  original idempotency key;
+- missing rotated token invalidates the session; no auth failure becomes success;
+- Email Address change rejects old identity, revokes every session, and requires
+  new sign-in;
+- Sign Out is blocked by a fixture Active Walk even though recording UI is not
+  yet public, proving the identity port contract without exposing a speculative
+  Feature dependency;
+- secrets and personal identifiers are absent from evidence;
+- the complete Access Account Journey passes on both main matrix runtimes.
+
+## PR 5 — Migrate Manage Owner Profile and Preferences
+
+### Outcome
+
+Deliver current Owner display/edit, Avatar prepare/upload/replace/remove,
+language, units, appearance, notification status/settings link, legal links,
+About, Email Change entry, and Sign Out composition.
+
+### API and contract
+
+- Implements `owner` queries/update, Owner name invariants, purpose-bound media
+  preparation, checksum/policy validation, compensation, and current Avatar.
+- Keeps language/units/appearance/notification/About off the API.
+
+### Mobile and Journey
+
+- Implements `owner-profile` and `preferences`, DisplayPreferences capability,
+  media normalization, system-settings, persistence adapters, Settings and Owner
+  routes.
+- Applies setting changes immediately and rolls back visible value when durable
+  persistence fails.
+- Promotes `Manage Owner Profile and Preferences`, including User Edit and
+  Settings sections; Contribution areas of Me stay absent until PR 10.
+
+### Exit criteria
+
+- Owner name, no-change Save, dirty discard, last-write-wins/refetch, Avatar
+  atomicity/removal/expiry/compensation, and broken-image fallback pass;
+- Japanese/English, km/mile, Light/Dark/Auto persist and update consumers through
+  the capability contract;
+- notification Not Requested/On/Off reflects iOS settings after return;
+- About shows real version/build without navigation; Terms/Privacy keep Settings
+  usable on failure;
+- Active Walk fixture still blocks Sign Out and points to the unavailable Walk
+  recovery shell honestly;
+- Owner/Profile/Settings Journey evidence passes without exposing Contribution.
+
+## PR 6 — Migrate Manage Dogs and Goals
+
+### Outcome
+
+Deliver Dogs tab, list/empty/error, create, detail, edit, Archive, partial
+Birthday, Gender, independent Daily/Weekly Goals, Avatar workflow, and Dog
+selection projection for the later Walk slice.
+
+### API and contract
+
+- Implements `dog` application/domain, repositories, exact-name uniqueness,
+  current/Archived lifecycle, Active Walk participation port, partial Birthday,
+  Gender, Goals, and Dog media.
+- Adds current Dogs, Dog detail, create/update/archive, and Dog Avatar operations.
+  Breed remains a reserved database column outside all contracts.
+
+### Mobile and Journey
+
+- Implements `dogs` public Feature, routes, forms, media adapter, partial
+  Birthday/age presentation, independent Goal editing, and in-memory/production
+  contracts.
+- Dog Detail exposes profile/Goal data only; contribution and history slots are
+  absent until their owning slices.
+- Promotes all Dogs List/Registration/Edit and Dog Detail profile/Goal sections.
+
+### Exit criteria
+
+- exact-character duplicate names fail while case/whitespace/Unicode variants
+  remain allowed; Archived names do not reserve uniqueness;
+- Birthday precision persists and age uses day 16 or July 1 only for calculation;
+- Gender rejects unknown/missing/case/whitespace values;
+- Daily 0–120 and Weekly 0–840 by five, defaults 30/120, zero/no-goal, and no
+  cycle conversion pass;
+- archive excludes current lists/selection, preserves references, and is blocked
+  for an Active participant;
+- Breed is absent from schema, operations, UI, fixtures, and evidence;
+- complete Manage Dogs and Goals Journey passes.
+
+## PR 7 — Migrate Record a Walk
+
+### Outcome
+
+Deliver Walk Ready/Starting/Recording/Finishing/Finished/Failed and recovery
+states, Dog selection, foreground/background location, Track Point outbox/batch,
+route quality, start/finish/interruption, restart/background/API reconciliation,
+and hidden Interrupted semantics.
+
+### API and contract
+
+- Implements `walk_recording`, PostgreSQL/Track Point/DynamoDB/SQS ports,
+  worker processing, idempotency, lifecycle transactions, distance/duration, and
+  one Active Walk per Owner.
+- Adds active/start/append/finish/interrupt operations and ordered per-point
+  Accepted/Rejected results.
+
+### Mobile and Journey
+
+- Implements `walk-recording` XState system, `ActiveWalkContext`, SQLite
+  repositories/outbox, location adapter, app lifecycle integration, stable map
+  shell, permissions, reconciliation, and Walk tab states.
+- Event controls remain absent until PR 8.
+- After authoritative completion, shows a saved confirmation in the Walk shell
+  and returns Ready because Review Walk History is not yet migrated. It does not
+  create a placeholder detail route. PR 9 replaces this composition outcome with
+  direct navigation to the real Completed Walk detail.
+- Promotes `Record a Walk` excluding event/photo-owned sections.
+
+### Exit criteria
+
+- no Dog or no foreground location blocks Start before API mutation;
+- durable local shell precedes acknowledged recording; failed Start creates no
+  fake progress;
+- background denial falls back to foreground; foreground loss/service disable or
+  30 seconds without a valid point interrupts and returns Ready without detail;
+- accuracy, monotonic time, 12 m/s, future time, batch identity/order, duplicate
+  replay, and outbox cleanup contracts pass;
+- app restart/background/API-only/local-only Active states reconcile exactly;
+- finish computes nonnegative authoritative metrics, confirms the saved Walk and
+  returns Ready; Interrupted remains absent from every exposed surface;
+- map shell does not remount during Ready-to-Recording transitions;
+- complete Record a Walk Journey and privacy-safe route evidence pass.
+
+## PR 8 — Migrate Capture Walk Events
+
+### Outcome
+
+Deliver per-Dog Pee/Poop, camera/deep-link Photo, purpose-bound direct upload,
+durable pending Event/Photo outbox, late sync, Retry/discard, and integration into
+the unchanged recording shell.
+
+### API and contract
+
+- Implements `walk_event`, event/media repositories and ports, participant/time
+  validation, distinct identities, idempotency, purpose-bound upload, and bounded
+  late sync to Completed/Interrupted Walks.
+- Adds Pee, Poop, Photo prepare/register operations; unknown writes are impossible.
+
+### Mobile and Journey
+
+- Implements `walk-events` with the sole direct Feature dependency on
+  `walk-recording` public `ActiveWalkContext`.
+- Persists each intent before acknowledgement; Photo normalization/upload may
+  continue after Walk completion.
+- Promotes `Capture Walk Events` and event/photo sections split from Walk Screen.
+
+### Exit criteria
+
+- every intentional tap creates one distinct event; in-flight button disabling
+  and same-identity retry prevent accidental duplicate effects;
+- multiple Dogs receive their explicit per-Dog event; nonparticipants fail;
+- Photo size/dimensions/checksum, 15-minute upload expiry, 60-second timeout,
+  compensation, pending-after-Finish, permanent failure, Retry, and discard pass;
+- late durable events sync only within final boundaries; out-of-bound values fail;
+- unknown read events and legacy out-of-bound events are omitted/count-safe;
+- deep-link camera action executes once and is cleared;
+- recording shell continuity and complete Capture Walk Events Journey pass.
+
+## PR 9 — Migrate Review Walk History
+
+### Outcome
+
+Deliver Me all-Dog and Dog-preselected history, Archived Dog filters, fixed cursor
+pages, refresh/next-page recovery, scroll/filter preservation, Completed detail,
+route/events/photos, pending Photo presentation, and Active Walk redirect.
+
+### API and contract
+
+- Implements `walk_insight` history/detail read ports and projections, stable
+  ordering, fixed 20 pages, opaque filter-bound cursor, current Owner/Dog
+  references, Completed-only filtering, and isolated unavailable rows.
+- Adds history/detail queries. Active and Interrupted never enter cursor math.
+
+### Mobile and Journey
+
+- Implements `walk-history` list/detail state, pagination, filters, mapping,
+  current unit formatting, map/timeline/photo modal, pending Photo state, and
+  route composition from Me/Dog.
+- The route boundary reads `walk-recording` public state for Active redirect;
+  `walk-history` does not import recording internals.
+- Promotes all Walk History and Walk Detail sections plus Dog recent Walks.
+
+### Exit criteria
+
+- ordering ties, fixed pages, duplicate bottom events, invalid/cyclic cursors,
+  next-page/refresh failure preservation, and scroll/filter restoration pass;
+- All/current/Archived Dog filters use IDs; multi-Dog Walk appears once per
+  applicable list; renamed current references update past presentation;
+- bad metrics isolate one row, fail detail, and never become zero;
+- unknown/out-of-bound events are omitted; known events preserve stable order;
+- expired/missing/broken Photo is explicit and modal always closes;
+- any detail intent during Active Walk redirects to recording without a loop;
+- successful Finish now navigates directly to the real saved detail, replacing
+  PR 7's temporary Ready confirmation without a compatibility path;
+- complete Review Walk History Journey passes.
+
+## PR 10 — Migrate Review Owner Contribution
+
+### Outcome
+
+Deliver Owner lifetime counts/distance/time, seven-day weekly graph, Walking
+Since, per-Dog Completed progress/statistics, Daily/Weekly Goal comparison, unit
+formatting, and complete Me/Dog composition.
+
+### API and contract
+
+- Extends `walk_insight` with authoritative Owner Contribution and Dog Walk
+  Progress read models over complete Completed data.
+- Adds contribution queries with explicit Unavailable results and controlled
+  timezone/time-window inputs/outputs required for deterministic presentation.
+
+### Mobile and Journey
+
+- Implements `contribution` public Feature and composes it into Me and Dog Detail
+  through routes. It consumes DisplayPreferences, never history pages or another
+  Feature's state.
+- Promotes User Screen aggregate/graph and Dog Detail statistics/progress sections.
+
+### Exit criteria
+
+- Completed only; multi-Dog counts once for Owner and once per Dog; zero remains
+  valid while malformed values become Unavailable;
+- device timezone, Monday week, startedAt classification, midnight/year/DST,
+  multiple same-day Walks, no-Walk days, and timezone changes pass;
+- aggregate unrounded seconds precede formatting; km/mile changes are consistent
+  across active/history/detail/Dog/Me surfaces;
+- Walking Since valid/missing/invalid/future behavior and safe contract evidence
+  pass;
+- Daily/Weekly progress uses independent Goal values without conversion;
+- complete Review Owner Contribution Journey passes.
+
+## PR 11 — Integrate, delete, and harden the full system
+
+### Outcome
+
+Prove the completed replacement as one system, finish negative architecture and
+contract fixtures, remove every obsolete/out-of-scope artifact, enforce the full
+CI matrix, measure flakiness/performance/resource cleanup, and freeze the final
+knowledge/ADR/runbook state.
+
+### Required work
+
+- Run all seven Journeys across iOS 18.3 and 26.5 plus the nightly small-screen,
+  accessibility, localization, appearance, units, timezone, failure, restart,
+  concurrency, and privacy matrix.
+- Verify every PR #366/#367 negative rule remains blocking with AI review absent.
+- Verify every normalized statement maps to one Journey scenario, API/Mobile
+  contract, and evidence comparison.
+- Delete old Compose/runbooks/scripts/schema/types/operations/tests/snapshots,
+  obsolete dependencies, Breed UI/API, Watch/Live Activity, Android/Web, and all
+  expired exceptions.
+- Update CONTEXT, ADRs, root maps, local Harness runbook, Journey catalog, quality
+  score, lessons learned, and validator rules for every migration finding.
+
+### Exit criteria
+
+- every deterministic PR/main/nightly/release gate is required and green;
+- intentional architecture, schema drift, privacy, setup, Journey, cleanup,
+  resource leak, and observability failures fail the expected stable rule;
+- no TODO/TBD/placeholder, unused export/dependency, compatibility alias, dual
+  runtime, dead route, unowned file, expired exception, or old asset remains;
+- flake repetitions have zero unexplained nondeterminism and no retry converts a
+  failure to success;
+- evidence retention and artifact privacy are verified;
+- final input-to-output audit is complete before human review.
+
+## Requirement-to-slice summary
+
+| Acceptance inventory | Primary slice | Later composition |
+| --- | --- | --- |
+| Sign Up | PR 4 | PR 11 full matrix |
+| Login | PR 4 | PR 7 Active Walk auth recovery |
+| Email Change | PR 4 | PR 5 Settings entry |
+| User Edit | PR 5 | PR 10 complete Me composition |
+| Settings | PR 5 | PR 7 real Active Walk Sign Out block |
+| User Screen | PR 10 | none |
+| Dogs List | PR 6 | PR 10 progress decoration |
+| Dog Registration | PR 6 | none |
+| Dog Edit | PR 6 | PR 7 real Active participant block |
+| Dog Detail | PR 6 | PR 9 history, PR 10 progress |
+| Walk Screen | PR 7 | PR 8 events/photos |
+| Walk History List | PR 9 | PR 10 no dependency |
+| Walk Detail | PR 9 | PR 8 event/media inputs already complete |
+
+The primary slice owns and promotes its source sections according to the
+ownership map; later composition does not redefine the earlier owner. Any fixture
+used before the real producer slice is a contract fixture, not a public partial
+Journey, and is deleted or converted when the producer migrates.
+
+## Self-review
+
+The sequence was checked against both architecture delivery orders, all module
+and Feature dependencies, the GraphQL operation matrix, Harness prerequisites,
+the approved wireflow, and every normalized inventory.
+
+Findings resolved during review:
+
+1. Walk History was placed after Capture Walk Events so its first public detail
+   contract includes complete event/photo behavior rather than a partial timeline.
+2. Review Owner Contribution was placed after History so it consumes complete API
+   read models, never a bounded Mobile page.
+3. Foundation schema generation was given a bootstrap-only revision query so PR 3
+   can prove deterministic schema/codegen without exposing a speculative product
+   field.
+4. Pre-slice Active Walk fixtures used by auth/archive checks are explicitly
+   contract fixtures and cannot be presented as migrated UI behavior.
+5. The approved visual artifact and review outcome are recorded before planning
+   user-facing implementation.
+6. PR 7 no longer invents a placeholder Walk Detail. It uses an explicit saved
+   confirmation until PR 9 delivers the separately owned Review History Journey;
+   the wireflow records both stage outcomes.
+
+No dependency cycle, partially exposed Journey, layer-only product merge,
+compatibility period, production-data migration, or unresolved sequence decision
+remains. Exact file paths, code/test steps, commands, and expected outputs belong
+to the file-level roadmap ticket that consumes this sequence.

--- a/docs/wayfinder/2026-07-11-deterministic-acceptance-observability-harness.md
+++ b/docs/wayfinder/2026-07-11-deterministic-acceptance-observability-harness.md
@@ -1,0 +1,390 @@
+# Deterministic Acceptance and Observability Harness
+
+## Purpose
+
+This document defines the single local and CI system that executes every
+normalized acceptance outcome without production dependencies. It integrates the
+API Testcontainers runtime, replacement GraphQL contract, iOS Mobile application,
+Maestro, fixtures, deterministic faults, observability, privacy checks, and
+evidence retention.
+
+Inputs:
+
+- `docs/wayfinder/2026-07-11-acceptance-spec-normalization.md`
+- `docs/wayfinder/2026-07-11-domain-journey-ownership-map.md`
+- API and Mobile architecture-kernel documents
+- replacement GraphQL contract and generation workflow
+- PR #366, PR #367, and all 13 `docs/tmp-testcases/` inventories
+
+## One runtime, no production dependency
+
+`apps/api/tools/harness-runtime` is the only development and test orchestration
+source. `cargo xtask harness serve` starts digest-pinned Testcontainers for:
+
+- PostgreSQL;
+- MinIO;
+- ElasticMQ;
+- DynamoDB Local;
+- deterministic authentication/JWKS provider;
+- Toxiproxy;
+- API and Track Point worker production binaries;
+- OpenTelemetry Collector with local trace/log exporters;
+- a Harness-only control plane.
+
+The runtime creates typed resource handles, provisions isolated resources, waits
+on explicit health/resource conditions, and writes
+`.harness-runs/<runId>/environment.json`. Mobile build/run and Maestro consume
+that manifest; they do not reconstruct URLs or credentials. Fixed host ports,
+fixed sleeps, `apps/compose.yml`, live AWS, production secrets, and production
+Cognito are forbidden in required checks.
+
+`cargo xtask harness down <runId>` collects evidence then destroys the run.
+Container labels, a renewable lease, process ownership, and a cleanup controller
+identify abandoned runs. A new runner reaps an expired run only after capturing
+its sanitized diagnostic manifest.
+
+## Run isolation
+
+Every invocation receives a random `runId` and exclusive namespace:
+
+| Resource | Isolation boundary |
+| --- | --- |
+| PostgreSQL | database/schema and database role |
+| MinIO | bucket or bucket prefix with run-only credentials |
+| ElasticMQ | queue and dead-letter queue |
+| DynamoDB Local | table prefix |
+| Authentication | tenant, signing key ID, accounts, challenges, sessions |
+| API/worker | run-scoped configuration and telemetry resource attributes |
+| Mobile | fresh Simulator clone and erased app container/keychain state |
+| SQLite | fresh application container database |
+| Clock/faults | run-scoped controller state |
+
+Owner, token, media, queue, database, keychain, SQLite, Simulator app data, and
+fault state are never shared between tests. Isolated runs and Journey shards may
+execute concurrently. Resource names contain only `runId` and stable fixture ID,
+never Email Address, Owner name, or Dog name.
+
+## Fixture system
+
+Each scenario references one versioned declarative fixture:
+
+```text
+apps/mobile/journeys/<journey-id>/
+├── journey.yaml
+└── fixtures/
+    ├── success.yaml
+    ├── validation.yaml
+    └── ...
+```
+
+A fixture declares schema version, fixture ID, controlled instant/timezone,
+Owner/account state, Dogs and Goals, Walks, Track Points, Events, media facts,
+authentication/provider state, expected API/resource/UI projections, fault
+manifest, evidence fields, and cleanup expectations. IDs and clocks are stable;
+secret values are generated per run and never committed.
+
+The fixture compiler validates closed enums, domain values, references, ordering,
+uniqueness, expected calculations, privacy classification, and exact Journey and
+Feature ownership. It produces typed Rust setup data, Harness control commands,
+Mobile runtime inputs, and expected comparison projections from one source.
+Handwritten parallel fixtures are forbidden.
+
+Normal state is seeded through application-level setup interfaces that exercise
+the same repositories and invariants as production. Direct database/resource
+injection is allowed only for explicitly classified impossible-state fixtures,
+such as malformed legacy read data, a future timestamp, cyclic cursor, unknown
+stored event, or broken media reference. Such a fixture names the contract rule
+it violates and cannot be reused as a success fixture.
+
+Before a scenario, the runner proves the actual starting projection equals the
+compiled fixture. After it, the runner compares API, database, queue, storage,
+DynamoDB, worker, SQLite, and visible UI outcomes before cleanup. Setup or cleanup
+drift fails independently of the Journey assertion.
+
+## Deterministic authentication and OTP
+
+Required local, PR, main, and nightly checks use the production
+`adapter-aws-cognito` against a deterministic Cognito-compatible provider
+endpoint and JWKS service owned by Harness. The API binary, application port,
+adapter mapping, refresh-rotation checks, and error translation are therefore the
+same as production; only the external provider is local. It supports:
+
+- Sign In eight-digit and Sign Up/Email Change six-digit challenges;
+- ten-minute expiry and 30-second resend availability;
+- resend invalidation and one-time consumption;
+- five requests per Email Address per controlled hour;
+- access and rotating refresh tokens;
+- deterministic JWKS/key rotation and invalid signatures;
+- global session revocation after Email Address change;
+- injected missing access/refresh token provider responses;
+- invalid, expired, consumed, wrong-length, rate-limited, and provider-failure
+  outcomes.
+
+OTP and challenge values are not fixed in source. The control plane issues a
+single-use opaque retrieval handle to the runner, which injects the OTP into the
+Maestro process through a masked ephemeral variable. Maestro, shell tracing,
+screenshots, video, app/API logs, and evidence never receive the retrieval
+response as printable output. The handle and OTP expire with the run.
+
+Real Cognito/SES behavior is a separate explicit or scheduled provider-contract
+job. It is not a required merge gate and cannot use production resources. Human
+OTP collection waits at most ten minutes and records `HUMAN_TIMEOUT`; it never
+hangs or prints the OTP/session/token. Required deterministic success does not
+depend on that job.
+
+The endpoint override is typed Harness environment configuration supplied by the
+runner, not a fault switch or alternate adapter. Architecture policy rejects a
+Harness authentication implementation from the production dependency graph and
+contract tests run the same identity suite against the deterministic provider and
+the explicitly scheduled real-provider adapter.
+
+## Harness-only failure control
+
+Failure injection exists only in tools and test adapters, never in production
+code, images, headers, accounts, Email Addresses, or configuration flags.
+
+The loopback/run-network control plane provides typed, authenticated run-scoped
+commands for:
+
+- authentication outcomes and controlled clock;
+- fixture projection, malformed contract data, cursor and ordering faults;
+- storage upload failure, corrupt/missing/expired media, compensation failure;
+- queue delay, duplicate delivery, visibility timeout, worker stop/restart;
+- DynamoDB read/write failure and duplicate Track Point identity;
+- API/worker termination and restart;
+- observability exporter failure and buffer inspection.
+
+Toxiproxy controls latency, timeout, disconnect, bandwidth, and reset between
+API, database, MinIO, ElasticMQ, DynamoDB, and authentication provider. The iOS
+runner controls foreground/background, process termination, network offline,
+location services, location/camera/photo permission, locale, appearance,
+Dynamic Type, VoiceOver, Reduce Motion, and timezone.
+
+A deterministic location feed replays normal routes, accuracy over 50 metres,
+non-increasing timestamps, speed over 12 m/s, delayed batches, and 30 seconds
+without a valid point. Controlled clocks advance OTP, rate-limit, day/week,
+timezone, media expiry, and idempotency-retention boundaries without sleeps.
+
+Every scenario declares faults in its fixture. The runner refuses undeclared
+fault commands, records activation/deactivation as safe events, and proves the
+fault state is empty at teardown. A fault that did not reach the intended seam is
+a failed test, not a passing recovery scenario.
+
+## Maestro Journey structure
+
+```text
+apps/mobile/e2e/maestro/
+├── journeys/
+│   ├── access-account/
+│   ├── manage-owner-profile-and-preferences/
+│   ├── manage-dogs-and-goals/
+│   ├── record-a-walk/
+│   ├── capture-walk-events/
+│   ├── review-walk-history/
+│   └── review-owner-contribution/
+├── shared/                           # navigation/accessibility primitives only
+└── fixtures/                         # generated safe runtime inputs
+```
+
+Each Journey directory has a parent flow and independently executable scenarios
+classified as `success`, `validation`, `permission`, `transport-recovery`,
+`persistence-recovery`, `empty-loading-error`, `accessibility`,
+`language-theme-units`, or `privacy-evidence`. Not every Journey invents every
+class: the registry declares the classes required by its normalized outcomes.
+
+Shared flows contain mechanics such as launching a clean run or selecting a
+stable tab. They cannot contain product assertions, hidden state mutation,
+hard-coded accounts, or fallback selectors. Stable accessibility IDs are public
+Feature/UI contracts. Text assertions verify localization separately.
+
+The Mobile architecture compiler derives affected Features/capabilities/routes
+and compares the selected Journey/scenario set with `journey.yaml`. Changes to
+shell, auth transport, navigation, GraphQL, persistence, localization,
+design-system, or Walk lifecycle expand selection to every registered consumer.
+Unowned diffs and an unjustified empty selection fail.
+
+## Evidence bundle
+
+Every run produces the following before resource cleanup:
+
+```text
+.harness-runs/<runId>/evidence/
+├── manifest.json
+├── journey-result.json
+├── graphql.jsonl
+├── api-spans.jsonl
+├── worker-spans.jsonl
+├── mobile-events.jsonl
+├── resource-state.json
+├── contract-comparison.json
+├── maestro/
+├── screenshots/
+└── privacy-scan.json
+```
+
+All records carry `runId`, Journey, scenario, and safe correlation IDs. GraphQL
+records operation name, result typename, HTTP/contract code, and duration, not
+variables or bodies. API/worker/mobile telemetry uses closed event names and
+error codes. Resource state is a safe projection, not raw rows, tokens, object
+keys, payloads, or coordinates.
+
+`contract-comparison.json` mechanically compares fixture values, ordered IDs,
+pageInfo/cursors, aggregates, database state, queue/storage effects, SQLite
+outbox, and UI semantic output. Screenshots and video are human-readable
+companions and never the sole data proof.
+
+Redaction occurs at structured event construction, before serialization. Tokens,
+OTPs, challenge/session values, Email Addresses, signed URLs, object keys,
+idempotency keys, unnecessary personal data, and precise location are prohibited.
+Location evidence uses a named synthetic route plus derived counts/distance and
+coarse bounding classification only. A final content/entropy/privacy scanner
+checks every file, image metadata, filename, and archive; detection fails the run
+and prevents artifact upload.
+
+The manifest records SHA-256 for every artifact, schema/fixture/tool versions,
+container digests, Git revision, controlled clock/timezone, Xcode, Simulator,
+Expo, Maestro, and runtime identifiers. Missing artifacts, hash drift, unknown
+files, exporter loss, or privacy-scan omission fail evidence completion.
+
+## iOS support and execution matrix
+
+The replacement Mobile minimum is iOS 18.0. Runtime and device identifiers are
+pinned; an Xcode/runtime upgrade is a dedicated change that reruns every Journey.
+
+| Schedule | Matrix |
+| --- | --- |
+| PR | iPhone 16, iOS 18.3, selected Journeys/scenarios |
+| main | iPhone 16/iOS 18.3 and iPhone 17 Pro/iOS 26.5, all seven Journey success and primary failures |
+| nightly | small iPhone SE-equivalent/iOS 18.3, iPhone 16/iOS 18.3, iPhone 17 Pro/iOS 26.5; full scenarios and presentation/accessibility matrix |
+| release candidate | main matrix plus every normalized scenario and final evidence audit |
+
+Nightly presentation/accessibility dimensions include maximum Dynamic Type,
+VoiceOver, Reduce Motion, Japanese/English, Light/Dark, km/mile, and representative
+timezones covering UTC, positive, negative, and daylight-saving offsets. Pairwise
+covering arrays may reduce redundant combinations, but each individual dimension
+and every declared interaction must appear in the generated matrix. The matrix
+manifest is committed and drift-checked.
+
+iOS 17 and earlier, iPad, Android, Web, Watch, and Live Activity are not initial
+acceptance targets. An iOS 18 API availability check blocks accidental use of a
+newer unguarded API even when iOS 26 tests pass.
+
+## CI schedule and sharding
+
+Fast deterministic gates run before simulator allocation. Journey runs use one
+isolated Harness namespace and Simulator clone per shard; no shard reuses app or
+backend state. The canonical commands are:
+
+```text
+cargo xtask harness verify
+cargo xtask journey select --intent <intent> --merge-base <sha>
+cargo xtask journey run <journey> --scenario <scenario> --device <matrix-id>
+cargo xtask journey run-all --profile main
+cargo xtask journey run-all --profile nightly
+cargo xtask evidence verify <runId>
+```
+
+PR selection is a required check. Main runs all seven Journeys with deterministic
+success and primary failure scenarios on both supported runtimes. Nightly runs
+the complete fault/presentation/accessibility matrix and deterministic flake
+repetitions. Provider contracts run in a separate scheduled/explicit workflow.
+
+An automatic retry never turns a failed attempt green. A retry may run only as a
+diagnostic follow-up and both attempts remain evidence. Flake rate, p50/p95 gate
+duration, setup failures, cleanup failures, resource leaks, and evidence failures
+are tracked. A deterministic failure blocks; repeated nondeterminism becomes a
+quality issue rather than an allow-failure job.
+
+## Artifact retention
+
+Only bundles that pass privacy scanning may leave the runner:
+
+| Run | Retention |
+| --- | --- |
+| local success | delete immediately after verification |
+| local failure | retain until explicit deletion |
+| PR success | 30 days |
+| PR failure | 60 days |
+| main | 90 days |
+| nightly | 30 days |
+| release candidate | one year |
+
+If privacy scanning fails, upload is prohibited, CI fails, and the local
+quarantine is securely cleaned after emitting only a safe finding summary.
+Artifact names contain no product/user values. CI-provider retention matches the
+manifest expiry. PR evidence contains the artifact link and manifest hash, not
+duplicated screenshots or raw logs.
+
+## Scenario coverage obligations
+
+The Journey registry must cover these cross-cutting normalized outcomes:
+
+- cached-data refresh failure versus first-load failure;
+- Not Found indistinguishability versus Retryable transport/provider failure;
+- 30-second GraphQL/location and 60-second media timeout;
+- mutation double-submit/back blocking and dirty-form discard;
+- camera/photo/location permission states and Open Settings recovery;
+- token refresh single-flight, rotation, missing token, revocation, and Active
+  Walk authentication recovery;
+- media normalization, checksum, expiry, compensation, pending retry/discard;
+- location quality, permission loss, 30-second invalid-point interruption,
+  foreground/background, restart, and API/local reconciliation;
+- idempotency same-input replay and different-input conflict;
+- fixed history pages, ordering ties, invalid/cyclic cursors, Archived Dog filter,
+  and Interrupted exclusion;
+- unknown/out-of-bound event omission and privacy-safe violation count;
+- timezone/day/week boundaries, partial Birthday age, units, Goal independence,
+  and Completed-only aggregates;
+- accessibility, localization, appearance, empty/loading/error, large values,
+  corrupted read models, and no-secret evidence.
+
+Every source section inherits one canonical Journey owner from the ownership map.
+The registry compiler rejects a normalized outcome with no scenario/evidence
+mapping or a scenario that claims behavior outside its owning Feature/module.
+
+## Harness exit criteria
+
+The harness design is implemented only when:
+
+- one command starts and tears down the full deterministic runtime without live
+  credentials;
+- two isolated Journey runs execute concurrently without cross-observation;
+- authentication success, expiry, resend, rotation, revocation, and provider
+  corruption are deterministic;
+- each failure-control family has a fixture proving it reaches the intended seam
+  and is absent from production artifacts;
+- all seven parent Journeys and scenario registries validate;
+- evidence mechanically reconciles UI, API, resources, and observability;
+- intentional secret and precise-location fixtures are stopped before upload;
+- pinned iOS 18.3 and 26.5 builds install, launch, and execute their scheduled
+  matrix;
+- intentional setup, Journey, cleanup, resource-leak, and evidence failures each
+  fail the correct required check;
+- `scripts/harness/validate-all.sh` includes and passes the new validators.
+
+## Self-review
+
+The design was compared in both directions with the 13 source inventories,
+normalized outcomes, seven Journey owners, six API modules, eight Mobile
+Features, GraphQL contracts, both architecture kernels, product principles,
+domain rules, and current Harness architecture.
+
+| Input obligation | Output location |
+| --- | --- |
+| No live production dependency | single Testcontainers runtime and deterministic auth |
+| Reproducible state and complete cleanup | run isolation, declarative fixtures, leases |
+| Success/failure/recovery execution | scenario taxonomy and typed fault plane |
+| Cognito/OTP semantics without secret evidence | deterministic adapter, masked single-use retrieval, separate provider job |
+| Location and native permission behavior | Simulator controls and deterministic feed |
+| Every normalized spec executable | scenario coverage obligations and registry compiler |
+| API/Mobile/data alignment | contract comparison and correlated telemetry |
+| Privacy | pre-serialization redaction, final scanner, upload prohibition |
+| PR/main/nightly/release confidence | pinned matrix and schedule |
+| Flake visibility | no green retry, duration/flake/resource metrics |
+| Evidence durability without indefinite PII | explicit retention policy |
+
+The first comparison found and corrected an authentication-seam error: a
+Harness-only identity adapter would have bypassed the production Cognito adapter.
+The final design uses the production adapter against a deterministic compatible
+provider. No unresolved Harness behavior remains. Actual flow files, fixture schemas,
+control APIs, and CI jobs are implementation tasks in the final roadmap.

--- a/docs/wayfinder/2026-07-11-domain-journey-ownership-map.md
+++ b/docs/wayfinder/2026-07-11-domain-journey-ownership-map.md
@@ -1,0 +1,207 @@
+# Domain and Journey Ownership Map
+
+## Purpose
+
+This map assigns every normalized acceptance area to one primary user journey,
+API application module, and Mobile feature module. It is the ownership input for
+the API and Mobile architecture kernels and the later implementation roadmap.
+Acceptance outcomes remain authoritative in
+`docs/wayfinder/2026-07-11-acceptance-spec-normalization.md`.
+
+## Ownership rules
+
+- A user journey is an Owner goal, not a screen or technical transaction.
+- Every acceptance statement has exactly one primary journey owner. Other
+  journeys may consume its outcome but do not redefine it.
+- API application modules group commands and queries that share invariants and
+  transactional meaning. GraphQL is an adapter, not an owner.
+- Mobile features group UI, local state, orchestration, and feature-specific
+  adapters that change for the same Owner goal.
+- Routes and app-shell composition may combine public feature interfaces. A
+  feature never imports another feature's internal hooks, stores, components,
+  GraphQL documents, or adapters.
+- Platform capabilities such as authenticated transport, display preferences,
+  secure storage, media I/O, clocks, and localization are injected through
+  public interfaces rather than accessed through application-wide mutable state.
+
+## Canonical user journeys
+
+| Journey | Owner outcome | Primary product axis |
+| --- | --- | --- |
+| Access Account | Enter, recover, change identity for, or leave the authenticated application safely | Owner contribution |
+| Manage Owner Profile and Preferences | Keep the Owner identity and device presentation accurate and usable | Owner contribution |
+| Manage Dogs and Goals | Maintain the current Dogs and a realistic time target for each | Dog experience |
+| Record a Walk | Turn a selected Dog outing into one valid Completed Walk, or safely interrupt it | Data-Maximized Walks |
+| Capture Walk Events | Preserve per-Dog moments during a Walk without duplicates or data loss | Dog experience |
+| Review Walk History | Revisit Completed Walk routes, events, photos, and participants | Data-Maximized Walks |
+| Review Owner Contribution | Understand Owner and per-Dog progress derived from Completed Walks | Owner contribution |
+
+All three product axes remain review considerations for every journey. The
+primary axis identifies the outcome the journey most directly advances.
+
+## API application ownership
+
+| Module | Owns | Does not own |
+| --- | --- | --- |
+| `identity` | OTP challenges, verification, token refresh, Email Address change, session revocation | Owner profile, secure-device storage, navigation |
+| `owner` | Owner profile reads/updates and Avatar reference changes | Device preferences, Contribution aggregation, media infrastructure |
+| `dog` | Current/Archived Dog lifecycle, exact-name uniqueness, Gender, Birthday, Walk Goal | Walk selection, history aggregation, object storage mechanics |
+| `walk_recording` | start, single Active Walk, Track Point intake, recovery, Completed/Interrupted finalization, distance and duration | Event meaning, history presentation, queue/database mechanics |
+| `walk_event` | Pee/Poop/Photo Event validity, participant association, time boundaries, idempotent late sync | Active Walk lifecycle, media infrastructure, history projection |
+| `walk_insight` | Completed-only Walk History/detail, cursor pagination, Contribution, Dog Walk Progress | lifecycle mutations, Goal mutation, Mobile formatting preferences |
+
+Media is a shared application port and policy used by `owner`, `dog`, and
+`walk_event`; S3/MinIO, object keys, upload transport, and compensation are
+adapters. Track-point persistence and delivery are ports of `walk_recording`.
+Cognito is an adapter of `identity`.
+
+Application modules do not import or invoke one another. A module defines the
+ports needed to make its own decision: for example, `dog` owns an
+`ActiveWalkParticipation` port and `walk_event` owns an `EventWalkContext` port.
+Adapters satisfy those contracts with the required transaction and locking
+semantics. `walk_insight` builds projections from read ports rather than calling
+mutation modules. The composition root wires modules to adapters but owns no
+domain decision. Account-to-Owner provisioning is an idempotent `identity` use
+case through an `OwnerProvisioning` port; it does not pretend Cognito and
+PostgreSQL share a distributed transaction.
+
+## API domain namespaces
+
+| Namespace | Owns |
+| --- | --- |
+| `domain::identity` | AccountId, Email Address, Authenticated Session, authentication challenge values |
+| `domain::owner` | OwnerId, Owner, OwnerName, Avatar reference |
+| `domain::dog` | DogId, current/Archived Dog, DogName, Gender, Birthday, Walk Goal, Dog Walk Progress values |
+| `domain::walk` | WalkId, lifecycle state, Walker, Track Point, Walk Event, event idempotency identity, Walk History, Contribution |
+
+Application modules import only the namespaces they need. IDs are owned by their
+domain namespace and are not collapsed into a generic entity ID. Domain
+namespaces may refer to another aggregate by its typed ID or explicit value but
+do not embed the foreign aggregate. GraphQL objects, SeaORM models, AWS SDK
+types, cursor mechanics, clocks, and upload/storage transport types are not
+domain types. New canonical types must not use ambiguous names such as User,
+Record, Data, or Item.
+
+## Mobile feature ownership
+
+| Feature | Public responsibility | Composition consumers |
+| --- | --- | --- |
+| `account-access` | Auth screens, challenge state, Authenticated Session lifecycle, Email Address change and Sign Out | app shell |
+| `owner-profile` | Owner summary/edit surfaces and Avatar workflow | Me route |
+| `preferences` | language, units, appearance, notification permission, About, legal links | app shell and Settings route |
+| `dogs` | Dogs list/create/detail/edit/archive, Gender, Birthday, Avatar, Walk Goal editing | Dogs routes and Walk-ready composition |
+| `walk-recording` | selection projection, permissions, GPS, state machine, durable Active Walk recovery and finish | Walk route and app lifecycle |
+| `walk-events` | per-Dog actions, camera, event outbox, Pending Walk Events and retry | Walk recording composition |
+| `walk-history` | history list/filter/page state, Walk detail, route/events/photos presentation | Me and Dog routes |
+| `contribution` | Owner totals/weekly graph and Dog Walk Progress presentation | Me and Dog routes |
+
+The only direct feature dependency is `walk-events` on the public
+`ActiveWalkContext` exported by `walk-recording`. Me composes `owner-profile` and
+`contribution`; Dog detail composes `dogs`, `contribution`, and `walk-history` at
+the route boundary. Authenticated transport and `DisplayPreferences` are
+app-shell capabilities, not feature dependencies.
+
+Every feature exposes one public entrypoint and declares allowed imports,
+exports, owned journeys, adapters, and tests in `module.yaml`. A validator rejects
+undeclared feature imports and imports through another feature's internal path.
+
+## Acceptance inventory ownership
+
+| Source inventory | Primary journey | API owner | Mobile owner | Secondary composition |
+| --- | --- | --- | --- | --- |
+| `signup-e2e-test-cases.md` | Access Account | `identity` | `account-access` | app shell injects configured Legal Links capability |
+| `login-screen-e2e-test-cases.md` | Access Account | `identity` | `account-access` | app shell enters authenticated tabs |
+| `email-change-screen-e2e-test-cases.md` | Access Account | `identity` | `account-access` | `owner-profile` displays the resulting Email Address |
+| `user-edit-screen-e2e-test-cases.md` | Manage Owner Profile and Preferences | `owner` | `owner-profile` | media port/adapter |
+| `settings-screen-e2e-test-cases.md` | Manage Owner Profile and Preferences | `identity` only for Sign Out; otherwise none | `preferences`; `account-access` owns Sign Out action | app shell composes the Settings route |
+| `user-screen-e2e-test-cases.md` | Review Owner Contribution | `walk_insight`; `owner` supplies profile | `contribution` | Me route composes `owner-profile` |
+| `dogs-list-e2e-test-cases.md` | Manage Dogs and Goals | `dog` | `dogs` | `contribution` projection may decorate rows through route composition |
+| `dog-registration-e2e-test-cases.md` | Manage Dogs and Goals | `dog` | `dogs` | media port/adapter |
+| `dog-edit-screen-e2e-test-cases.md` | Manage Dogs and Goals | `dog` | `dogs` | `ActiveWalkParticipation` port enforces archive prohibition |
+| `dog-detail-screen-e2e-test-cases.md` | Manage Dogs and Goals | `dog` | `dogs` | route composes `contribution` and `walk-history` |
+| `walk-screen-e2e-test-cases.md` | Record a Walk | `walk_recording`; `walk_event` for event commands | `walk-recording` | route composes `walk-events` |
+| `walk-history-list-e2e-test-cases.md` | Review Walk History | `walk_insight` | `walk-history` | Dog and Me routes provide entry context |
+| `walk-detail-screen-e2e-test-cases.md` | Review Walk History | `walk_insight` | `walk-history` | active-state redirect reads `walk-recording` capability at route boundary |
+
+`walk-events-photo.md` behavior embedded in the broad walk-screen inventory is
+owned by Capture Walk Events, `walk_event`, and `walk-events`, even though the
+source file's primary owner is Record a Walk. Requirement-level traceability in
+the final roadmap must split those rows rather than assigning the whole file to
+one implementation task.
+
+## Requirement-area exceptions
+
+The source files are screen inventories, so the following areas intentionally
+override their file-level primary owner:
+
+| Requirement area | Journey | API owner | Mobile owner |
+| --- | --- | --- | --- |
+| Pee, Poop, Photo actions and offline retry in Walk screen | Capture Walk Events | `walk_event` | `walk-events` |
+| Dog statistics and Goal progress in Dog detail | Review Owner Contribution | `walk_insight` | `contribution` |
+| Dog recent Walks in Dog detail | Review Walk History | `walk_insight` | `walk-history` |
+| Owner profile header/edit navigation in Me | Manage Owner Profile and Preferences | `owner` | `owner-profile` |
+| Settings navigation from Me | Manage Owner Profile and Preferences | none | `preferences` |
+| Sign Out in Settings | Access Account | `identity` | `account-access` |
+| Active Walk redirect from Walk detail | Record a Walk | `walk_recording` | `walk-recording` |
+
+## Source-section ownership audit
+
+Section numbers refer to the numbered headings in each source inventory. Shared
+accessibility and evidence sections inherit the owners of the behaviors they
+exercise; they are not separate journeys.
+
+| Source | Sections and primary Mobile owner |
+| --- | --- |
+| Sign Up | 1–6 `account-access` |
+| Login | 1–7 `account-access` |
+| Email Change | 1–7 `account-access` |
+| Settings | 1–6 `preferences`; 7 `account-access`; 8 inherits both |
+| User Edit | 1–11 `owner-profile` |
+| User Screen | 1–4, 7 `owner-profile`; 5–6 `contribution`; 8 `account-access`; 9 `preferences`; 10–12 inherit affected owners |
+| Dogs List | 1–9 `dogs`; any progress decoration is `contribution` composed at the route |
+| Dog Registration | 1–13 `dogs`; Breed statements are excluded by the normalized scope |
+| Dog Edit | 1–6 `dogs` |
+| Dog Detail | 1–2, 6 `dogs`; 3–4 `contribution`; 5 `walk-history`; 7 inherits all three |
+| Walk Screen | 1–8, 11–12 `walk-recording`; 9–10 `walk-events`; 13–14 inherit both |
+| Walk History List | 1–13 `walk-history` |
+| Walk Detail | 1, 3–12 `walk-history`; 2 `walk-recording` redirect capability |
+
+This audit assigns every numbered source section once. Requirement-level rows
+that cross a section boundary use the explicit exception table above; no
+screen-file owner may absorb the behavior merely because it renders the result.
+
+## Boundary scenarios
+
+- Renaming an Owner changes current profile presentation through `owner`; past
+  Walk detail resolves that current reference through `walk_insight` without
+  giving history ownership of profile mutation.
+- Archiving a Dog is a `dog` command. Its `ActiveWalkParticipation` port determines
+  whether the Dog is in the Active Walk within the same transactional contract;
+  `dog` owns the prohibition and outcome. Completed history continues to resolve
+  the Archived Dog by identifier.
+- Finishing a Walk belongs to `walk_recording`. Pending Photo Event upload and
+  registration continue under `walk-events`/`walk_event`; completion does not
+  transfer lifecycle ownership to the event module.
+- Interrupted Walks remain internal lifecycle records of `walk_recording` and are
+  excluded by `walk_insight` before history pagination or aggregation.
+- Walk Goal mutation belongs to `dog`; progress calculation belongs to
+  `walk_insight`; progress presentation belongs to `contribution`.
+- Unit selection belongs to `preferences`; canonical metric values belong to
+  `walk_insight`; localized formatting belongs to the consuming Mobile feature
+  through injected `DisplayPreferences`.
+
+## Superseded harness journey mapping
+
+The six existing journey files are migration inputs, not final boundaries:
+
+| Existing journey | Canonical replacement |
+| --- | --- |
+| Auth Onboarding | Access Account |
+| Dog Profile | Manage Dogs and Goals |
+| Walk Goal | Manage Dogs and Goals + Review Owner Contribution |
+| Walk Lifecycle | Record a Walk |
+| Walk Events And Photo | Capture Walk Events |
+| Walk History And Owner Contribution | Review Walk History + Review Owner Contribution |
+
+The later harness ticket must create/update canonical journey contracts and
+Maestro evidence without retaining overlapping ownership from the old files.

--- a/docs/wayfinder/2026-07-11-final-roadmap-self-audit.md
+++ b/docs/wayfinder/2026-07-11-final-roadmap-self-audit.md
@@ -1,0 +1,203 @@
+# Final Roadmap Input/Output Self-Audit
+
+## Scope and method
+
+This is the required self-review before human review of
+`docs/roadmaps/2026-07-11-api-mobile-replacement-implementation-plan.md`.
+The audit compares inputs to roadmap outputs and then walks outputs backward to
+an authoritative input. It checks coverage, contradictions, placeholders,
+interface names, dependencies, files, commands, completion claims, visual-review
+evidence, and privacy/verifiability.
+
+Inputs audited:
+
+- complete PR #366 and PR #367 architecture designs;
+- all 125 numbered sections across the 13 `docs/tmp-testcases/` inventories;
+- every superseding decision in the acceptance normalization;
+- `CONTEXT.md`, product principles, domain rules, ownership map;
+- API/Mobile kernels, GraphQL contract, Harness design, migration sequence;
+- approved Mobile wireflow and its review/fix history;
+- root `AGENTS.md` mechanical and Journey-evidence rules.
+
+Audit outcomes are `covered`, `excluded by explicit decision`, or `gap`. No item
+may be merely implied by a screenshot, generic “test everything” statement, or a
+future follow-up.
+
+## Architecture coverage
+
+### PR #366 / API design
+
+| Input area | Roadmap implementation | Status |
+| --- | --- | --- |
+| Greenfield cutover/no compatibility | PR 1 deletes product/migration/consumer crates; global constraints | covered |
+| Virtual workspace and dependency direction | Tasks 1.1–1.2 exact crates, policy, metadata checks | covered |
+| Default-deny third-party/features/targets | Task 1.2 graph/AST fixtures and `cargo metadata --locked --all-features` | covered |
+| Twelve AST rules and diagnostics | Task 1.2 stable positive/negative fixtures, SARIF/human output | covered |
+| Exact 30-day exceptions | API policy files plus PR 11 expired-exception deletion | covered |
+| Immutable change intent | Task 1.2 `intent.rs`; every PR global intent requirement | covered |
+| Atomic Journey generator | Task 1.2 generator source/templates/collision and `verify-generated` tests | covered after audit fix |
+| Single Testcontainers runtime | PR 3 Harness runtime; old Compose/dev scripts deleted PR 1 | covered |
+| Five required API checks | PR 3 creates separate architecture, unit, integration, GraphQL, Journey workflows | covered after audit fix |
+| Knowledge promotion | PR 11 CONTEXT/Journey/ADR/validator/runbook work | covered |
+| Permanent invariants/no hidden fallback | global constraints, negative fixtures, PR 11 residue scan | covered |
+| Kernel exit/production deployability | PR 1 required result and deployment workflow update | covered |
+
+### PR #367 / Mobile design
+
+| Input area | Roadmap implementation | Status |
+| --- | --- | --- |
+| Vertical modular monolith | PR 2 exact roots and eight Feature manifests | covered |
+| Route-only composition/public entrypoints | Task 2.2 compiler fixtures and each Journey route task | covered |
+| Default-deny graph/cycles/deep imports | Task 2.2 `MOB-ARCH-001`–`014` fixtures | covered |
+| No app-wide mutable state | PR 2 removes Zustand; explicit XState/Query/React/SQLite owners | covered |
+| Explicit lifecycle machines | PR 4 auth and PR 7 Walk XState tests | covered |
+| Two real adapters per seam | module compiler plus production/in-memory contract tasks in PRs 4–10 | covered |
+| Generated GraphQL transport only | Task 3.1 and every schema/codegen step | covered |
+| Typed errors/recovery | Mobile Result/error kernel; operation contracts and Journey failures | covered |
+| Machine-readable manifests | Task 2.2 schema/compiler and exact Journey ledger | covered |
+| Small knowledge system | PR 11 documentation/promotion constraints | covered |
+| Editing/commit/PR/main/nightly gates | PR 2 fast gates, PR 3 workflows, PR 11 matrix | covered |
+| Interface-leverage testing | per-slice domain/application/adapter/Feature/Maestro order | covered |
+| AI-agent intent/context/review protocol | intent compiler and generated review input/workflow/dismissal tests | covered after audit fix |
+| Initial delivery order/foundation slice | PRs 1–4; Access Account is first representative product Journey | covered |
+| iOS-only scope | deployment target 18.0 and explicit target deletion | covered |
+| No speculative Watch/Live Activity | PR 2 deletion and architecture rejection | covered |
+
+## Acceptance inventory coverage
+
+Every numbered section is assigned once through the ownership map and an exact
+Journey scenario ledger. Section ranges below cover all 125 sections.
+
+| Inventory | Sections | Primary roadmap owner | Scenario evidence | Status |
+| --- | ---: | --- | --- | --- |
+| Sign Up | 1–6 | Tasks 4.1–4.2 | Access Account | covered |
+| Login | 1–7 | Tasks 4.1–4.2 | Access Account; PR 7 adds Active auth recovery | covered |
+| Email Change | 1–7 | Tasks 4.1–4.2 | Access Account; Settings entry composed PR 5 | covered |
+| User Edit | 1–11 | Tasks 5.1–5.2 | Owner/Profile success, validation, media, recovery, accessibility/privacy | covered |
+| Settings | 1–6,8 | Task 5.2 | Profile/Preferences scenarios | covered |
+| Settings | 7 | Tasks 4.1–4.2 and PR 5 composition | Access Account plus Active-Walk guard fixture | covered |
+| User Screen | 1–4,7 | Task 5.2 | Owner/Profile states and navigation | covered |
+| User Screen | 5–6,10–12 | Tasks 10.1–10.2 | Owner Contribution matrix/evidence | covered |
+| User Screen | 8–9 | PRs 4–5 route composition | Access/Preferences | covered |
+| Dogs List | 1–9 | Tasks 6.1–6.2 | Dogs success/empty/error/refresh/accessibility/privacy | covered |
+| Dog Registration | 1–4,6–13 | Tasks 6.1–6.2 | Dogs validation/media/permission/recovery | covered |
+| Dog Registration | 5 Breed | Normalization and global constraints exclude Mobile/API Breed; PR 6 negative proof | excluded by explicit decision |
+| Dog Edit | 1–6 | Tasks 6.1–6.2 | Dogs edit/archive/error/accessibility/privacy | covered |
+| Dog Detail | 1–2,6–7 | Task 6.2 | Dogs detail | covered |
+| Dog Detail | 3–4 | Tasks 10.1–10.2 | Dog Contribution/Goal progress | covered |
+| Dog Detail | 5 | Tasks 9.1–9.2 | Dog-filtered History | covered |
+| Walk Screen | 1–8,11–14 | Tasks 7.1–7.2 | Record Walk location/lifecycle/recovery/accessibility/privacy | covered |
+| Walk Screen | 9–10 | Tasks 8.1–8.2 | Capture Events/Photo | covered |
+| Walk History | 1–13 | Tasks 9.1–9.2 | History success/validation/error/empty/accessibility/units/privacy | covered |
+| Walk Detail | 1,3–12 | Tasks 9.1–9.2 | Detail route/map/time/participants/metrics/events/media/error/evidence | covered |
+| Walk Detail | 2 | Tasks 7.2 and 9.2 route composition | Active Walk override | covered |
+
+The scenario ledger contains 52 fixture basenames and 52 corresponding Maestro
+flows. Registry validation requires every scenario to name the exact normalized
+outcomes and evidence fields it covers; count alone cannot satisfy the gate.
+
+## Superseding decision audit
+
+| Decision | Roadmap proof | Status |
+| --- | --- | --- |
+| Exact-character Dog-name uniqueness only | PR 6 tests and API/Mobile contracts | covered |
+| Breed reserved DB column, no API/UI | PR 6 negative tests; PR 11 residue scan | covered |
+| Partial Birthday and midpoint age calculation | PR 6 domain/UI tests | covered |
+| Independent Daily/Weekly, defaults 30/120, no conversion | PR 6 Goal tests | covered |
+| Interrupted hidden everywhere | PR 7 lifecycle plus PRs 9–10 read-model tests | covered |
+| Foreground denial blocks Start; loss interrupts | PR 7 permission/location scenarios | covered |
+| Last-write-wins Owner/Dog | PRs 5–6 mutation/refetch tests | covered |
+| Current names/images, no snapshots | PR 9 history contracts | covered |
+| Unknown events ignored and counted safely | PRs 8–9 contracts/evidence | covered |
+| Completed-only metrics/history/contribution | PRs 7,9,10 boundaries | covered |
+| Fixed 20 pages and stable ordering | PR 9 cursor/order tests | covered |
+| Media normalization/atomicity/pending retry | PRs 5,6,8 | covered |
+| 30s/60s timeouts and dirty/double-submit rules | exact Journey scenario obligations and Feature tests | covered |
+| No production-data/device-data migration | PR 1/2 destructive baselines and rollback discipline | covered |
+
+## Interface and dependency consistency
+
+- API application names are exactly `identity`, `owner`, `dog`,
+  `walk_recording`, `walk_event`, and `walk_insight` in the ownership map,
+  kernels, sequence, and file-level tasks.
+- Mobile Feature names are exactly `account-access`, `owner-profile`,
+  `preferences`, `dogs`, `walk-recording`, `walk-events`, `walk-history`, and
+  `contribution` everywhere.
+- The only direct Feature edge is `walk-events -> walk-recording` through
+  `ActiveWalkContext`; auth, preferences, Me/Dog composition, and Active detail
+  redirect use shell/public capabilities.
+- GraphQL root/operation ownership matches the six API modules. Authentication
+  failure is consistently HTTP 401/top-level `AUTHENTICATION_REQUIRED`; resource
+  authorization is typed indistinguishable Not Found.
+- XState, TanStack Query, React local state, SQLite, and SecureStore have distinct
+  owners. Effect, Zustand, Graffle, AsyncStorage domain state, and client cache
+  alternatives are deleted.
+- PR order has no cycle: Dogs precede recording; recording precedes events;
+  events precede complete History; History precedes Contribution. Fixtures used
+  before a producer are explicitly non-public contract fixtures.
+- PR 7 does not invent Walk Detail. PR 9 replaces saved-confirmation-to-Ready with
+  direct real detail navigation. The approved wireflow records both outcomes.
+
+No inconsistent type, module, Feature, route, Journey, operation, capability, or
+state-owner name was found after correction.
+
+## File, command, and completion-claim audit
+
+- Every PR names created/modified/deleted roots and each Task names its produced
+  interface. Exact Journey/fixture/flow basenames are listed centrally and
+  referenced by tasks.
+- Commands cover Cargo metadata/check/test/fmt/clippy, schema/codegen clean diff,
+  npm install/test/type/lint/Knip/architecture/GraphQL, Harness verification,
+  selected/all Journey profiles, evidence/privacy, iOS build/install/launch, and
+  repository validation.
+- Expected results are observable: pass/fail rule IDs, HTTP readiness, no diff,
+  exact UI/API/resource comparison, no unsafe artifact, no leak, and exit 0.
+- PR exit criteria never claim a not-yet-migrated Journey. Foundation shells are
+  explicitly honest. Later PRs rerun every previously migrated Journey.
+- Rollback selects the previous complete API image/Mobile build pair and never
+  activates legacy code or mixes schemas.
+
+## Placeholder and ambiguity audit
+
+Scans cover `TBD`, `TODO`, “implement later”, “fill in”, “appropriate error”,
+“Similar to”, wildcard fixture paths, nonexistent route references, and warning
+gates. Matches remaining in the roadmap are prohibitions, not placeholders.
+
+Directory braces in file lists are finite path expansions, not undetermined
+work. PR 11's deletion report is intentionally derived from authoritative Git,
+Cargo metadata, Knip, and ownership reports because the exact set is the output
+of prior PRs; its zero-residue condition is mechanically testable.
+
+## Findings and resolutions
+
+| Finding | Resolution |
+| --- | --- |
+| API Journey generator absent from file-level plan | Added generator source, templates, collision/closed-registry/adapter/contract/observability tests, and `verify-generated` command to Task 1.2 |
+| Mobile independent AI review evidence absent | Added deterministic review-input generator and advisory workflow/durable P0/P1 dismissal tests |
+| API five required checks collapsed into generic workflow | Split exact architecture, unit, integration, GraphQL, and Journey workflow paths |
+| Initial GraphQL design put authentication in operation unions | Corrected to shared 401 single-flight refresh; resource authorization remains Not Found |
+| Harness initially proposed an alternate identity adapter | Corrected to production Cognito adapter against deterministic compatible provider |
+| Wireflow referenced nonexistent `WALK-05` and omitted Email Change routes | Added AUTH-04/AUTH-05 and staged PR 7/PR 9 completion destinations |
+| File-level roadmap used fixture globs and vague matching scenarios | Added exact 52-pair scenario ledger and exact legacy Journey deletion points |
+
+All findings were fixed in the authoritative roadmap/design outputs before this
+audit was marked complete. There are zero open findings.
+
+## Verification record
+
+- `git diff --no-index --check /dev/null` on every new planning document and the
+  HTML artifact: no whitespace diagnostic.
+- roadmap placeholder/ambiguous-glob scan: no unresolved match.
+- browser artifact QA: filter and detail interactions pass; 1280px and 390px
+  layouts have no horizontal overflow; print preserves all nodes.
+- `scripts/harness/validate-all.sh`: exit 0 with no output after final corrections.
+- Wayfinder issues #369–#377 contain resolution comments and are closed before
+  this audit.
+
+## Audit conclusion
+
+The roadmap covers every PR #366/#367 architecture obligation and all 125
+numbered acceptance sections, including explicit exclusions and superseding
+decisions. It has no known contradiction, placeholder, unmapped requirement,
+inconsistent interface, missing dependency, or unverifiable completion claim.
+It is ready for human review; implementation has not started.

--- a/docs/wayfinder/2026-07-11-graphql-contract-and-generation.md
+++ b/docs/wayfinder/2026-07-11-graphql-contract-and-generation.md
@@ -1,0 +1,470 @@
+# Replacement GraphQL Contract and Generation Workflow
+
+## Purpose
+
+This document defines the only API–Mobile product contract for the replacement
+system. It covers every normalized Journey without preserving the current schema,
+Mobile operation names, handwritten types, aliases, or runtime compatibility.
+API application modules own decisions; GraphQL adapts typed inputs and outcomes;
+Mobile Features own operations and map generated transport types into their
+domain models.
+
+Inputs:
+
+- PR #366 API architecture prevention design
+- PR #367 Mobile architecture prevention design
+- `docs/wayfinder/2026-07-11-acceptance-spec-normalization.md`
+- `docs/wayfinder/2026-07-11-domain-journey-ownership-map.md`
+- the API and Mobile architecture-kernel documents
+- all 13 inventories under `docs/tmp-testcases/`
+
+## Contract principles
+
+- The schema models canonical domain and read-model outcomes, never current
+  screens or database rows.
+- Every root field maps to exactly one API application command or query.
+- Resolvers translate transport values and do not perform retries, storage,
+  aggregation, authorization policy, or lifecycle decisions.
+- Types are non-null by default. `null` represents only a valid absence such as
+  no Birthday or Avatar, never loading, Not Found, failure, or bad provider data.
+- Expected operation-specific failures are non-null result unions. GraphQL
+  top-level errors are reserved for authentication transport failure, invalid
+  GraphQL documents, and unexpected faults.
+- There is no global Node interface, generic record type, arbitrary JSON scalar,
+  client-selected page size, compatibility alias, or speculative subscription.
+- API metric values are canonical metres and seconds. Mobile owns unit and locale
+  formatting, not aggregation or time-window calculation.
+
+## Root query contract
+
+Queries are Journey/read-model entrypoints rather than a giant nested `viewer`:
+
+```graphql
+type Query {
+  currentOwner: CurrentOwnerResult!
+  currentDogs: CurrentDogsResult!
+  dog(id: DogId!): DogResult!
+  activeWalk: ActiveWalkResult!
+  walkHistory(filter: WalkHistoryFilter!, after: Cursor): WalkHistoryResult!
+  walk(id: WalkId!): WalkDetailResult!
+  ownerContribution: OwnerContributionResult!
+  dogContribution(dogId: DogId!): DogContributionResult!
+}
+```
+
+`currentOwner` is owned by `owner`; `currentDogs` and `dog` by `dog`;
+`activeWalk` by `walk_recording`; and history/detail/contribution fields by
+`walk_insight`. Nested object fields contain values already returned by the
+application query. They cannot trigger another application module or database
+lookup. Cross-Feature screens call and compose public Feature interfaces rather
+than growing a screen-shaped GraphQL query.
+
+## Root mutation contract
+
+The replacement mutation surface is:
+
+| API owner | Mutations |
+| --- | --- |
+| `identity` | `requestSignInCode`, `verifySignInCode`, `requestSignUpCode`, `verifySignUpCode`, `requestEmailChangeCode`, `verifyEmailChangeCode`, `refreshSession`, `signOut` |
+| `owner` | `prepareOwnerAvatarUpload`, `updateOwner` |
+| `dog` | `prepareDogAvatarUpload`, `createDog`, `updateDog`, `archiveDog` |
+| `walk_recording` | `startWalk`, `appendTrackPoints`, `finishWalk`, `interruptWalk` |
+| `walk_event` | `recordPeeEvent`, `recordPoopEvent`, `prepareWalkPhotoUpload`, `recordPhotoEvent` |
+
+Settings language, units, appearance, and notification status are device state
+and have no GraphQL mutation. Breed has no GraphQL type, field, filter, input, or
+operation. Contribution and history are read models and expose no mutation.
+
+Every side-effecting input contains `idempotencyKey: IdempotencyKey!`. Separate
+Pee, Poop, and Photo mutations prevent an unknown or unsupported event enum from
+being written. `interruptWalk` is an explicit terminal command used for location,
+authentication-recovery, and irrecoverable recording failure; it never creates a
+Mobile-visible history entry.
+
+## Typed result and problem model
+
+Each root field returns an operation-specific union whose success member is
+named after the operation. It includes only problems the caller can handle. For
+example:
+
+```graphql
+union CreateDogResult =
+    CreateDogSuccess
+  | ValidationProblem
+  | DuplicateDogNameProblem
+  | MediaUploadProblem
+  | RetryableProblem
+
+type CreateDogSuccess { dog: Dog! }
+
+interface Problem {
+  code: ProblemCode!
+  retryability: Retryability!
+  correlationId: CorrelationId!
+}
+```
+
+Problem implementations may add closed, safe metadata:
+
+- `ValidationProblem`: non-empty `[FieldViolation!]!` with a closed field enum
+  and validation code; no localized message;
+- `DuplicateDogNameProblem`: the `NAME_ALREADY_EXISTS` code only, without
+  returning another Dog;
+- `NotFoundProblem`: no existence, ownership, or authorization distinction;
+- `InvalidCursorProblem`: no decoded ordering/filter content;
+- `IdempotencyConflictProblem`: the operation and key fingerprint identifier,
+  never either request body;
+- `RetryableProblem`: a closed reason and optional `retryAfter` instant;
+- `MediaUploadProblem`: expired, incomplete, checksum, media-policy, or purpose
+  category without object key or signed URL;
+- `ContractProblem`: used only where a read model can isolate one unavailable row
+  or aggregate while preserving safe surrounding data.
+
+`retryability` is `NEVER`, `SAME_INPUT`, or `AFTER_USER_ACTION`. The API never
+returns UI prose, provider exception strings, SQL/storage details, tokens, OTPs,
+precise coordinates, object keys, or signed URLs in a Problem. Mobile maps the
+union exhaustively by `__typename`; an unknown member or impossible metadata is a
+contract violation rather than a fallback.
+
+### Required result matrix
+
+`IdempotencyConflictProblem` is additionally present on every mutation, and the
+shared 401 envelope may replace any authenticated operation before its resolver.
+The remaining required members are:
+
+| Operation | Success/no-data outcome | Required operation problems |
+| --- | --- | --- |
+| `currentOwner` | `CurrentOwnerSuccess` | `RetryableProblem`, `ContractProblem` |
+| `currentDogs` | `CurrentDogsSuccess` with possibly empty list | `RetryableProblem`, `ContractProblem` |
+| `dog` | `DogSuccess` | `NotFoundProblem`, `RetryableProblem`, `ContractProblem` |
+| `activeWalk` | `ActiveWalkSuccess` or `NoActiveWalk` | `RetryableProblem`, `ContractProblem` |
+| `walkHistory` | `WalkHistorySuccess` | `NotFoundProblem` for Dog filter, `InvalidCursorProblem`, `RetryableProblem`, `ContractProblem` |
+| `walk` | `WalkDetailSuccess` | `NotFoundProblem`, `RetryableProblem`, `ContractProblem` |
+| `ownerContribution` | `OwnerContributionSuccess` | `RetryableProblem`, `ContractProblem` |
+| `dogContribution` | `DogContributionSuccess` | `NotFoundProblem`, `RetryableProblem`, `ContractProblem` |
+| code-request mutations | challenge with code length, expiry, resend time | `ValidationProblem`, `RateLimitedProblem`, `RetryableProblem` |
+| code-verification mutations | rotated `AuthenticatedSession` or Email-change completion | `ValidationProblem`, `ChallengeInvalidProblem`, `ChallengeExpiredProblem`, `ChallengeConsumedProblem`, `RateLimitedProblem`, `RetryableProblem` |
+| `refreshSession` | rotated `AuthenticatedSession` | `InvalidSessionProblem`, `RetryableProblem` |
+| `signOut` | `SignOutSuccess` | `ActiveWalkBlocksSignOutProblem`, `RetryableProblem` |
+| Avatar prepare mutations | upload ID, redacted-at-boundary PUT URL, expiry | `ValidationProblem`, `MediaUploadProblem`, `RetryableProblem` |
+| `updateOwner` | final current Owner | `ValidationProblem`, `MediaUploadProblem`, `RetryableProblem` |
+| `createDog` | created current Dog | `ValidationProblem`, `DuplicateDogNameProblem`, `MediaUploadProblem`, `RetryableProblem` |
+| `updateDog` | final current Dog | `NotFoundProblem`, `ValidationProblem`, `DuplicateDogNameProblem`, `MediaUploadProblem`, `RetryableProblem` |
+| `archiveDog` | archived Dog ID | `NotFoundProblem`, `ActiveWalkParticipantProblem`, `RetryableProblem` |
+| `startWalk` | authoritative Active Walk | `ValidationProblem`, `NotFoundProblem`, `ActiveWalkAlreadyExistsProblem`, `RetryableProblem` |
+| `appendTrackPoints` | ordered result for every point | `NotFoundProblem`, `WalkNotActiveProblem`, `ValidationProblem`, `RetryableProblem` |
+| `finishWalk` | authoritative Completed Walk ID and metrics | `NotFoundProblem`, `WalkNotActiveProblem`, `ValidationProblem`, `RetryableProblem` |
+| `interruptWalk` | hidden Interrupted acknowledgement | `NotFoundProblem`, `WalkNotActiveProblem`, `ValidationProblem`, `RetryableProblem` |
+| Pee/Poop mutations | committed Event | `NotFoundProblem`, `EventOutsideWalkProblem`, `ValidationProblem`, `RetryableProblem` |
+| `prepareWalkPhotoUpload` | upload ID, redacted-at-boundary PUT URL, expiry | `NotFoundProblem`, `ValidationProblem`, `MediaUploadProblem`, `RetryableProblem` |
+| `recordPhotoEvent` | committed or idempotently replayed Photo Event | `NotFoundProblem`, `ValidationProblem`, `MediaUploadProblem`, `EventOutsideWalkProblem`, `RetryableProblem` |
+
+Rate-limit results expose only an absolute `retryAfter`. Authentication session
+success contains non-null access and refresh tokens and their expiries, but those
+fields are classified secret and may be consumed only by `account-access` secure
+storage. Email-change success contains no reusable challenge or old identity and
+signals that every session has been revoked.
+
+Event registration accepts an Active Walk, or a Completed Walk when the original
+event time lies inside its finalized boundary. This permits durable offline
+outbox replay after completion. Mobile permits creation of a new intent only
+while Active; the API independently enforces Owner, participant, time boundary,
+event identity, and idempotency. Interrupted Walks likewise accept a bounded
+original outbox event after finalization, but never expose it to history or
+aggregates.
+
+History isolation uses an explicit row union:
+
+```graphql
+union WalkHistoryItem = WalkSummary | WalkDataUnavailable
+type WalkConnection { nodes: [WalkHistoryItem!]!, pageInfo: PageInfo! }
+```
+
+`WalkDataUnavailable` contains the stable Walk ID and safe retry classification,
+not fabricated zero metrics. Walk detail returns a whole-operation
+`ContractProblem`; contribution and Dog progress return explicit Unavailable
+results. Empty successful lists remain `[]`.
+
+## Authentication and authorization envelope
+
+Missing, expired, malformed, or unverifiable access credentials are a shared
+transport failure, not an operation-union member. The API returns HTTP 401, no
+partial data, and one top-level GraphQL error with extension code
+`AUTHENTICATION_REQUIRED` plus a safe correlation ID. The response never reveals
+token claims or provider cause.
+
+The Mobile authenticated transport single-flights concurrent refresh attempts,
+then replays each original operation at most once with identical variables and
+idempotency key. Refresh uses rotation and succeeds only when both new access and
+refresh tokens exist. Failure invalidates the session and invokes the normalized
+Active Walk authentication-recovery contract. Public authentication mutations
+are an explicit middleware allowlist and cannot recursively refresh.
+
+An authenticated Owner asking for another Owner's Dog, Walk, or media receives
+the same operation-specific `NotFoundProblem` as an invalid identifier. This is
+application authorization, not a 401. Unexpected faults produce a top-level
+`INTERNAL` code, no partial data, and sanitized observability; they never become
+an empty success or generic retryable union member.
+
+## Scalars and value contracts
+
+Meaningful values use validated custom scalars:
+
+| Scalar | Contract |
+| --- | --- |
+| `OwnerId`, `DogId`, `WalkId`, `WalkEventId`, `TrackPointId`, `MediaUploadId` | canonical opaque UUID representation and distinct Mobile brand |
+| `IdempotencyKey` | client-generated UUID; never returned in logs/evidence |
+| `Cursor` | opaque, versioned, filter-bound pagination state |
+| `DateTime` | canonical RFC 3339 UTC instant; offset input normalized to UTC |
+| `CalendarYear` | integer 1900 through API clock current year where used |
+| `EmailAddress` | trimmed/lowercased valid address, at most 254 characters, no controls |
+| `OwnerName`, `DogName` | validated user-perceived-character values with distinct whitespace rules |
+| `OtpCode` | ASCII digits whose exact length is checked against its challenge |
+| `GoalMinutes` | integer minutes validated against its Daily or Weekly context |
+| `DistanceMeters` | finite, nonnegative decimal |
+| `DurationSeconds` | nonnegative integer |
+| `Latitude` | finite -90 through 90 |
+| `Longitude` | finite -180 through 180 |
+| `HorizontalAccuracyMeters` | finite and nonnegative |
+| `MediaUrl` | opaque HTTPS read URL with no exposed storage-key contract |
+| `MediaChecksum` | lowercase SHA-256 digest |
+| `CorrelationId` | opaque diagnostic identifier containing no user data |
+
+Each scalar is enforced at GraphQL parse/serialize, API value construction, and
+Mobile parsing with positive/negative contract fixtures. Codegen maps scalar
+inputs to their branded input type but scalar outputs to `unknown`, with
+`strictScalars: true`; a Feature GraphQL adapter must parse and construct its
+domain value. No cast may turn a plain string or number into a branded Mobile
+value.
+
+Birthday output is a union of `YearBirthday`, `YearMonthBirthday`, and
+`FullDateBirthday`, with all member fields non-null. Birthday input is a validated
+`BirthdayInput` scalar accepting exactly `YYYY`, `YYYY-MM`, or `YYYY-MM-DD`; it
+preserves precision and never guesses a missing component. Absence is the one
+nullable Birthday field. Gender is a non-null `MALE | FEMALE | OTHER` enum.
+
+### Input invariants
+
+- Owner names are 1–50 user-perceived characters after trimming and reject
+  newline/control characters. Dog names are 1–50, preserve surrounding
+  whitespace, reject whitespace-only/newline/control values, and use exact
+  character-sequence uniqueness.
+- Authentication inputs normalize Email Address before application handling.
+  Challenge output supplies exact `codeLength`; Sign In accepts eight digits and
+  Sign Up/Email Change six. Unexpected length is a contract failure.
+- Dog create/update accepts independent `dailyGoalMinutes` and
+  `weeklyGoalMinutes`: Daily is 0–120, Weekly 0–840, both multiples of five.
+  Omitted unchanged update fields use an explicit patch input, while clearing
+  Birthday or Avatar uses an explicit clear operation rather than ambiguous null.
+- `startWalk` requires a non-empty, duplicate-free list of current Dog IDs.
+  Event inputs require participant Dog ID, original `occurredAt`, and identity;
+  Photo additionally requires a purpose-bound `MediaUploadId`.
+- Future Walk, Event, and Track Point instants fail using the API controlled clock
+  with no skew allowance. A finalized Event must lie within its Walk boundary.
+
+## Read models
+
+`Owner`, `Dog`, `ActiveWalk`, `WalkSummary`, `WalkDetail`,
+`OwnerContribution`, and `DogContribution` expose only normalized values.
+Important constraints include:
+
+- Avatar/Photo references expose a CDN read URL as an opaque `MediaUrl` value;
+  storage keys and signing details never appear.
+- Current Dog reads exclude Archived Dogs. History filters can explicitly name a
+  current or Archived Dog by ID and resolve its final current name.
+- Walk History and detail expose Completed Walks only. `activeWalk` is the only
+  public Active representation. Interrupted Walks have no query surface.
+- A Completed Walk has non-null `startedAt`, `endedAt`, `distanceM`, and
+  `durationSec`. Invalid timestamps or metrics cannot serialize as a normal Walk.
+- Walk participants and Walker resolve current names/images rather than snapshots.
+- Event order is `occurredAt ASC, eventId ASC`; unknown and out-of-bound stored
+  events are omitted before transport and counted only in privacy-safe
+  observability.
+- Contribution and progress are complete API read models over Completed Walks,
+  not calculations over the current history page. They expose canonical seconds,
+  metres, counts, and server-selected daily/weekly buckets with UTC instants for
+  boundaries and no display strings.
+
+## History connection and cursor
+
+`WalkHistoryFilter` is exactly All Dogs or one Dog ID; it has no date, Walker, or
+page-size field. The API returns fixed 20-item pages ordered by `startedAt DESC,
+walkId DESC`. Active and Interrupted Walks are excluded before cursor calculation.
+A multi-Dog Walk appears once for All Dogs and once in each applicable Dog filter.
+
+`PageInfo` has nullable `endCursor` and non-null `hasNextPage`. A successful empty
+page is valid only with no cursor and `hasNextPage: false`. The opaque cursor
+contains a version, ordering keys, and filter identity but no PII or storage data.
+Malformed, changed-filter, cyclic, and unsupported-version cursors return
+`InvalidCursorProblem`. Mobile preserves server order, rejects duplicated IDs,
+and rejects inconsistent pageInfo; it never sorts, deduplicates, or repairs.
+
+## Idempotency
+
+Every side-effecting mutation uses `Owner + operation + IdempotencyKey` as its
+scope. The API hashes canonical validated input. Same key and fingerprint replays
+the original committed result; same key with a different fingerprint returns
+`IdempotencyConflictProblem`. Provider calls, resolvers, queues, and storage
+adapters never replace the caller identity.
+
+Identity and fingerprint are retained for the lifetime of created Dogs, Walks,
+Walk Events, Track Points, and other durable entities. Commands without a
+separately durable created entity retain result and fingerprint for 30 days.
+After that boundary, a new user intent requires a new key. Mobile retains pending
+Event, Photo, and Track Point identities without expiry until success or explicit
+discard. Controlled-clock tests prove the cleanup boundary.
+
+## Media workflow
+
+Image bytes do not pass through GraphQL multipart upload. The purpose-specific
+prepare mutations receive declared JPEG MIME, byte count, dimensions, checksum,
+and idempotency key. They validate the Avatar or Walk Photo policy and return a
+15-minute, one-use signed PUT URL plus opaque `MediaUploadId`. The URL is the sole
+intentional signed-URL exposure and is always redacted from logs/evidence.
+
+Mobile normalizes and validates locally, uploads with a 60-second request timeout,
+then passes only `MediaUploadId` to create/update/photo-event mutation. The owning
+application module revalidates Owner, purpose, expiry, checksum, and object facts.
+The database reference commits before an old Avatar is deleted. Failed database
+commit compensates the new object. Uncommitted objects are reaped after expiry.
+Pending Walk Photos preserve the same event identity until registration succeeds;
+Walk completion does not wait for them.
+
+## Track Point batch contract
+
+`appendTrackPoints` accepts 1–50 points ordered by `recordedAt ASC,
+trackPointId ASC`. Each point carries a stable TrackPoint ID, original GPS instant,
+latitude, longitude, and accuracy. Mobile sends the SQLite outbox and retries the
+same IDs and mutation identity.
+
+Structural invalidity, future time, another Walk/Owner, non-Active lifecycle, or
+same TrackPoint ID with different input fails the entire batch as a typed result.
+Quality rejection is per point: accuracy over 50 metres, time not later than the
+last accepted point, or implied speed over 12 m/s returns
+`RejectedTrackPoint` and never changes route/distance. The success member contains
+exactly one ordered Accepted/Rejected result per input ID. Missing, duplicate, or
+reordered results are a Mobile contract violation. Only confirmed results leave
+the outbox.
+
+The 30-second no-valid-point interruption uses the original GPS timeline and
+current Walk state, not transport batching latency. API and Mobile controlled
+clocks verify foreground loss, delayed upload, recovery, and terminal interruption.
+
+## Operation ownership
+
+Each Mobile operation and fragment belongs to exactly one Feature under
+`features/<feature>/adapters/graphql/operations/`. Operation names carry the
+Feature prefix. A Feature may reuse its own fragment, but there is no global or
+cross-Feature fragment library. The same field may be selected independently for
+different Feature domain mappings.
+
+The Mobile architecture compiler compares document location, operation prefix,
+import sites, Feature manifest, API field owner, and affected Journeys. Routes,
+UI, domain, and public Feature types cannot import operations or generated
+transport types. Screen composition happens through public Feature interfaces,
+not by sharing one large query.
+
+## Checked-in schema and code generation
+
+The Rust schema definition is the executable source. The `api-bootstrap` schema
+binary deterministically writes `apps/api/schema.graphql`, which is committed and
+read-only to humans. Mobile codegen consumes that local file only; remote
+introspection is forbidden.
+
+GraphQL Code Generator uses pinned versions of `typescript`,
+`typescript-operations`, and `typed-document-node`. It generates
+`TypedDocumentNode<Result, Variables>` values under
+`apps/mobile/generated/graphql`, with `avoidOptionals: true`, string-union enums,
+immutable values, exact operation/result types, `strictScalars: true`, branded
+custom-scalar inputs, and `unknown` custom-scalar outputs. It generates no React
+hooks, cache runtime, fragment-masking runtime, or client-specific types.
+
+`platform/graphql` uses standard `fetch` to execute the typed document. TanStack
+Query is the refetchable server-cache owner at the Feature boundary. Apollo,
+Relay, Graffle, handwritten GraphQL strings, handwritten response/variable types,
+`any`, unchecked casts, and parallel transport runtimes are absent.
+
+## Atomic schema-change workflow
+
+Schema and consumer changes are one merge unit:
+
+1. change API Rust schema/application contracts;
+2. regenerate checked-in schema;
+3. update Feature-owned operations;
+4. regenerate Mobile typed documents;
+5. run API result/scalar/auth/idempotency contracts;
+6. run operation validation and Mobile adapter contracts;
+7. run selected canonical Journeys and privacy evidence;
+8. prove a second generation produces no diff.
+
+The Intent declares `none`, `non-breaking`, or `breaking` schema impact and the
+actual semantic diff must agree. Since API and Mobile deploy from this repository,
+breaking changes are atomic and preferred over aliases or deprecation periods.
+Old/new fields, compatibility aliases, and indefinite deprecated fields are
+forbidden. Main never contains an API/Mobile contract mismatch.
+
+## Drift and quality gates
+
+The required contract check fails on:
+
+- schema generation diff or nondeterministic output;
+- operation parse/validation failure, anonymous operation, duplicate name, or
+  document outside its owning Feature;
+- missing `__typename` exhaustiveness for a result union;
+- unused operation/fragment, cross-Feature fragment, or operation without a
+  manifest/Journey owner;
+- hand-edited or stale generated output;
+- unchecked/incorrect custom-scalar mapping;
+- new nullable field/list item without an exact schema-policy exception;
+- unexpected enum/union change, parallel alias, generic JSON, or leaked storage
+  field;
+- query complexity/depth above policy, introspection enabled outside development,
+  or resolver/application ownership mismatch;
+- HTTP/auth envelope, Not Found indistinguishability, idempotency, pagination,
+  media, or Track Point contract failure;
+- unredacted token, OTP, Email Address, coordinate, object key, signed URL, or
+  idempotency key in logs/evidence.
+
+Contract fixtures intentionally break every class above and assert stable rule
+IDs and locations. CI runs schema generation before Mobile generation and both
+before builds/tests. Required checks never fetch a remote schema or call live AWS.
+
+## Self-review against normalized inventories
+
+| Inventory | Contract coverage |
+| --- | --- |
+| Sign Up | request/verify sign-up code, typed validation/rate limits, secure auth envelope, legal links remain configured Mobile URLs |
+| Login | request/verify sign-in code, refresh single-flight and one replay |
+| Email Change | request/verify change, session revocation outcome and forced reauthentication |
+| User Screen | current Owner plus authoritative Owner Contribution read model |
+| User Edit | owner update, media prepare/commit/compensation, last-write-wins refetch |
+| Settings | signOut only; other settings correctly remain device-owned |
+| Dogs List | currentDogs with Archived exclusion and explicit empty/error outcomes |
+| Dog Registration | create, exact-name duplicate, partial Birthday, Gender, independent Goals, Avatar workflow; no Breed |
+| Dog Edit | dog/update/archive, Active participant prohibition, media removal/replacement |
+| Dog Detail | dog plus authoritative contribution/history composition |
+| Walk Screen | active/start/append/finish/interrupt, current Dogs, Track Point quality, distinct events, pending Photo workflow |
+| Walk History | Completed-only fixed cursor connection, All/one-Dog filter, stable ordering and unavailable rows |
+| Walk Detail | whole-detail contract, current references, validated route/events/photos, Active redirect input |
+
+## Self-review against architecture inputs
+
+- PR #366: every resolver maps one application operation; lifecycle, storage,
+  pagination, idempotency, media, and provider decisions remain behind ports.
+- PR #367: operations are Feature-owned, generated output is transport-only,
+  domain mapping is strict, routes do not consume GraphQL, and drift is
+  deterministic.
+- API kernel: schema generation belongs to `api-bootstrap`; schema/contract gates
+  integrate with the compiler-first workspace and Testcontainers harness.
+- Mobile kernel: branded generated types remain in adapters, authenticated fetch
+  is a Platform capability, and Feature manifests/Journey selection own evidence.
+- Normalized behavior: exact duplicate names, partial Birthday, no Breed,
+  Completed-only insight, hidden Interrupted Walks, current names, fixed pages,
+  unit-independent metrics, permission-driven interruption, unknown-event
+  omission, media atomicity, and last-write-wins are preserved.
+
+The first comparison found and corrected one inconsistency: access-token failure
+was initially proposed as an operation union member. It is now a shared 401
+transport contract so refresh is single-flight and Feature-independent, while
+resource authorization remains indistinguishable Not Found. No unresolved
+contract decision remains in this ticket.

--- a/docs/wayfinder/2026-07-11-mobile-architecture-kernel.md
+++ b/docs/wayfinder/2026-07-11-mobile-architecture-kernel.md
@@ -1,0 +1,456 @@
+# Mobile Architecture Kernel and Fail-Closed Gates
+
+## Purpose
+
+This document adapts the approved Mobile architecture in PR #367 to a
+compatibility-breaking replacement of `apps/mobile`. It fixes the module shape,
+manifest contract, dependency compiler, state and persistence ownership,
+GraphQL generation boundary, testing model, exceptions, and required CI gates.
+Product journeys are implemented after this kernel.
+
+Migration cost, diff size, and reuse of the current Mobile source are not design
+constraints. Reproducibility, explicit ownership, correctness, diagnosability,
+maintainability, and mechanical enforcement take priority.
+
+Inputs:
+
+- PR #367, `Design next-generation Mobile architecture safeguards`
+- `docs/wayfinder/2026-07-11-current-architecture-inventory.md`
+- `docs/wayfinder/2026-07-11-domain-journey-ownership-map.md`
+- `docs/wayfinder/2026-07-11-acceptance-spec-normalization.md`
+
+## Cutover and platform decision
+
+The Mobile Architecture Kernel replaces the current application structure in one
+merge. The old routes, screens, root `hooks`, `stores`, `components`, `lib`, and
+`types` are removed rather than preserved behind flags or compatibility layers.
+The kernel exits with a localized, accessible routing shell that builds, installs,
+and launches, but exposes no migrated product journey. Each later journey slice
+must restore a usable end-to-end outcome before the next slice begins.
+
+Initial acceptance and required builds are iOS only. Android, Web, Watch, and
+Live Activity code, configuration, scripts, dependencies, and speculative ports
+are removed. Cross-platform Expo or React Native APIs remain valid when they are
+the best iOS implementation. A second platform is added only with an actual use
+case and concrete adapter.
+
+There is no device-data migration. The new persistence schema starts empty.
+Rollback uses the prior install/build, never a legacy runtime inside the new app.
+
+## Repository layout
+
+```text
+apps/mobile/
+├── app/                              # Expo Router composition only
+├── features/
+│   ├── account-access/
+│   ├── owner-profile/
+│   ├── preferences/
+│   ├── dogs/
+│   ├── walk-recording/
+│   ├── walk-events/
+│   ├── walk-history/
+│   └── contribution/
+├── platform/
+│   ├── graphql/
+│   ├── query/
+│   ├── secure-storage/
+│   ├── persistence/
+│   ├── location/
+│   ├── media/
+│   ├── observability/
+│   └── system-settings/
+├── generated/graphql/               # generated transport code only
+├── design-system/                    # tokens and reusable presentation
+├── journeys/                         # machine-readable Journey/evidence registry
+├── architecture/
+│   ├── module.schema.json
+│   ├── dependency-policy.yaml
+│   ├── exceptions.yaml
+│   ├── intents/
+│   └── fixtures/
+├── tools/mobile-architecture/        # architecture compiler and generators
+└── test-support/                     # harness clients and shared test adapters
+```
+
+Every feature has the same internal shape:
+
+```text
+features/<feature>/
+├── module.yaml
+├── index.ts                         # the only public entrypoint
+├── domain/
+├── application/
+├── react/
+├── ui/
+├── adapters/
+│   ├── graphql/
+│   ├── persistence/
+│   └── native/
+└── tests/
+    ├── contract/
+    ├── integration/
+    └── fixtures/
+```
+
+Directories may be absent when the feature has no corresponding responsibility.
+Empty placeholder layers are prohibited. No technology-wide root `hooks`,
+`stores`, `components`, `lib`, or `types` directory may be introduced.
+
+`journeys/<journey-id>/journey.yaml` is the Mobile execution registry. It points
+to one canonical contract under `docs/harness/journeys/`, the owning Feature
+manifests, Maestro flow, fixture identity, success/failure/data evidence, and
+privacy classification. It does not duplicate behavioral prose. A registry whose
+canonical document, flow, fixture, or owner is missing fails validation.
+
+`app` owns navigation, provider construction, and composition of public Feature
+APIs. It contains no GraphQL document, storage query, location operation, domain
+decision, or workflow. `design-system` owns presentation primitives only and has
+no product concept, transport, persistence, navigation, or Feature dependency.
+
+## Module manifest contract
+
+Every Feature and Platform module owns one `module.yaml`, validated by
+`architecture/module.schema.json`. Unknown keys fail. The schema version is
+explicit and upgrades are atomic across the repository.
+
+```yaml
+schemaVersion: 1
+id: walk-recording
+kind: feature
+concepts: [Active Walk, Track Point, Walk Recording]
+publicEntrypoint: index.ts
+dependencies:
+  features: []
+  platform: [graphql, persistence, location, observability]
+capabilities:
+  provides: [ActiveWalkContext]
+  consumes: [AuthenticatedClient, DisplayPreferences]
+adapters:
+  - port: ActiveWalkRepository
+    production: adapters/persistence/sqlite-active-walk-repository.ts
+    test: tests/fixtures/in-memory-active-walk-repository.ts
+    contract: tests/contract/active-walk-repository.contract.ts
+journeys: [record-a-walk]
+productAxes:
+  primary: walk-data
+  considered: [dog-experience, owner-contribution]
+errors:
+  - permission-denied
+  - persistence
+  - contract-violation
+  - terminal
+```
+
+Required fields are schema version, stable ID, kind, owned canonical concepts,
+public entrypoint, outgoing dependencies, provided/consumed capabilities,
+adapters and shared contracts, canonical journeys, all three product axes, and
+declared error categories. Values come from closed registries generated from
+`CONTEXT.md`, the ownership map, Journey manifests, and architecture policy.
+
+The compiler compares declarations with actual imports, exports, production and
+test adapters, contract locations, changed files, and selected Journey evidence
+in both directions. A declaration cannot authorize an unused edge, and an actual
+edge cannot exist without a declaration.
+
+## Dependency and public API policy
+
+`architecture/dependency-policy.yaml` is versioned and default-deny. The initial
+production direction is:
+
+```text
+app routes
+  -> Feature public entrypoints + design-system
+Feature public entrypoint
+  -> that Feature's react/application/domain/UI
+Feature implementation
+  -> declared Platform public entrypoints + generated GraphQL transport
+Platform implementation
+  -> native/Expo/React Native/vendor SDKs
+```
+
+Rules:
+
+- Feature cycles and Platform cycles are forbidden.
+- A Feature may import another Feature only through its `index.ts` and only when
+  both manifests declare the edge. Initially only `walk-events ->
+  walk-recording`, consuming `ActiveWalkContext`, is allowed.
+- Routes may import Feature and Platform composition factories only from public
+  entrypoints. Routes cannot import Feature internals, `generated`, native SDKs,
+  GraphQL, persistence, location, or media APIs.
+- A Feature cannot re-export another Feature, Platform implementation, generated
+  GraphQL type, native/vendor type, or private adapter.
+- Deep relative paths that escape the current module and aliases targeting a
+  module interior are forbidden. Tests obey the same rule except for their own
+  module's explicit test surface.
+- Domain and application code cannot import React, React Native, Expo Router,
+  TanStack Query, XState React bindings, native SDKs, generated GraphQL, or
+  concrete adapters.
+- `generated/graphql` can be imported only by GraphQL Platform code and a
+  Feature's GraphQL adapter. Generated types never enter domain, UI, route, or
+  public signatures.
+- Platform modules cannot import Features or `app`. `test-support` and compiler
+  tools cannot enter a production graph.
+- Dynamic import, CommonJS `require`, barrel files other than registered public
+  entrypoints, and path aliases that obscure ownership fail unless explicitly
+  classified by policy.
+
+## Mobile architecture compiler
+
+`npm run architecture` invokes the repository-owned compiler under
+`tools/mobile-architecture`. It uses the TypeScript Compiler API, the resolved
+`tsconfig`, package metadata, JSON Schema, and repository registries. ESLint
+provides fast editor feedback; the compiler is the CI root of trust.
+
+The compiler discovers all TypeScript/TSX modules, route files, tests, generated
+outputs, native entrypoints, package exports, and manifests. Dead or currently
+unreachable files are still checked. It resolves aliases, type-only imports,
+dynamic imports, re-exports, barrels, and package subpaths. Parse or resolution
+failure, an unknown file owner, an unknown module, or an incomplete rule fails.
+
+Initial rules:
+
+| Rule | Fail-closed prohibition |
+| --- | --- |
+| `MOB-ARCH-001` | Source file without exactly one registered owner |
+| `MOB-ARCH-002` | Manifest and actual dependency/export mismatch |
+| `MOB-ARCH-003` | Feature or Platform dependency cycle |
+| `MOB-ARCH-004` | Feature deep import or import other than public `index.ts` |
+| `MOB-ARCH-005` | Route imports anything except registered public composition APIs and design system |
+| `MOB-ARCH-006` | React/native/transport/persistence dependency in domain or application |
+| `MOB-ARCH-007` | Generated GraphQL type/document outside permitted adapter code |
+| `MOB-ARCH-008` | Global mutable store or cross-Feature shared mutable state |
+| `MOB-ARCH-009` | Native/vendor type or concrete adapter in a public signature |
+| `MOB-ARCH-010` | Port without production adapter, test adapter, and shared contract suite |
+| `MOB-ARCH-011` | Undeclared Journey, product axis, concept, capability, or error category |
+| `MOB-ARCH-012` | Handwritten GraphQL transport type/document or edited/stale generated output |
+| `MOB-ARCH-013` | Secret, OTP, signed URL, storage key, or precise coordinate in logs/evidence |
+| `MOB-ARCH-014` | Android, Web, Watch, or Live Activity production target in the iOS-only kernel |
+
+Each rule has passing fixtures and multiple failing fixtures, including aliases,
+re-exports, type imports, dynamic imports, and misleading file names where
+applicable. Tests assert rule ID and exact location. Output supports concise
+human diagnostics and SARIF; there is no warning mode.
+
+## Change intent and agent protocol
+
+Before a product edit, `npm run intent:new -- <id>` creates an immutable manifest
+under `architecture/intents/`. It declares the issue, Owner, affected product
+axes and Journeys, concept owners, changed public interfaces, existing seams,
+both concrete adapters for any new seam, GraphQL/schema impact, durable-state
+impact, success/failure/recovery contracts, and expected evidence.
+
+The architecture compiler derives changed modules, concepts, exports,
+dependencies, operations, adapters, routes, and Journeys from the merge-base
+diff and compares them with the intent in both directions. Unknown values,
+multiple intents claiming one product file, unclaimed product files, missing
+evidence, and secret-like content fail. Merged intents remain as a compact
+change-reason corpus.
+
+Agent work follows `intent -> selected context -> contract -> implementation ->
+deterministic verification -> independent review -> evidence`. Selected context
+is limited to the affected Journey, manifests, domain terms, and ADRs. A separate
+review agent does not edit the change and evaluates depth, deletion impact,
+caller knowledge of ordering/error modes, production/test interface parity,
+domain leakage, seam legitimacy, locality, and evidence fit. New exports,
+dependencies, fallbacks, optional domain values, and module mutable state are
+always highlighted in its input.
+
+Independent AI review is advisory because model judgment is nondeterministic. A
+P0/P1 finding requires a fix or a human-authored durable dismissal linked from
+the intent. AI output alone never changes merge status; deterministic gates stay
+effective when AI review is unavailable.
+
+## State and workflow ownership
+
+Zustand and every app-wide mutable store are removed. State has exactly one
+owner:
+
+- TanStack Query owns refetchable server cache, never authoritative business
+  lifecycle state.
+- XState owns multi-stage, failure-sensitive, restorable Feature lifecycles such
+  as authentication, Walk recording, and pending media synchronization.
+- React local state owns ephemeral state confined to one screen or component.
+- SQLite owns durable non-secret device state.
+- SecureStore owns authentication secrets only.
+
+XState is not used for simple controls. A lifecycle machine declares states,
+events, guards, invoked operations, terminal outcomes, and recovery. React
+subscribes to a snapshot and sends typed intents; it does not orchestrate GPS,
+persistence, uploads, token refresh, or recovery.
+
+`walk-recording` begins with `ready`, `starting`, `recording`, `finishing`,
+`finished`, and `failed`, and may add explicit permission, restoration,
+interruption, or authentication-recovery substates demanded by the normalized
+specification. Unknown persisted state fails restoration visibly; it never maps
+silently to `ready`.
+
+Application and domain boundaries return `Promise<Result<T, MobileError>>` for
+expected failure. `MobileError` is a closed tagged union containing permission,
+authentication, not-found, validation, contract, transport, timeout,
+persistence, deferred-sync, native-capability, terminal, and unexpected
+categories. Adapters translate thrown SDK/provider failures at the boundary.
+Features decide recovery; UI renders category plus typed recovery action rather
+than inspecting strings. Catch-and-ignore, null/zero/default substitution, and
+untyped fallbacks are prohibited.
+
+No additional effect runtime is introduced. XState, TanStack Query, React local
+state, and the small Result algebra have distinct responsibilities.
+
+## Persistence and synchronization
+
+SecureStore contains tokens and other authentication secrets. SQLite is the
+only authoritative device persistence for Active Walk state, Track Points,
+Pending Events/Photos, idempotency identities, and synchronization state.
+AsyncStorage cannot hold durable domain state. Query cache persistence, if later
+justified, remains a disposable presentation optimization.
+
+`platform/persistence` owns SQLite opening, schema, transactions, and migrations.
+Features own repository ports and domain mapping; neither SQL nor SQLite types
+cross the Platform entrypoint. Every external seam has a production adapter, an
+in-memory test adapter, and the same reusable contract suite. New seams are not
+created until two concrete adapters exist.
+
+A write that must precede an acknowledged Owner action fails closed. For
+example, a Walk cannot enter `recording` before its durable shell is committed,
+and an offline event is not accepted until its identity and payload are durable.
+Outbox removal occurs only after confirmed idempotent synchronization or an
+explicitly confirmed discard required by the acceptance specification.
+
+## GraphQL contract boundary
+
+The new API's generated `schema.graphql` is the only Mobile contract input.
+GraphQL Code Generator validates Feature-owned `.graphql` operations and emits
+transport documents and types under `generated/graphql`. The Mobile build does
+not introspect a remote environment and does not support old schemas.
+
+Feature GraphQL adapters map generated transport values into domain values and
+reject missing invariants, invalid enums, invalid ordering, duplicate IDs, and
+malformed pagination. Routes, UI, domain, and public APIs never see generated
+types. Handwritten GraphQL strings, handwritten response mirrors, compatibility
+aliases, parallel old/new operations, unused operations, invalid operations, and
+uncommitted generation drift fail CI.
+
+## Tests and Journey selection
+
+Testing follows the highest-leverage interface:
+
+1. pure domain and formatting tests;
+2. application use-case and XState model/transition tests;
+3. reusable port contract suites against in-memory and production adapters;
+4. SQLite, SecureStore wrapper, GraphQL transport, media, and location boundary
+   integration tests;
+5. route/Feature integration tests using public entrypoints;
+6. iOS build-and-launch smoke tests;
+7. canonical Maestro Journeys selected from manifests and changed ownership.
+
+Tests do not import private code from another module. Native modules use an
+explicit test adapter rather than ambient Jest mocks. Contract suites prove
+observable behavior, error classification, cancellation, idempotency, and
+concurrency semantics rather than method-call choreography.
+
+The architecture compiler maps every changed Feature, capability, operation,
+and route to canonical Journeys. It rejects missing and unjustified evidence.
+Broad shell, authentication, navigation, settings, persistence, GraphQL, or
+Walk-lifecycle changes select every affected Journey; an unowned product diff
+fails instead of defaulting to no Journey.
+
+## Required CI gates
+
+All Mobile changes require, in fail-fast order:
+
+1. `mobile-architecture`: manifests, graph, ownership, exports, fixtures, and
+   exceptions;
+2. `mobile-graphql-contract`: API schema generation, operation validation,
+   codegen, and clean generated diff;
+3. `mobile-static`: formatting, TypeScript, ESLint, and Knip;
+4. `mobile-unit`: domain, application, Result mapping, and XState tests;
+5. `mobile-adapter-contract`: shared contracts against every declared adapter;
+6. `mobile-integration`: real local persistence and transport boundaries;
+7. `mobile-ios-release`: Release-equivalent Simulator build, install, launch,
+   and crash-free routing-shell smoke test;
+8. `mobile-journey-selection`: diff-to-Journey completeness;
+9. `mobile-maestro`: every selected iOS Journey and sanitized evidence bundle;
+10. `mobile-privacy`: deterministic forbidden-data checks over logs and evidence;
+11. repository `scripts/harness/validate-all.sh`.
+
+Pull requests also publish the independent AI architecture review and any durable
+human dismissals. This report is required evidence but is not itself a
+nondeterministic pass/fail gate.
+
+Main and pull requests run all deterministic gates. Nightly validation repeats
+the full Journey set and native failure scenarios to detect flakiness and
+environment drift. A retry does not convert an initial failure into success;
+flaky evidence remains a failure until diagnosed.
+
+## Time-limited exceptions
+
+There is no global bypass. `architecture/exceptions.yaml` follows the API kernel
+model: one rule, module, file, symbol, AST fingerprint, Owner, creation date,
+expiry, open removal issue, one-to-one ADR, and justification per entry. Globs,
+directories, multiple rules, unused entries, fingerprint drift, and unknown
+owners fail.
+
+Maximum duration is 30 days. CI warns seven days before expiry and fails on the
+expiry date. Extension requires a new ID, ADR, risk review, and approval. No
+environment variable, local flag, AI instruction, comment directive, or CLI
+switch can bypass a rule. Generated output and tests use explicit classification,
+not exceptions.
+
+## Kernel exit criteria
+
+The kernel is complete only when:
+
+- the old source shape and out-of-scope platform code are absent;
+- the iOS routing shell builds, installs, launches, localizes, supports Dynamic
+  Type/VoiceOver basics, and exposes no product claim it cannot fulfill;
+- all eight Feature manifests and all required Platform manifests validate;
+- compiler fixtures prove cycles, deep imports, route leaks, invalid exports,
+  stale GraphQL, missing adapters/contracts, unowned files, and privacy leaks fail;
+- XState, Result, TanStack Query, SQLite, and SecureStore boundaries are encoded
+  by policy and representative tests;
+- the new API schema generates the empty/initial Mobile contract deterministically;
+- every required CI gate is present and required;
+- `scripts/harness/validate-all.sh` passes.
+
+The first product slice after the kernel is `account-access`, following PR #367's
+sequence. Subsequent slices follow the canonical Journey roadmap, not the old
+screen/file order.
+
+The broader PR #367 foundation is complete only after that `account-access`
+slice runs one representative Journey through route, public Feature interface,
+GraphQL transport, secure native storage, production and in-memory adapters, and
+the same contract suite. The kernel intentionally establishes the enforcement
+system first; it does not mislabel an empty shell as the representative vertical
+slice.
+
+## Self-review against inputs
+
+| Input obligation | Output coverage |
+| --- | --- |
+| Vertical modular monolith and route-only composition | Repository layout and dependency policy |
+| Feature-owned domain, application, React, UI, adapters, tests | Uniform Feature shape without empty placeholders |
+| One public entrypoint and no deep imports/cycles | Manifest, graph policy, `MOB-ARCH-003/004/005/009` |
+| No app-wide mutable store | State ownership and `MOB-ARCH-008` |
+| Explicit lifecycle machines | XState standard and Walk baseline states |
+| Generated GraphQL transport only | API-sourced generation and `MOB-ARCH-007/012` |
+| Typed recovery-aware failures | Closed Result/Error algebra and adapter translation |
+| Manifest matches graph, adapters, contracts, journeys, axes | Schema, bidirectional compiler comparison, rules 002/010/011 |
+| Production and test adapters at real seams | Persistence model and shared adapter contracts |
+| Editing/PR/main/nightly prevention | ESLint feedback, required CI, and nightly repeat |
+| AI-agent work protocol and independent review | Change intent, selected context, deterministic verification, advisory independent review, durable human dismissal |
+| PR #367 sequence | Kernel then `account-access`; no legacy coexistence |
+| Eight Features and single allowed Feature edge | Ownership-map names and `walk-events -> walk-recording` only |
+| iOS-only normalized acceptance | iOS build target; Android/Web/Watch/Live Activity rejected |
+| No compatibility or production-data migration | Destructive cutover and empty persistence baseline |
+| Normalized durable Walk/event recovery | SQLite authority and fail-closed acknowledgements |
+| Mobile `journeys/` plus canonical knowledge sources | Machine registry points to canonical docs, Maestro, fixtures, evidence, and owners without duplicating prose |
+| Human-visible, privacy-safe Journey evidence | Journey selection, Maestro, privacy gate |
+| Product decision axes | Required manifest fields and compiler registry |
+
+The first comparison found missing Mobile Journey registry, change-intent, and
+independent-review details; all three are now covered above. A second comparison
+found no uncovered PR #367 or normalized-acceptance architecture obligation.
+Screen-level visual design is intentionally not decided here; the
+final implementation roadmap must satisfy the repository requirement to present
+a visual companion before planning user-facing UI implementation.

--- a/docs/wayfinder/artifacts/2026-07-11-mobile-journey-wireflow.html
+++ b/docs/wayfinder/artifacts/2026-07-11-mobile-journey-wireflow.html
@@ -1,0 +1,246 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Walking Dog — Mobile Journey Wireflow</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --ink: #17211d;
+      --muted: #63706a;
+      --paper: #f6f2e8;
+      --panel: #fffdf7;
+      --line: #c9c8bb;
+      --green: #246b4e;
+      --green-soft: #dcecdf;
+      --blue: #245b78;
+      --blue-soft: #dcebf1;
+      --amber: #9a5c16;
+      --amber-soft: #f5e5c9;
+      --red: #a13b32;
+      --red-soft: #f5dcd7;
+      --shadow: 0 12px 30px rgb(38 47 42 / 9%);
+      --radius: 16px;
+      font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    * { box-sizing: border-box; }
+    body { margin: 0; background: var(--paper); color: var(--ink); }
+    button, select { font: inherit; }
+    header {
+      padding: 38px clamp(20px, 5vw, 72px) 24px;
+      border-bottom: 1px solid var(--line);
+      background: linear-gradient(135deg, #fffdf7 0%, #edf3ea 100%);
+    }
+    h1, h2, h3, p { margin-top: 0; }
+    h1 { max-width: 900px; font-size: clamp(34px, 5vw, 64px); line-height: .98; letter-spacing: -.045em; margin-bottom: 18px; }
+    h2 { font-size: 27px; letter-spacing: -.025em; }
+    h3 { font-size: 17px; }
+    .lede { max-width: 900px; color: var(--muted); font-size: 17px; line-height: 1.55; }
+    .meta, .legend, .filters { display: flex; flex-wrap: wrap; gap: 9px; align-items: center; }
+    .chip { border: 1px solid var(--line); border-radius: 999px; padding: 6px 10px; background: rgb(255 255 255 / 64%); font-size: 12px; }
+    .legend { margin-top: 18px; }
+    .legend .chip::before { content: ""; width: 18px; height: 2px; display: inline-block; margin-right: 7px; vertical-align: middle; background: var(--green); }
+    .legend .modal::before { background: repeating-linear-gradient(90deg, var(--amber), var(--amber) 4px, transparent 4px, transparent 7px); }
+    .legend .override::before { background: var(--red); }
+    main { padding: 28px clamp(16px, 4vw, 58px) 80px; max-width: 1700px; margin: auto; }
+    .toolbar { position: sticky; top: 0; z-index: 5; display: flex; justify-content: space-between; gap: 14px; align-items: center; padding: 12px; margin-bottom: 20px; background: rgb(246 242 232 / 92%); backdrop-filter: blur(12px); border: 1px solid var(--line); border-radius: 14px; }
+    select, .reset { border: 1px solid var(--line); border-radius: 9px; background: var(--panel); padding: 8px 10px; color: var(--ink); }
+    .reset { cursor: pointer; }
+    .map { display: grid; gap: 18px; }
+    .lane { display: grid; grid-template-columns: 190px minmax(0, 1fr); border: 1px solid var(--line); border-radius: var(--radius); background: rgb(255 253 247 / 70%); overflow: hidden; box-shadow: var(--shadow); }
+    .lane-label { padding: 22px; border-right: 1px solid var(--line); background: rgb(255 255 255 / 45%); }
+    .lane-label p { color: var(--muted); font-size: 12px; line-height: 1.45; margin-bottom: 0; }
+    .nodes { padding: 20px; display: grid; grid-template-columns: repeat(auto-fit, minmax(205px, 1fr)); gap: 14px; align-items: stretch; }
+    .node { appearance: none; text-align: left; color: inherit; border: 1px solid var(--line); border-left: 5px solid var(--green); border-radius: 12px; background: var(--panel); padding: 14px; cursor: pointer; min-height: 132px; box-shadow: 0 4px 14px rgb(38 47 42 / 5%); transition: transform .16s ease, box-shadow .16s ease, opacity .16s ease; }
+    .node:hover, .node:focus-visible { transform: translateY(-2px); box-shadow: var(--shadow); outline: 3px solid rgb(36 107 78 / 18%); }
+    .node[data-kind="modal"] { border-left-color: var(--amber); }
+    .node[data-kind="override"] { border-left-color: var(--red); background: #fff9f7; }
+    .node[data-kind="state"] { border-left-color: var(--blue); background: #f7fbfc; }
+    .node[hidden] { display: none; }
+    .route { font: 700 11px ui-monospace, SFMono-Regular, Menlo, monospace; color: var(--muted); letter-spacing: .02em; }
+    .node strong { display: block; margin: 9px 0 8px; font-size: 17px; }
+    .node small { display: block; color: var(--muted); line-height: 1.4; }
+    .tags { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 10px; }
+    .tag { font-size: 10px; border-radius: 999px; padding: 4px 7px; background: var(--green-soft); color: #174a36; }
+    .tag.slice { background: var(--blue-soft); color: #164760; }
+    .tag.override { background: var(--red-soft); color: #762820; }
+    .state-rail { margin: 18px 0 34px; display: grid; grid-template-columns: repeat(6, 1fr); gap: 9px; }
+    .state { border: 1px solid var(--line); background: var(--panel); border-radius: 10px; padding: 11px; text-align: center; font-size: 12px; color: var(--blue); }
+    .section-head { display: flex; justify-content: space-between; align-items: end; gap: 18px; margin: 45px 0 18px; }
+    .section-head p { color: var(--muted); max-width: 720px; margin-bottom: 0; }
+    .phones { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 24px; align-items: start; }
+    .phone-wrap { display: grid; gap: 11px; }
+    .phone-title { font-weight: 750; }
+    .phone { max-width: 360px; width: 100%; margin: auto; min-height: 650px; border: 9px solid #1f2924; border-radius: 38px; background: #fff; overflow: hidden; box-shadow: var(--shadow); display: flex; flex-direction: column; }
+    .statusbar { height: 28px; padding: 7px 18px; font-size: 10px; display: flex; justify-content: space-between; background: #f8faf7; }
+    .screen { padding: 18px; flex: 1; display: flex; flex-direction: column; gap: 14px; }
+    .screen h3 { font-size: 25px; letter-spacing: -.03em; margin-bottom: 0; }
+    .screen p { color: var(--muted); font-size: 13px; line-height: 1.45; margin-bottom: 0; }
+    .field, .row, .card, .mapbox { border: 1px solid #d6dbd7; border-radius: 12px; padding: 13px; background: #fafcf9; }
+    .field { color: #7c8580; }
+    .row { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+    .avatar { width: 44px; height: 44px; border-radius: 50%; background: var(--green-soft); display: grid; place-items: center; font-weight: 800; }
+    .primary { border: 0; border-radius: 12px; padding: 14px; background: var(--green); color: white; font-weight: 750; text-align: center; }
+    .secondary { border: 1px solid var(--green); border-radius: 12px; padding: 13px; color: var(--green); font-weight: 750; text-align: center; }
+    .mapbox { min-height: 230px; display: grid; place-items: center; color: var(--blue); background: radial-gradient(circle at 35% 45%, #dcebf1 0 4px, transparent 5px), linear-gradient(35deg, #f3f6ee 45%, #e2eee5 46% 53%, #f3f6ee 54%); }
+    .metrics { display: grid; grid-template-columns: repeat(3, 1fr); gap: 7px; }
+    .metric { border: 1px solid #d6dbd7; border-radius: 10px; padding: 9px 6px; text-align: center; }
+    .metric b { display: block; font-size: 16px; }
+    .metric small { color: var(--muted); }
+    .tabs { height: 63px; border-top: 1px solid #d6dbd7; display: grid; grid-template-columns: repeat(3, 1fr); place-items: center; font-size: 11px; color: var(--muted); }
+    .tabs .active { color: var(--green); font-weight: 800; }
+    .detail { position: fixed; inset: auto 22px 22px auto; z-index: 10; width: min(430px, calc(100vw - 44px)); max-height: calc(100vh - 44px); overflow: auto; border: 1px solid var(--line); border-radius: 16px; background: var(--panel); padding: 20px; box-shadow: 0 25px 70px rgb(20 31 26 / 24%); }
+    .detail[hidden] { display: none; }
+    .detail button { float: right; border: 0; background: transparent; font-size: 22px; cursor: pointer; }
+    .detail dl { display: grid; grid-template-columns: 100px 1fr; gap: 8px; font-size: 13px; }
+    .detail dt { color: var(--muted); }
+    .detail dd { margin: 0; }
+    .unassigned { margin-top: 30px; border: 1px solid var(--green); background: var(--green-soft); border-radius: 12px; padding: 14px; color: #174a36; }
+    @media (max-width: 760px) {
+      .lane { grid-template-columns: 1fr; }
+      .lane-label { border-right: 0; border-bottom: 1px solid var(--line); }
+      .toolbar { position: static; align-items: stretch; flex-direction: column; }
+      .state-rail { grid-template-columns: repeat(2, 1fr); }
+    }
+    @media print {
+      body { background: white; }
+      .toolbar, .detail { display: none !important; }
+      .lane, .phone { box-shadow: none; break-inside: avoid; }
+      .node[hidden] { display: block; }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="meta"><span class="chip">Planning artifact</span><span class="chip">iOS 18+</span><span class="chip">7 journeys</span><span class="chip">8 features</span><span class="chip">11 slices</span></div>
+    <h1>Walking Dog<br>Mobile Journey Wireflow</h1>
+    <p class="lede">A structural companion for the migration roadmap. It shows route ownership, canonical journeys, delivery slices, and the states that override ordinary navigation. It is not a final visual design or copy specification.</p>
+    <div class="legend"><span class="chip">Normal navigation</span><span class="chip modal">Modal / pushed task</span><span class="chip override">Forced override</span></div>
+  </header>
+
+  <main>
+    <div class="toolbar">
+      <div class="filters">
+        <label>Journey <select id="journey"><option value="all">All journeys</option></select></label>
+        <label>Feature <select id="feature"><option value="all">All features</option></select></label>
+        <label>Slice <select id="slice"><option value="all">All slices</option></select></label>
+      </div>
+      <button class="reset" id="reset" type="button">Reset filters</button>
+    </div>
+
+    <section aria-labelledby="map-heading">
+      <div class="section-head"><div><h2 id="map-heading">Route and override map</h2><p>Select a node for entry conditions, success destination, failure destination, and ownership. Filters never remove information when printed.</p></div></div>
+      <div class="map" id="map">
+        <article class="lane">
+          <div class="lane-label"><h3>Unauthenticated</h3><p>Access Account owns every entry before a valid authenticated session.</p></div>
+          <div class="nodes">
+            <button class="node" data-route="AUTH-01" data-title="Sign In" data-feature="account-access" data-journey="access-account" data-slice="4" data-kind="normal" data-entry="No authenticated session" data-success="AUTH-03 OTP verification" data-failure="Validation or retryable error on the same screen"><span class="route">AUTH-01 · /sign-in</span><strong>Sign In</strong><small>Email entry, legal links, Sign Up choice.</small><span class="tags"><span class="tag">account-access</span><span class="tag slice">Slice 4</span></span></button>
+            <button class="node" data-route="AUTH-02" data-title="Sign Up" data-feature="account-access" data-journey="access-account" data-slice="4" data-kind="normal" data-entry="Owner chooses Sign Up" data-success="AUTH-03 OTP verification" data-failure="Validation or retryable error on the same screen"><span class="route">AUTH-02 · /sign-up</span><strong>Sign Up</strong><small>Email-only account creation; Terms and Privacy links.</small><span class="tags"><span class="tag">account-access</span><span class="tag slice">Slice 4</span></span></button>
+            <button class="node" data-route="AUTH-03" data-title="OTP Verification" data-feature="account-access" data-journey="access-account" data-slice="4" data-kind="normal" data-entry="Live challenge with declared code length" data-success="Authenticated shell: Dogs tab" data-failure="Clear invalid code; expired/consumed/rate-limit recovery"><span class="route">AUTH-03 · /verify</span><strong>OTP Verification</strong><small>8 digits for Sign In; 6 for Sign Up and Email Change.</small><span class="tags"><span class="tag">account-access</span><span class="tag slice">Slice 4</span></span></button>
+          </div>
+        </article>
+
+        <article class="lane">
+          <div class="lane-label"><h3>Dogs tab</h3><p>Manage Dogs and Goals. Contribution and History are composed at route boundaries.</p></div>
+          <div class="nodes">
+            <button class="node" data-route="DOG-01" data-title="Dogs List" data-feature="dogs" data-journey="manage-dogs-and-goals" data-slice="6" data-kind="normal" data-entry="Authenticated; Dogs tab selected" data-success="DOG-02 detail or DOG-03 registration" data-failure="Cached update error or full retryable error"><span class="route">DOG-01 · /(tabs)/dogs</span><strong>Dogs List</strong><small>Current Dogs only, explicit empty/loading/error states.</small><span class="tags"><span class="tag">dogs</span><span class="tag slice">Slice 6</span></span></button>
+            <button class="node" data-route="DOG-03" data-title="Register Dog" data-feature="dogs" data-journey="manage-dogs-and-goals" data-slice="6" data-kind="modal" data-entry="Add from header, empty state, or Walk empty state" data-success="DOG-02 new Dog detail" data-failure="Preserve dirty form and media for retry"><span class="route">DOG-03 · /dogs/new</span><strong>Register Dog</strong><small>Name, Gender, partial Birthday, independent Goals, Avatar.</small><span class="tags"><span class="tag">dogs</span><span class="tag slice">Slice 6</span></span></button>
+            <button class="node" data-route="DOG-02" data-title="Dog Detail" data-feature="dogs,contribution,walk-history" data-journey="manage-dogs-and-goals,review-owner-contribution,review-walk-history" data-slice="6,9,10" data-kind="normal" data-entry="Current or Archived Dog ID owned by Owner" data-success="Edit, Goal progress, recent Walks, filtered History" data-failure="Not Found or retryable/contract error"><span class="route">DOG-02 · /dogs/:dogId</span><strong>Dog Detail</strong><small>Route composition: profile + progress + Completed Walk history.</small><span class="tags"><span class="tag">3 features</span><span class="tag slice">Slices 6/9/10</span></span></button>
+            <button class="node" data-route="DOG-04" data-title="Edit Dog" data-feature="dogs" data-journey="manage-dogs-and-goals" data-slice="6" data-kind="modal" data-entry="DOG-02 Edit" data-success="DOG-02 with authoritative refetch" data-failure="Preserve form; Not Found; archive blocked by Active Walk"><span class="route">DOG-04 · /dogs/:dogId/edit</span><strong>Edit / Archive Dog</strong><small>No-change Save disabled; explicit media removal; dirty discard.</small><span class="tags"><span class="tag">dogs</span><span class="tag slice">Slice 6</span></span></button>
+          </div>
+        </article>
+
+        <article class="lane">
+          <div class="lane-label"><h3>Walk tab</h3><p>One stable shell changes state without remounting. Events compose through ActiveWalkContext.</p></div>
+          <div class="nodes">
+            <button class="node" data-route="WALK-01" data-title="Walk Ready" data-feature="walk-recording,dogs" data-journey="record-a-walk" data-slice="7" data-kind="state" data-entry="Authenticated; no API Active Walk" data-success="WALK-02 starting, then WALK-03 recording" data-failure="Start blocked without Dog or foreground location"><span class="route">WALK-01 · /(tabs)/walk · ready</span><strong>Ready</strong><small>Select current Dogs, inspect today progress, start with location.</small><span class="tags"><span class="tag">walk-recording</span><span class="tag slice">Slice 7</span></span></button>
+            <button class="node" data-route="WALK-02" data-title="Walk Starting" data-feature="walk-recording" data-journey="record-a-walk" data-slice="7" data-kind="state" data-entry="Start intent accepted locally" data-success="Durable shell + API success → recording" data-failure="Return Ready with typed retry; no fake progress"><span class="route">WALK-02 · same route · starting</span><strong>Starting</strong><small>Persist shell, request foreground fix, create authoritative Active Walk.</small><span class="tags"><span class="tag">walk-recording</span><span class="tag slice">Slice 7</span></span></button>
+            <button class="node" data-route="WALK-03" data-title="Walk Recording" data-feature="walk-recording,walk-events" data-journey="record-a-walk,capture-walk-events" data-slice="7,8" data-kind="state" data-entry="Authoritative API Active Walk and valid foreground location" data-success="Slice 7: saved confirmation then Ready; Slice 9: HIST-02 detail" data-failure="Permission/location/auth recovery or Interrupted → Ready"><span class="route">WALK-03 · same route · recording</span><strong>Recording</strong><small>Stable map, time/distance, per-Dog Pee/Poop, Photo, Finish.</small><span class="tags"><span class="tag">2 features</span><span class="tag slice">Slices 7/8</span></span></button>
+            <button class="node" data-route="WALK-04" data-title="Photo Capture" data-feature="walk-events" data-journey="capture-walk-events" data-slice="8" data-kind="modal" data-entry="Camera intent while recording" data-success="Pending Photo appears; upload and registration continue" data-failure="Permission explanation, Retry, or confirmed discard"><span class="route">WALK-04 · camera modal</span><strong>Photo Capture</strong><small>Normalized JPEG, durable outbox, pending state after Finish.</small><span class="tags"><span class="tag">walk-events</span><span class="tag slice">Slice 8</span></span></button>
+          </div>
+        </article>
+
+        <article class="lane">
+          <div class="lane-label"><h3>Me tab</h3><p>Profile and preferences arrive before insight surfaces; History and Contribution are authoritative API read models.</p></div>
+          <div class="nodes">
+            <button class="node" data-route="ME-01" data-title="Me" data-feature="owner-profile,contribution" data-journey="manage-owner-profile-and-preferences,review-owner-contribution" data-slice="5,10" data-kind="normal" data-entry="Authenticated; Me tab selected" data-success="Edit Owner, History, Settings" data-failure="Cached update error or full retryable/contract error"><span class="route">ME-01 · /(tabs)/me</span><strong>Me / Contribution</strong><small>Current Owner, totals, weekly graph, Walking Since.</small><span class="tags"><span class="tag">2 features</span><span class="tag slice">Slices 5/10</span></span></button>
+            <button class="node" data-route="ME-02" data-title="Edit Owner" data-feature="owner-profile" data-journey="manage-owner-profile-and-preferences" data-slice="5" data-kind="modal" data-entry="ME-01 Edit" data-success="ME-01 authoritative refetch" data-failure="Preserve dirty form/media; retry"><span class="route">ME-02 · /owner/edit</span><strong>Edit Owner</strong><small>Name and Avatar replacement/removal with atomic visible result.</small><span class="tags"><span class="tag">owner-profile</span><span class="tag slice">Slice 5</span></span></button>
+            <button class="node" data-route="ME-03" data-title="Settings" data-feature="preferences,account-access" data-journey="manage-owner-profile-and-preferences,access-account" data-slice="5" data-kind="normal" data-entry="ME-01 Settings" data-success="Apply language/theme/units; email change; sign out" data-failure="Persistence rollback; legal-link error; Active Walk blocks sign out"><span class="route">ME-03 · /settings</span><strong>Settings</strong><small>Language, units, appearance, notifications, legal, About, Sign Out.</small><span class="tags"><span class="tag">2 features</span><span class="tag slice">Slice 5</span></span></button>
+            <button class="node" data-route="AUTH-04" data-title="Change Email Address" data-feature="account-access" data-journey="access-account" data-slice="4" data-kind="modal" data-entry="Authenticated account entry; Settings link arrives in Slice 5" data-success="AUTH-05 six-digit verification" data-failure="Validation, rate-limit, or retryable error with input preserved"><span class="route">AUTH-04 · /settings/email</span><strong>Change Email Address</strong><small>New identity request; the old address remains active until verification.</small><span class="tags"><span class="tag">account-access</span><span class="tag slice">Slice 4</span></span></button>
+            <button class="node" data-route="AUTH-05" data-title="Verify Email Change" data-feature="account-access" data-journey="access-account" data-slice="4" data-kind="modal" data-entry="Live Email Change challenge" data-success="All sessions revoked; AUTH-01 Sign In with the new address" data-failure="Invalid/expired/consumed challenge remains recoverable"><span class="route">AUTH-05 · /settings/email/verify</span><strong>Verify Email Change</strong><small>Successful verification ends every session and requires Sign In.</small><span class="tags"><span class="tag">account-access</span><span class="tag slice">Slice 4</span></span></button>
+            <button class="node" data-route="HIST-01" data-title="Walk History" data-feature="walk-history" data-journey="review-walk-history" data-slice="9" data-kind="normal" data-entry="ME-01 all Dogs, or DOG-02 preselected Dog" data-success="HIST-02 Walk detail" data-failure="Invalid cursor, retryable error, isolated unavailable row"><span class="route">HIST-01 · /walks</span><strong>Walk History</strong><small>Completed only; All/current/Archived Dog; fixed 20-item pages.</small><span class="tags"><span class="tag">walk-history</span><span class="tag slice">Slice 9</span></span></button>
+            <button class="node" data-route="HIST-02" data-title="Walk Detail" data-feature="walk-history" data-journey="review-walk-history" data-slice="9" data-kind="normal" data-entry="Completed Walk ID and no Active Walk" data-success="Route, current participants, events, photos" data-failure="Not Found, retryable, whole-detail contract error"><span class="route">HIST-02 · /walks/:walkId</span><strong>Walk Detail</strong><small>Validated route and metrics; current names; pending Photo state.</small><span class="tags"><span class="tag">walk-history</span><span class="tag slice">Slice 9</span></span></button>
+          </div>
+        </article>
+
+        <article class="lane">
+          <div class="lane-label"><h3>Navigation overrides</h3><p>These transitions supersede an otherwise valid route and must be tested as state-machine outcomes.</p></div>
+          <div class="nodes">
+            <button class="node" data-route="OVR-01" data-title="Active Walk Redirect" data-feature="walk-recording" data-journey="record-a-walk" data-slice="7" data-kind="override" data-entry="Any Walk detail requested while API Active Walk exists" data-success="WALK-03 recording controls" data-failure="No detail/recording navigation loop"><span class="route">OVR-01 · forced redirect</span><strong>Active Walk wins</strong><small>Every Walk detail intent returns to the recording shell.</small><span class="tags"><span class="tag override">override</span><span class="tag slice">Slice 7</span></span></button>
+            <button class="node" data-route="OVR-02" data-title="Location Interruption" data-feature="walk-recording" data-journey="record-a-walk" data-slice="7" data-kind="override" data-entry="Foreground permission/service lost or no valid point for 30 seconds" data-success="Interrupted explanation, then WALK-01 Ready" data-failure="Pending events continue hidden synchronization"><span class="route">OVR-02 · terminal override</span><strong>Location loss interrupts</strong><small>No detail/history; API Interrupted Walk remains hidden.</small><span class="tags"><span class="tag override">override</span><span class="tag slice">Slice 7</span></span></button>
+            <button class="node" data-route="OVR-03" data-title="Authentication Recovery" data-feature="account-access,walk-recording" data-journey="access-account,record-a-walk" data-slice="4,7" data-kind="override" data-entry="Refresh fails during Active Walk" data-success="Stop new events; finalize Interrupted; reauthenticate; resume sync" data-failure="Remain in explicit recovery; never fake authentication"><span class="route">OVR-03 · recovery state</span><strong>Auth loss during Walk</strong><small>Cross-feature composition through public capabilities only.</small><span class="tags"><span class="tag override">override</span><span class="tag slice">Slices 4/7</span></span></button>
+            <button class="node" data-route="OVR-04" data-title="API Reconciliation" data-feature="walk-recording" data-journey="record-a-walk" data-slice="7" data-kind="override" data-entry="Startup, sign-in, or foreground return" data-success="Restore API Active Walk or stop orphaned local shell" data-failure="Typed unrecoverable event state until confirmed discard"><span class="route">OVR-04 · lifecycle reconcile</span><strong>API state is authoritative</strong><small>Device-only state never creates or resumes a missing Walk.</small><span class="tags"><span class="tag override">override</span><span class="tag slice">Slice 7</span></span></button>
+          </div>
+        </article>
+      </div>
+
+      <div class="state-rail" aria-label="Shared route states"><div class="state">Loading</div><div class="state">Empty</div><div class="state">Cached + update error</div><div class="state">Retryable error</div><div class="state">Not Found</div><div class="state">Contract error</div></div>
+      <div class="unassigned"><strong>Coverage check:</strong> 0 unassigned routes · 0 unowned Journey entries · 0 Feature-internal imports represented.</div>
+    </section>
+
+    <section aria-labelledby="screens-heading">
+      <div class="section-head"><div><h2 id="screens-heading">Representative structural wireframes</h2><p>These frames validate hierarchy and primary actions. They deliberately avoid final colors, type scale, illustration, motion, exact copy, and component-library choices.</p></div></div>
+      <div class="phones">
+        <div class="phone-wrap"><div class="phone-title">AUTH-01 · Sign In</div><div class="phone"><div class="statusbar"><span>9:41</span><span>● ● ●</span></div><div class="screen"><p>Walking Dog</p><h3>Welcome back</h3><p>Sign in with your email address to continue caring through better walks.</p><div class="field">Email address</div><div class="primary">Continue</div><div class="secondary">Create account</div><div style="margin-top:auto"><p>Terms · Privacy</p><p>Validation and retryable errors stay actionable on this screen.</p></div></div></div></div>
+        <div class="phone-wrap"><div class="phone-title">DOG-01 · Dogs</div><div class="phone"><div class="statusbar"><span>9:41</span><span>● ● ●</span></div><div class="screen"><div class="row" style="border:0;background:white;padding:0"><h3>Dogs</h3><b>＋</b></div><div class="row"><div class="avatar">M</div><div style="flex:1"><b>Mugi</b><p>30 min daily goal</p></div><span>›</span></div><div class="row"><div class="avatar">S</div><div style="flex:1"><b>Sora</b><p>120 min weekly goal</p></div><span>›</span></div><div class="card" style="margin-top:auto"><b>Empty state contract</b><p>No Dogs is distinct from loading and failure. Add Dog routes to DOG-03.</p></div></div><div class="tabs"><span class="active">Dogs</span><span>Walk</span><span>Me</span></div></div></div>
+        <div class="phone-wrap"><div class="phone-title">WALK-01 · Ready</div><div class="phone"><div class="statusbar"><span>9:41</span><span>● ● ●</span></div><div class="screen"><h3>Ready to walk?</h3><p>Select one or more current Dogs. Foreground location is required before Start.</p><div class="row"><span>✓ Mugi</span><b>Today 18 / 30 min</b></div><div class="row"><span>○ Sora</span><b>This week 65 / 120</b></div><div class="mapbox">Map shell mounts here and remains stable</div><div class="primary">Start walk</div></div><div class="tabs"><span>Dogs</span><span class="active">Walk</span><span>Me</span></div></div></div>
+        <div class="phone-wrap"><div class="phone-title">WALK-03 · Recording</div><div class="phone"><div class="statusbar"><span>9:41</span><span>● ● ●</span></div><div class="screen"><div class="mapbox">Stable route map · accepted points only</div><div class="metrics"><div class="metric"><b>18:42</b><small>time</small></div><div class="metric"><b>1.34</b><small>km</small></div><div class="metric"><b>13:57</b><small>pace</small></div></div><div class="row"><b>Mugi</b><span>💧 Pee &nbsp; ● Poop</span></div><div class="row"><b>Sora</b><span>💧 Pee &nbsp; ● Poop</span></div><div class="secondary">Add photo · pending states visible</div><div class="primary" style="background:var(--red)">Finish walk</div></div><div class="tabs"><span>Dogs</span><span class="active">Walk</span><span>Me</span></div></div></div>
+        <div class="phone-wrap"><div class="phone-title">ME-01 · Contribution</div><div class="phone"><div class="statusbar"><span>9:41</span><span>● ● ●</span></div><div class="screen"><div class="row"><div class="avatar">A</div><div style="flex:1"><b>Akira</b><p>Walking since July 2026</p></div><span>⚙</span></div><h3>Your contribution</h3><div class="metrics"><div class="metric"><b>42</b><small>walks</small></div><div class="metric"><b>71.2</b><small>km</small></div><div class="metric"><b>16h</b><small>time</small></div></div><div class="card"><b>This week</b><p>Mon ▂ Tue ▆ Wed ▂ Thu █ Fri ▂ Sat ▂ Sun ▂</p></div><div class="row"><b>Walk history</b><span>All Dogs ›</span></div><div class="card"><b>Completed only</b><p>Active and Interrupted Walks never affect these values.</p></div></div><div class="tabs"><span>Dogs</span><span>Walk</span><span class="active">Me</span></div></div></div>
+      </div>
+    </section>
+  </main>
+
+  <aside class="detail" id="detail" hidden aria-live="polite">
+    <button type="button" id="close" aria-label="Close detail">×</button>
+    <span class="route" id="detail-route"></span>
+    <h2 id="detail-title"></h2>
+    <dl><dt>Feature</dt><dd id="detail-feature"></dd><dt>Journey</dt><dd id="detail-journey"></dd><dt>Slice</dt><dd id="detail-slice"></dd><dt>Entry</dt><dd id="detail-entry"></dd><dt>Success</dt><dd id="detail-success"></dd><dt>Failure</dt><dd id="detail-failure"></dd></dl>
+  </aside>
+
+  <script>
+    const nodes = [...document.querySelectorAll('.node')];
+    const controls = {
+      journey: document.querySelector('#journey'),
+      feature: document.querySelector('#feature'),
+      slice: document.querySelector('#slice')
+    };
+    function values(key) {
+      return [...new Set(nodes.flatMap(node => node.dataset[key].split(',')))].sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+    }
+    Object.entries(controls).forEach(([key, select]) => {
+      values(key).forEach(value => select.add(new Option(key === 'slice' ? `Slice ${value}` : value, value)));
+      select.addEventListener('change', applyFilters);
+    });
+    function applyFilters() {
+      nodes.forEach(node => {
+        node.hidden = Object.entries(controls).some(([key, select]) => select.value !== 'all' && !node.dataset[key].split(',').includes(select.value));
+      });
+    }
+    document.querySelector('#reset').addEventListener('click', () => {
+      Object.values(controls).forEach(select => select.value = 'all');
+      applyFilters();
+    });
+    const detail = document.querySelector('#detail');
+    nodes.forEach(node => node.addEventListener('click', () => {
+      ['route', 'title', 'feature', 'journey', 'slice', 'entry', 'success', 'failure'].forEach(key => {
+        document.querySelector(`#detail-${key}`).textContent = node.dataset[key];
+      });
+      detail.hidden = false;
+      document.querySelector('#close').focus();
+    }));
+    document.querySelector('#close').addEventListener('click', () => detail.hidden = true);
+    document.addEventListener('keydown', event => { if (event.key === 'Escape') detail.hidden = true; });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- records the normalized acceptance specification derived from `docs/tmp-testcases/`
- fixes the target API, Mobile, GraphQL, Harness, and Journey architecture
- defines the sequential PR 1–11 implementation roadmap and self-audit
- records the approved Mobile wireflow and durable ADRs

## Why

This establishes the reviewed system of record before the compatibility-breaking API and Mobile replacement begins.

## Product impact

Documentation only. No runtime or user Journey changes are included.

## Validation

- `scripts/harness/validate-all.sh`
- `git diff --cached --check`
- Wayfinder input/output self-audit with zero open findings